### PR TITLE
make complement, reverse_complement consistent

### DIFF
--- a/Bio/AlignIO/MafIO.py
+++ b/Bio/AlignIO/MafIO.py
@@ -815,7 +815,7 @@ class MafIndex:
         for seqid, seq in subseq.items():
             seq = Seq(seq)
 
-            seq = seq if strand == ref_first_strand else seq.reverse_complement()
+            seq = seq if strand == ref_first_strand else seq.reverse_complement(inplace=False)  # TODO: remove inplace=False
 
             result_multiseq.append(SeqRecord(seq, id=seqid, name=seqid, description=""))
 

--- a/Bio/AlignIO/MafIO.py
+++ b/Bio/AlignIO/MafIO.py
@@ -815,7 +815,11 @@ class MafIndex:
         for seqid, seq in subseq.items():
             seq = Seq(seq)
 
-            seq = seq if strand == ref_first_strand else seq.reverse_complement(inplace=False)  # TODO: remove inplace=False
+            seq = (
+                seq
+                if strand == ref_first_strand
+                else seq.reverse_complement(inplace=False)
+            )  # TODO: remove inplace=False
 
             result_multiseq.append(SeqRecord(seq, id=seqid, name=seqid, description=""))
 

--- a/Bio/Restriction/PrintFormat.py
+++ b/Bio/Restriction/PrintFormat.py
@@ -363,7 +363,9 @@ class PrintFormat:
             mapping = remaining
         cutloc[x] = mapping
         sequence = str(self.sequence)
-        revsequence = str(self.sequence.complement(inplace=False))  # TODO: remove inplace=False
+        revsequence = str(
+            self.sequence.complement(inplace=False)
+        )  # TODO: remove inplace=False
         a = "|"
         base, counter = 0, 0
         emptyline = " " * 60

--- a/Bio/Restriction/PrintFormat.py
+++ b/Bio/Restriction/PrintFormat.py
@@ -363,7 +363,7 @@ class PrintFormat:
             mapping = remaining
         cutloc[x] = mapping
         sequence = str(self.sequence)
-        revsequence = str(self.sequence.complement())
+        revsequence = str(self.sequence.complement(inplace=False))  # TODO: remove inplace=False
         a = "|"
         base, counter = 0, 0
         emptyline = " " * 60

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -3339,7 +3339,6 @@ def complement(sequence, inplace=None):
     raised if ``reverse_complement`` is called on a ``Seq`` object with
     ``inplace=True``.
     """
-
     from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
 
     if inplace is None:

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -486,7 +486,12 @@ class _SeqAbstractBaseClass(ABC):
         """
         if not isinstance(other, numbers.Integral):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(self._data * other)
+        # we would like to simply write
+        # data = self._data * other
+        # here, but currently that causes a bug on PyPy if self._data is a
+        # bytearray and other is a numpy integer. Using this workaround:
+        data = self._data.__mul__(other)
+        return self.__class__(data)
 
     def __rmul__(self, other):
         """Multiply integer by sequence.
@@ -497,7 +502,12 @@ class _SeqAbstractBaseClass(ABC):
         """
         if not isinstance(other, numbers.Integral):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(self._data * other)
+        # we would like to simply write
+        # data = self._data * other
+        # here, but currently that causes a bug on PyPy if self._data is a
+        # bytearray and other is a numpy integer. Using this workaround:
+        data = self._data.__mul__(other)
+        return self.__class__(data)
 
     def __imul__(self, other):
         """Multiply the sequence object by other and assign.
@@ -526,7 +536,12 @@ class _SeqAbstractBaseClass(ABC):
         """
         if not isinstance(other, numbers.Integral):
             raise TypeError(f"can't multiply {self.__class__.__name__} by non-int type")
-        return self.__class__(self._data * other)
+        # we would like to simply write
+        # data = self._data * other
+        # here, but currently that causes a bug on PyPy if self._data is a
+        # bytearray and other is a numpy integer. Using this workaround:
+        data = self._data.__mul__(other)
+        return self.__class__(data)
 
     def count(self, sub, start=None, end=None):
         """Return a non-overlapping count, like that of a python string.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1433,7 +1433,7 @@ class _SeqAbstractBaseClass(ABC):
                         BiopythonDeprecationWarning,
                     )
                     inplace = True
-                if (b"U" in self._data or b"u" in self._data):
+                if b"U" in self._data or b"u" in self._data:
                     warnings.warn(
                         "mutable_seq.complement() will change in the near "
                         "future to always return DNA nucleotides only. "
@@ -3225,6 +3225,7 @@ def reverse_complement(sequence, inplace=None):
     sequence = sequence.decode("ASCII")
     return sequence[::-1]
 
+
 def reverse_complement_rna(sequence, inplace=False):
     """Return the reverse complement as an RNA sequence.
 
@@ -3288,6 +3289,7 @@ def reverse_complement_rna(sequence, inplace=False):
     sequence = sequence.translate(_rna_complement_table)
     sequence = sequence.decode("ASCII")
     return sequence[::-1]
