### PR TITLE
Seq and SeqRecord can now use numpy int

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1482,13 +1482,6 @@ class Alignment:
                             line += "-"
                         else:
                             sequence = sequences[i]
-                            # SeqRecord __getitem__ does not allow numpy int
-                            try:
-                                sequence = sequence.seq
-                            except AttributeError:
-                                pass
-                            # Seq __getitem__ does not allow numpy int
-                            sequence = str(sequence)
                             line += sequence[e - offset]
                     return line
                 if row.indices(n) != (0, n, 1):


### PR DESCRIPTION
Crossref  #3642 . Now that Seq and SeqRecord can handle numpy integers, the code in `Bio.Align` can be simplified.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
