### PR TITLE
Partially defined sequences

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2857,14 +2857,28 @@ class _PartiallyDefinedSequenceData(SequenceDataAbstractBaseClass):
             data = []
             for s, d in zip(self._starts, self._data):
                 indices = range(-s, -s + self._length)[key]
-                if indices.stop <= 0:
-                    continue
-                if indices.start < 0:
-                    s = indices.start % step
-                else:
-                    s = indices.start
-                start = (s - indices.start) // step
                 e = indices.stop
+                if step > 0:
+                    if e <= 0:
+                        continue
+                else:
+                    if e < 0:
+                        e = None
+                if step > 0:
+                    if indices.start < 0:
+                        s = indices.start % step
+                    else:
+                        s = indices.start
+                    start = (s - indices.start) // step
+                else:
+                    end = len(d) - 1
+                    if indices.start > end:
+                        s = end + (indices.start - end) % step
+                    else:
+                        s = indices.start
+                    if s < 0:
+                        continue
+                    start = (s - indices.start) // step
                 d = d[s:e:step]
                 if d:
                     starts.append(start)

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1730,12 +1730,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> my_protein.transcribe()
         Seq('MAIVMGRU')
         """
-        try:
-            data = self._data.replace(b"T", b"U").replace(b"t", b"u")
-        except UndefinedSequenceError:
-            # transcribing an undefined sequence yields an undefined sequence
-            # of the same length
-            return self
+        data = self._data.replace(b"T", b"U").replace(b"t", b"u")
         if inplace:
             if not isinstance(self._data, bytearray):
                 raise TypeError("Sequence is immutable")
@@ -1783,12 +1778,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> my_protein.back_transcribe()
         Seq('MAIVMGRT')
         """
-        try:
-            data = self._data.replace(b"U", b"T").replace(b"u", b"t")
-        except UndefinedSequenceError:
-            # back-transcribing an undefined sequence yields an undefined
-            # sequence of the same length
-            return self
+        data = self._data.replace(b"U", b"T").replace(b"u", b"t")
         if inplace:
             if not isinstance(self._data, bytearray):
                 raise TypeError("Sequence is immutable")
@@ -3242,7 +3232,7 @@ def _translate_str(
                     "Use str(my_seq).translate(...) instead."
                 ) from None
             else:
-                raise
+                raise TypeError("table argument must be integer or string") from None
     except (AttributeError, TypeError):
         # Assume it's a CodonTable object
         if isinstance(table, CodonTable.CodonTable):

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2885,6 +2885,9 @@ class _PartiallyDefinedSequenceData(SequenceDataAbstractBaseClass):
             if len(data) == 1:
                 if starts[0] == 0 and len(data[0]) == size:
                     return data[0]  # Fully defined sequence; return bytes
+            if step < 0:
+                starts.reverse()
+                data.reverse()
             return _PartiallyDefinedSequenceData(size, starts, data)
         elif self._length <= key:
             raise IndexError("sequence index out of range")

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2986,7 +2986,10 @@ class _PartiallyDefinedSequenceData(SequenceDataAbstractBaseClass):
                 if seq is not None and len(seq) == size:
                     return seq  # Fully defined sequence; return bytes
             if step < 0:
-                data = {start: data[start] for start in reversed(data)}
+                # use this after we drop Python 3.7:
+                # data = {start: data[start] for start in reversed(data)}
+                # use this as long as we support Python 3.7:
+                data = {start: data[start] for start in reversed(list(data.keys()))}
             return _PartiallyDefinedSequenceData(size, data)
         elif self._length <= key:
             raise IndexError("sequence index out of range")

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2861,16 +2861,13 @@ class _PartiallyDefinedSequenceData(SequenceDataAbstractBaseClass):
                 if step > 0:
                     if e <= 0:
                         continue
-                else:
-                    if e < 0:
-                        e = None
-                if step > 0:
                     if indices.start < 0:
                         s = indices.start % step
                     else:
                         s = indices.start
-                    start = (s - indices.start) // step
-                else:
+                else:  # step < 0
+                    if e < 0:
+                        e = None
                     end = len(d) - 1
                     if indices.start > end:
                         s = end + (indices.start - end) % step
@@ -2878,16 +2875,16 @@ class _PartiallyDefinedSequenceData(SequenceDataAbstractBaseClass):
                         s = indices.start
                     if s < 0:
                         continue
-                    start = (s - indices.start) // step
+                start = (s - indices.start) // step
                 d = d[s:e:step]
                 if d:
                     starts.append(start)
                     data.append(d)
-            if len(starts) == 0:
+            if len(starts) == 0:  # Fully undefined sequence
                 return _UndefinedSequenceData(size)
             if len(data) == 1:
                 if starts[0] == 0 and len(data[0]) == size:
-                    return data[0]
+                    return data[0]  # Fully defined sequence; return bytes
             return _PartiallyDefinedSequenceData(size, starts, data)
         elif self._length <= key:
             raise IndexError("sequence index out of range")

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1945,15 +1945,32 @@ class Seq(_SeqAbstractBaseClass):
         sequence contents of a Seq object created in this way will raise
         an UndefinedSequenceError:
 
-        >>> my_undefined_seq = Seq(None, 20)
-        >>> my_undefined_seq
+        >>> my_undefined_sequence = Seq(None, 20)
+        >>> my_undefined_sequence
         Seq(None, length=20)
-        >>> len(my_undefined_seq)
+        >>> len(my_undefined_sequence)
         20
-        >>> print(my_undefined_seq)
+        >>> print(my_undefined_sequence)
         Traceback (most recent call last):
         ...
         Bio.Seq.UndefinedSequenceError: Sequence content is undefined
+
+        If the sequence contents is known for parts of the sequence only, use
+        a dictionary for the data argument to pass the known sequence segments:
+
+        >>> my_partially_defined_sequence = Seq({3: "ACGT"}, 10)
+        >>> my_partially_defined_sequence
+        Seq({3: 'ACGT'}, length=10)
+        >>> len(my_partially_defined_sequence)
+        10
+        >>> print(my_partially_defined_sequence)
+        Traceback (most recent call last):
+        ...
+        Bio.Seq.UndefinedSequenceError: Sequence content is only partially defined
+        >>> my_partially_defined_sequence[3:7]
+        Seq('ACGT')
+        >>> print(my_partially_defined_sequence[3:7])
+        ACGT
         """
         if data is None:
             if length is None:

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2899,9 +2899,9 @@ class _UndefinedSequenceData(SequenceDataAbstractBaseClass):
 
     Objects of this class can be used to create a Seq object to represent
     sequences with a known length, but an unknown sequence contents.
-    Calling __len__ returns the sequence length, calling __getitem__ raises a
-    ValueError except for requests of zero size, for which it returns an empty
-    bytes object.
+    Calling __len__ returns the sequence length, calling __getitem__ raises an
+    UndefinedSequenceError except for requests of zero size, for which it
+    returns an empty bytes object.
     """
 
     __slots__ = ("_length",)
@@ -2957,10 +2957,11 @@ class _PartiallyDefinedSequenceData(SequenceDataAbstractBaseClass):
     """Stores the length of a sequence with an undefined sequence contents (PRIVATE).
 
     Objects of this class can be used to create a Seq object to represent
-    sequences with a known length, but an unknown sequence contents.
-    Calling __len__ returns the sequence length, calling __getitem__ raises a
-    ValueError except for requests of zero size, for which it returns an empty
-    bytes object.
+    sequences with a known length, but with a sequence contents that is only
+    partially known.
+    Calling __len__ returns the sequence length, calling __getitem__ returns
+    the sequence contents if known, otherwise an UndefinedSequenceError is
+    raised.
     """
 
     __slots__ = ("_length", "_data")

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -184,7 +184,10 @@ class SequenceDataAbstractBaseClass(ABC):
                     previous = start
                 end = start + len(seq)
             return _PartiallyDefinedSequenceData(length, data)
-        raise TypeError("unsupported operante type(s) for +: '%s' and '%s'" % (type(self).__name__, type(other).__name))
+        raise TypeError(
+            "unsupported operante type(s) for +: '%s' and '%s'"
+            % (type(self).__name__, type(other).__name)
+        )
 
     def __radd__(self, other):
         return SequenceDataAbstractBaseClass.__add__(other, self)
@@ -3107,7 +3110,8 @@ class _PartiallyDefinedSequenceData(SequenceDataAbstractBaseClass):
         if len(old) != len(new):
             raise UndefinedSequenceError(
                 "Sequence content is only partially defined; substring \n"
-                "replacement cannot be performed reliably")
+                "replacement cannot be performed reliably"
+            )
         items = self._data.items()
         data = {start: seq.replace(old, new) for start, seq in items}
         return _PartiallyDefinedSequenceData(self._length, data)

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -466,14 +466,10 @@ class _SeqAbstractBaseClass(ABC):
             return self.__class__(self._data + other._data)
         elif isinstance(other, str):
             return self.__class__(self._data + other.encode("ASCII"))
-
-        from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
-
-        if isinstance(other, SeqRecord):
-            # Get the SeqRecord's __radd__ to handle this
-            return NotImplemented
         else:
-            raise TypeError
+            # If other is a SeqRecord, then SeqRecord's __radd__ will handle
+            # this. If not, returning NotImplemented will trigger a TypeError.
+            return NotImplemented
 
     def __radd__(self, other):
         """Add a sequence string on the left.
@@ -486,9 +482,7 @@ class _SeqAbstractBaseClass(ABC):
 
         Adding two sequence objects is handled via the __add__ method.
         """
-        if isinstance(other, _SeqAbstractBaseClass):
-            return self.__class__(other._data + self._data)
-        elif isinstance(other, str):
+        if isinstance(other, str):
             return self.__class__(other.encode("ASCII") + self._data)
         else:
             return NotImplemented

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -173,6 +173,7 @@ class SequenceDataAbstractBaseClass(ABC):
         if data is not None:
             # merge adjacent sequence segments
             end = -1
+            previous = None  # not needed here, but it keeps flake happy
             items = data.items()
             data = {}
             for start, seq in items:
@@ -3024,6 +3025,7 @@ class _PartiallyDefinedSequenceData(SequenceDataAbstractBaseClass):
                 return _UndefinedSequenceData(size)
             # merge adjacent sequence segments
             end = -1
+            previous = None  # not needed here, but it keeps flake happy
             items = data.items()
             data = {}
             for start, seq in items:
@@ -3044,7 +3046,7 @@ class _PartiallyDefinedSequenceData(SequenceDataAbstractBaseClass):
             raise IndexError("sequence index out of range")
         else:
             for start, seq in self._data.items():
-                if start <= key and key < start + len(seqdate):
+                if start <= key and key < start + len(seq):
                     return seq[key - start]
             raise UndefinedSequenceError("Sequence at position %d is undefined" % key)
 
@@ -3061,6 +3063,7 @@ class _PartiallyDefinedSequenceData(SequenceDataAbstractBaseClass):
         items = self._data.items()
         data = {}
         end = -1
+        previous = None  # not needed here, but it keeps flake happy
         for i in range(other):
             for start, seq in items:
                 start += i * length
@@ -3070,7 +3073,7 @@ class _PartiallyDefinedSequenceData(SequenceDataAbstractBaseClass):
                     data[start] = seq
                     previous = start
             end = start + len(seq)
-        return _PartiallyDefinedSequenceData(length*other, data)
+        return _PartiallyDefinedSequenceData(length * other, data)
 
     def upper(self):
         """Return an upper case copy of the sequence."""

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -619,6 +619,52 @@ Bio.Seq.UndefinedSequenceError: Sequence content is undefined
 >>>
 \end{minted}
 
+\section{Sequences with partially defined sequence contents}
+
+Sometimes the sequence contents is defined for parts of the sequence only, and undefined elsewhere. For example, the following excerpt of a MAF (Multiple Alignment Format) file shows an alignment of human, chimp, macaque, mouse, rat, dog, and opossum  genome sequences:
+
+\begin{minted}{text}
+s hg38.chr7     117512683 36 + 159345973 TTGAAAACCTGAATGTGAGAGTCAGTCAAGGATAGT
+s panTro4.chr7  119000876 36 + 161824586 TTGAAAACCTGAATGTGAGAGTCACTCAAGGATAGT
+s rheMac3.chr3  156330991 36 + 198365852 CTGAAATCCTGAATGTGAGAGTCAATCAAGGATGGT
+s mm10.chr6      18207101 36 + 149736546 CTGAAAACCTAAGTAGGAGAATCAACTAAGGATAAT
+s rn5.chr4       42326848 36 + 248343840 CTGAAAACCTAAGTAGGAGAGACAGTTAAAGATAAT
+s canFam3.chr14  56325207 36 +  60966679 TTGAAAAACTGATTATTAGAGTCAATTAAGGATAGT
+s monDom5.chr8  173163865 36 + 312544902 TTAAGAAACTGGAAATGAGGGTTGAATGACAAACTT
+\end{minted}
+
+In each row, the first number indicates the starting position (in zero-based coordinates) of the aligned sequence on the chromosome, followed by the size of the aligned sequence, the strand, the size of the full chromosome, and the aligned sequence.
+
+A \verb+Seq+ object representing such a partially defined sequence can be created using a dictionary for the \verb+data+ argument, where the keys are the starting coordinates of the known sequence segments, and the values are the corresponding sequence contents. For example, for the first sequence we would use
+
+%doctest
+\begin{minted}{pycon}
+>>> from Bio.Seq import Seq
+>>> seq = Seq({117512683: "TTGAAAACCTGAATGTGAGAGTCAGTCAAGGATAGT"}, length=159345973)
+\end{minted}
+
+Extracting a subsequence from a partially define sequence may return a fully defined sequence, an undefined sequence, or a partially defined sequence, depending on the coordinates:
+
+%cont-doctest
+\begin{minted}{pycon}
+>>> seq[1000:1020]
+Seq(None, length=20)
+>>> seq[117512690:117512700]
+Seq('CCTGAATGTG')
+>>> seq[117512670:117512690]
+Seq({13: 'TTGAAAA'}, length=20)
+>>> seq[117512700:]
+Seq({0: 'AGAGTCAGTCAAGGATAGT'}, length=41833273)
+\end{minted}
+
+Partially defined sequences can also be created by appending sequences, if at least one of the sequences is partially or fully undefined:
+%cont-doctest
+\begin{minted}{pycon}
+>>> seq = Seq("ACGT")
+>>> undefined_seq = Seq(None, length=10)
+>>> seq + undefined_seq + seq
+Seq({0: 'ACGT', 14: 'ACGT'}, length=18)
+\end{minted}
 
 \section{MutableSeq objects}
 \label{sec:mutable-seq}

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -143,20 +143,23 @@ class SeqIOFeatureTestBaseClass(SeqIOTestBaseClass):
             new_seq = new.seq
         else:
             new_seq = new.seq[:100]
