### PR TITLE
The tf_class and tf_family in Bio.motifs.jaspar.db should be string array

### DIFF
--- a/Bio/motifs/jaspar/db.py
+++ b/Bio/motifs/jaspar/db.py
@@ -26,8 +26,8 @@ appropriate::
     TF name ETS1
     Matrix ID   MA0098.3
     Collection  CORE
-    TF class    Tryptophan cluster factors
-    TF family   Ets-related factors
+    TF class    ['Tryptophan cluster factors']
+    TF family   ['Ets-related factors']
     Species 9606
     Taxonomic group vertebrates
     Accession   ['P14921']
@@ -403,13 +403,18 @@ class JASPAR5:
         # fetch remaining annotation as tags from the ANNOTATION table
         cur.execute("select TAG, VAL from MATRIX_ANNOTATION where id = %s", (int_id,))
         rows = cur.fetchall()
+
+        # Since JASPAR 2018 tf_family and tf_class are return as array.
+        tf_family = []
+        tf_class = []
+
         for row in rows:
             attr = row[0]
             val = row[1]
             if attr == "class":
-                motif.tf_class = val
+                tf_class.append(val)
             elif attr == "family":
-                motif.tf_family = val
+                tf_family.append(val)
             elif attr == "tax_group":
                 motif.tax_group = val
             elif attr == "type":
@@ -424,6 +429,9 @@ class JASPAR5:
                 # TODO If we were to implement additional abitrary tags
                 # motif.tag(attr, val)
                 pass
+
+        motif.tf_family = tf_family
+        motif.tf_class = tf_class
 
         return motif
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -40,6 +40,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Ariel Aptekmann <https://github.com/aralap>
 - Artemi Bendandi <https://github.com/artbendandi>
 - Austin Varela <https://github.com/austinv11>
+- Aziz Khan <https://github.com/asntech>
 - Barbara Mühlemann <https://github.com/bamueh>
 - Bart de Koning <bratdaking gmail>
 - Bartek Wilczynski <bartek at domain rezolwenta.eu.org>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -26,6 +26,12 @@ Fixed typos of triple underscore.
 - Chenghao Zhu
 - Fabian Egli
 
+The ``Bio.motifs.jaspar.db`` now returns ``tf_family`` and ``tf_class`` as a
+string array since the JASPAR 2018 release.
+
+- Aziz Khan
+
+
 3 June 2021: Biopython 1.79
 ================================
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

The ``tf_family`` and ``tf_class`` in the ``Bio.motifs.jaspar.db`` module was returning string value.
Since the JASPAR 2018 release, it should be a string array. For example, the ASPAR RESTful API returns an array (http://jaspar.genereg.net/api/v1/matrix/MA0006.1.json)
