### PR TITLE
make AlignIO imports work without sqlite3

### DIFF
--- a/Bio/AlignIO/MafIO.py
+++ b/Bio/AlignIO/MafIO.py
@@ -35,7 +35,12 @@ A 1-column wide alignment would have ``start == end``.
 import os
 
 from itertools import islice
-from sqlite3 import dbapi2
+
+try:
+    from sqlite3 import dbapi2
+    from sqlite3.dbapi2 import OperationalError, DatabaseError
+except ImportError:
+    dbapi2 = OperationalError = DatabaseError = None
 
 from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
@@ -258,6 +263,14 @@ class MafIndex:
 
     def __init__(self, sqlite_file, maf_file, target_seqname):
         """Indexes or loads the index of a MAF file."""
+        if dbapi2 is None:
+            # Python was compiled without sqlite3 support
+            from Bio import MissingPythonDependencyError
+
+            raise MissingPythonDependencyError(
+                "Python was compiled without the sqlite3 module"
+            )
+
         self._target_seqname = target_seqname
         # example: Tests/MAF/ucsc_mm9_chr10.mafindex
         self._index_filename = sqlite_file
@@ -347,7 +360,7 @@ class MafIndex:
 
             return records_found
 
-        except (dbapi2.OperationalError, dbapi2.DatabaseError) as err:
+        except (OperationalError, DatabaseError) as err:
             raise ValueError("Problem with SQLite database: %s" % err) from None
 
     def __make_new_index(self):

--- a/Bio/AlignIO/MafIO.py
+++ b/Bio/AlignIO/MafIO.py
@@ -38,9 +38,8 @@ from itertools import islice
 
 try:
     from sqlite3 import dbapi2
-    from sqlite3.dbapi2 import OperationalError, DatabaseError
 except ImportError:
-    dbapi2 = OperationalError = DatabaseError = None
+    dbapi2 = None
 
 from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
@@ -360,7 +359,7 @@ class MafIndex:
 
             return records_found
 
-        except (OperationalError, DatabaseError) as err:
+        except (dbapi2.OperationalError, dbapi2.DatabaseError) as err:
             raise ValueError("Problem with SQLite database: %s" % err) from None
 
     def __make_new_index(self):


### PR DESCRIPTION

- [ X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed.

This fixes a hard dependency on sqlite3 introduced in 4e77946e4c3c711e35d4a4ad40f52ae1dbc5e3bb.