+        old_seq_upper = old.seq.upper()
         try:
-            old_seq_upper = old.seq.upper()
+            bytes(old_seq)
         except UndefinedSequenceError:
-            old_seq_upper = None
             old_seq = None
+        new_seq_upper = new.seq.upper()
         try:
-            new_seq_upper = new.seq.upper()
+            bytes(new_seq)
         except UndefinedSequenceError:
-            new_seq_upper = None
             new_seq = None
         err_msg = "'%s' vs '%s'" % (old_seq, new_seq)
         if msg:
             err_msg = "%s; %s" % (msg, err_msg)
-        self.assertEqual(old_seq_upper, new_seq_upper, msg=err_msg)
+        if old_seq is None and new_seq is None:
+            self.assertEqual(repr(old_seq_upper), repr(new_seq_upper), msg=err_msg)
+        else:
+            self.assertEqual(old_seq_upper, new_seq_upper, msg=err_msg)
         if old.features and new.features:
             self.assertEqual(len(old.features), len(new.features), msg=msg)
             for old_feature, new_feature in zip(old.features, new.features):

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1686,6 +1686,8 @@ class PartialSequenceTests(unittest.TestCase):
         u2 = Seq(None, length=9)
         p1 = Seq({3: "KLM", 11: "XYZ"}, length=17)
         p2 = Seq({0: "PQRST", 8: "HIJ"}, length=13)
+        records = SeqIO.parse("TwoBit/sequence.littleendian.2bit", "twobit")
+        t = records['seq6'].seq  # ACGTacgtNNNNnn, lazy-loaded
         self.assertEqual(s1 + s1, Seq("ABCDABCD"))
         self.assertEqual(s1 + s2, Seq("ABCDEFG"))
         self.assertEqual(repr(s1 + u1), "Seq({0: 'ABCD'}, length=11)")
@@ -1694,6 +1696,7 @@ class PartialSequenceTests(unittest.TestCase):
             repr(s1 + p1), "Seq({0: 'ABCD', 7: 'KLM', 15: 'XYZ'}, length=21)"
         )
         self.assertEqual(repr(s1 + p2), "Seq({0: 'ABCDPQRST', 12: 'HIJ'}, length=17)")
+        self.assertEqual(s1 + t, Seq("ABCDACGTacgtNNNNnn"))
         self.assertEqual(s2 + s1, Seq("EFGABCD"))
         self.assertEqual(s2 + s2, Seq("EFGEFG"))
         self.assertEqual(repr(s2 + u1), "Seq({0: 'EFG'}, length=10)")
@@ -1702,18 +1705,21 @@ class PartialSequenceTests(unittest.TestCase):
             repr(s2 + p1), "Seq({0: 'EFG', 6: 'KLM', 14: 'XYZ'}, length=20)"
         )
         self.assertEqual(repr(s2 + p2), "Seq({0: 'EFGPQRST', 11: 'HIJ'}, length=16)")
+        self.assertEqual(s2 + t, Seq("EFGACGTacgtNNNNnn"))
         self.assertEqual(repr(u1 + s1), "Seq({7: 'ABCD'}, length=11)")
         self.assertEqual(repr(u1 + s2), "Seq({7: 'EFG'}, length=10)")
         self.assertEqual(repr(u1 + u1), "Seq(None, length=14)")
         self.assertEqual(repr(u1 + u2), "Seq(None, length=16)")
         self.assertEqual(repr(u1 + p1), "Seq({10: 'KLM', 18: 'XYZ'}, length=24)")
         self.assertEqual(repr(u1 + p2), "Seq({7: 'PQRST', 15: 'HIJ'}, length=20)")
+        self.assertEqual(repr(u1 + t), "Seq({7: 'ACGTacgtNNNNnn'}, length=21)")
         self.assertEqual(repr(u2 + s1), "Seq({9: 'ABCD'}, length=13)")
         self.assertEqual(repr(u2 + s2), "Seq({9: 'EFG'}, length=12)")
         self.assertEqual(repr(u2 + u1), "Seq(None, length=16)")
         self.assertEqual(repr(u2 + u2), "Seq(None, length=18)")
         self.assertEqual(repr(u2 + p1), "Seq({12: 'KLM', 20: 'XYZ'}, length=26)")
         self.assertEqual(repr(u2 + p2), "Seq({9: 'PQRST', 17: 'HIJ'}, length=22)")
+        self.assertEqual(repr(u2 + t), "Seq({9: 'ACGTacgtNNNNnn'}, length=23)")
         self.assertEqual(
             repr(p1 + s1), "Seq({3: 'KLM', 11: 'XYZ', 17: 'ABCD'}, length=21)"
         )
@@ -1728,6 +1734,10 @@ class PartialSequenceTests(unittest.TestCase):
         self.assertEqual(
             repr(p1 + p2),
             "Seq({3: 'KLM', 11: 'XYZ', 17: 'PQRST', 25: 'HIJ'}, length=30)",
+        )
+        self.assertEqual(
+            repr(p1 + t),
+            "Seq({3: 'KLM', 11: 'XYZ', 17: 'ACGTacgtNNNNnn'}, length=31)",
         )
         self.assertEqual(
             repr(p2 + s1), "Seq({0: 'PQRST', 8: 'HIJ', 13: 'ABCD'}, length=17)"
@@ -1745,6 +1755,23 @@ class PartialSequenceTests(unittest.TestCase):
             repr(p2 + p2),
             "Seq({0: 'PQRST', 8: 'HIJ', 13: 'PQRST', 21: 'HIJ'}, length=26)",
         )
+        self.assertEqual(
+            repr(p2 + t),
+            "Seq({0: 'PQRST', 8: 'HIJ', 13: 'ACGTacgtNNNNnn'}, length=27)",
+        )
+        self.assertEqual(t + s1, Seq('ACGTacgtNNNNnnABCD'))
+        self.assertEqual(t + s2, Seq('ACGTacgtNNNNnnEFG'))
+        self.assertEqual(repr(t + u1), "Seq({0: 'ACGTacgtNNNNnn'}, length=21)")
+        self.assertEqual(repr(t + u2), "Seq({0: 'ACGTacgtNNNNnn'}, length=23)")
+        self.assertEqual(
+            repr(t + p1),
+            "Seq({0: 'ACGTacgtNNNNnn', 17: 'KLM', 25: 'XYZ'}, length=31)"
+        )
+        self.assertEqual(
+            repr(t + p2),
+            "Seq({0: 'ACGTacgtNNNNnnPQRST', 22: 'HIJ'}, length=27)"
+        )
+        self.assertEqual(t + t, Seq("ACGTacgtNNNNnnACGTacgtNNNNnn"))
 
     def test_lower_upper(self):
         u = Seq({3: "KLM", 11: "XYZ"}, length=17)

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1687,7 +1687,7 @@ class PartialSequenceTests(unittest.TestCase):
         p1 = Seq({3: "KLM", 11: "XYZ"}, length=17)
         p2 = Seq({0: "PQRST", 8: "HIJ"}, length=13)
         records = SeqIO.parse("TwoBit/sequence.littleendian.2bit", "twobit")
-        t = records['seq6'].seq  # ACGTacgtNNNNnn, lazy-loaded
+        t = records["seq6"].seq  # ACGTacgtNNNNnn, lazy-loaded
         self.assertEqual(s1 + s1, Seq("ABCDABCD"))
         self.assertEqual(s1 + s2, Seq("ABCDEFG"))
         self.assertEqual(repr(s1 + u1), "Seq({0: 'ABCD'}, length=11)")
@@ -1736,8 +1736,7 @@ class PartialSequenceTests(unittest.TestCase):
             "Seq({3: 'KLM', 11: 'XYZ', 17: 'PQRST', 25: 'HIJ'}, length=30)",
         )
         self.assertEqual(
-            repr(p1 + t),
-            "Seq({3: 'KLM', 11: 'XYZ', 17: 'ACGTacgtNNNNnn'}, length=31)",
+            repr(p1 + t), "Seq({3: 'KLM', 11: 'XYZ', 17: 'ACGTacgtNNNNnn'}, length=31)",
         )
         self.assertEqual(
             repr(p2 + s1), "Seq({0: 'PQRST', 8: 'HIJ', 13: 'ABCD'}, length=17)"
@@ -1759,17 +1758,15 @@ class PartialSequenceTests(unittest.TestCase):
             repr(p2 + t),
             "Seq({0: 'PQRST', 8: 'HIJ', 13: 'ACGTacgtNNNNnn'}, length=27)",
         )
-        self.assertEqual(t + s1, Seq('ACGTacgtNNNNnnABCD'))
-        self.assertEqual(t + s2, Seq('ACGTacgtNNNNnnEFG'))
+        self.assertEqual(t + s1, Seq("ACGTacgtNNNNnnABCD"))
+        self.assertEqual(t + s2, Seq("ACGTacgtNNNNnnEFG"))
         self.assertEqual(repr(t + u1), "Seq({0: 'ACGTacgtNNNNnn'}, length=21)")
         self.assertEqual(repr(t + u2), "Seq({0: 'ACGTacgtNNNNnn'}, length=23)")
         self.assertEqual(
-            repr(t + p1),
-            "Seq({0: 'ACGTacgtNNNNnn', 17: 'KLM', 25: 'XYZ'}, length=31)"
+            repr(t + p1), "Seq({0: 'ACGTacgtNNNNnn', 17: 'KLM', 25: 'XYZ'}, length=31)"
         )
         self.assertEqual(
-            repr(t + p2),
-            "Seq({0: 'ACGTacgtNNNNnnPQRST', 22: 'HIJ'}, length=27)"
+            repr(t + p2), "Seq({0: 'ACGTacgtNNNNnnPQRST', 22: 'HIJ'}, length=27)"
         )
         self.assertEqual(t + t, Seq("ACGTacgtNNNNnnACGTacgtNNNNnn"))
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -800,10 +800,12 @@ class StringMethodTests(unittest.TestCase):
         with self.assertRaises(TypeError) as cm:
             Seq("ACGT").complement_rna(inplace=True)
         self.assertEqual(str(cm.exception), "Sequence is immutable")
-        self.assertEqual(repr(Seq(None, length=20).complement()),
-                         "Seq(None, length=20)")
-        self.assertEqual(repr(Seq(None, length=20).complement_rna()),
-                         "Seq(None, length=20)")
+        self.assertEqual(
+            repr(Seq(None, length=20).complement()), "Seq(None, length=20)"
+        )
+        self.assertEqual(
+            repr(Seq(None, length=20).complement_rna()), "Seq(None, length=20)"
+        )
 
     def test_the_reverse_complement(self):
         """Check obj.reverse_complement() method."""
@@ -831,10 +833,12 @@ class StringMethodTests(unittest.TestCase):
         with self.assertRaises(TypeError) as cm:
             Seq("ACGT").reverse_complement_rna(inplace=True)
         self.assertEqual(str(cm.exception), "Sequence is immutable")
-        self.assertEqual(repr(Seq(None, length=20).reverse_complement()),
-                         "Seq(None, length=20)")
-        self.assertEqual(repr(Seq(None, length=20).reverse_complement_rna()),
-                         "Seq(None, length=20)")
+        self.assertEqual(
+            repr(Seq(None, length=20).reverse_complement()), "Seq(None, length=20)"
+        )
+        self.assertEqual(
+            repr(Seq(None, length=20).reverse_complement_rna()), "Seq(None, length=20)"
+        )
 
     def test_the_transcription(self):
         """Check obj.transcribe() method."""
@@ -855,8 +859,9 @@ class StringMethodTests(unittest.TestCase):
         with self.assertRaises(TypeError) as cm:
             Seq("ACGT").transcribe(inplace=True)
         self.assertEqual(str(cm.exception), "Sequence is immutable")
-        self.assertEqual(repr(Seq(None, length=20).transcribe()),
-                         "Seq(None, length=20)")
+        self.assertEqual(
+            repr(Seq(None, length=20).transcribe()), "Seq(None, length=20)"
+        )
 
     def test_the_back_transcription(self):
         """Check obj.back_transcribe() method."""
@@ -874,8 +879,9 @@ class StringMethodTests(unittest.TestCase):
         with self.assertRaises(TypeError) as cm:
             Seq("ACGU").back_transcribe(inplace=True)
         self.assertEqual(str(cm.exception), "Sequence is immutable")
-        self.assertEqual(repr(Seq(None, length=20).back_transcribe()),
-                         "Seq(None, length=20)")
+        self.assertEqual(
+            repr(Seq(None, length=20).back_transcribe()), "Seq(None, length=20)"
+        )
 
     def test_the_translate(self):
         """Check obj.translate() method."""
@@ -901,7 +907,10 @@ class StringMethodTests(unittest.TestCase):
             Seq("ABCD").translate("XYZ")
         with self.assertWarns(BiopythonWarning) as cm:
             Seq(None, length=20).translate()
-        self.assertEqual(str(cm.warning), "Partial codon, len(sequence) not a multiple of three. This may become an error in future.")
+        self.assertEqual(
+            str(cm.warning),
+            "Partial codon, len(sequence) not a multiple of three. This may become an error in future.",
+        )
 
     def test_the_translation_of_stops(self):
         """Check obj.translate() method with stop codons."""
