### PR TITLE
add support for gaf2.2 format

### DIFF
--- a/Bio/UniProt/GOA.py
+++ b/Bio/UniProt/GOA.py
@@ -12,6 +12,7 @@ Uniprot-GOA README + GAF format description:
 ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/UNIPROT/README
 
 Gene Association File, GAF formats:
+http://geneontology.org/docs/go-annotation-file-gaf-format-2.2/
 http://geneontology.org/docs/go-annotation-file-gaf-format-2.1/
 http://geneontology.org/docs/go-annotation-file-gaf-format-2.0/
 
@@ -385,16 +386,22 @@ def gafbyproteiniterator(handle):
         # Handle GAF 2.1 as GAF 2.0 for now TODO: fix
         # sys.stderr.write("gaf 2.1\n")
         return _gaf20byproteiniterator(handle)
+    elif inline.strip() == "!gaf-version: 2.2":
+        # Handle GAF 2.2 as GAF 2.0 for now. Change from
+        # 2.1 to 2.2 is that Qualifier field is no longer optional.
+        # As this type of checks has not been done before, we can
+        # continue to use the gaf2.0 parser
+        return _gaf20byproteiniterator(handle)
     else:
         raise ValueError(f"Unknown GAF version {inline}\n")
 
 
 def gafiterator(handle):
-    """Iterate over a GAF 1.0 or 2.0 file.
+    """Iterate over a GAF 1.0 or 2.x file.
 
     This function should be called to read a
     gene_association.goa_uniprot file. Reads the first record and
-    returns a gaf 2.0 or a gaf 1.0 iterator as needed
+    returns a gaf 2.x or a gaf 1.0 iterator as needed
 
     Example: open, read, interat and filter results.
 
@@ -433,6 +440,12 @@ def gafiterator(handle):
     elif inline.strip() == "!gaf-version: 2.1":
         # sys.stderr.write("gaf 2.1\n")
         # Handle GAF 2.1 as GAF 2.0 for now. TODO: fix
+        return _gaf20iterator(handle)
+    elif inline.strip() == "!gaf-version: 2.2":
+        # Handle GAF 2.2 as GAF 2.0 for now. Change from
+        # 2.1 to 2.2 is that Qualifier field is no longer optional.
+        # As this type of checks has not been done before, we can
+        # continue to use the gaf2.0 parser
         return _gaf20iterator(handle)
     elif inline.strip() == "!gaf-version: 1.0":
         # sys.stderr.write("gaf 1.0\n")


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3649

incremental change in format GAF2.1 -> GAF2.2 very minor
(see http://geneontology.org/docs/go-annotation-file-gaf-format-2.2/)

existing parser for 2.1 can directly be used, as so far no checks on
expected cardinality are made anyways.