+
 
 def complement(sequence, inplace=None):
     """Return the complement as a DNA sequence.

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -51,7 +51,10 @@ def _maketrans(complement_mapping):
     return bytes.maketrans(keys + keys.lower(), values + values.lower())
 
 
-_dna_complement_table = _maketrans(IUPACData.ambiguous_dna_complement)
+ambiguous_dna_complement = dict(IUPACData.ambiguous_dna_complement)
+ambiguous_dna_complement["U"] = ambiguous_dna_complement["T"]
+_dna_complement_table = _maketrans(ambiguous_dna_complement)
+del ambiguous_dna_complement
 ambiguous_rna_complement = dict(IUPACData.ambiguous_rna_complement)
 ambiguous_rna_complement["T"] = ambiguous_rna_complement["U"]
 _rna_complement_table = _maketrans(ambiguous_rna_complement)
@@ -1379,6 +1382,83 @@ class _SeqAbstractBaseClass(ABC):
             _translate_str(str(self), table, stop_symbol, to_stop, cds, gap=gap)
         )
 
+    def complement(self, inplace=None):
+        """Return the complement as a DNA sequence.
+
+        >>> Seq("CGA").complement()
+        Seq('GCT')
+
+        Any U in the sequence is treated as a T:
+
+        >>> Seq("CGAUT").complement(inplace=False)
+        Seq('GCTAA')
+
+        In contrast, ``complement_rna`` returns an RNA sequence:
+
+        >>> Seq("CGAUT").complement_rna()
+        Seq('GCUAA')
+
+        The sequence is modified in-place and returned if inplace is True:
+
+        >>> my_seq = MutableSeq("CGA")
+        >>> my_seq
+        MutableSeq('CGA')
+        >>> my_seq.complement(inplace=False)
+        MutableSeq('GCT')
+        >>> my_seq
+        MutableSeq('CGA')
+
+        >>> my_seq.complement(inplace=True)
+        MutableSeq('GCT')
+        >>> my_seq
+        MutableSeq('GCT')
+
+        As ``Seq`` objects are immutable, a ``TypeError`` is raised if
+        ``complement_rna`` is called on a ``Seq`` object with ``inplace=True``.
+        """
+        ttable = _dna_complement_table
+        try:
+            if inplace is None:
+                # deprecated
+                if isinstance(self._data, bytearray):  # MutableSeq
+                    warnings.warn(
+                        "mutable_seq.complement() will change in the near "
+                        "future and will no longer change the sequence in-"
+                        "place by default. Please use\n"
+                        "\n"
+                        "mutable_seq.complement(inplace=True)\n"
+                        "\n"
+                        "if you want to continue to use this method to change "
+                        "a mutable sequence in-place.",
+                        BiopythonDeprecationWarning,
+                    )
+                    inplace = True
+                if (b"U" in self._data or b"u" in self._data):
+                    warnings.warn(
+                        "mutable_seq.complement() will change in the near "
+                        "future to always return DNA nucleotides only. "
+                        "Please use\n"
+                        "\n"
+                        "mutable_seq.complement_rna()\n"
+                        "\n"
+                        "if you want to receive an RNA sequence instead.",
+                        BiopythonDeprecationWarning,
+                    )
+                    if b"t" in self._data or b"T" in self._data:
+                        raise ValueError("Mixed RNA/DNA found")
+                    ttable = _rna_complement_table
+            data = self._data.translate(ttable)
+        except UndefinedSequenceError:
+            # complement of an undefined sequence is an undefined sequence
+            # of the same length
+            return self
+        if inplace:
+            if not isinstance(self._data, bytearray):
+                raise TypeError("Sequence is immutable")
+            self._data[:] = data
+            return self
+        return self.__class__(data)
+
     def complement_rna(self, inplace=False):
         """Return the complement as an RNA sequence.
 
@@ -1426,6 +1506,85 @@ class _SeqAbstractBaseClass(ABC):
             return self
         return self.__class__(data)
 
+    def reverse_complement(self, inplace=None):
+        """Return the reverse complement as a DNA sequence.
+
+        >>> Seq("CGA").reverse_complement(inplace=False)
+        Seq('TCG')
+
+        Any U in the sequence is treated as a T:
+
+        >>> Seq("CGAUT").reverse_complement(inplace=False)
+        Seq('AATCG')
+
+        In contrast, ``reverse_complement_rna`` returns an RNA sequence:
+
+        >>> Seq("CGA").reverse_complement_rna()
+        Seq('UCG')
+
+        The sequence is modified in-place and returned if inplace is True:
+
+        >>> my_seq = MutableSeq("CGA")
+        >>> my_seq
+        MutableSeq('CGA')
+        >>> my_seq.reverse_complement(inplace=False)
+        MutableSeq('TCG')
+        >>> my_seq
+        MutableSeq('CGA')
+
+        >>> my_seq.reverse_complement(inplace=True)
+        MutableSeq('TCG')
+        >>> my_seq
+        MutableSeq('TCG')
+
+        As ``Seq`` objects are immutable, a ``TypeError`` is raised if
+        ``reverse_complement`` is called on a ``Seq`` object with
+        ``inplace=True``.
+        """
+        try:
+            if inplace is None:
+                # deprecated
+                if isinstance(self._data, bytearray):  # MutableSeq
+                    warnings.warn(
+                        "mutable_seq.reverse_complement() will change in the "
+                        "near future and will no longer change the sequence in-"
+                        "place by default. Please use\n"
+                        "\n"
+                        "mutable_seq.reverse_complement(inplace=True)\n"
+                        "\n"
+                        "if you want to continue to use this method to change "
+                        "a mutable sequence in-place.",
+                        BiopythonDeprecationWarning,
+                    )
+                    inplace = True
+                else:
+                    inplace = False
+                if b"U" in self._data or b"u" in self._data:
+                    warnings.warn(
+                        "mutable_seq.reverse_complement() will change in the "
+                        "near future to always return DNA nucleotides only. "
+                        "Please use\n"
+                        "\n"
+                        "mutable_seq.reverse_complement_rna()\n"
+                        "\n"
+                        "if you want to receive an RNA sequence instead.",
+                        BiopythonDeprecationWarning,
+                    )
+                    if b"t" in self._data or b"T" in self._data:
+                        raise ValueError("Mixed RNA/DNA found")
+                    return self.reverse_complement_rna(inplace=inplace)
+            data = self._data.translate(_dna_complement_table)
+        except UndefinedSequenceError:
+            # reverse complement of an undefined sequence is an undefined sequence
+            # of the same length
+            return self
+        if inplace:
+            if not isinstance(self._data, bytearray):
+                raise TypeError("Sequence is immutable")
+            self._data[::-1] = data
+            return self
+        return self.__class__(data[::-1])
+
     def reverse_complement_rna(self, inplace=False):
         """Return the reverse complement as an RNA sequence.
 
@@ -1437,9 +1596,9 @@ class _SeqAbstractBaseClass(ABC):
         >>> Seq("CGAUT").reverse_complement_rna()
         Seq('AAUCG')
 
-        In contrast, ``reverse_complement`` returns a DNA sequence by default:
+        In contrast, ``reverse_complement`` returns a DNA sequence:
 
-        >>> Seq("CGA").reverse_complement()
+        >>> Seq("CGA").reverse_complement(inplace=False)
         Seq('TCG')
 
         The sequence is modified in-place and returned if inplace is True:
@@ -1775,141 +1934,6 @@ class Seq(_SeqAbstractBaseClass):
             BiopythonDeprecationWarning,
         )
         return str(self).encode(encoding, errors)
-
-    def complement(self):
-        """Return the complement sequence by creating a new Seq object.
-
-        This method is intended for use with DNA sequences:
-
-        >>> from Bio.Seq import Seq
-        >>> my_dna = Seq("CCCCCGATAG")
-        >>> my_dna
-        Seq('CCCCCGATAG')
-        >>> my_dna.complement()
-        Seq('GGGGGCTATC')
-
-        You can of course used mixed case sequences,
-
-        >>> from Bio.Seq import Seq
-        >>> my_dna = Seq("CCCCCgatA-GD")
-        >>> my_dna
-        Seq('CCCCCgatA-GD')
-        >>> my_dna.complement()
-        Seq('GGGGGctaT-CH')
-
-        Note in the above example, ambiguous character D denotes
-        G, A or T so its complement is H (for C, T or A).
-
-        Note that if the sequence contains neither T nor U, we
-        assume it is DNA and map any A character to T:
-
-        >>> Seq("CGA").complement()
-        Seq('GCT')
-        >>> Seq("CGAT").complement()
-        Seq('GCTA')
-
-        If you actually have RNA, this currently works but we
-        may deprecate this later. We recommend using the new
-        complement_rna method instead:
-
-        >>> Seq("CGAU").complement()
-        Seq('GCUA')
-        >>> Seq("CGAU").complement_rna()
-        Seq('GCUA')
-
-        If the sequence contains both T and U, an exception is
-        raised:
-
-        >>> Seq("CGAUT").complement()
-        Traceback (most recent call last):
-           ...
-        ValueError: Mixed RNA/DNA found
-
-        Trying to complement a protein sequence gives a meaningless
-        sequence:
-
-        >>> my_protein = Seq("MAIVMGR")
-        >>> my_protein.complement()
-        Seq('KTIBKCY')
-
-        Here "M" was interpreted as the IUPAC ambiguity code for
-        "A" or "C", with complement "K" for "T" or "G". Likewise
-        "A" has complement "T". The letter "I" has no defined
-        meaning under the IUPAC convention, and is unchanged.
-        """
-        if isinstance(self._data, _UndefinedSequenceData):
-            # complement of an undefined sequence is an undefined sequence
-            # of the same length
-            return self
-        if (b"U" in self._data or b"u" in self._data) and (
-            b"T" in self._data or b"t" in self._data
-        ):
-            # TODO - Handle this cleanly?
-            raise ValueError("Mixed RNA/DNA found")
-        elif b"U" in self._data or b"u" in self._data:
-            ttable = _rna_complement_table
-        else:
-            ttable = _dna_complement_table
-        # Much faster on really long sequences than the previous loop based
-        # one. Thanks to Michael Palmer, University of Waterloo.
-        return Seq(self._data.translate(ttable))
-
-    def reverse_complement(self):
-        """Return the reverse complement sequence by creating a new Seq object.
-
-        This method is intended for use with DNA sequences:
-
-        >>> from Bio.Seq import Seq
-        >>> my_dna = Seq("CCCCCGATAGNR")
-        >>> my_dna
-        Seq('CCCCCGATAGNR')
-        >>> my_dna.reverse_complement()
-        Seq('YNCTATCGGGGG')
-
-        Note in the above example, since R = G or A, its complement
-        is Y (which denotes C or T).
-
-        You can of course used mixed case sequences,
-
-        >>> from Bio.Seq import Seq
-        >>> my_dna = Seq("CCCCCgatA-G")
-        >>> my_dna
-        Seq('CCCCCgatA-G')
-        >>> my_dna.reverse_complement()
-        Seq('C-TatcGGGGG')
-
-        As discussed for the complement method, if the sequence
-        contains neither T nor U, is is assumed to be DNA and
-        will map any letter A to T.
-
-        If you are dealing with RNA you should use the new
-        reverse_complement_rna method instead
-
-        >>> Seq("CGA").reverse_complement()  # defaults to DNA
-        Seq('TCG')
-        >>> Seq("CGA").reverse_complement_rna()
-        Seq('UCG')
-
-        If the sequence contains both T and U, an exception is raised:
-
-        >>> Seq("CGAUT").reverse_complement()
-        Traceback (most recent call last):
-           ...
-        ValueError: Mixed RNA/DNA found
-
-        Trying to reverse complement a protein sequence will give
-        a meaningless sequence:
-
-        >>> from Bio.Seq import Seq
-        >>> my_protein = Seq("MAIVMGR")
-        >>> my_protein.reverse_complement()
-        Seq('YCKBITK')
-
-        Here "M" was interpreted as the IUPAC ambiguity code for
-        "A" or "C", with complement "K" for "T" or "G" - and so on.
-        """
-        # Use -1 stride/step to reverse the complement
-        return self.complement()[::-1]
 
     def ungap(self, gap="-"):
         """Return a copy of the sequence without the gap character(s) (OBSOLETE).