@@ -1021,7 +1030,7 @@ class StringMethodTests(unittest.TestCase):
         self.assertRaises(TypeError, MutableSeq, ["A", "C", "G", "T"])
         self.assertRaises(TypeError, MutableSeq, 1)
         self.assertRaises(TypeError, MutableSeq, 1.0)
-        self.assertRaises(ValueError, MutableSeq, array.array("i", [1,2,3,4]))
+        self.assertRaises(ValueError, MutableSeq, array.array("i", [1, 2, 3, 4]))
 
     def test_join_Seq_TypeError(self):
         """Checks that a TypeError is thrown for all non-iterable types."""
@@ -1598,7 +1607,9 @@ class PartialSequenceTests(unittest.TestCase):
         self.assertEqual(str(cm.exception), "Sequence data are overlapping.")
         with self.assertRaises(ValueError) as cm:
             Seq({5: "PQRST"}, length=8)
-        self.assertEqual(str(cm.exception), "Provided sequence data extend beyond sequence length.")
+        self.assertEqual(
+            str(cm.exception), "Provided sequence data extend beyond sequence length."
+        )
 
     def test_repr(self):
         seq = Seq({5: "ACGT", 14: "GGC"}, length=20)
@@ -1948,16 +1959,27 @@ class PartialSequenceTests(unittest.TestCase):
         self.assertEqual(t + t, Seq("ACGTacgtNNNNnnACGTacgtNNNNnn"))
         p1 = Seq({3: "KLM", 11: "XYZ"}, length=14)
         p2 = Seq({0: "PQRST", 8: "HIJ"}, length=11)
-        self.assertEqual(repr(p1 + p2), "Seq({3: 'KLM', 11: 'XYZPQRST', 22: 'HIJ'}, length=25)")
-        self.assertEqual(repr(p2 + p1), "Seq({0: 'PQRST', 8: 'HIJ', 14: 'KLM', 22: 'XYZ'}, length=25)")
+        self.assertEqual(
+            repr(p1 + p2), "Seq({3: 'KLM', 11: 'XYZPQRST', 22: 'HIJ'}, length=25)"
+        )
+        self.assertEqual(
+            repr(p2 + p1),
+            "Seq({0: 'PQRST', 8: 'HIJ', 14: 'KLM', 22: 'XYZ'}, length=25)",
+        )
         self.assertEqual(repr(p1 + s1), "Seq({3: 'KLM', 11: 'XYZABCD'}, length=18)")
         self.assertEqual(repr(p1 + s2), "Seq({3: 'KLM', 11: 'XYZEFG'}, length=17)")
 
     def test_multiplication(self):
         p1 = Seq({3: "KLM", 11: "XYZ"}, length=17)
         p2 = Seq({0: "PQRST", 8: "HIJ"}, length=11)
-        self.assertEqual(repr(3 * p1), "Seq({3: 'KLM', 11: 'XYZ', 20: 'KLM', 28: 'XYZ', 37: 'KLM', 45: 'XYZ'}, length=51)")
-        self.assertEqual(repr(3 * p2), "Seq({0: 'PQRST', 8: 'HIJPQRST', 19: 'HIJPQRST', 30: 'HIJ'}, length=33)")
+        self.assertEqual(
+            repr(3 * p1),
+            "Seq({3: 'KLM', 11: 'XYZ', 20: 'KLM', 28: 'XYZ', 37: 'KLM', 45: 'XYZ'}, length=51)",
+        )
+        self.assertEqual(
+            repr(3 * p2),
+            "Seq({0: 'PQRST', 8: 'HIJPQRST', 19: 'HIJPQRST', 30: 'HIJ'}, length=33)",
+        )
 
     def test_lower_upper(self):
         u = Seq({3: "KLM", 11: "XYZ"}, length=17)

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1636,6 +1636,29 @@ class PartialSequenceTests(unittest.TestCase):
         # ?????ABCD?????EFG???
         seq = Seq({5: "ABCD", 14: "EFG"}, length=20)
         self.assertEqual(repr(seq), "Seq({5: 'ABCD', 14: 'EFG'}, length=20)")
+        # index
+        with self.assertRaises(UndefinedSequenceError) as cm:
+            seq[0]
+        self.assertEqual(str(cm.exception), "Sequence at position 0 is undefined")
+        with self.assertRaises(UndefinedSequenceError) as cm:
+            seq[1]
+        self.assertEqual(str(cm.exception), "Sequence at position 1 is undefined")
+        self.assertEqual(seq[5], "A")
+        self.assertEqual(seq[6], "B")
+        self.assertEqual(seq[7], "C")
+        self.assertEqual(seq[8], "D")
+        with self.assertRaises(UndefinedSequenceError) as cm:
+            seq[10]
+        self.assertEqual(str(cm.exception), "Sequence at position 10 is undefined")
+        self.assertEqual(seq[14], "E")
+        self.assertEqual(seq[15], "F")
+        self.assertEqual(seq[16], "G")
+        with self.assertRaises(UndefinedSequenceError) as cm:
+            seq[17]
+        self.assertEqual(str(cm.exception), "Sequence at position 17 is undefined")
+        with self.assertRaises(IndexError) as cm:
+            seq[30]
+        self.assertEqual(str(cm.exception), "sequence index out of range")
         # step = 0
         with self.assertRaises(ValueError) as cm:
             s = seq[::0]
@@ -1848,22 +1871,6 @@ class PartialSequenceTests(unittest.TestCase):
         self.assertEqual(repr(s), "Seq({1: 'C', 3: 'G'}, length=6)")
         s = seq[4::4]
         self.assertEqual(repr(s), "Seq({1: 'DF'}, length=4)")
-        # test exceptions
-        with self.assertRaises(IndexError) as cm:
-            seq[30]
-        self.assertEqual(str(cm.exception), "sequence index out of range")
-        with self.assertRaises(UndefinedSequenceError) as cm:
-            seq[0]
-        self.assertEqual(str(cm.exception), "Sequence at position 0 is undefined")
-        with self.assertRaises(UndefinedSequenceError) as cm:
-            seq[1]
-        self.assertEqual(str(cm.exception), "Sequence at position 1 is undefined")
-        with self.assertRaises(UndefinedSequenceError) as cm:
-            seq[10]
-        self.assertEqual(str(cm.exception), "Sequence at position 10 is undefined")
-        with self.assertRaises(UndefinedSequenceError) as cm:
-            seq[17]
-        self.assertEqual(str(cm.exception), "Sequence at position 17 is undefined")
         # test length 0
         self.assertEqual(Seq({}, length=0), "")
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1660,8 +1660,3 @@ class PartialSequenceTests(unittest.TestCase):
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)
     unittest.main(testRunner=runner)
-
-
-if __name__ == "__main__":
-    runner = unittest.TextTestRunner(verbosity=2)
-    unittest.main(testRunner=runner)

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1734,6 +1734,43 @@ class PartialSequenceTests(unittest.TestCase):
         self.assertEqual(repr(m.upper()), "Seq({5: 'ABCD', 10: 'EFGH'}, length=20)")
         self.assertEqual(repr(m.lower()), "Seq({5: 'abcd', 10: 'efgh'}, length=20)")
 
+    def test_complement(self):
+        s = Seq({3: "AACC", 11: "CGT"}, length=20)
+        u = Seq({3: "AACC", 11: "CGU"}, length=20)
+        self.assertEqual(repr(s.complement()),
+                         "Seq({3: 'TTGG', 11: 'GCA'}, length=20)")
+        self.assertEqual(repr(u.complement(inplace=False)),
+                         "Seq({3: 'TTGG', 11: 'GCA'}, length=20)")
+                         # TODO: remove inplace=False
+        self.assertEqual(repr(s.reverse_complement()),
+                         "Seq({6: 'ACG', 13: 'GGTT'}, length=20)")
+        self.assertEqual(repr(u.reverse_complement(inplace=False)),
+                         "Seq({6: 'ACG', 13: 'GGTT'}, length=20)")
+                         # TODO: remove inplace=False
+        self.assertEqual(repr(s.complement_rna()),
+                         "Seq({3: 'UUGG', 11: 'GCA'}, length=20)")
+        self.assertEqual(repr(u.complement_rna()),
+                         "Seq({3: 'UUGG', 11: 'GCA'}, length=20)")
+        self.assertEqual(repr(s.reverse_complement_rna()),
+                         "Seq({6: 'ACG', 13: 'GGUU'}, length=20)")
+        self.assertEqual(repr(u.reverse_complement_rna()),
+                         "Seq({6: 'ACG', 13: 'GGUU'}, length=20)")
+
+    def test_replace(self):
+        s = Seq({3: "AACC", 11: "CGT"}, length=20)
+        self.assertEqual(repr(s.replace("A", "X")),
+                         "Seq({3: 'XXCC', 11: 'CGT'}, length=20)")
+        self.assertEqual(repr(s.replace("CC", "YY")),
+                         "Seq({3: 'AAYY', 11: 'CGT'}, length=20)")
+        self.assertRaises(UndefinedSequenceError, s.replace, "A", "XX")
+
+    def test_transcribe(self):
+        s = Seq({3: "acgt", 11: "ACGT"}, length=20)
+        u = s.transcribe()
+        self.assertEqual(repr(u), "Seq({3: 'acgu', 11: 'ACGU'}, length=20)")
+        s = u.back_transcribe()
+        self.assertEqual(repr(s), "Seq({3: 'acgt', 11: 'ACGT'}, length=20)")
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1486,95 +1486,54 @@ class PartialSequenceTests(unittest.TestCase):
         #           1    1    2
         # 0    5    0    5    0
         # ?????ABCD?????EFG???
-        seq = Seq([b"ABCD", b"EFG"], length=20, starts=[5, 14])
-        self.assertEqual(seq._data._starts, [5, 14])
-        self.assertEqual(seq._data._data, [b"ABCD", b"EFG"])
-        self.assertEqual(seq._data._length, 20)
+        seq = Seq({5: "ABCD", 14: "EFG"}, length=20)
+        self.assertEqual(repr(seq), "Seq({5: 'ABCD', 14: 'EFG'}, length=20)")
         # step = 1, stop = +inf
         s = seq[:]  # ?????ABCD?????EFG???
-        self.assertEqual(s._data._starts, [5, 14])
-        self.assertEqual(s._data._data, [b"ABCD", b"EFG"])
-        self.assertEqual(s._data._length, 20)
+        self.assertEqual(repr(s), "Seq({5: 'ABCD', 14: 'EFG'}, length=20)")
         s = seq[0:]  # ?????ABCD?????EFG???
-        self.assertEqual(s._data._starts, [5, 14])
-        self.assertEqual(s._data._data, [b"ABCD", b"EFG"])
-        self.assertEqual(s._data._length, 20)
+        self.assertEqual(repr(s), "Seq({5: 'ABCD', 14: 'EFG'}, length=20)")
         s = seq[1:]  # ????ABCD?????EFG???
-        self.assertEqual(s._data._starts, [4, 13])
-        self.assertEqual(s._data._data, [b"ABCD", b"EFG"])
-        self.assertEqual(s._data._length, 19)
+        self.assertEqual(repr(s), "Seq({4: 'ABCD', 13: 'EFG'}, length=19)")
         s = seq[4:]  # ?ABCD?????EFG???
-        self.assertEqual(s._data._starts, [1, 10])
-        self.assertEqual(s._data._data, [b"ABCD", b"EFG"])
-        self.assertEqual(s._data._length, 16)
+        self.assertEqual(repr(s), "Seq({1: 'ABCD', 10: 'EFG'}, length=16)")
         s = seq[5:]  # ABCD?????EFG???
-        self.assertEqual(s._data._starts, [0, 9])
-        self.assertEqual(s._data._data, [b"ABCD", b"EFG"])
-        self.assertEqual(s._data._length, 15)
+        self.assertEqual(repr(s), "Seq({0: 'ABCD', 9: 'EFG'}, length=15)")
         s = seq[6:]  # BCD?????EFG???
-        self.assertEqual(s._data._starts, [0, 8])
-        self.assertEqual(s._data._data, [b"BCD", b"EFG"])
-        self.assertEqual(s._data._length, 14)
+        self.assertEqual(repr(s), "Seq({0: 'BCD', 8: 'EFG'}, length=14)")
         s = seq[7:]  # CD?????EFG???
-        self.assertEqual(s._data._starts, [0, 7])
-        self.assertEqual(s._data._data, [b"CD", b"EFG"])
-        self.assertEqual(s._data._length, 13)
+        self.assertEqual(repr(s), "Seq({0: 'CD', 7: 'EFG'}, length=13)")
         s = seq[8:]  # D?????EFG???
-        self.assertEqual(s._data._starts, [0, 6])
-        self.assertEqual(s._data._data, [b"D", b"EFG"])
-        self.assertEqual(s._data._length, 12)
+        self.assertEqual(repr(s), "Seq({0: 'D', 6: 'EFG'}, length=12)")
         s = seq[9:]  # ?????EFG???
-        self.assertEqual(s._data._starts, [5])
-        self.assertEqual(s._data._data, [b"EFG"])
-        self.assertEqual(s._data._length, 11)
+        self.assertEqual(repr(s), "Seq({5: 'EFG'}, length=11)")
         s = seq[10:]  # ????EFG???
-        self.assertEqual(s._data._starts, [4])
-        self.assertEqual(s._data._data, [b"EFG"])
-        self.assertEqual(s._data._length, 10)
+        self.assertEqual(repr(s), "Seq({4: 'EFG'}, length=10)")
         s = seq[13:]  # ?EFG???
-        self.assertEqual(s._data._starts, [1])
-        self.assertEqual(s._data._data, [b"EFG"])
-        self.assertEqual(s._data._length, 7)
+        self.assertEqual(repr(s), "Seq({1: 'EFG'}, length=7)")
         s = seq[14:]  # EFG???
