### PR TITLE
skip atoms with invalid coords in PERMISSIVE mode

### DIFF
--- a/Bio/PDB/PDBParser.py
+++ b/Bio/PDB/PDBParser.py
@@ -211,10 +211,9 @@ class PDBParser:
                     y = float(line[38:46])
                     z = float(line[46:54])
                 except Exception:
-                    # Should we allow parsing to continue in permissive mode?
-                    # If so, what coordinates should we default to?  Easier to abort!
+                    # Skip the whole line if permissive
                     if self.PERMISSIVE:
-                        continue # Skip the whole line if permissive
+                        continue
                     raise PDBConstructionException(
                         "Invalid or missing coordinate(s) at line %i."
                         % global_line_counter

--- a/Bio/PDB/PDBParser.py
+++ b/Bio/PDB/PDBParser.py
@@ -213,6 +213,8 @@ class PDBParser:
                 except Exception:
                     # Should we allow parsing to continue in permissive mode?
                     # If so, what coordinates should we default to?  Easier to abort!
+                    if self.PERMISSIVE:
+                        continue # Skip the whole line if permissive
                     raise PDBConstructionException(
                         "Invalid or missing coordinate(s) at line %i."
                         % global_line_counter

--- a/Tests/test_PQR.py
+++ b/Tests/test_PQR.py
@@ -48,7 +48,7 @@ class ParseSimplePQR(unittest.TestCase):
         data = "ATOM      1  N   PRO     1      00abc1  02.000 3.0000 -0.1000  1.0000       N\n"
 
         # Get sole atom of this structure
-        parser = PDBParser(is_pqr=True)  # default initialization
+        parser = PDBParser(is_pqr=True, PERMISSIVE=False)
         self.assertRaises(
             PDBConstructionException, parser.get_structure, "example", StringIO(data)
         )


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Sometimes it may be better to get an incomplete 3D-structure than not getting any. The final user can then choose wether to keep the incomplete structure once built by examining it or throw it if too much information is missing, e.g. by counting the numer of atoms through `model.get_atoms()`.