@@ -2689,32 +2713,6 @@ class MutableSeq(_SeqAbstractBaseClass):
         """
         self._data.reverse()
 
-    def complement(self):
-        """Modify the mutable sequence to take on its complement.
-
-        No return value.
-
-        If the sequence contains neither T nor U, DNA is assumed
-        and any A will be mapped to T.
-
-        If the sequence contains both T and U, an exception is raised.
-        """
-        if ord("U") in self._data and ord("T") in self._data:
-            raise ValueError("Mixed RNA/DNA found")
-        elif ord("U") in self._data:
-            table = _rna_complement_table
-        else:
-            table = _dna_complement_table
-        self._data = self._data.translate(table)
-
-    def reverse_complement(self):
-        """Modify the mutable sequence to take on its reverse complement.
-
-        No return value.
-        """
-        self.complement()
-        self._data.reverse()
-
     def extend(self, other):
         """Add a sequence to the original mutable sequence object.
 
@@ -3119,93 +3117,348 @@ def translate(
         return _translate_str(sequence, table, stop_symbol, to_stop, cds, gap=gap)
 
 
-def reverse_complement(sequence):
-    """Return the reverse complement sequence of a nucleotide string.
+def reverse_complement(sequence, inplace=None):
+    """Return the reverse complement as a DNA sequence.
 
     If given a string, returns a new string object.
-    Given a Seq or a MutableSeq, returns a new Seq object.
+    Given a Seq object, returns a new Seq object.
+    Given a MutableSeq, returns a new MutableSeq object.
+    Given a SeqRecord object, returns a new SeqRecord object.
 
-    Supports unambiguous and ambiguous nucleotide sequences.
+    >>> my_seq = "CGA"
+    >>> reverse_complement(my_seq, inplace=False)
+    'TCG'
+    >>> my_seq = Seq("CGA")
+    >>> reverse_complement(my_seq, inplace=False)
+    Seq('TCG')
+    >>> my_seq = MutableSeq("CGA")
+    >>> reverse_complement(my_seq, inplace=False)
+    MutableSeq('TCG')
+    >>> my_seq
+    MutableSeq('CGA')
 
-    e.g.
+    Any U in the sequence is treated as a T:
 
-    >>> reverse_complement("ACTG-NH")
-    'DN-CAGT'
+    >>> reverse_complement(Seq("CGAUT"), inplace=False)
+    Seq('AATCG')
 
-    If neither T nor U is present, DNA is assumed and A is mapped to T:
+    In contrast, ``reverse_complement_rna`` returns an RNA sequence:
 
-    >>> reverse_complement("A")
-    'T'
+    >>> reverse_complement_rna(Seq("CGAUT"))
+    Seq('AAUCG')
+
+    Supports and lower- and upper-case characters, and unambiguous and
+    ambiguous nucleotides. All other characters are not converted:
+
+    >>> reverse_complement("ACGTUacgtuXYZxyz", inplace=False)
+    'zrxZRXaacgtAACGT'
+
+    The sequence is modified in-place and returned if inplace is True:
+
+    >>> my_seq = MutableSeq("CGA")
+    >>> reverse_complement(my_seq, inplace=True)
+    MutableSeq('TCG')
+    >>> my_seq
+    MutableSeq('TCG')
+
+    As strings and ``Seq`` objects are immutable, a ``TypeError`` is
+    raised if ``reverse_complement`` is called on a ``Seq`` object with
+    ``inplace=True``.
     """
-    return complement(sequence)[::-1]
+    from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
 
-
-def complement(sequence):
-    """Return the complement sequence of a DNA string.
-
-    If given a string, returns a new string object.
-
-    Given a Seq or a MutableSeq, returns a new Seq object.
-
-    Supports unambiguous and ambiguous nucleotide sequences.
-
-    e.g.
-
-    >>> complement("ACTG-NH")
-    'TGAC-ND'
-
-    If neither T nor U is present, DNA is assumed and A is mapped to T:
-
-    >>> complement("A")
-    'T'
-
-    However, this may not be supported in future. Please use the
-    complement_rna function if you have RNA.
-    """
-    if isinstance(sequence, Seq):
-        # Return a Seq
-        return sequence.complement()
-    elif isinstance(sequence, MutableSeq):
-        # Return a Seq
-        # Don't use the MutableSeq reverse_complement method as it is
-        # 'in place'.
-        return Seq(sequence).complement()
-
+    if inplace is None:
+        # deprecated
+        if isinstance(sequence, Seq):
+            if b"U" in sequence._data or b"u" in sequence._data:
+                warnings.warn(
+                    "reverse_complement(sequence) will change in the "
+                    "near future to always return DNA nucleotides only. "
+                    "Please use\n"
+                    "\n"
+                    "reverse_complement_rna(sequence)\n"
+                    "\n"
+                    "if you want to receive an RNA sequence instead.",
+                    BiopythonDeprecationWarning,
+                )
+                if b"T" in sequence._data or b"t" in sequence._data:
+                    raise ValueError("Mixed RNA/DNA found")
+                return sequence.reverse_complement_rna()
+        elif isinstance(sequence, MutableSeq):
+            # Return a Seq
+            # Don't use the MutableSeq reverse_complement method as it is
+            # 'in place'.
+            warnings.warn(
+                "reverse_complement(mutable_seq) will change in the near "
+                "future to return a MutableSeq object instead of a Seq object.",
+                BiopythonDeprecationWarning,
+            )
+            return Seq(sequence).reverse_complement()
+        else:  # str
+            if "U" in sequence or "u" in sequence:
+                warnings.warn(
+                    "reverse_complement(sequence) will change in the "
+                    "near future to always return DNA nucleotides only. "
+                    "Please use\n"
+                    "\n"
+                    "reverse_complement_rna(sequence)\n"
+                    "\n"
+                    "if you want to receive an RNA sequence instead.",
+                    BiopythonDeprecationWarning,
+                )
+                if "T" in sequence or "t" in sequence:
+                    raise ValueError("Mixed RNA/DNA found")
+                sequence = sequence.encode("ASCII")
+                sequence = sequence.translate(_rna_complement_table)
+                return sequence.decode("ASCII")[::-1]
+    if isinstance(sequence, (Seq, MutableSeq)):
+        return sequence.reverse_complement(inplace)
+    if isinstance(sequence, SeqRecord):
+        if inplace:
+            raise TypeError("SeqRecords are immutable")
+        return sequence.reverse_complement()
     # Assume it's a string.
-    # In order to avoid some code duplication, the old code would turn the
-    # string into a Seq, use the reverse_complement method, and convert back
-    # to a string.
-    # This worked, but is over five times slower on short sequences!
+    if inplace:
+        raise TypeError("strings are immutable")
     sequence = sequence.encode("ASCII")
-    if (b"U" in sequence or b"u" in sequence) and (
-        b"T" in sequence or b"t" in sequence
-    ):  # ugly but this is what black wants
-        raise ValueError("Mixed RNA/DNA found")
-    elif b"U" in sequence or b"u" in sequence:
-        # TODO - warning or exception in future?
-        ttable = _rna_complement_table
-    else:
-        ttable = _dna_complement_table
-    sequence = sequence.translate(ttable)
+    sequence = sequence.translate(_dna_complement_table)
+    sequence = sequence.decode("ASCII")
+    return sequence[::-1]
+
+def reverse_complement_rna(sequence, inplace=False):
+    """Return the reverse complement as an RNA sequence.
+
+    If given a string, returns a new string object.
+    Given a Seq object, returns a new Seq object.
+    Given a MutableSeq, returns a new MutableSeq object.
+    Given a SeqRecord object, returns a new SeqRecord object.
+
+    >>> my_seq = "CGA"
+    >>> reverse_complement_rna(my_seq)
+    'UCG'
+    >>> my_seq = Seq("CGA")
+    >>> reverse_complement_rna(my_seq)
+    Seq('UCG')
+    >>> my_seq = MutableSeq("CGA")
+    >>> reverse_complement_rna(my_seq)
+    MutableSeq('UCG')
+    >>> my_seq
+    MutableSeq('CGA')
+
+    Any T in the sequence is treated as a U:
+
+    >>> reverse_complement_rna(Seq("CGAUT"))
+    Seq('AAUCG')
+
+    In contrast, ``reverse_complement`` returns a DNA sequence:
+
+    >>> reverse_complement(Seq("CGAUT"), inplace=False)
+    Seq('AATCG')
+
+    Supports and lower- and upper-case characters, and unambiguous and
+    ambiguous nucleotides. All other characters are not converted:
+
+    >>> reverse_complement_rna("ACGTUacgtuXYZxyz")
+    'zrxZRXaacguAACGU'
+
+    The sequence is modified in-place and returned if inplace is True:
+
+    >>> my_seq = MutableSeq("CGA")
+    >>> reverse_complement_rna(my_seq, inplace=True)
+    MutableSeq('UCG')
+    >>> my_seq
+    MutableSeq('UCG')
+
+    As strings and ``Seq`` objects are immutable, a ``TypeError`` is
+    raised if ``reverse_complement`` is called on a ``Seq`` object with
+    ``inplace=True``.
+    """
+    from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
+
+    if isinstance(sequence, (Seq, MutableSeq)):
+        return sequence.reverse_complement_rna(inplace)
+    if isinstance(sequence, SeqRecord):
+        if inplace:
+            raise TypeError("SeqRecords are immutable")
+        return sequence.reverse_complement_rna()
+    # Assume it's a string.
+    if inplace:
+        raise TypeError("strings are immutable")
+    sequence = sequence.encode("ASCII")
+    sequence = sequence.translate(_rna_complement_table)
+    sequence = sequence.decode("ASCII")
+    return sequence[::-1]
+
+def complement(sequence, inplace=None):
+    """Return the complement as a DNA sequence.
+
+    If given a string, returns a new string object.
+    Given a Seq object, returns a new Seq object.
+    Given a MutableSeq, returns a new MutableSeq object.
+    Given a SeqRecord object, returns a new SeqRecord object.
+
+    >>> my_seq = "CGA"
+    >>> complement(my_seq, inplace=False)
+    'GCT'
+    >>> my_seq = Seq("CGA")
+    >>> complement(my_seq, inplace=False)
+    Seq('GCT')
+    >>> my_seq = MutableSeq("CGA")
+    >>> complement(my_seq, inplace=False)
+    MutableSeq('GCT')
+    >>> my_seq
+    MutableSeq('CGA')
+
+    Any U in the sequence is treated as a T:
+
+    >>> complement(Seq("CGAUT"), inplace=False)
+    Seq('GCTAA')
+
+    In contrast, ``complement_rna`` returns an RNA sequence:
+
+    >>> complement_rna(Seq("CGAUT"))
+    Seq('GCUAA')
+
+    Supports and lower- and upper-case characters, and unambiguous and
+    ambiguous nucleotides. All other characters are not converted:
+
+    >>> complement("ACGTUacgtuXYZxyz", inplace=False)
+    'TGCAAtgcaaXRZxrz'
+
+    The sequence is modified in-place and returned if inplace is True:
+
+    >>> my_seq = MutableSeq("CGA")
+    >>> complement(my_seq, inplace=True)
+    MutableSeq('GCT')
+    >>> my_seq
+    MutableSeq('GCT')
+
+    As strings and ``Seq`` objects are immutable, a ``TypeError`` is
+    raised if ``reverse_complement`` is called on a ``Seq`` object with
+    ``inplace=True``.
+    """
+
+    from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
+
+    if inplace is None:
+        # deprecated
+        if isinstance(sequence, Seq):
+            # Return a Seq
+            if b"U" in sequence._data or b"u" in sequence._data:
+                warnings.warn(
+                    "complement(sequence) will change in the near "
+                    "future to always return DNA nucleotides only. "
+                    "Please use\n"
+                    "\n"
+                    "complement_rna(sequence)\n"
+                    "\n"
+                    "if you want to receive an RNA sequence instead.",
+                    BiopythonDeprecationWarning,
+                )
+                if b"T" in sequence._data or b"t" in sequence._data:
+                    raise ValueError("Mixed RNA/DNA found")
+                return sequence.complement_rna()
+        elif isinstance(sequence, MutableSeq):
+            # Return a Seq
+            # Don't use the MutableSeq reverse_complement method as it is
+            # 'in place'.
+            warnings.warn(
+                "complement(mutable_seq) will change in the near future"
+                "to return a MutableSeq object instead of a Seq object.",
+                BiopythonDeprecationWarning,
+            )
+            return Seq(sequence).complement()
+        else:
+            if "U" in sequence or "u" in sequence:
+                warnings.warn(
+                    "complement(sequence) will change in the near "
+                    "future to always return DNA nucleotides only. "
+                    "Please use\n"
+                    "\n"
+                    "complement_rna(sequence)\n"
+                    "\n"
+                    "if you want to receive an RNA sequence instead.",
+                    BiopythonDeprecationWarning,
+                )
+                if "T" in sequence or "t" in sequence:
+                    raise ValueError("Mixed RNA/DNA found")
+                ttable = _rna_complement_table
+                sequence = sequence.encode("ASCII")
+                sequence = sequence.translate(ttable)
+                return sequence.decode("ASCII")
+    if isinstance(sequence, (Seq, MutableSeq)):
+        return sequence.complement(inplace)
+    if isinstance(sequence, SeqRecord):
+        if inplace:
+            raise TypeError("SeqRecords are immutable")
+        return sequence.complement()
+    # Assume it's a string.
+    if inplace:
+        raise TypeError("strings are immutable")
+    sequence = sequence.encode("ASCII")
+    sequence = sequence.translate(_dna_complement_table)
     return sequence.decode("ASCII")
 
 
-def complement_rna(sequence):
-    """Return the complement sequence of an RNA string.
+def complement_rna(sequence, inplace=False):
+    """Return the complement as an RNA sequence.
 
-    >>> complement("ACG")  # assumed DNA
-    'TGC'
-    >>> complement_rna("ACG")
-    'UGC'
+    If given a string, returns a new string object.
+    Given a Seq object, returns a new Seq object.
+    Given a MutableSeq, returns a new MutableSeq object.
+    Given a SeqRecord object, returns a new SeqRecord object.
 
-    Any T in the sequence is treated as a U.
+    >>> my_seq = "CGA"
+    >>> complement_rna(my_seq)
+    'GCU'
+    >>> my_seq = Seq("CGA")
+    >>> complement_rna(my_seq)
+    Seq('GCU')
+    >>> my_seq = MutableSeq("CGA")
+    >>> complement_rna(my_seq)
+    MutableSeq('GCU')
+    >>> my_seq
+    MutableSeq('CGA')
+
+    Any T in the sequence is treated as a U:
+
+    >>> complement_rna(Seq("CGAUT"))
+    Seq('GCUAA')
+
+    In contrast, ``complement`` returns a DNA sequence:
+
+    >>> complement(Seq("CGAUT"),inplace=False)
+    Seq('GCTAA')
+
+    Supports and lower- and upper-case characters, and unambiguous and
+    ambiguous nucleotides. All other characters are not converted:
+
+    >>> complement_rna("ACGTUacgtuXYZxyz")
+    'UGCAAugcaaXRZxrz'
+
+    The sequence is modified in-place and returned if inplace is True:
+
+    >>> my_seq = MutableSeq("CGA")
+    >>> complement(my_seq, inplace=True)
+    MutableSeq('GCT')
+    >>> my_seq
+    MutableSeq('GCT')
+
+    As strings and ``Seq`` objects are immutable, a ``TypeError`` is
+    raised if ``reverse_complement`` is called on a ``Seq`` object with
+    ``inplace=True``.
     """
-    if isinstance(sequence, Seq):
-        # Return a Seq
+    from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
+
+    if isinstance(sequence, (Seq, MutableSeq)):
+        return sequence.complement_rna(inplace)
+    if isinstance(sequence, SeqRecord):
+        if inplace:
+            raise TypeError("SeqRecords are immutable")
         return sequence.complement_rna()
-    elif isinstance(sequence, MutableSeq):
-        # Return a Seq
-        return Seq(sequence).complement_rna()
+    # Assume it's a string.
+    if inplace:
+        raise TypeError("strings are immutable")
     sequence = sequence.encode("ASCII")
     sequence = sequence.translate(_rna_complement_table)
     return sequence.decode("ASCII")

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1103,8 +1103,7 @@ class FeatureLocation:
         """Extract the sequence from supplied parent sequence using the FeatureLocation object.
 
         The parent_sequence can be a Seq like object or a string, and will
-        generally return an object of the same type. The exception to this is
-        a MutableSeq as the parent sequence will return a Seq object.
+        return an object of the same type.
         If the location refers to other records, they must be supplied
         in the optional dictionary references.
 
@@ -1135,17 +1134,11 @@ class FeatureLocation:
                 parent_sequence = parent_sequence.seq
             except AttributeError:
                 pass
-        if isinstance(parent_sequence, MutableSeq):
-            # This avoids complications with reverse complements
-            # (the MutableSeq reverse complement acts in situ)
-            parent_sequence = Seq(parent_sequence)
         f_seq = parent_sequence[self.nofuzzy_start : self.nofuzzy_end]
+        if isinstance(f_seq, MutableSeq):
+            f_seq = Seq(f_seq)
         if self.strand == -1:
-            try:
-                f_seq = f_seq.reverse_complement()
-            except AttributeError:
-                assert isinstance(f_seq, str)
-                f_seq = reverse_complement(f_seq)
+            f_seq = reverse_complement(f_seq, inplace=False)  # TODO: remove inplace=False
         return f_seq
 
 

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1103,7 +1103,8 @@ class FeatureLocation:
         """Extract the sequence from supplied parent sequence using the FeatureLocation object.
 
         The parent_sequence can be a Seq like object or a string, and will
-        return an object of the same type.
+        generally return an object of the same type. The exception to this is
+        a MutableSeq as the parent sequence will return a Seq object.
         If the location refers to other records, they must be supplied
         in the optional dictionary references.
 
@@ -1138,7 +1139,9 @@ class FeatureLocation:
         if isinstance(f_seq, MutableSeq):
             f_seq = Seq(f_seq)
         if self.strand == -1:
-            f_seq = reverse_complement(f_seq, inplace=False)  # TODO: remove inplace=False
+            f_seq = reverse_complement(
+                f_seq, inplace=False
+            )  # TODO: remove inplace=False
         return f_seq
 
 

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -1205,18 +1205,13 @@ class SeqRecord:
         if "protein" in self.annotations.get("molecule_type", ""):
             raise ValueError("Proteins do not have complements!")
         if "RNA" in self.annotations.get("molecule_type", ""):
-            if isinstance(self.seq, MutableSeq):
-                # Does not currently have reverse_complement_rna method:
-                answer = SeqRecord(Seq(self.seq).reverse_complement_rna())
-            else:
-                answer = SeqRecord(self.seq.reverse_complement_rna())
+            seq = self.seq.reverse_complement_rna(inplace=False)  # TODO: remove inplace=False
         else:
-            # Default to DNA
-            if isinstance(self.seq, MutableSeq):
-                # Currently the MutableSeq reverse complement is in situ
-                answer = SeqRecord(Seq(self.seq).reverse_complement())
-            else:
-                answer = SeqRecord(self.seq.reverse_complement())
+            # Default to DNA)
+            seq = self.seq.reverse_complement(inplace=False)  # TODO: remove inplace=False
+        if isinstance(self.seq, MutableSeq):
+            seq = Seq(seq)
+        answer = SeqRecord(seq)
         if isinstance(id, str):
             answer.id = id
         elif id:

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -1205,10 +1205,14 @@ class SeqRecord:
         if "protein" in self.annotations.get("molecule_type", ""):
             raise ValueError("Proteins do not have complements!")
         if "RNA" in self.annotations.get("molecule_type", ""):
-            seq = self.seq.reverse_complement_rna(inplace=False)  # TODO: remove inplace=False
+            seq = self.seq.reverse_complement_rna(
+                inplace=False
+            )  # TODO: remove inplace=False
         else:
             # Default to DNA)
-            seq = self.seq.reverse_complement(inplace=False)  # TODO: remove inplace=False
+            seq = self.seq.reverse_complement(
+                inplace=False
+            )  # TODO: remove inplace=False
         if isinstance(self.seq, MutableSeq):
             seq = Seq(seq)
         answer = SeqRecord(seq)

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -402,7 +402,7 @@ def six_frame_translations(seq, genetic_code=1):
 
     >>> from Bio.SeqUtils import six_frame_translations
     >>> print(six_frame_translations("AUGGCCAUUGUAAUGGGCCGCUGA"))
-    GC_Frame: a:5 t:0 g:8 c:5 
+    GC_Frame: a:5 t:0 g:8 c:5
     Sequence: auggccauug ... gggccgcuga, 24 nt, 54.17 %GC
     <BLANKLINE>
     <BLANKLINE>
@@ -412,7 +412,7 @@ def six_frame_translations(seq, genetic_code=1):
     M  A  I  V  M  G  R  *
     auggccauuguaaugggccgcuga   54 %
     uaccgguaacauuacccggcgacu
-    A  M  T  I  P  R  Q 
+    A  M  T  I  P  R  Q
      H  G  N  Y  H  A  A  S
       P  W  Q  L  P  G  S
     <BLANKLINE>
@@ -421,7 +421,7 @@ def six_frame_translations(seq, genetic_code=1):
     """  # noqa for pep8 W291 trailing whitespace
     from Bio.Seq import reverse_complement, reverse_complement_rna, translate
 
-    if 'u' in seq.lower():
+    if "u" in seq.lower():
         anti = reverse_complement_rna(seq)
     else:
         anti = reverse_complement(seq, inplace=False)  # TODO: remove inplace=False

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -382,7 +382,7 @@ def molecular_weight(
 
     if double_stranded:
         if seq_type == "protein":
-            raise ValueError("double-stranded proteins await their discovery")
+            raise ValueError("protein sequences cannot be double-stranded")
         elif seq_type == "DNA":
             seq = complement(seq, inplace=False)  # TODO: remove inplace=False
         elif seq_type == "RNA":

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -13,7 +13,7 @@
 import re
 from math import pi, sin, cos
 
-from Bio.Seq import Seq, complement
+from Bio.Seq import Seq, complement, complement_rna
 from Bio.Data import IUPACData
 
 

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -438,9 +438,9 @@ def six_frame_translations(seq, genetic_code=1):
         short = "%s ... %s" % (seq[:10], seq[-10:])
     else:
         short = seq
-    header = "GC_Frame: "
+    header = "GC_Frame:"
     for nt in ["a", "t", "g", "c"]:
-        header += "%s:%d " % (nt, seq.count(nt.upper()))
+        header += " %s:%d" % (nt, seq.count(nt.upper()))
 
     header += "\nSequence: %s, %d nt, %0.2f %%GC\n\n\n" % (
         short.lower(),
@@ -461,7 +461,7 @@ def six_frame_translations(seq, genetic_code=1):
         res += subseq.lower() + "%5d %%\n" % int(GC(subseq))
         res += csubseq.lower() + "\n"
         # - frames
-        res += "  ".join(frames[-2][p : p + 20]) + " \n"
+        res += "  ".join(frames[-2][p : p + 20]) + "\n"
         res += " " + "  ".join(frames[-1][p : p + 20]) + "\n"
         res += "  " + "  ".join(frames[-3][p : p + 20]) + "\n\n"
     return res

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -246,8 +246,10 @@ class Instances(list):
             # TODO: remove inplace=False
             if isinstance(instance, (Seq, MutableSeq)):
                 instance = instance.reverse_complement(inplace=False)
-            if isinstance(instance, (str, SeqRecord)):
+            elif isinstance(instance, (str, SeqRecord)):
                 instance = instance.reverse_complement()
+            else:
+                raise RuntimeError("instance has unexpected type %s" % type(instance))
             instances.append(instance)
         return instances
 

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -237,10 +237,17 @@ class Instances(list):
 
     def reverse_complement(self):
         """Compute reverse complement of sequences."""
+        from Bio.Seq import Seq, MutableSeq
+        from Bio.SeqRecord import SeqRecord
+
         instances = Instances(alphabet=self.alphabet)
         instances.length = self.length
         for instance in self:
-            instance = instance.reverse_complement()
+            # TODO: remove inplace=False
+            if isinstance(instance, (Seq, MutableSeq)):
+                instance = instance.reverse_complement(inplace=False)
+            if isinstance(instance, (str, SeqRecord)):
+                instance = instance.reverse_complement()
             instances.append(instance)
         return instances
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -719,6 +719,8 @@ class StringMethodTests(unittest.TestCase):
             if isinstance(example1, UnknownSeq):
                 with self.assertWarns(BiopythonDeprecationWarning):
                     comp = example1.complement()
+            elif "u" in example1 or "U" in example1:
+                comp = example1.complement_rna()
             else:
                 comp = example1.complement()
             str1 = str(example1)
@@ -738,6 +740,8 @@ class StringMethodTests(unittest.TestCase):
             if isinstance(example1, UnknownSeq):
                 with self.assertWarns(BiopythonDeprecationWarning):
                     comp = example1.reverse_complement()
+            elif "u" in example1 or "U" in example1:
+                comp = example1.reverse_complement_rna()
             else:
                 comp = example1.reverse_complement()
             str1 = str(example1)

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -711,8 +711,15 @@ class TestMutableSeq(unittest.TestCase):
         """Test reverse using -1 stride."""
         self.assertEqual(Seq.MutableSeq("GTACTACGTAGGAAAACT"), self.mutable_s[::-1])
 
+    def test_complement_old(self):
+        # old approach
+        with self.assertWarns(BiopythonDeprecationWarning):
+            self.mutable_s.complement()
+        self.assertEqual("AGTTTTCCTACGTAGTAC", self.mutable_s)
+
     def test_complement(self):
-        self.mutable_s.complement()
+        # new approach
+        self.mutable_s.complement(inplace=True)
         self.assertEqual("AGTTTTCCTACGTAGTAC", self.mutable_s)
 
     def test_complement_rna(self):
@@ -754,22 +761,47 @@ class TestMutableSeq(unittest.TestCase):
         self.assertEqual(d, "TCAAAAGGATGCATCATG")
 
     def test_complement_mixed_aphabets(self):
+        # new approach
         seq = Seq.MutableSeq("AUGaaaCTG")
-        with self.assertRaises(ValueError):
-            seq.complement()
+        seq.complement_rna(inplace=True)
+        self.assertEqual("UACuuuGAC", seq)
+        # old approach
+        seq = Seq.MutableSeq("AUGaaaCTG")
+        with self.assertWarns(BiopythonDeprecationWarning):
+            with self.assertRaises(ValueError):
+                seq.complement()
 
     def test_complement_rna_string(self):
+        # new approach
         seq = Seq.MutableSeq("AUGaaaCUG")
-        seq.complement()
+        seq.complement_rna(inplace=True)
+        self.assertEqual("UACuuuGAC", seq)
+        # old approach
+        seq = Seq.MutableSeq("AUGaaaCUG")
+        with self.assertWarns(BiopythonDeprecationWarning):
+            seq.complement()
         self.assertEqual("UACuuuGAC", seq)
 
     def test_complement_dna_string(self):
+        # new approach
         seq = Seq.MutableSeq("ATGaaaCTG")
-        seq.complement()
+        seq.complement(inplace=True)
+        self.assertEqual("TACtttGAC", seq)
+        # old approach
+        seq = Seq.MutableSeq("ATGaaaCTG")
+        with self.assertWarns(BiopythonDeprecationWarning):
+            seq.complement()
         self.assertEqual("TACtttGAC", seq)
 
     def test_reverse_complement(self):
-        self.mutable_s.reverse_complement()
+        # new approach
+        self.mutable_s.reverse_complement(inplace=True)
+        self.assertEqual("CATGATGCATCCTTTTGA", self.mutable_s)
+
+    def test_reverse_complement_old(self):
+        # old approach
+        with self.assertWarns(BiopythonDeprecationWarning):
+            self.mutable_s.reverse_complement()
         self.assertEqual("CATGATGCATCCTTTTGA", self.mutable_s)
 
     def test_extend_method(self):
@@ -932,14 +964,24 @@ class TestComplement(unittest.TestCase):
     def test_complement_ambiguous_rna_values(self):
         for ambig_char, values in sorted(ambiguous_rna_values.items()):
             # Will default to DNA if neither T nor U found...
-            compl_values = Seq.Seq(values).complement().transcribe()
+            if "u" in values or "U" in values:
+                compl_values = Seq.Seq(values).complement_rna().transcribe()
+            else:
+                compl_values = Seq.Seq(values).complement().transcribe()
             ambig_values = ambiguous_rna_values[ambiguous_rna_complement[ambig_char]]
             self.assertCountEqual(compl_values, ambig_values)
 
     def test_complement_incompatible_letters(self):
         seq = Seq.Seq("CAGGTU")
-        with self.assertRaises(ValueError):
-            seq.complement()
+        # new approach
+        dna = seq.complement(inplace=False)  # TODO: remove inplace=False
+        self.assertEqual("GTCCAA", dna)
+        rna = seq.complement_rna()
+        self.assertEqual("GUCCAA", rna)
+        # old approach
+        with self.assertWarns(BiopythonDeprecationWarning):
+            with self.assertRaises(ValueError):
+                seq.complement()
 
     def test_complement_of_mixed_dna_rna(self):
         seq = "AUGAAACTG"  # U and T
@@ -947,7 +989,13 @@ class TestComplement(unittest.TestCase):
 
     def test_complement_of_rna(self):
         seq = "AUGAAACUG"
-        self.assertEqual("UACUUUGAC", Seq.complement(seq))
+        # new approach
+        rna = Seq.complement_rna(seq)
+        self.assertEqual("UACUUUGAC", rna)
+        # old approach
+        with self.assertWarns(BiopythonDeprecationWarning):
+            rna = Seq.complement(seq)
+        self.assertEqual("UACUUUGAC", rna)
 
     def test_complement_of_dna(self):
         seq = "ATGAAACTG"
@@ -960,7 +1008,25 @@ class TestReverseComplement(unittest.TestCase):
         test_seqs_copy.pop(13)
 
         for nucleotide_seq in test_seqs_copy:
-            if isinstance(nucleotide_seq, Seq.Seq):
+            if not isinstance(nucleotide_seq, Seq.Seq):
+                continue
+            if "u" in nucleotide_seq or "U" in nucleotide_seq:
+                expected = Seq.reverse_complement_rna(nucleotide_seq)
+                self.assertEqual(
+                    repr(expected), repr(nucleotide_seq.reverse_complement_rna())
+                )
+                self.assertEqual(
+                    repr(expected[::-1]), repr(nucleotide_seq.complement_rna())
+                )
+                self.assertEqual(
+                    nucleotide_seq.complement_rna(),
+                    Seq.reverse_complement_rna(nucleotide_seq)[::-1],
+                )
+                self.assertEqual(
+                    nucleotide_seq.reverse_complement_rna(),
+                    Seq.reverse_complement_rna(nucleotide_seq),
+                )
+            else:
                 expected = Seq.reverse_complement(nucleotide_seq)
                 self.assertEqual(
                     repr(expected), repr(nucleotide_seq.reverse_complement())
@@ -982,8 +1048,14 @@ class TestReverseComplement(unittest.TestCase):
         self.assertRaises(ValueError, Seq.reverse_complement, seq)
 
     def test_reverse_complement_of_rna(self):
+        # old approach
         seq = "AUGAAACUG"
-        self.assertEqual("CAGUUUCAU", Seq.reverse_complement(seq))
+        with self.assertWarns(BiopythonDeprecationWarning):
+            rna = Seq.reverse_complement(seq)
+        self.assertEqual("CAGUUUCAU", rna)
+        # new approach
+        dna = Seq.reverse_complement(seq, inplace=False)  # TODO: remove inplace=False
+        self.assertEqual("CAGTTTCAT", dna)
 
     def test_reverse_complement_of_dna(self):
         seq = "ATGAAACTG"
@@ -996,14 +1068,19 @@ class TestDoubleReverseComplement(unittest.TestCase):
         sorted_amb_rna = sorted(ambiguous_rna_values)
         sorted_amb_dna = sorted(ambiguous_dna_values)
         for sequence in [
-            Seq.Seq("".join(sorted_amb_rna)),
             Seq.Seq("".join(sorted_amb_dna)),
-            Seq.Seq("".join(sorted_amb_rna).replace("X", "")),
             Seq.Seq("".join(sorted_amb_dna).replace("X", "")),
-            Seq.Seq("AWGAARCKG"),
-        ]:  # Note no U or T
+            Seq.Seq("AWGAARCKG"),  # Note no U or T
+        ]:
             reversed_sequence = sequence.reverse_complement()
             self.assertEqual(sequence, reversed_sequence.reverse_complement())
+        for sequence in [
+            Seq.Seq("".join(sorted_amb_rna)),
+            Seq.Seq("".join(sorted_amb_rna).replace("X", "")),
+            Seq.Seq("AWGAARCKG"),  # Note no U or T
+        ]:
+            reversed_sequence = sequence.reverse_complement_rna()
+            self.assertEqual(sequence, reversed_sequence.reverse_complement_rna())
 
 
 class TestTranscription(unittest.TestCase):


### PR DESCRIPTION
Currently, the `complement` and `reverse_complement` methods and functions in `Bio.Seq` are inconsistent in their handling of RNA sequences and mutable sequences. Sometimes the presence of a `U` indicates RNA, sometimes the presence of a `u` or `U` means RNA, sometimes mutable sequences are acted on in place, sometimes a `Seq` object is returned.

This PR aims to make `complement` and `reverse_complement` consistent by adding an `inplace` keyword argument (same as for `strip`, `upper` etc. in the same module).

**In the future**, `inplace` will be `False` by default, and `inplace=None` will be disallowed.
**For now**, `inplace` is `None` by default.

- If `inplace` is `False`, the function/method does not act in place, and returns a new object of the same type as the sequence it acts on;
- If `inplace` is `True`, the function/method tries to act in place, and raises a `TypeError` if the sequence passed is immutable. If successful, the function/method returns the sequence is acted on;
- If `inplace` is `True` or `False`, then
    - `complement` and `reverse_complement` return a DNA sequence;
    - `complement_rna` and `reverse_complement_rna` return an RNA sequence.
- If `inplace` is `None`, then `complement`, `reverse_complement` will act the same as in release <= 1.79.  However, if function/method will behave differently for the sequence provided once the default value of `inplace` becomes `False`, a `BiopythonDeprecationWarning` will be issued encouraging the user to either set `inplace=True`, or use `complement_rna` and `reverse_complement_rna`.

In a few places, `inplace=False` was added to calls to `complement`, `reverse_complement` to avoid the deprecation warning; these can be removed once the default value of `inplace` becomes `False`.

The tutorial documentation has not yet been fully updated; I wanted to see first if there are any strong objections to this PR.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)