-        self.assertEqual(s._data._starts, [0])
-        self.assertEqual(s._data._data, [b"EFG"])
-        self.assertEqual(s._data._length, 6)
+        self.assertEqual(repr(s), "Seq({0: 'EFG'}, length=6)")
         s = seq[15:]  # FG???
-        self.assertEqual(s._data._starts, [0])
-        self.assertEqual(s._data._data, [b"FG"])
-        self.assertEqual(s._data._length, 5)
+        self.assertEqual(repr(s), "Seq({0: 'FG'}, length=5)")
         s = seq[16:]  # G???
-        self.assertEqual(s._data._starts, [0])
-        self.assertEqual(s._data._data, [b"G"])
-        self.assertEqual(s._data._length, 4)
+        self.assertEqual(repr(s), "Seq({0: 'G'}, length=4)")
         s = seq[17:]  # ???
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 3)
+        self.assertEqual(repr(s), "Seq(None, length=3)")
         s = seq[18:]  # ??
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 2)
+        self.assertEqual(repr(s), "Seq(None, length=2)")
         s = seq[19:]  # ?
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 1)
+        self.assertEqual(repr(s), "Seq(None, length=1)")
         s = seq[20:]  # empty sequence
-        self.assertEqual(s._data, b"")
+        self.assertEqual(repr(s), "Seq('')")
         # step = 1, stop = 9
         s = seq[:9]  # ?????ABCD
-        self.assertEqual(s._data._starts, [5])
-        self.assertEqual(s._data._data, [b"ABCD"])
-        self.assertEqual(s._data._length, 9)
+        self.assertEqual(repr(s), "Seq({5: 'ABCD'}, length=9)")
         s = seq[0:9]  # ?????ABCD
-        self.assertEqual(s._data._starts, [5])
-        self.assertEqual(s._data._data, [b"ABCD"])
-        self.assertEqual(s._data._length, 9)
+        self.assertEqual(repr(s), "Seq({5: 'ABCD'}, length=9)")
         s = seq[1:9]  # ????ABCD
-        self.assertEqual(s._data._starts, [4])
-        self.assertEqual(s._data._data, [b"ABCD"])
-        self.assertEqual(s._data._length, 8)
+        self.assertEqual(repr(s), "Seq({4: 'ABCD'}, length=8)")
         s = seq[4:9]  # ?ABCD
-        self.assertEqual(s._data._starts, [1])
-        self.assertEqual(s._data._data, [b"ABCD"])
-        self.assertEqual(s._data._length, 5)
+        self.assertEqual(repr(s), "Seq({1: 'ABCD'}, length=5)")
         s = seq[5:9]  # ABCD
         self.assertEqual(s._data, b"ABCD")
         s = seq[6:9]  # BCD
@@ -1584,244 +1543,185 @@ class PartialSequenceTests(unittest.TestCase):
         s = seq[8:9]  # D
         self.assertEqual(s._data, b"D")
         s = seq[9:9]  # empty sequence
-        self.assertEqual(s._data, b"")
+        self.assertEqual(repr(s), "Seq('')")
         s = seq[10:9]  # empty sequence
-        self.assertEqual(s._data, b"")
+        self.assertEqual(repr(s), "Seq('')")
         # step = 2, stop = +inf
         s = seq[::2]  # ???BD??EG?
-        self.assertEqual(s._data._starts, [3, 7])
-        self.assertEqual(s._data._data, [b"BD", b"EG"])
-        self.assertEqual(s._data._length, 10)
+        self.assertEqual(repr(s), "Seq({3: 'BD', 7: 'EG'}, length=10)")
         s = seq[0::2]  # ???BD??EG?
-        self.assertEqual(s._data._starts, [3, 7])
-        self.assertEqual(s._data._data, [b"BD", b"EG"])
-        self.assertEqual(s._data._length, 10)
+        self.assertEqual(repr(s), "Seq({3: 'BD', 7: 'EG'}, length=10)")
         s = seq[1::2]  # ??AC???F??
-        self.assertEqual(s._data._starts, [2, 7])
-        self.assertEqual(s._data._data, [b"AC", b"F"])
-        self.assertEqual(s._data._length, 10)
+        self.assertEqual(repr(s), "Seq({2: 'AC', 7: 'F'}, length=10)")
         s = seq[4::2]  # ?BD??EG?
-        self.assertEqual(s._data._starts, [1, 5])
-        self.assertEqual(s._data._data, [b"BD", b"EG"])
-        self.assertEqual(s._data._length, 8)
+        self.assertEqual(repr(s), "Seq({1: 'BD', 5: 'EG'}, length=8)")
         s = seq[5::2]  # AC???F??
-        self.assertEqual(s._data._starts, [0, 5])
-        self.assertEqual(s._data._data, [b"AC", b"F"])
-        self.assertEqual(s._data._length, 8)
+        self.assertEqual(repr(s), "Seq({0: 'AC', 5: 'F'}, length=8)")
         s = seq[6::2]  # BD??EG?
-        self.assertEqual(s._data._starts, [0, 4])
-        self.assertEqual(s._data._data, [b"BD", b"EG"])
-        self.assertEqual(s._data._length, 7)
+        self.assertEqual(repr(s), "Seq({0: 'BD', 4: 'EG'}, length=7)")
         s = seq[7::2]  # C???F??
-        self.assertEqual(s._data._starts, [0, 4])
-        self.assertEqual(s._data._data, [b"C", b"F"])
-        self.assertEqual(s._data._length, 7)
+        self.assertEqual(repr(s), "Seq({0: 'C', 4: 'F'}, length=7)")
         s = seq[8::2]  # D??EG?
-        self.assertEqual(s._data._starts, [0, 3])
-        self.assertEqual(s._data._data, [b"D", b"EG"])
-        self.assertEqual(s._data._length, 6)
+        self.assertEqual(repr(s), "Seq({0: 'D', 3: 'EG'}, length=6)")
         s = seq[9::2]  # ???F??
-        self.assertEqual(s._data._starts, [3])
-        self.assertEqual(s._data._data, [b"F"])
-        self.assertEqual(s._data._length, 6)
+        self.assertEqual(repr(s), "Seq({3: 'F'}, length=6)")
         s = seq[10::2]  # ??EG?
-        self.assertEqual(s._data._starts, [2])
-        self.assertEqual(s._data._data, [b"EG"])
-        self.assertEqual(s._data._length, 5)
+        self.assertEqual(repr(s), "Seq({2: 'EG'}, length=5)")
         s = seq[13::2]  # ?F??
-        self.assertEqual(s._data._starts, [1])
-        self.assertEqual(s._data._data, [b"F"])
-        self.assertEqual(s._data._length, 4)
+        self.assertEqual(repr(s), "Seq({1: 'F'}, length=4)")
         s = seq[14::2]  # EG?
-        self.assertEqual(s._data._starts, [0])
-        self.assertEqual(s._data._data, [b"EG"])
-        self.assertEqual(s._data._length, 3)
+        self.assertEqual(repr(s), "Seq({0: 'EG'}, length=3)")
         s = seq[15::2]  # F??
-        self.assertEqual(s._data._starts, [0])
-        self.assertEqual(s._data._data, [b"F"])
-        self.assertEqual(s._data._length, 3)
+        self.assertEqual(repr(s), "Seq({0: 'F'}, length=3)")
         s = seq[16::2]  # G?
-        self.assertEqual(s._data._starts, [0])
-        self.assertEqual(s._data._data, [b"G"])
-        self.assertEqual(s._data._length, 2)
+        self.assertEqual(repr(s), "Seq({0: 'G'}, length=2)")
         s = seq[17::2]  # ??
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 2)
+        self.assertEqual(repr(s), "Seq(None, length=2)")
         s = seq[18::2]  # ?
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 1)
+        self.assertEqual(repr(s), "Seq(None, length=1)")
         s = seq[19::2]  # ?
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 1)
+        self.assertEqual(repr(s), "Seq(None, length=1)")
         s = seq[20::2]  # empty sequence
-        self.assertEqual(s._data, b"")
+        self.assertEqual(repr(s), "Seq('')")
         # step = -1, start = None
         s = seq[::-1]  # ???GFE?????DCBA?????
-        self.assertEqual(s._data._starts, [3, 11])
-        self.assertEqual(s._data._data, [b"GFE", b"DCBA"])
-        self.assertEqual(s._data._length, 20)
+        self.assertEqual(repr(s), "Seq({3: 'GFE', 11: 'DCBA'}, length=20)")
         s = seq[:0:-1]  # ???GFE?????DCBA????
-        self.assertEqual(s._data._starts, [3, 11])
-        self.assertEqual(s._data._data, [b"GFE", b"DCBA"])
-        self.assertEqual(s._data._length, 19)
+        self.assertEqual(repr(s), "Seq({3: 'GFE', 11: 'DCBA'}, length=19)")
         s = seq[:1:-1]  # ???GFE?????DCBA???
-        self.assertEqual(s._data._starts, [3, 11])
-        self.assertEqual(s._data._data, [b"GFE", b"DCBA"])
-        self.assertEqual(s._data._length, 18)
+        self.assertEqual(repr(s), "Seq({3: 'GFE', 11: 'DCBA'}, length=18)")
         s = seq[:4:-1]  # ???GFE?????DCBA
-        self.assertEqual(s._data._starts, [3, 11])
-        self.assertEqual(s._data._data, [b"GFE", b"DCBA"])
-        self.assertEqual(s._data._length, 15)
+        self.assertEqual(repr(s), "Seq({3: 'GFE', 11: 'DCBA'}, length=15)")
         s = seq[:5:-1]  # ???GFE?????DCB
-        self.assertEqual(s._data._starts, [3, 11])
-        self.assertEqual(s._data._data, [b"GFE", b"DCB"])
-        self.assertEqual(s._data._length, 14)
+        self.assertEqual(repr(s), "Seq({3: 'GFE', 11: 'DCB'}, length=14)")
         s = seq[:6:-1]  # ???GFE?????DC
-        self.assertEqual(s._data._starts, [3, 11])
-        self.assertEqual(s._data._data, [b"GFE", b"DC"])
-        self.assertEqual(s._data._length, 13)
+        self.assertEqual(repr(s), "Seq({3: 'GFE', 11: 'DC'}, length=13)")
         s = seq[:7:-1]  # ???GFE?????D
-        self.assertEqual(s._data._starts, [3, 11])
-        self.assertEqual(s._data._data, [b"GFE", b"D"])
-        self.assertEqual(s._data._length, 12)
+        self.assertEqual(repr(s), "Seq({3: 'GFE', 11: 'D'}, length=12)")
         s = seq[:8:-1]  # ???GFE?????
-        self.assertEqual(s._data._starts, [3, ])
-        self.assertEqual(s._data._data, [b"GFE", ])
-        self.assertEqual(s._data._length, 11)
+        self.assertEqual(repr(s), "Seq({3: 'GFE'}, length=11)")
         s = seq[:9:-1]  # ???GFE????
-        self.assertEqual(s._data._starts, [3, ])
-        self.assertEqual(s._data._data, [b"GFE", ])
-        self.assertEqual(s._data._length, 10)
+        self.assertEqual(repr(s), "Seq({3: 'GFE'}, length=10)")
         s = seq[:10:-1]  # ???GFE???
-        self.assertEqual(s._data._starts, [3])
-        self.assertEqual(s._data._data, [b"GFE", ])
-        self.assertEqual(s._data._length, 9)
+        self.assertEqual(repr(s), "Seq({3: 'GFE'}, length=9)")
         s = seq[:13:-1]  # ???GFE
-        self.assertEqual(s._data._starts, [3])
-        self.assertEqual(s._data._data, [b"GFE"])
-        self.assertEqual(s._data._length, 6)
+        self.assertEqual(repr(s), "Seq({3: 'GFE'}, length=6)")
         s = seq[:14:-1]  # ???GF
-        self.assertEqual(s._data._starts, [3])
-        self.assertEqual(s._data._data, [b"GF"])
-        self.assertEqual(s._data._length, 5)
+        self.assertEqual(repr(s), "Seq({3: 'GF'}, length=5)")
         s = seq[:15:-1]  # ???G
-        self.assertEqual(s._data._starts, [3])
-        self.assertEqual(s._data._data, [b"G"])
-        self.assertEqual(s._data._length, 4)
+        self.assertEqual(repr(s), "Seq({3: 'G'}, length=4)")
         s = seq[:16:-1]  # ???
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 3)
+        self.assertEqual(repr(s), "Seq(None, length=3)")
         s = seq[:17:-1]  # ??
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 2)
+        self.assertEqual(repr(s), "Seq(None, length=2)")
         s = seq[:18:-1]  # ?
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 1)
+        self.assertEqual(repr(s), "Seq(None, length=1)")
         s = seq[:19:-1]  # empty sequence
-        self.assertEqual(s._data, b"")
+        self.assertEqual(repr(s), "Seq('')")
         s = seq[:20:-1]  # empty sequence
-        self.assertEqual(s._data, b"")
+        self.assertEqual(repr(s), "Seq('')")
         # step = -1, stop = 9
         s = seq[9::-1]  # ?DCBA?????
-        self.assertEqual(s._data._starts, [1])
-        self.assertEqual(s._data._data, [b"DCBA"])
-        self.assertEqual(s._data._length, 10)
+        self.assertEqual(repr(s), "Seq({1: 'DCBA'}, length=10)")
         s = seq[9:0:-1]  # ?DCBA????
-        self.assertEqual(s._data._starts, [1])
-        self.assertEqual(s._data._data, [b"DCBA"])
-        self.assertEqual(s._data._length, 9)
+        self.assertEqual(repr(s), "Seq({1: 'DCBA'}, length=9)")
         s = seq[9:1:-1]  # ?DCBA???
-        self.assertEqual(s._data._starts, [1])
-        self.assertEqual(s._data._data, [b"DCBA"])
-        self.assertEqual(s._data._length, 8)
+        self.assertEqual(repr(s), "Seq({1: 'DCBA'}, length=8)")
         s = seq[9:4:-1]  # ?DCBA
-        self.assertEqual(s._data._starts, [1])
-        self.assertEqual(s._data._data, [b"DCBA"])
-        self.assertEqual(s._data._length, 5)
+        self.assertEqual(repr(s), "Seq({1: 'DCBA'}, length=5)")
         s = seq[9:5:-1]  # ?DCB
-        self.assertEqual(s._data._starts, [1])
-        self.assertEqual(s._data._data, [b"DCB"])
-        self.assertEqual(s._data._length, 4)
+        self.assertEqual(repr(s), "Seq({1: 'DCB'}, length=4)")
         s = seq[9:6:-1]  # ?DC
-        self.assertEqual(s._data._starts, [1])
-        self.assertEqual(s._data._data, [b"DC"])
-        self.assertEqual(s._data._length, 3)
+        self.assertEqual(repr(s), "Seq({1: 'DC'}, length=3)")
         s = seq[9:7:-1]  # ?D
-        self.assertEqual(s._data._starts, [1])
-        self.assertEqual(s._data._data, [b"D"])
-        self.assertEqual(s._data._length, 2)
+        self.assertEqual(repr(s), "Seq({1: 'D'}, length=2)")
         s = seq[9:8:-1]  # ?
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 1)
+        self.assertEqual(repr(s), "Seq(None, length=1)")
         s = seq[9:9:-1]  # empty sequence
-        self.assertEqual(s._data, b"")
+        self.assertEqual(repr(s), "Seq('')")
         s = seq[9:10:-1]  # empty sequence
-        self.assertEqual(s._data, b"")
+        self.assertEqual(repr(s), "Seq('')")
         # step = -2, stop = None
         s = seq[::-2]  # ??F???CA??
-        self.assertEqual(s._data._starts, [2, 6])
-        self.assertEqual(s._data._data, [b"F", b"CA"])
-        self.assertEqual(s._data._length, 10)
+        self.assertEqual(repr(s), "Seq({2: 'F', 6: 'CA'}, length=10)")
         s = seq[:0:-2]  # ??F???CA??
-        self.assertEqual(s._data._starts, [2, 6])
-        self.assertEqual(s._data._data, [b"F", b"CA"])
-        self.assertEqual(s._data._length, 10)
+        self.assertEqual(repr(s), "Seq({2: 'F', 6: 'CA'}, length=10)")
         s = seq[:1:-2]  # ??F???CA?
-        self.assertEqual(s._data._starts, [2, 6])
-        self.assertEqual(s._data._data, [b"F", b"CA"])
-        self.assertEqual(s._data._length, 9)
+        self.assertEqual(repr(s), "Seq({2: 'F', 6: 'CA'}, length=9)")
         s = seq[:4:-2]  # ??F???CA
-        self.assertEqual(s._data._starts, [2, 6])
-        self.assertEqual(s._data._data, [b"F", b"CA"])
-        self.assertEqual(s._data._length, 8)
+        self.assertEqual(repr(s), "Seq({2: 'F', 6: 'CA'}, length=8)")
         s = seq[:5:-2]  # ??F???C
-        self.assertEqual(s._data._starts, [2, 6])
-        self.assertEqual(s._data._data, [b"F", b"C"])
-        self.assertEqual(s._data._length, 7)
+        self.assertEqual(repr(s), "Seq({2: 'F', 6: 'C'}, length=7)")
         s = seq[:6:-2]  # ??F???C
-        self.assertEqual(s._data._starts, [2, 6])
-        self.assertEqual(s._data._data, [b"F", b"C"])
-        self.assertEqual(s._data._length, 7)
+        self.assertEqual(repr(s), "Seq({2: 'F', 6: 'C'}, length=7)")
         s = seq[:7:-2]  # ??F???
-        self.assertEqual(s._data._starts, [2, ])
-        self.assertEqual(s._data._data, [b"F", ])
-        self.assertEqual(s._data._length, 6)
+        self.assertEqual(repr(s), "Seq({2: 'F'}, length=6)")
         s = seq[:8:-2]  # ??F???
-        self.assertEqual(s._data._starts, [2, ])
-        self.assertEqual(s._data._data, [b"F", ])
-        self.assertEqual(s._data._length, 6)
+        self.assertEqual(repr(s), "Seq({2: 'F'}, length=6)")
         s = seq[:9:-2]  # ??F??
-        self.assertEqual(s._data._starts, [2])
-        self.assertEqual(s._data._data, [b"F"])
-        self.assertEqual(s._data._length, 5)
+        self.assertEqual(repr(s), "Seq({2: 'F'}, length=5)")
         s = seq[:10:-2]  # ??F??
-        self.assertEqual(s._data._starts, [2])
-        self.assertEqual(s._data._data, [b"F"])
-        self.assertEqual(s._data._length, 5)
+        self.assertEqual(repr(s), "Seq({2: 'F'}, length=5)")
         s = seq[:13:-2]  # ??F
-        self.assertEqual(s._data._starts, [2])
-        self.assertEqual(s._data._data, [b"F"])
-        self.assertEqual(s._data._length, 3)
+        self.assertEqual(repr(s), "Seq({2: 'F'}, length=3)")
         s = seq[:14:-2]  # ??F
-        self.assertEqual(s._data._starts, [2])
-        self.assertEqual(s._data._data, [b"F"])
-        self.assertEqual(s._data._length, 3)
+        self.assertEqual(repr(s), "Seq({2: 'F'}, length=3)")
         s = seq[:15:-2]  # ??
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 2)
+        self.assertEqual(repr(s), "Seq(None, length=2)")
         s = seq[:16:-2]  # ??
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 2)
+        self.assertEqual(repr(s), "Seq(None, length=2)")
         s = seq[:17:-2]  # ?
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 1)
+        self.assertEqual(repr(s), "Seq(None, length=1)")
         s = seq[:18:-2]  # ?
-        self.assertIsInstance(s._data, _UndefinedSequenceData)
-        self.assertEqual(len(s), 1)
+        self.assertEqual(repr(s), "Seq(None, length=1)")
         s = seq[:19:-2]  # empty sequence
-        self.assertEqual(s._data, b"")
+        self.assertEqual(repr(s), "Seq('')")
         s = seq[:20:-2]  # empty sequence
-        self.assertEqual(s._data, b"")
+        self.assertEqual(repr(s), "Seq('')")
+
+    def test_addition(self):
+        s1 = Seq("ABCD")
+        s2 = Seq("EFG")
+        u1 = Seq(None, length=7)
+        u2 = Seq(None, length=9)
+        p1 = Seq({3: "KLM", 11: "XYZ"}, length=17)
+        p2 = Seq({0: "PQRST", 8: "HIJ"}, length=13)
+        self.assertEqual(s1 + s1, Seq("ABCDABCD"))
+        self.assertEqual(s1 + s2, Seq("ABCDEFG"))
+        self.assertEqual(repr(s1 + u1), "Seq({0: 'ABCD'}, length=11)")
+        self.assertEqual(repr(s1 + u2), "Seq({0: 'ABCD'}, length=13)")
+        self.assertEqual(repr(s1 + p1), "Seq({0: 'ABCD', 7: 'KLM', 15: 'XYZ'}, length=21)")
+        self.assertEqual(repr(s1 + p2), "Seq({0: 'ABCDPQRST', 12: 'HIJ'}, length=17)")
+        self.assertEqual(s2 + s1, Seq('EFGABCD'))
+        self.assertEqual(s2 + s2, Seq('EFGEFG'))
+        self.assertEqual(repr(s2 + u1), "Seq({0: 'EFG'}, length=10)")
+        self.assertEqual(repr(s2 + u2), "Seq({0: 'EFG'}, length=12)")
+        self.assertEqual(repr(s2 + p1), "Seq({0: 'EFG', 6: 'KLM', 14: 'XYZ'}, length=20)")
+        self.assertEqual(repr(s2 + p2), "Seq({0: 'EFGPQRST', 11: 'HIJ'}, length=16)")
+        self.assertEqual(repr(u1 + s1), "Seq({7: 'ABCD'}, length=11)")
+        self.assertEqual(repr(u1 + s2), "Seq({7: 'EFG'}, length=10)")
+        self.assertEqual(repr(u1 + u1), "Seq(None, length=14)")
+        self.assertEqual(repr(u1 + u2), "Seq(None, length=16)")
+        self.assertEqual(repr(u1 + p1), "Seq({10: 'KLM', 18: 'XYZ'}, length=24)")
+        self.assertEqual(repr(u1 + p2), "Seq({7: 'PQRST', 15: 'HIJ'}, length=20)")
+        self.assertEqual(repr(u2 + s1), "Seq({9: 'ABCD'}, length=13)")
+        self.assertEqual(repr(u2 + s2), "Seq({9: 'EFG'}, length=12)")
+        self.assertEqual(repr(u2 + u1), "Seq(None, length=16)")
+        self.assertEqual(repr(u2 + u2), "Seq(None, length=18)")
+        self.assertEqual(repr(u2 + p1), "Seq({12: 'KLM', 20: 'XYZ'}, length=26)")
+        self.assertEqual(repr(u2 + p2), "Seq({9: 'PQRST', 17: 'HIJ'}, length=22)")
+        self.assertEqual(repr(p1 + s1), "Seq({3: 'KLM', 11: 'XYZ', 17: 'ABCD'}, length=21)")
+        self.assertEqual(repr(p1 + s2), "Seq({3: 'KLM', 11: 'XYZ', 17: 'EFG'}, length=20)")
+        self.assertEqual(repr(p1 + u1), "Seq({3: 'KLM', 11: 'XYZ'}, length=24)")
+        self.assertEqual(repr(p1 + u2), "Seq({3: 'KLM', 11: 'XYZ'}, length=26)")
+        self.assertEqual(repr(p1 + p1), "Seq({3: 'KLM', 11: 'XYZ', 20: 'KLM', 28: 'XYZ'}, length=34)")
+        self.assertEqual(repr(p1 + p2), "Seq({3: 'KLM', 11: 'XYZ', 17: 'PQRST', 25: 'HIJ'}, length=30)")
+        self.assertEqual(repr(p2 + s1), "Seq({0: 'PQRST', 8: 'HIJ', 13: 'ABCD'}, length=17)")
+        self.assertEqual(repr(p2 + s2), "Seq({0: 'PQRST', 8: 'HIJ', 13: 'EFG'}, length=16)")
+        self.assertEqual(repr(p2 + u1), "Seq({0: 'PQRST', 8: 'HIJ'}, length=20)")
+        self.assertEqual(repr(p2 + u2), "Seq({0: 'PQRST', 8: 'HIJ'}, length=22)")
+        self.assertEqual(repr(p2 + p1), "Seq({0: 'PQRST', 8: 'HIJ', 16: 'KLM', 24: 'XYZ'}, length=30)")
+        self.assertEqual(repr(p2 + p2), "Seq({0: 'PQRST', 8: 'HIJ', 13: 'PQRST', 21: 'HIJ'}, length=26)")
 
 
 if __name__ == "__main__":

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1655,6 +1655,173 @@ class PartialSequenceTests(unittest.TestCase):
         self.assertEqual(len(s), 1)
         s = seq[20::2]  # empty sequence
         self.assertEqual(s._data, b"")
+        # step = -1, start = None
+        s = seq[::-1]  # ???GFE?????DCBA?????
+        self.assertEqual(s._data._starts, [3, 11])
+        self.assertEqual(s._data._data, [b"GFE", b"DCBA"])
+        self.assertEqual(s._data._length, 20)
+        s = seq[:0:-1]  # ???GFE?????DCBA????
+        self.assertEqual(s._data._starts, [3, 11])
+        self.assertEqual(s._data._data, [b"GFE", b"DCBA"])
+        self.assertEqual(s._data._length, 19)
+        s = seq[:1:-1]  # ???GFE?????DCBA???
+        self.assertEqual(s._data._starts, [3, 11])
+        self.assertEqual(s._data._data, [b"GFE", b"DCBA"])
+        self.assertEqual(s._data._length, 18)
+        s = seq[:4:-1]  # ???GFE?????DCBA
+        self.assertEqual(s._data._starts, [3, 11])
+        self.assertEqual(s._data._data, [b"GFE", b"DCBA"])
+        self.assertEqual(s._data._length, 15)
+        s = seq[:5:-1]  # ???GFE?????DCB
+        self.assertEqual(s._data._starts, [3, 11])
+        self.assertEqual(s._data._data, [b"GFE", b"DCB"])
+        self.assertEqual(s._data._length, 14)
+        s = seq[:6:-1]  # ???GFE?????DC
+        self.assertEqual(s._data._starts, [3, 11])
+        self.assertEqual(s._data._data, [b"GFE", b"DC"])
+        self.assertEqual(s._data._length, 13)
+        s = seq[:7:-1]  # ???GFE?????D
+        self.assertEqual(s._data._starts, [3, 11])
+        self.assertEqual(s._data._data, [b"GFE", b"D"])
+        self.assertEqual(s._data._length, 12)
+        s = seq[:8:-1]  # ???GFE?????
+        self.assertEqual(s._data._starts, [3, ])
+        self.assertEqual(s._data._data, [b"GFE", ])
+        self.assertEqual(s._data._length, 11)
+        s = seq[:9:-1]  # ???GFE????
+        self.assertEqual(s._data._starts, [3, ])
+        self.assertEqual(s._data._data, [b"GFE", ])
+        self.assertEqual(s._data._length, 10)
+        s = seq[:10:-1]  # ???GFE???
+        self.assertEqual(s._data._starts, [3])
+        self.assertEqual(s._data._data, [b"GFE", ])
+        self.assertEqual(s._data._length, 9)
+        s = seq[:13:-1]  # ???GFE
+        self.assertEqual(s._data._starts, [3])
+        self.assertEqual(s._data._data, [b"GFE"])
+        self.assertEqual(s._data._length, 6)
+        s = seq[:14:-1]  # ???GF
+        self.assertEqual(s._data._starts, [3])
+        self.assertEqual(s._data._data, [b"GF"])
+        self.assertEqual(s._data._length, 5)
+        s = seq[:15:-1]  # ???G
+        self.assertEqual(s._data._starts, [3])
+        self.assertEqual(s._data._data, [b"G"])
+        self.assertEqual(s._data._length, 4)
+        s = seq[:16:-1]  # ???
+        self.assertIsInstance(s._data, _UndefinedSequenceData)
+        self.assertEqual(len(s), 3)
+        s = seq[:17:-1]  # ??
+        self.assertIsInstance(s._data, _UndefinedSequenceData)
+        self.assertEqual(len(s), 2)
+        s = seq[:18:-1]  # ?
+        self.assertIsInstance(s._data, _UndefinedSequenceData)
+        self.assertEqual(len(s), 1)
+        s = seq[:19:-1]  # empty sequence
+        self.assertEqual(s._data, b"")
+        s = seq[:20:-1]  # empty sequence
+        self.assertEqual(s._data, b"")
+        # step = -1, stop = 9
+        s = seq[9::-1]  # ?DCBA?????
+        self.assertEqual(s._data._starts, [1])
+        self.assertEqual(s._data._data, [b"DCBA"])
+        self.assertEqual(s._data._length, 10)
+        s = seq[9:0:-1]  # ?DCBA????
+        self.assertEqual(s._data._starts, [1])
+        self.assertEqual(s._data._data, [b"DCBA"])
+        self.assertEqual(s._data._length, 9)
+        s = seq[9:1:-1]  # ?DCBA???
+        self.assertEqual(s._data._starts, [1])
+        self.assertEqual(s._data._data, [b"DCBA"])
+        self.assertEqual(s._data._length, 8)
+        s = seq[9:4:-1]  # ?DCBA
+        self.assertEqual(s._data._starts, [1])
+        self.assertEqual(s._data._data, [b"DCBA"])
+        self.assertEqual(s._data._length, 5)
+        s = seq[9:5:-1]  # ?DCB
+        self.assertEqual(s._data._starts, [1])
+        self.assertEqual(s._data._data, [b"DCB"])
+        self.assertEqual(s._data._length, 4)
+        s = seq[9:6:-1]  # ?DC
+        self.assertEqual(s._data._starts, [1])
+        self.assertEqual(s._data._data, [b"DC"])
+        self.assertEqual(s._data._length, 3)
+        s = seq[9:7:-1]  # ?D
+        self.assertEqual(s._data._starts, [1])
+        self.assertEqual(s._data._data, [b"D"])
+        self.assertEqual(s._data._length, 2)
+        s = seq[9:8:-1]  # ?
+        self.assertIsInstance(s._data, _UndefinedSequenceData)
+        self.assertEqual(len(s), 1)
+        s = seq[9:9:-1]  # empty sequence
+        self.assertEqual(s._data, b"")
+        s = seq[9:10:-1]  # empty sequence
+        self.assertEqual(s._data, b"")
+        # step = -2, stop = None
+        s = seq[::-2]  # ??F???CA??
+        self.assertEqual(s._data._starts, [2, 6])
+        self.assertEqual(s._data._data, [b"F", b"CA"])
+        self.assertEqual(s._data._length, 10)
+        s = seq[:0:-2]  # ??F???CA??
+        self.assertEqual(s._data._starts, [2, 6])
+        self.assertEqual(s._data._data, [b"F", b"CA"])
+        self.assertEqual(s._data._length, 10)
+        s = seq[:1:-2]  # ??F???CA?
+        self.assertEqual(s._data._starts, [2, 6])
+        self.assertEqual(s._data._data, [b"F", b"CA"])
+        self.assertEqual(s._data._length, 9)
+        s = seq[:4:-2]  # ??F???CA
+        self.assertEqual(s._data._starts, [2, 6])
+        self.assertEqual(s._data._data, [b"F", b"CA"])
+        self.assertEqual(s._data._length, 8)
+        s = seq[:5:-2]  # ??F???C
+        self.assertEqual(s._data._starts, [2, 6])
+        self.assertEqual(s._data._data, [b"F", b"C"])
+        self.assertEqual(s._data._length, 7)
+        s = seq[:6:-2]  # ??F???C
+        self.assertEqual(s._data._starts, [2, 6])
+        self.assertEqual(s._data._data, [b"F", b"C"])
+        self.assertEqual(s._data._length, 7)
+        s = seq[:7:-2]  # ??F???
+        self.assertEqual(s._data._starts, [2, ])
+        self.assertEqual(s._data._data, [b"F", ])
+        self.assertEqual(s._data._length, 6)
+        s = seq[:8:-2]  # ??F???
+        self.assertEqual(s._data._starts, [2, ])
+        self.assertEqual(s._data._data, [b"F", ])
+        self.assertEqual(s._data._length, 6)
+        s = seq[:9:-2]  # ??F??
+        self.assertEqual(s._data._starts, [2])
+        self.assertEqual(s._data._data, [b"F"])
+        self.assertEqual(s._data._length, 5)
+        s = seq[:10:-2]  # ??F??
+        self.assertEqual(s._data._starts, [2])
+        self.assertEqual(s._data._data, [b"F"])
+        self.assertEqual(s._data._length, 5)
+        s = seq[:13:-2]  # ??F
+        self.assertEqual(s._data._starts, [2])
+        self.assertEqual(s._data._data, [b"F"])
+        self.assertEqual(s._data._length, 3)
+        s = seq[:14:-2]  # ??F
+        self.assertEqual(s._data._starts, [2])
+        self.assertEqual(s._data._data, [b"F"])
+        self.assertEqual(s._data._length, 3)
+        s = seq[:15:-2]  # ??
+        self.assertIsInstance(s._data, _UndefinedSequenceData)
+        self.assertEqual(len(s), 2)
+        s = seq[:16:-2]  # ??
+        self.assertIsInstance(s._data, _UndefinedSequenceData)
+        self.assertEqual(len(s), 2)
+        s = seq[:17:-2]  # ?
+        self.assertIsInstance(s._data, _UndefinedSequenceData)
+        self.assertEqual(len(s), 1)
+        s = seq[:18:-2]  # ?
+        self.assertIsInstance(s._data, _UndefinedSequenceData)
+        self.assertEqual(len(s), 1)
+        s = seq[:19:-2]  # empty sequence
+        self.assertEqual(s._data, b"")
+        s = seq[:20:-2]  # empty sequence
+        self.assertEqual(s._data, b"")
 
 
 if __name__ == "__main__":

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1489,6 +1489,12 @@ class ComparisonTests(unittest.TestCase):
 class PartialSequenceTests(unittest.TestCase):
     """Test Seq objects with partially defined sequences."""
 
+    def test_init(self):
+        seq = Seq({5: "ACGT"}, length=20)
+        self.assertEqual(repr(seq), "Seq({5: 'ACGT'}, length=20)")
+        with self.assertRaises(ValueError, msg="Length must not be negative"):
+            Seq({5: "ACGT"}, length=-10)
+
     def test_repr(self):
         seq = Seq({5: "ACGT", 14: "GGC"}, length=20)
         self.assertEqual(repr(seq), "Seq({5: 'ACGT', 14: 'GGC'}, length=20)")

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -603,6 +603,13 @@ class StringMethodTests(unittest.TestCase):
         t = m.replace("AC", "XYZ", inplace=True)
         self.assertEqual(m, "AAGTXYZGT")
         self.assertEqual(t, "AAGTXYZGT")
+        u = Seq(None, length=20)
+        t = u.replace("AT", "CG")
+        self.assertEqual(repr(t), "Seq(None, length=20)")
+        with self.assertRaises(UndefinedSequenceError,
+                               msg="Sequence content is undefined"):
+            u.replace("AT", "ACGT")  # unequal length
+
 
     def test_str_encode(self):
         """Check matches the python string encode method."""

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1692,8 +1692,8 @@ class PartialSequenceTests(unittest.TestCase):
         self.assertEqual(repr(s1 + u2), "Seq({0: 'ABCD'}, length=13)")
         self.assertEqual(repr(s1 + p1), "Seq({0: 'ABCD', 7: 'KLM', 15: 'XYZ'}, length=21)")
         self.assertEqual(repr(s1 + p2), "Seq({0: 'ABCDPQRST', 12: 'HIJ'}, length=17)")
-        self.assertEqual(s2 + s1, Seq('EFGABCD'))
-        self.assertEqual(s2 + s2, Seq('EFGEFG'))
+        self.assertEqual(s2 + s1, Seq("EFGABCD"))
+        self.assertEqual(s2 + s2, Seq("EFGEFG"))
         self.assertEqual(repr(s2 + u1), "Seq({0: 'EFG'}, length=10)")
         self.assertEqual(repr(s2 + u2), "Seq({0: 'EFG'}, length=12)")
         self.assertEqual(repr(s2 + p1), "Seq({0: 'EFG', 6: 'KLM', 14: 'XYZ'}, length=20)")
@@ -1741,12 +1741,12 @@ class PartialSequenceTests(unittest.TestCase):
                          "Seq({3: 'TTGG', 11: 'GCA'}, length=20)")
         self.assertEqual(repr(u.complement(inplace=False)),
                          "Seq({3: 'TTGG', 11: 'GCA'}, length=20)")
-                         # TODO: remove inplace=False
+        # TODO: remove inplace=False
         self.assertEqual(repr(s.reverse_complement()),
                          "Seq({6: 'ACG', 13: 'GGTT'}, length=20)")
         self.assertEqual(repr(u.reverse_complement(inplace=False)),
                          "Seq({6: 'ACG', 13: 'GGTT'}, length=20)")
-                         # TODO: remove inplace=False
+        # TODO: remove inplace=False
         self.assertEqual(repr(s.complement_rna()),
                          "Seq({3: 'UUGG', 11: 'GCA'}, length=20)")
         self.assertEqual(repr(u.complement_rna()),

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1482,6 +1482,25 @@ class ComparisonTests(unittest.TestCase):
 class PartialSequenceTests(unittest.TestCase):
     """Test Seq objects with partially defined sequences."""
 
+    def test_repr(self):
+        seq = Seq({5: "ACGT", 14: "GGC"}, length=20)
+        self.assertEqual(repr(seq), "Seq({5: 'ACGT', 14: 'GGC'}, length=20)")
+        seq = Seq({5: "ACGT" * 25, 140: "GGC"}, length=143)
+        self.assertEqual(
+            repr(seq),
+            "Seq({5: 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTAC...CGT', 140: 'GGC'}, length=143)",
+        )
+        seq = Seq({5: "ACGT" * 25, 140: "GGC"}, length=150)
+        self.assertEqual(
+            repr(seq),
+            "Seq({5: 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTAC...CGT', 140: 'GGC'}, length=150)",
+        )
+        seq = Seq({5: "ACGT" * 25, 140: "acgt" * 20}, length=250)
+        self.assertEqual(
+            repr(seq),
+            "Seq({5: 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTAC...CGT', 140: 'acgtacgtacgtacgtacgtacgtacgtacgtacgtacgtacgtacgtacgtac...cgt'}, length=250)",
+        )
+
     def test_getitem(self):
         #           1    1    2
         # 0    5    0    5    0

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -606,10 +606,10 @@ class StringMethodTests(unittest.TestCase):
         u = Seq(None, length=20)
         t = u.replace("AT", "CG")
         self.assertEqual(repr(t), "Seq(None, length=20)")
-        with self.assertRaises(UndefinedSequenceError,
-                               msg="Sequence content is undefined"):
+        with self.assertRaises(
+            UndefinedSequenceError, msg="Sequence content is undefined"
+        ):
             u.replace("AT", "ACGT")  # unequal length
-
 
     def test_str_encode(self):
         """Check matches the python string encode method."""

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -955,8 +955,7 @@ class StringMethodTests(unittest.TestCase):
         """Checks if Seq join correctly concatenates sequence with the spacer."""
         spacer = Seq("NNNNN")
         self.assertEqual(
-            "N" * 15,
-            spacer.join([Seq("NNNNN"), Seq("NNNNN")]),
+            "N" * 15, spacer.join([Seq("NNNNN"), Seq("NNNNN")]),
         )
 
         spacer1 = Seq("")
@@ -1018,12 +1017,10 @@ class StringMethodTests(unittest.TestCase):
         """Check MutableSeq objects can be joined."""
         spacer = MutableSeq("NNNNN")
         self.assertEqual(
-            "N" * 15,
-            spacer.join([MutableSeq("NNNNN"), MutableSeq("NNNNN")]),
+            "N" * 15, spacer.join([MutableSeq("NNNNN"), MutableSeq("NNNNN")]),
         )
         self.assertRaises(
-            TypeError,
-            spacer.join([Seq("NNNNN"), MutableSeq("NNNNN")]),
+            TypeError, spacer.join([Seq("NNNNN"), MutableSeq("NNNNN")]),
         )
 
     def test_join_Seq_with_file(self):

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1491,101 +1491,169 @@ class PartialSequenceTests(unittest.TestCase):
         self.assertEqual(seq._data._data, [b"ABCD", b"EFG"])
         self.assertEqual(seq._data._length, 20)
         # step = 1, stop = +inf
-        s = seq[:]
+        s = seq[:]  # ?????ABCD?????EFG???
         self.assertEqual(s._data._starts, [5, 14])
         self.assertEqual(s._data._data, [b"ABCD", b"EFG"])
         self.assertEqual(s._data._length, 20)
-        s = seq[0:]
+        s = seq[0:]  # ?????ABCD?????EFG???
         self.assertEqual(s._data._starts, [5, 14])
         self.assertEqual(s._data._data, [b"ABCD", b"EFG"])
         self.assertEqual(s._data._length, 20)
-        s = seq[1:]
+        s = seq[1:]  # ????ABCD?????EFG???
         self.assertEqual(s._data._starts, [4, 13])
         self.assertEqual(s._data._data, [b"ABCD", b"EFG"])
         self.assertEqual(s._data._length, 19)
-        s = seq[4:]
+        s = seq[4:]  # ?ABCD?????EFG???
         self.assertEqual(s._data._starts, [1, 10])
         self.assertEqual(s._data._data, [b"ABCD", b"EFG"])
         self.assertEqual(s._data._length, 16)
-        s = seq[5:]
+        s = seq[5:]  # ABCD?????EFG???
         self.assertEqual(s._data._starts, [0, 9])
         self.assertEqual(s._data._data, [b"ABCD", b"EFG"])
         self.assertEqual(s._data._length, 15)
-        s = seq[6:]
+        s = seq[6:]  # BCD?????EFG???
         self.assertEqual(s._data._starts, [0, 8])
         self.assertEqual(s._data._data, [b"BCD", b"EFG"])
         self.assertEqual(s._data._length, 14)
-        s = seq[7:]
+        s = seq[7:]  # CD?????EFG???
         self.assertEqual(s._data._starts, [0, 7])
         self.assertEqual(s._data._data, [b"CD", b"EFG"])
         self.assertEqual(s._data._length, 13)
-        s = seq[8:]
+        s = seq[8:]  # D?????EFG???
         self.assertEqual(s._data._starts, [0, 6])
         self.assertEqual(s._data._data, [b"D", b"EFG"])
         self.assertEqual(s._data._length, 12)
-        s = seq[9:]
+        s = seq[9:]  # ?????EFG???
         self.assertEqual(s._data._starts, [5])
         self.assertEqual(s._data._data, [b"EFG"])
         self.assertEqual(s._data._length, 11)
-        s = seq[10:]
+        s = seq[10:]  # ????EFG???
         self.assertEqual(s._data._starts, [4])
         self.assertEqual(s._data._data, [b"EFG"])
         self.assertEqual(s._data._length, 10)
-        s = seq[13:]
+        s = seq[13:]  # ?EFG???
         self.assertEqual(s._data._starts, [1])
         self.assertEqual(s._data._data, [b"EFG"])
         self.assertEqual(s._data._length, 7)
-        s = seq[14:]
+        s = seq[14:]  # EFG???
         self.assertEqual(s._data._starts, [0])
         self.assertEqual(s._data._data, [b"EFG"])
         self.assertEqual(s._data._length, 6)
-        s = seq[15:]
+        s = seq[15:]  # FG???
         self.assertEqual(s._data._starts, [0])
         self.assertEqual(s._data._data, [b"FG"])
         self.assertEqual(s._data._length, 5)
-        s = seq[16:]
+        s = seq[16:]  # G???
         self.assertEqual(s._data._starts, [0])
         self.assertEqual(s._data._data, [b"G"])
         self.assertEqual(s._data._length, 4)
-        s = seq[17:]
+        s = seq[17:]  # ???
         self.assertIsInstance(s._data, _UndefinedSequenceData)
         self.assertEqual(len(s), 3)
-        s = seq[18:]
+        s = seq[18:]  # ??
         self.assertIsInstance(s._data, _UndefinedSequenceData)
         self.assertEqual(len(s), 2)
-        s = seq[19:]
+        s = seq[19:]  # ?
         self.assertIsInstance(s._data, _UndefinedSequenceData)
         self.assertEqual(len(s), 1)
-        s = seq[20:]
+        s = seq[20:]  # empty sequence
         self.assertEqual(s._data, b"")
         # step = 1, stop = 9
-        s = seq[:9]
+        s = seq[:9]  # ?????ABCD
         self.assertEqual(s._data._starts, [5])
         self.assertEqual(s._data._data, [b"ABCD"])
         self.assertEqual(s._data._length, 9)
-        s = seq[0:9]
+        s = seq[0:9]  # ?????ABCD
         self.assertEqual(s._data._starts, [5])
         self.assertEqual(s._data._data, [b"ABCD"])
         self.assertEqual(s._data._length, 9)
-        s = seq[1:9]
+        s = seq[1:9]  # ????ABCD
         self.assertEqual(s._data._starts, [4])
         self.assertEqual(s._data._data, [b"ABCD"])
         self.assertEqual(s._data._length, 8)
-        s = seq[4:9]
+        s = seq[4:9]  # ?ABCD
         self.assertEqual(s._data._starts, [1])
         self.assertEqual(s._data._data, [b"ABCD"])
         self.assertEqual(s._data._length, 5)
-        s = seq[5:9]
+        s = seq[5:9]  # ABCD
         self.assertEqual(s._data, b"ABCD")
-        s = seq[6:9]
+        s = seq[6:9]  # BCD
         self.assertEqual(s._data, b"BCD")
-        s = seq[7:9]
+        s = seq[7:9]  # CD
         self.assertEqual(s._data, b"CD")
-        s = seq[8:9]
+        s = seq[8:9]  # D
         self.assertEqual(s._data, b"D")
-        s = seq[9:9]
+        s = seq[9:9]  # empty sequence
         self.assertEqual(s._data, b"")
-        s = seq[10:9]
+        s = seq[10:9]  # empty sequence
+        self.assertEqual(s._data, b"")
+        # step = 2, stop = +inf
+        s = seq[::2]  # ???BD??EG?
+        self.assertEqual(s._data._starts, [3, 7])
+        self.assertEqual(s._data._data, [b"BD", b"EG"])
+        self.assertEqual(s._data._length, 10)
+        s = seq[0::2]  # ???BD??EG?
+        self.assertEqual(s._data._starts, [3, 7])
+        self.assertEqual(s._data._data, [b"BD", b"EG"])
+        self.assertEqual(s._data._length, 10)
+        s = seq[1::2]  # ??AC???F??
+        self.assertEqual(s._data._starts, [2, 7])
+        self.assertEqual(s._data._data, [b"AC", b"F"])
+        self.assertEqual(s._data._length, 10)
+        s = seq[4::2]  # ?BD??EG?
+        self.assertEqual(s._data._starts, [1, 5])
+        self.assertEqual(s._data._data, [b"BD", b"EG"])
+        self.assertEqual(s._data._length, 8)
+        s = seq[5::2]  # AC???F??
+        self.assertEqual(s._data._starts, [0, 5])
+        self.assertEqual(s._data._data, [b"AC", b"F"])
+        self.assertEqual(s._data._length, 8)
+        s = seq[6::2]  # BD??EG?
+        self.assertEqual(s._data._starts, [0, 4])
+        self.assertEqual(s._data._data, [b"BD", b"EG"])
+        self.assertEqual(s._data._length, 7)
+        s = seq[7::2]  # C???F??
+        self.assertEqual(s._data._starts, [0, 4])
+        self.assertEqual(s._data._data, [b"C", b"F"])
+        self.assertEqual(s._data._length, 7)
+        s = seq[8::2]  # D??EG?
+        self.assertEqual(s._data._starts, [0, 3])
+        self.assertEqual(s._data._data, [b"D", b"EG"])
+        self.assertEqual(s._data._length, 6)
+        s = seq[9::2]  # ???F??
+        self.assertEqual(s._data._starts, [3])
+        self.assertEqual(s._data._data, [b"F"])
+        self.assertEqual(s._data._length, 6)
+        s = seq[10::2]  # ??EG?
+        self.assertEqual(s._data._starts, [2])
+        self.assertEqual(s._data._data, [b"EG"])
+        self.assertEqual(s._data._length, 5)
+        s = seq[13::2]  # ?F??
+        self.assertEqual(s._data._starts, [1])
+        self.assertEqual(s._data._data, [b"F"])
+        self.assertEqual(s._data._length, 4)
+        s = seq[14::2]  # EG?
+        self.assertEqual(s._data._starts, [0])
+        self.assertEqual(s._data._data, [b"EG"])
+        self.assertEqual(s._data._length, 3)
+        s = seq[15::2]  # F??
+        self.assertEqual(s._data._starts, [0])
+        self.assertEqual(s._data._data, [b"F"])
+        self.assertEqual(s._data._length, 3)
+        s = seq[16::2]  # G?
+        self.assertEqual(s._data._starts, [0])
+        self.assertEqual(s._data._data, [b"G"])
+        self.assertEqual(s._data._length, 2)
+        s = seq[17::2]  # ??
+        self.assertIsInstance(s._data, _UndefinedSequenceData)
+        self.assertEqual(len(s), 2)
+        s = seq[18::2]  # ?
+        self.assertIsInstance(s._data, _UndefinedSequenceData)
+        self.assertEqual(len(s), 1)
+        s = seq[19::2]  # ?
+        self.assertIsInstance(s._data, _UndefinedSequenceData)
+        self.assertEqual(len(s), 1)
+        s = seq[20::2]  # empty sequence
         self.assertEqual(s._data, b"")
 
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1723,6 +1723,17 @@ class PartialSequenceTests(unittest.TestCase):
         self.assertEqual(repr(p2 + p1), "Seq({0: 'PQRST', 8: 'HIJ', 16: 'KLM', 24: 'XYZ'}, length=30)")
         self.assertEqual(repr(p2 + p2), "Seq({0: 'PQRST', 8: 'HIJ', 13: 'PQRST', 21: 'HIJ'}, length=26)")
 
+    def test_lower_upper(self):
+        u = Seq({3: "KLM", 11: "XYZ"}, length=17)
+        l = Seq({0: "pqrst", 8: "hij"}, length=13)
+        m = Seq({5: "ABCD", 10: "efgh"}, length=20)
+        self.assertEqual(repr(u.upper()), "Seq({3: 'KLM', 11: 'XYZ'}, length=17)")
+        self.assertEqual(repr(u.lower()), "Seq({3: 'klm', 11: 'xyz'}, length=17)")
+        self.assertEqual(repr(l.upper()), "Seq({0: 'PQRST', 8: 'HIJ'}, length=13)")
+        self.assertEqual(repr(l.lower()), "Seq({0: 'pqrst', 8: 'hij'}, length=13)")
+        self.assertEqual(repr(m.upper()), "Seq({5: 'ABCD', 10: 'EFGH'}, length=20)")
+        self.assertEqual(repr(m.lower()), "Seq({5: 'abcd', 10: 'efgh'}, length=20)")
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -955,7 +955,8 @@ class StringMethodTests(unittest.TestCase):
         """Checks if Seq join correctly concatenates sequence with the spacer."""
         spacer = Seq("NNNNN")
         self.assertEqual(
-            "N" * 15, spacer.join([Seq("NNNNN"), Seq("NNNNN")]),
+            "N" * 15,
+            spacer.join([Seq("NNNNN"), Seq("NNNNN")]),
         )
 
         spacer1 = Seq("")
@@ -1017,10 +1018,12 @@ class StringMethodTests(unittest.TestCase):
         """Check MutableSeq objects can be joined."""
         spacer = MutableSeq("NNNNN")
         self.assertEqual(
-            "N" * 15, spacer.join([MutableSeq("NNNNN"), MutableSeq("NNNNN")]),
+            "N" * 15,
+            spacer.join([MutableSeq("NNNNN"), MutableSeq("NNNNN")]),
         )
         self.assertRaises(
-            TypeError, spacer.join([Seq("NNNNN"), MutableSeq("NNNNN")]),
+            TypeError,
+            spacer.join([Seq("NNNNN"), MutableSeq("NNNNN")]),
         )
 
     def test_join_Seq_with_file(self):
@@ -1690,13 +1693,17 @@ class PartialSequenceTests(unittest.TestCase):
         self.assertEqual(s1 + s2, Seq("ABCDEFG"))
         self.assertEqual(repr(s1 + u1), "Seq({0: 'ABCD'}, length=11)")
         self.assertEqual(repr(s1 + u2), "Seq({0: 'ABCD'}, length=13)")
-        self.assertEqual(repr(s1 + p1), "Seq({0: 'ABCD', 7: 'KLM', 15: 'XYZ'}, length=21)")
+        self.assertEqual(
+            repr(s1 + p1), "Seq({0: 'ABCD', 7: 'KLM', 15: 'XYZ'}, length=21)"
+        )
         self.assertEqual(repr(s1 + p2), "Seq({0: 'ABCDPQRST', 12: 'HIJ'}, length=17)")
         self.assertEqual(s2 + s1, Seq("EFGABCD"))
         self.assertEqual(s2 + s2, Seq("EFGEFG"))
         self.assertEqual(repr(s2 + u1), "Seq({0: 'EFG'}, length=10)")
         self.assertEqual(repr(s2 + u2), "Seq({0: 'EFG'}, length=12)")
-        self.assertEqual(repr(s2 + p1), "Seq({0: 'EFG', 6: 'KLM', 14: 'XYZ'}, length=20)")
+        self.assertEqual(
+            repr(s2 + p1), "Seq({0: 'EFG', 6: 'KLM', 14: 'XYZ'}, length=20)"
+        )
         self.assertEqual(repr(s2 + p2), "Seq({0: 'EFGPQRST', 11: 'HIJ'}, length=16)")
         self.assertEqual(repr(u1 + s1), "Seq({7: 'ABCD'}, length=11)")
         self.assertEqual(repr(u1 + s2), "Seq({7: 'EFG'}, length=10)")
@@ -1710,18 +1717,37 @@ class PartialSequenceTests(unittest.TestCase):
         self.assertEqual(repr(u2 + u2), "Seq(None, length=18)")
         self.assertEqual(repr(u2 + p1), "Seq({12: 'KLM', 20: 'XYZ'}, length=26)")
         self.assertEqual(repr(u2 + p2), "Seq({9: 'PQRST', 17: 'HIJ'}, length=22)")
-        self.assertEqual(repr(p1 + s1), "Seq({3: 'KLM', 11: 'XYZ', 17: 'ABCD'}, length=21)")
-        self.assertEqual(repr(p1 + s2), "Seq({3: 'KLM', 11: 'XYZ', 17: 'EFG'}, length=20)")
+        self.assertEqual(
+            repr(p1 + s1), "Seq({3: 'KLM', 11: 'XYZ', 17: 'ABCD'}, length=21)"
+        )
+        self.assertEqual(
+            repr(p1 + s2), "Seq({3: 'KLM', 11: 'XYZ', 17: 'EFG'}, length=20)"
+        )
         self.assertEqual(repr(p1 + u1), "Seq({3: 'KLM', 11: 'XYZ'}, length=24)")
         self.assertEqual(repr(p1 + u2), "Seq({3: 'KLM', 11: 'XYZ'}, length=26)")
-        self.assertEqual(repr(p1 + p1), "Seq({3: 'KLM', 11: 'XYZ', 20: 'KLM', 28: 'XYZ'}, length=34)")
-        self.assertEqual(repr(p1 + p2), "Seq({3: 'KLM', 11: 'XYZ', 17: 'PQRST', 25: 'HIJ'}, length=30)")
-        self.assertEqual(repr(p2 + s1), "Seq({0: 'PQRST', 8: 'HIJ', 13: 'ABCD'}, length=17)")
-        self.assertEqual(repr(p2 + s2), "Seq({0: 'PQRST', 8: 'HIJ', 13: 'EFG'}, length=16)")
+        self.assertEqual(
+            repr(p1 + p1), "Seq({3: 'KLM', 11: 'XYZ', 20: 'KLM', 28: 'XYZ'}, length=34)"
+        )
+        self.assertEqual(
+            repr(p1 + p2),
+            "Seq({3: 'KLM', 11: 'XYZ', 17: 'PQRST', 25: 'HIJ'}, length=30)",
+        )
+        self.assertEqual(
+            repr(p2 + s1), "Seq({0: 'PQRST', 8: 'HIJ', 13: 'ABCD'}, length=17)"
+        )
+        self.assertEqual(
+            repr(p2 + s2), "Seq({0: 'PQRST', 8: 'HIJ', 13: 'EFG'}, length=16)"
+        )
         self.assertEqual(repr(p2 + u1), "Seq({0: 'PQRST', 8: 'HIJ'}, length=20)")
         self.assertEqual(repr(p2 + u2), "Seq({0: 'PQRST', 8: 'HIJ'}, length=22)")
-        self.assertEqual(repr(p2 + p1), "Seq({0: 'PQRST', 8: 'HIJ', 16: 'KLM', 24: 'XYZ'}, length=30)")
-        self.assertEqual(repr(p2 + p2), "Seq({0: 'PQRST', 8: 'HIJ', 13: 'PQRST', 21: 'HIJ'}, length=26)")
+        self.assertEqual(
+            repr(p2 + p1),
+            "Seq({0: 'PQRST', 8: 'HIJ', 16: 'KLM', 24: 'XYZ'}, length=30)",
+        )
+        self.assertEqual(
+            repr(p2 + p2),
+            "Seq({0: 'PQRST', 8: 'HIJ', 13: 'PQRST', 21: 'HIJ'}, length=26)",
+        )
 
     def test_lower_upper(self):
         u = Seq({3: "KLM", 11: "XYZ"}, length=17)
@@ -1737,31 +1763,40 @@ class PartialSequenceTests(unittest.TestCase):
     def test_complement(self):
         s = Seq({3: "AACC", 11: "CGT"}, length=20)
         u = Seq({3: "AACC", 11: "CGU"}, length=20)
-        self.assertEqual(repr(s.complement()),
-                         "Seq({3: 'TTGG', 11: 'GCA'}, length=20)")
-        self.assertEqual(repr(u.complement(inplace=False)),
-                         "Seq({3: 'TTGG', 11: 'GCA'}, length=20)")
+        self.assertEqual(repr(s.complement()), "Seq({3: 'TTGG', 11: 'GCA'}, length=20)")
+        self.assertEqual(
+            repr(u.complement(inplace=False)), "Seq({3: 'TTGG', 11: 'GCA'}, length=20)"
+        )
         # TODO: remove inplace=False
-        self.assertEqual(repr(s.reverse_complement()),
-                         "Seq({6: 'ACG', 13: 'GGTT'}, length=20)")
-        self.assertEqual(repr(u.reverse_complement(inplace=False)),
-                         "Seq({6: 'ACG', 13: 'GGTT'}, length=20)")
+        self.assertEqual(
+            repr(s.reverse_complement()), "Seq({6: 'ACG', 13: 'GGTT'}, length=20)"
+        )
+        self.assertEqual(
+            repr(u.reverse_complement(inplace=False)),
+            "Seq({6: 'ACG', 13: 'GGTT'}, length=20)",
+        )
         # TODO: remove inplace=False
-        self.assertEqual(repr(s.complement_rna()),
-                         "Seq({3: 'UUGG', 11: 'GCA'}, length=20)")
-        self.assertEqual(repr(u.complement_rna()),
-                         "Seq({3: 'UUGG', 11: 'GCA'}, length=20)")
-        self.assertEqual(repr(s.reverse_complement_rna()),
-                         "Seq({6: 'ACG', 13: 'GGUU'}, length=20)")
-        self.assertEqual(repr(u.reverse_complement_rna()),
-                         "Seq({6: 'ACG', 13: 'GGUU'}, length=20)")
+        self.assertEqual(
+            repr(s.complement_rna()), "Seq({3: 'UUGG', 11: 'GCA'}, length=20)"
+        )
+        self.assertEqual(
+            repr(u.complement_rna()), "Seq({3: 'UUGG', 11: 'GCA'}, length=20)"
+        )
+        self.assertEqual(
+            repr(s.reverse_complement_rna()), "Seq({6: 'ACG', 13: 'GGUU'}, length=20)"
+        )
+        self.assertEqual(
+            repr(u.reverse_complement_rna()), "Seq({6: 'ACG', 13: 'GGUU'}, length=20)"
+        )
 
     def test_replace(self):
         s = Seq({3: "AACC", 11: "CGT"}, length=20)
-        self.assertEqual(repr(s.replace("A", "X")),
-                         "Seq({3: 'XXCC', 11: 'CGT'}, length=20)")
-        self.assertEqual(repr(s.replace("CC", "YY")),
-                         "Seq({3: 'AAYY', 11: 'CGT'}, length=20)")
+        self.assertEqual(
+            repr(s.replace("A", "X")), "Seq({3: 'XXCC', 11: 'CGT'}, length=20)"
+        )
+        self.assertEqual(
+            repr(s.replace("CC", "YY")), "Seq({3: 'AAYY', 11: 'CGT'}, length=20)"
+        )
         self.assertRaises(UndefinedSequenceError, s.replace, "A", "XX")
 
     def test_transcribe(self):

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -1001,6 +1001,7 @@ class TestComplement(unittest.TestCase):
 
     def test_immutable(self):
         from Bio.SeqRecord import SeqRecord
+
         r = SeqRecord(Seq.Seq("ACGT"))
         with self.assertRaises(TypeError) as cm:
             Seq.complement(r, inplace=True)
@@ -1014,6 +1015,7 @@ class TestComplement(unittest.TestCase):
         with self.assertRaises(TypeError) as cm:
             Seq.complement_rna("ACGT", inplace=True)
         self.assertEqual(str(cm.exception), "strings are immutable")
+
 
 class TestReverseComplement(unittest.TestCase):
     def test_reverse_complement(self):
@@ -1076,6 +1078,7 @@ class TestReverseComplement(unittest.TestCase):
 
     def test_immutable(self):
         from Bio.SeqRecord import SeqRecord
+
         r = SeqRecord(Seq.Seq("ACGT"))
         with self.assertRaises(TypeError) as cm:
             Seq.reverse_complement(r, inplace=True)
@@ -1089,6 +1092,7 @@ class TestReverseComplement(unittest.TestCase):
         with self.assertRaises(TypeError) as cm:
             Seq.reverse_complement_rna("ACGT", inplace=True)
         self.assertEqual(str(cm.exception), "strings are immutable")
+
 
 class TestDoubleReverseComplement(unittest.TestCase):
     def test_reverse_complements(self):

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -1268,8 +1268,13 @@ class TestTranslating(unittest.TestCase):
 
     def test_translation_with_bad_table_argument(self):
         table = {}
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as cm:
             Seq.translate("GTGGCCATTGTAATGGGCCGC", table=table)
+        self.assertEqual(str(cm.exception), "Bad table argument")
+        table = b"0x"
+        with self.assertRaises(TypeError) as cm:
+            Seq.translate("GTGGCCATTGTAATGGGCCGC", table=table)
+        self.assertEqual(str(cm.exception), "table argument must be integer or string")
 
     def test_translation_with_codon_table_as_table_argument(self):
         table = standard_dna_table

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -240,8 +240,7 @@ class TestSeqStringMethods(unittest.TestCase):
             self.s + {}
 
     def test_radd_method_using_wrong_object(self):
-        with self.assertRaises(TypeError):
-            self.s.__radd__({})
+        self.assertEqual(self.s.__radd__({}), NotImplemented)
 
     def test_contains_method(self):
         self.assertIn("AAAA", self.s)
@@ -595,8 +594,7 @@ class TestMutableSeq(unittest.TestCase):
             self.mutable_s + 1234
 
     def test_radd_method_wrong_type(self):
-        with self.assertRaises(TypeError):
-            self.mutable_s.__radd__(1234)
+        self.assertEqual(self.mutable_s.__radd__(1234), NotImplemented)
 
     def test_contains_method(self):
         self.assertIn("AAAA", self.mutable_s)

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -926,12 +926,12 @@ class TestUnknownSeq(unittest.TestCase):
     def test_upper(self):
         seq = Seq.UnknownSeq(6, character="N")
         self.assertEqual("NNNNNN", seq.upper())
-        self.assertRaises(ValueError, self.u.upper)
+        self.assertEqual("Seq(None, length=6)", repr(self.u.upper()))
 
     def test_lower(self):
         seq = Seq.UnknownSeq(6, character="N")
         self.assertEqual("nnnnnn", seq.lower())
-        self.assertRaises(ValueError, self.u.lower)
+        self.assertEqual("Seq(None, length=6)", repr(self.u.lower()))
 
     def test_translation(self):
         self.assertEqual("XX", self.s.translate())

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -999,6 +999,21 @@ class TestComplement(unittest.TestCase):
         seq = "ATGAAACTG"
         self.assertEqual("TACTTTGAC", Seq.complement(seq))
 
+    def test_immutable(self):
+        from Bio.SeqRecord import SeqRecord
+        r = SeqRecord(Seq.Seq("ACGT"))
+        with self.assertRaises(TypeError) as cm:
+            Seq.complement(r, inplace=True)
+        self.assertEqual(str(cm.exception), "SeqRecords are immutable")
+        with self.assertRaises(TypeError) as cm:
+            Seq.complement("ACGT", inplace=True)
+        self.assertEqual(str(cm.exception), "strings are immutable")
+        with self.assertRaises(TypeError) as cm:
+            Seq.complement_rna(r, inplace=True)
+        self.assertEqual(str(cm.exception), "SeqRecords are immutable")
+        with self.assertRaises(TypeError) as cm:
+            Seq.complement_rna("ACGT", inplace=True)
+        self.assertEqual(str(cm.exception), "strings are immutable")
 
 class TestReverseComplement(unittest.TestCase):
     def test_reverse_complement(self):
@@ -1059,6 +1074,21 @@ class TestReverseComplement(unittest.TestCase):
         seq = "ATGAAACTG"
         self.assertEqual("CAGTTTCAT", Seq.reverse_complement(seq))
 
+    def test_immutable(self):
+        from Bio.SeqRecord import SeqRecord
+        r = SeqRecord(Seq.Seq("ACGT"))
+        with self.assertRaises(TypeError) as cm:
+            Seq.reverse_complement(r, inplace=True)
+        self.assertEqual(str(cm.exception), "SeqRecords are immutable")
+        with self.assertRaises(TypeError) as cm:
+            Seq.reverse_complement("ACGT", inplace=True)
+        self.assertEqual(str(cm.exception), "strings are immutable")
+        with self.assertRaises(TypeError) as cm:
+            Seq.reverse_complement_rna(r, inplace=True)
+        self.assertEqual(str(cm.exception), "SeqRecords are immutable")
+        with self.assertRaises(TypeError) as cm:
+            Seq.reverse_complement_rna("ACGT", inplace=True)
+        self.assertEqual(str(cm.exception), "strings are immutable")
 
 class TestDoubleReverseComplement(unittest.TestCase):
     def test_reverse_complements(self):


### PR DESCRIPTION
Add support for partially defined sequences to `Seq` objects.

Such partially defined sequences are frequently encountered in alignment files, for example in this line from a MAF file:
```
s hg38.chr7     117512683 36 + 159345973 TTGAAAACCTGAATGTGAGAGTCAGTCAAGGATAGT
```
where 117512683 is the starting position of the sequence on chromosome 7, and 159345973 is the size of chromosome 7. This line defines the sequence contents for positions 117512683:117512719; the sequence contents elsewhere is undefined.

The PR allows such sequences to be defined using a dictionary with the starting position and sequence contents of the defined sequence segment:
```python
>>> from Bio.Seq import Seq
>>> s = Seq({117512683: "TTGAAAACCTGAATGTGAGAGTCAGTCAAGGATAGT"}, length=159345973)
```

Operations on partially defined sequences are supported as much as possible, for example
```python
>>> s
Seq({117512683: 'TTGAAAACCTGAATGTGAGAGTCAGTCAAGGATAGT'}, length=159345973)
>>> len(s)
159345973
>>> s[117512690:117512700]
Seq('CCTGAATGTG')  # fully defined sequence
>>> s[:10]
Seq(None, length=10)
>>> s.reverse_complement()
Seq({41833254: 'ACTATCCTTGACTGACTCTCACATTCAGGTTTTCAA'}, length=159345973)
>>> print(s)
...
Bio.Seq.UndefinedSequenceError: Sequence content is only partially defined
```

More than one defined sequence segment is allowed, to enable addition of sequences:
```python
>>> s = Seq({3: "ABCD", 10: "XYZ"}, length=20)
>>> s
Seq({3: 'ABCD', 10: 'XYZ'}, length=20)
>>> s + s
Seq({3: 'ABCD', 10: 'XYZ', 23: 'ABCD', 30: 'XYZ'}, length=40)
```

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
