### PR TITLE
Draw tree with different orientations in Phylo/__utils.py

### DIFF
--- a/Bio/Phylo/_utils.py
+++ b/Bio/Phylo/_utils.py
@@ -285,7 +285,9 @@ def draw(
     import matplotlib.collections as mpcollections
 
     if orient_tree not in ["horizontal", "vertical", "circular"]:
-        raise ValueError("orient_tree must be one of 'horizontal', 'vertical' or 'circular'")
+        raise ValueError(
+            "orient_tree must be one of 'horizontal', 'vertical' or 'circular'"
+        )
     if orient_tree == "vertical" and vertical_direction not in ["right", "left"]:
         raise ValueError("vertical_direction must be one of 'right' or 'left'")
     elif orient_tree == "horizontal" and horizontal_direction not in ["up", "down"]:
@@ -403,7 +405,9 @@ def draw(
             axes.set_yticklabels([])
     elif orient_tree == "circular":
         if str(axes.name) != "polar":
-            raise ValueError("Axes %s must have projection='polar' for a circular plot" % axes)
+            raise ValueError(
+                "Axes %s must have projection='polar' for a circular plot" % axes
+            )
     elif not isinstance(axes, plt.matplotlib.axes.Axes):
         raise ValueError("Invalid argument for axes: %s" % axes)
 
@@ -425,11 +429,16 @@ def draw(
         customized by altering this function.
         """
         if not use_linecollection and orientation == "horizontal":
-            axes.hlines(y_here, x_start, x_here, color=color, lw=lw, linestyle=linestyle)
+            axes.hlines(
+                y_here, x_start, x_here, color=color, lw=lw, linestyle=linestyle
+            )
         elif use_linecollection and orientation == "horizontal":
             horizontal_linecollections.append(
                 mpcollections.LineCollection(
-                    [[(x_start, y_here), (x_here, y_here)]], color=color, lw=lw, linestyle=linestyle
+                    [[(x_start, y_here), (x_here, y_here)]],
+                    color=color,
+                    lw=lw,
+                    linestyle=linestyle,
                 )
             )
         elif not use_linecollection and orientation == "vertical":
@@ -437,7 +446,10 @@ def draw(
         elif use_linecollection and orientation == "vertical":
             vertical_linecollections.append(
                 mpcollections.LineCollection(
-                    [[(x_here, y_bot), (x_here, y_top)]], color=color, lw=lw, linestyle=linestyle
+                    [[(x_here, y_bot), (x_here, y_top)]],
+                    color=color,
+                    lw=lw,
+                    linestyle=linestyle,
                 )
             )
 
@@ -573,7 +585,7 @@ def draw(
                         verticalalignment=va,
                         horizontalalignment=ha,
                         color=get_label_color(label),
-                        rotation=90
+                        rotation=90,
                     )
 
             # Add label above the branch (optional)
@@ -638,7 +650,13 @@ def draw(
         # labels then add a dashed line going from the end of the branch to
         # the start of the label
         if clade in tree.get_terminals() and align_labels:
-            axes.plot([y_start, y_here], [x_here, xmax], color=color, lw=(lw - 1), linestyle="-.")
+            axes.plot(
+                [y_start, y_here],
+                [x_here, xmax],
+                color=color,
+                lw=(lw - 1),
+                linestyle="-.",
+            )
 
         # plot the labels on branches and rotate them appropriately
         rot = y_here * (180 / np.pi)
@@ -659,7 +677,16 @@ def draw(
                 va, ha = "center", "left"
 
             if draw_labels:
-                axes.text(y_here, xplc, label, color="k", rotation=rot, rotation_mode="anchor", va=va, ha=ha)
+                axes.text(
+                    y_here,
+                    xplc,
+                    label,
+                    color="k",
+                    rotation=rot,
+                    rotation_mode="anchor",
+                    va=va,
+                    ha=ha,
+                )
 
         if clade.clades:
 

--- a/Bio/Phylo/_utils.py
+++ b/Bio/Phylo/_utils.py
@@ -188,6 +188,12 @@ def draw(
     axes=None,
     branch_labels=None,
     label_colors=None,
+    orient_tree='vertical',
+    horizontal_direction='down',
+    vertical_direction='right',
+    circular_span=355,
+    draw_labels=True,
+    align_labels=False,
     *args,
     **kwargs
 ):
@@ -243,6 +249,27 @@ def draw(
             A function or a dictionary specifying the color of the tip label.
             If the tip label can't be found in the dict or label_colors is
             None, the label will be shown in black.
+        orient_tree : string of 'horizontal', 'vertical' or 'circular'
+            Whether the tree should be vertically oriented (default; i.e. leaves
+            are plotted from top to bottom), horizontally oriented (i.e. leaves 
+            are plotted from left to right) or a circular tree. Note that confidence
+            labels will not be plotted on a circular tree.
+        vertical_direction : string of 'left' or 'right'
+            If the tree is vertical, whether the leaves should be on the left 
+            (default) or the right.
+        horizontal_direction : string of 'up' or 'down'
+            If the tree is horizontal, whether the leaves should be on the bottom
+            (default - down) or the top (up).
+        circular_span : int or float between 0 and 365
+            How much of a circle the circular plot should span. This value is in 
+            degrees and is 355 (i.e. a small gap between the first and last leaf)
+            by default.
+        draw_labels : boolean
+            Whether labels should be added to the tree (both branches and leaves).
+            True by default.
+        align_labels : boolean
+            Whether leaf labels should be aligned so as they are all in the same 
+            position and have a dotted line joining them. False by default.
 
     """
     try:
@@ -256,6 +283,13 @@ def draw(
             ) from None
 
     import matplotlib.collections as mpcollections
+    
+    if orient_tree not in ["horizontal", "vertical", "circular"]:
+        raise ValueError("orient_tree must be one of 'horizontal', 'vertical' or 'circular'")
+    if orient_tree == "vertical" and vertical_direction not in ["right", "left"]:
+        raise ValueError("vertical_direction must be one of 'right' or 'left'")
+    elif orient_tree == "horizontal" and horizontal_direction not in ["up", "down"]:
+        raise ValueError("horizontal_direction must be one of 'up' or 'down'")
 
     # Arrays that store lines for the plot of clades
     horizontal_linecollections = []
@@ -362,6 +396,14 @@ def draw(
     if axes is None:
         fig = plt.figure()
         axes = fig.add_subplot(1, 1, 1)
+        if orient_tree == "circular":
+            axes = fig.add_subplot(1, 1, 1, projection="polar")
+            axes.yaxis.grid(False)
+            axes.set_xticks([])
+            axes.set_yticklabels([])
+    elif orient_tree == "circular":
+        if str(axes.name) != "polar":
+            raise ValueError("Axes %s must have projection='polar' for a circular plot" % axes)
     elif not isinstance(axes, plt.matplotlib.axes.Axes):
         raise ValueError("Invalid argument for axes: %s" % axes)
 
@@ -375,6 +417,7 @@ def draw(
         y_top=0,
         color="black",
         lw=".1",
+        linestyle="solid",
     ):
         """Create a line with or without a line collection object.
 
@@ -382,19 +425,19 @@ def draw(
         customized by altering this function.
         """
         if not use_linecollection and orientation == "horizontal":
-            axes.hlines(y_here, x_start, x_here, color=color, lw=lw)
+            axes.hlines(y_here, x_start, x_here, color=color, lw=lw, linestyle=linestyle)
         elif use_linecollection and orientation == "horizontal":
             horizontal_linecollections.append(
                 mpcollections.LineCollection(
-                    [[(x_start, y_here), (x_here, y_here)]], color=color, lw=lw
+                    [[(x_start, y_here), (x_here, y_here)]], color=color, lw=lw, linestyle=linestyle
                 )
             )
         elif not use_linecollection and orientation == "vertical":
-            axes.vlines(x_here, y_bot, y_top, color=color)
+            axes.vlines(x_here, y_bot, y_top, color=color, linestyle=linestyle)
         elif use_linecollection and orientation == "vertical":
             vertical_linecollections.append(
                 mpcollections.LineCollection(
-                    [[(x_here, y_bot), (x_here, y_top)]], color=color, lw=lw
+                    [[(x_here, y_bot), (x_here, y_top)]], color=color, lw=lw, linestyle=linestyle
                 )
             )
 
@@ -402,67 +445,310 @@ def draw(
         """Recursively draw a tree, down from the given clade."""
         x_here = x_posns[clade]
         y_here = y_posns[clade]
+        xmax = max(x_posns.values())
         # phyloXML-only graphics annotations
         if hasattr(clade, "color") and clade.color is not None:
             color = clade.color.to_hex()
         if hasattr(clade, "width") and clade.width is not None:
             lw = clade.width * plt.rcParams["lines.linewidth"]
         # Draw a horizontal line from start to here
-        draw_clade_lines(
-            use_linecollection=True,
-            orientation="horizontal",
-            y_here=y_here,
-            x_start=x_start,
-            x_here=x_here,
-            color=color,
-            lw=lw,
-        )
-        # Add node/taxon labels
-        label = label_func(clade)
-        if label not in (None, clade.__class__.__name__):
-            axes.text(
-                x_here,
-                y_here,
-                " %s" % label,
-                verticalalignment="center",
-                color=get_label_color(label),
-            )
-        # Add label above the branch (optional)
-        conf_label = format_branch_label(clade)
-        if conf_label:
-            axes.text(
-                0.5 * (x_start + x_here),
-                y_here,
-                conf_label,
-                fontsize="small",
-                horizontalalignment="center",
-            )
-        if clade.clades:
-            # Draw a vertical line connecting all children
-            y_top = y_posns[clade.clades[0]]
-            y_bot = y_posns[clade.clades[-1]]
-            # Only apply widths to horizontal lines, like Archaeopteryx
+        if orient_tree == "vertical":
             draw_clade_lines(
                 use_linecollection=True,
-                orientation="vertical",
+                orientation="horizontal",
+                y_here=y_here,
+                x_start=x_start,
                 x_here=x_here,
-                y_bot=y_bot,
-                y_top=y_top,
                 color=color,
                 lw=lw,
             )
-            # Draw descendents
+            #if this is one of the terminal branches and we want to align the 
+            #labels then add a dashed line going from the end of the branch to
+            #the start of the label
+            if clade in tree.get_terminals() and align_labels:
+                draw_clade_lines(
+                    use_linecollection=True,
+                    orientation="horizontal",
+                    y_here=y_here,
+                    x_start=x_here,
+                    x_here=xmax,
+                    color=color,
+                    lw=lw-1,
+                    linestyle="-.",
+                )
+            # Add node/taxon labels
+            label = label_func(clade)
+            if label not in (None, clade.__class__.__name__):
+                if align_labels and clade in tree.get_terminals():
+                    xplc = max(x_posns.values())+max(x_posns.values())/30
+                else:
+                    xplc = x_here
+                if draw_labels:
+                    if vertical_direction == "right":
+                        va = "center"
+                        ha = "left"
+                    else:
+                        va = "center"
+                        ha = "right"
+                    axes.text(
+                        xplc,
+                        y_here,
+                        " %s" % label,
+                        verticalalignment=va,
+                        horizontalalignment=ha,
+                        color=get_label_color(label),
+                        )
+            
+            # Add label above the branch (optional)
+            if draw_labels:
+                conf_label = format_branch_label(clade)
+                if conf_label:
+                    axes.text(
+                        0.5 * (x_start + x_here),
+                        y_here,
+                        conf_label,
+                        fontsize="small",
+                        horizontalalignment="center",
+                    )
+            if clade.clades:
+                # Draw a vertical line connecting all children
+                y_top = y_posns[clade.clades[0]]
+                y_bot = y_posns[clade.clades[-1]]
+                # Only apply widths to horizontal lines, like Archaeopteryx
+                draw_clade_lines(
+                    use_linecollection=True,
+                    orientation="vertical",
+                    x_here=x_here,
+                    y_bot=y_bot,
+                    y_top=y_top,
+                    color=color,
+                    lw=lw,
+                )
+                # Draw descendents
+                for child in clade:
+                    draw_clade(child, x_here, color, lw)
+                    
+        elif orient_tree == "horizontal":
+            draw_clade_lines(
+                use_linecollection=True,
+                orientation="vertical", 
+                x_here=y_here, 
+                y_bot=x_start, 
+                y_top=x_here,
+                color=color,
+                lw=lw,
+            )
+            #if this is one of the terminal branches and we want to align the 
+            #labels then add a dashed line going from the end of the branch to
+            #the start of the label
+            if clade in tree.get_terminals() and align_labels:
+                draw_clade_lines(
+                    use_linecollection=True,
+                    orientation="vertical", 
+                    x_here=y_here, 
+                    y_bot=x_here, 
+                    y_top=xmax,
+                    color=color,
+                    lw=lw-1,
+                    linestyle="-.",
+                )
+            # Add node/taxon labels
+            label = label_func(clade)
+            if label not in (None, clade.__class__.__name__):
+                if align_labels and clade in tree.get_terminals():
+                    xplc = max(x_posns.values())+max(x_posns.values())/30
+                else:
+                    xplc = x_here
+                if draw_labels:
+                    if horizontal_direction == "up":
+                        va = "bottom"
+                        ha = "center"
+                    else:
+                        va = "top"
+                        ha = "center"
+                    axes.text(
+                        y_here, 
+                        xplc,  
+                        " %s" % label, 
+                        verticalalignment=va, 
+                        horizontalalignment=ha, 
+                        color=get_label_color(label),
+                        rotation=90
+                        )
+                    
+            # Add label above the branch (optional)
+            if draw_labels:
+                conf_label = format_branch_label(clade)
+                if conf_label:
+                    axes.text(
+                        0.5 * (y_posns[clade.clades[-1]] + y_here),
+                        x_here,
+                        conf_label,
+                        fontsize="small",
+                        horizontalalignment="center",
+                    )
+            if clade.clades:
+                # Draw a vertical line connecting all children
+                y_top = y_posns[clade.clades[0]]
+                y_bot = y_posns[clade.clades[-1]]
+                # Only apply widths to horizontal lines, like Archaeopteryx
+                draw_clade_lines(
+                    use_linecollection=True,
+                    orientation="horizontal",
+                    y_here=x_here,
+                    x_start=y_bot,
+                    x_here=y_top,
+                    color=color,
+                    lw=lw,
+                )
+                # Draw descendents
+                for child in clade:
+                    draw_clade(child, x_here, color, lw)
+    
+    
+    def draw_clade_polar(clade, color, lw, x_start=0, y_start=0):
+        
+        try:
+            import numpy as np
+        except ImportError:
+                raise MissingPythonDependencyError(
+                    "Install numpy if you want to draw a circular tree."
+                ) from None
+        
+        try:
+            from scipy.interpolate import interp1d
+        except ImportError:
+                raise MissingPythonDependencyError(
+                    "Install scipy if you want to draw a circular tree."
+                ) from None
+        
+        #get the maximum y value and divide this by the circular span defined to give the angle that each y value is associated with
+        ymax = max(y_posns.values())
+        yang = circular_span/ymax
+        xmax = max(x_posns.values())+max(x_posns.values())/30
+        
+        #convert the circular span from degrees to radians
+        rad = (circular_span*np.pi/180)/ymax
+    
+        x_here = x_posns[clade]
+        y_here = y_posns[clade]*rad
+        
+        #if x_here != 0: 
+        axes.plot([y_start, y_here], [x_start, x_here], color=color, lw=lw)
+        #if this is one of the terminal branches and we want to align the 
+        #labels then add a dashed line going from the end of the branch to
+        #the start of the label
+        if clade in tree.get_terminals() and align_labels:
+            axes.plot([y_start, y_here], [x_here, xmax], color=color, lw=lw-1, linestyle='-.')
+        
+        #plot the labels on branches and rotate them appropriately
+        rot = y_here*(180/np.pi)
+        label = label_func(clade)
+        if clade.name not in (None, clade.__class__.__name__):
+            if align_labels and clade in tree.get_terminals(): 
+                xplc = xmax
+            else: 
+                xplc = x_here
+            
+            if rot <= 90: 
+                va, ha = "center", "left"
+            elif rot <= 180: 
+                va, ha, rot = "center", "right", rot-180
+            elif rot <= 270: 
+                va, ha, rot = "center", "right", rot-180
+            else: 
+                va, ha = "center", "left"
+            
+            if draw_labels: 
+                axes.text(y_here, xplc, label, color='k', rotation=rot, rotation_mode='anchor', va=va, ha=ha)
+            
+
+        if clade.clades:
+            
+            #multiply the y values by the angle needed and convert this to radians
+            y_top = y_posns[clade.clades[0]]*yang*np.pi/180
+            y_bot = y_posns[clade.clades[-1]]*yang*np.pi/180
+            
+            #plot a curve between this angle and the previous angle along the x axis
+            curve = [[y_bot, y_top], [x_here, x_here]]
+            
+            x = np.linspace(curve[0][0], curve[0][1], 500)
+            y = interp1d(curve[0], curve[1])(x)
+            axes.plot(x, y, color=color, lw=lw)
+            
+            #calculate the distance between each branch coming from this x line
+            ymin, ymax = min(x), max(x)
+            ydiff = ymax-ymin
+            c1 = [1 for child in clade]
+            c1 = sum(c1)-2
+            
+            locs = [ymin]
+            for a in range(c1):
+                locs.append(ydiff/(c1+1)+ymin)
+            locs.append(ymax)
+            
+            #plot the children, ensuring that they start on one of the x locations
+            #along the branch that we've calculated
+            count = 0
             for child in clade:
-                draw_clade(child, x_here, color, lw)
+                if child in tree.get_terminals(): 
+                    y_start = y_posns[child]*rad
+                else:
+                    y_start = locs[count]
+                draw_clade_polar(child, color, lw, x_start=x_here, y_start=y_start)
+                count += 1
+        
+        
+        return
+    
+    if orient_tree in ["horizontal", "vertical"]:
+        draw_clade(tree.root, 0, "k", plt.rcParams["lines.linewidth"])
+        # If line collections were used to create clade lines, here they are added
+        # to the pyplot plot.
+        for i in horizontal_linecollections:
+            axes.add_collection(i)
+        for i in vertical_linecollections:
+            axes.add_collection(i)
+        
+        if orient_tree == "vertical":
+            axes.set_xlabel("branch length")
+            axes.set_ylabel("taxa")
+            # Add margins around the tree to prevent overlapping the axes
+            # Also invert the y-axis (origin at the top)
+            # Add a small vertical margin, but avoid including 0 and N+1 on the y axis
+            axes.set_ylim(max(y_posns.values()) + 0.8, 0.2)
+            xmax = max(x_posns.values())
+            if vertical_direction == "right":
+                axes.set_xlim(-0.05 * xmax, 1.25 * xmax)
+            else:
+                axes.set_xlim(1.25 * xmax, -0.05 * xmax)
+        else:
+            axes.set_ylabel("branch length")
+            axes.set_xlabel("taxa")
+            # Add margins around the tree to prevent overlapping the axes
+            # Add a small horizontal margin, but avoid including 0 and N+1 on the y axis
+            axes.set_xlim(max(y_posns.values()) + 0.8, 0.2)
+            xmax = max(x_posns.values())
+            if horizontal_direction == "down" and align_labels:
+                axes.set_ylim(1.5 * xmax, -0.05 * xmax)
+            elif horizontal_direction == "down":
+                axes.set_ylim(1.25 * xmax, -0.05 * xmax)
+            elif horizontal_direction == "up" and align_labels:
+                axes.set_ylim(-0.05 * xmax, 1.6 * xmax)
+            else:
+                axes.set_ylim(-0.05 * xmax, 1.25 * xmax)
+            
+        
+    elif orient_tree == "circular":
+        draw_clade_polar(tree.root, "k", plt.rcParams["lines.linewidth"])
+        xmax = max(x_posns.values())
+        if draw_labels and align_labels:
+            axes.set_ylim([0, 1.5*xmax])
+        elif draw_labels:
+            axes.set_ylim([0, 1.25*xmax])
+        else:
+            axes.set_ylim([0, xmax])
 
-    draw_clade(tree.root, 0, "k", plt.rcParams["lines.linewidth"])
-
-    # If line collections were used to create clade lines, here they are added
-    # to the pyplot plot.
-    for i in horizontal_linecollections:
-        axes.add_collection(i)
-    for i in vertical_linecollections:
-        axes.add_collection(i)
 
     # Aesthetics
 
@@ -473,14 +759,7 @@ def draw(
     else:
         if name:
             axes.set_title(name)
-    axes.set_xlabel("branch length")
-    axes.set_ylabel("taxa")
-    # Add margins around the tree to prevent overlapping the axes
-    xmax = max(x_posns.values())
-    axes.set_xlim(-0.05 * xmax, 1.25 * xmax)
-    # Also invert the y-axis (origin at the top)
-    # Add a small vertical margin, but avoid including 0 and N+1 on the y axis
-    axes.set_ylim(max(y_posns.values()) + 0.8, 0.2)
+    
 
     # Parse and process key word arguments as pyplot options
     for key, value in kwargs.items():

--- a/Bio/Phylo/_utils.py
+++ b/Bio/Phylo/_utils.py
@@ -473,7 +473,7 @@ def draw(
                     x_start=x_here,
                     x_here=xmax,
                     color=color,
-                    lw=( lw - 1 ),
+                    lw=(lw - 1),
                     linestyle="-.",
                 )
             # Add node/taxon labels
@@ -549,7 +549,7 @@ def draw(
                     y_bot=x_here,
                     y_top=xmax,
                     color=color,
-                    lw=( lw - 1 ),
+                    lw=(lw - 1),
                     linestyle="-.",
                 )
             # Add node/taxon labels
@@ -627,10 +627,10 @@ def draw(
         xmax = max(x_posns.values()) + max(x_posns.values()) / 30
 
         # convert the circular span from degrees to radians
-        rad = ( circular_span * np.pi / 180 ) / ymax
+        rad = (circular_span * np.pi / 180) / ymax
 
         x_here = x_posns[clade]
-        y_here = y_posns[clade]*rad
+        y_here = y_posns[clade] * rad
 
         # if x_here != 0:
         axes.plot([y_start, y_here], [x_start, x_here], color=color, lw=lw)
@@ -638,10 +638,10 @@ def draw(
         # labels then add a dashed line going from the end of the branch to
         # the start of the label
         if clade in tree.get_terminals() and align_labels:
-            axes.plot([y_start, y_here], [x_here, xmax], color=color, lw=( lw - 1 ), linestyle="-.")
+            axes.plot([y_start, y_here], [x_here, xmax], color=color, lw=(lw - 1), linestyle="-.")
 
         # plot the labels on branches and rotate them appropriately
-        rot = y_here * ( 180 / np.pi )
+        rot = y_here * (180 / np.pi)
         label = label_func(clade)
         if clade.name not in (None, clade.__class__.__name__):
             if align_labels and clade in tree.get_terminals():
@@ -682,7 +682,7 @@ def draw(
 
             locs = [ymin]
             for a in range(c1):
-                locs.append( ydiff / ( c1 + 1 ) + ymin )
+                locs.append(ydiff / (c1 + 1) + ymin)
             locs.append(ymax)
 
             # plot the children, ensuring that they start on one of the x locations

--- a/Bio/Phylo/_utils.py
+++ b/Bio/Phylo/_utils.py
@@ -188,9 +188,9 @@ def draw(
     axes=None,
     branch_labels=None,
     label_colors=None,
-    orient_tree='vertical',
-    horizontal_direction='down',
-    vertical_direction='right',
+    orient_tree="vertical",
+    horizontal_direction="down",
+    vertical_direction="right",
     circular_span=355,
     draw_labels=True,
     align_labels=False,
@@ -251,24 +251,24 @@ def draw(
             None, the label will be shown in black.
         orient_tree : string of 'horizontal', 'vertical' or 'circular'
             Whether the tree should be vertically oriented (default; i.e. leaves
-            are plotted from top to bottom), horizontally oriented (i.e. leaves 
+            are plotted from top to bottom), horizontally oriented (i.e. leaves
             are plotted from left to right) or a circular tree. Note that confidence
             labels will not be plotted on a circular tree.
         vertical_direction : string of 'left' or 'right'
-            If the tree is vertical, whether the leaves should be on the left 
+            If the tree is vertical, whether the leaves should be on the left
             (default) or the right.
         horizontal_direction : string of 'up' or 'down'
             If the tree is horizontal, whether the leaves should be on the bottom
             (default - down) or the top (up).
         circular_span : int or float between 0 and 365
-            How much of a circle the circular plot should span. This value is in 
+            How much of a circle the circular plot should span. This value is in
             degrees and is 355 (i.e. a small gap between the first and last leaf)
             by default.
         draw_labels : boolean
             Whether labels should be added to the tree (both branches and leaves).
             True by default.
         align_labels : boolean
-            Whether leaf labels should be aligned so as they are all in the same 
+            Whether leaf labels should be aligned so as they are all in the same
             position and have a dotted line joining them. False by default.
 
     """
@@ -283,7 +283,7 @@ def draw(
             ) from None
 
     import matplotlib.collections as mpcollections
-    
+
     if orient_tree not in ["horizontal", "vertical", "circular"]:
         raise ValueError("orient_tree must be one of 'horizontal', 'vertical' or 'circular'")
     if orient_tree == "vertical" and vertical_direction not in ["right", "left"]:
@@ -462,9 +462,9 @@ def draw(
                 color=color,
                 lw=lw,
             )
-            #if this is one of the terminal branches and we want to align the 
-            #labels then add a dashed line going from the end of the branch to
-            #the start of the label
+            # if this is one of the terminal branches and we want to align the
+            # labels then add a dashed line going from the end of the branch to
+            # the start of the label
             if clade in tree.get_terminals() and align_labels:
                 draw_clade_lines(
                     use_linecollection=True,
@@ -473,14 +473,14 @@ def draw(
                     x_start=x_here,
                     x_here=xmax,
                     color=color,
-                    lw=lw-1,
+                    lw=( lw - 1 ),
                     linestyle="-.",
                 )
             # Add node/taxon labels
             label = label_func(clade)
             if label not in (None, clade.__class__.__name__):
                 if align_labels and clade in tree.get_terminals():
-                    xplc = max(x_posns.values())+max(x_posns.values())/30
+                    xplc = max(x_posns.values()) + max(x_posns.values()) / 30
                 else:
                     xplc = x_here
                 if draw_labels:
@@ -497,8 +497,8 @@ def draw(
                         verticalalignment=va,
                         horizontalalignment=ha,
                         color=get_label_color(label),
-                        )
-            
+                    )
+
             # Add label above the branch (optional)
             if draw_labels:
                 conf_label = format_branch_label(clade)
@@ -527,36 +527,36 @@ def draw(
                 # Draw descendents
                 for child in clade:
                     draw_clade(child, x_here, color, lw)
-                    
+
         elif orient_tree == "horizontal":
             draw_clade_lines(
                 use_linecollection=True,
-                orientation="vertical", 
-                x_here=y_here, 
-                y_bot=x_start, 
+                orientation="vertical",
+                x_here=y_here,
+                y_bot=x_start,
                 y_top=x_here,
                 color=color,
                 lw=lw,
             )
-            #if this is one of the terminal branches and we want to align the 
-            #labels then add a dashed line going from the end of the branch to
-            #the start of the label
+            # if this is one of the terminal branches and we want to align the
+            # labels then add a dashed line going from the end of the branch to
+            # the start of the label
             if clade in tree.get_terminals() and align_labels:
                 draw_clade_lines(
                     use_linecollection=True,
-                    orientation="vertical", 
-                    x_here=y_here, 
-                    y_bot=x_here, 
+                    orientation="vertical",
+                    x_here=y_here,
+                    y_bot=x_here,
                     y_top=xmax,
                     color=color,
-                    lw=lw-1,
+                    lw=( lw - 1 ),
                     linestyle="-.",
                 )
             # Add node/taxon labels
             label = label_func(clade)
             if label not in (None, clade.__class__.__name__):
                 if align_labels and clade in tree.get_terminals():
-                    xplc = max(x_posns.values())+max(x_posns.values())/30
+                    xplc = max(x_posns.values()) + max(x_posns.values()) / 30
                 else:
                     xplc = x_here
                 if draw_labels:
@@ -567,15 +567,15 @@ def draw(
                         va = "top"
                         ha = "center"
                     axes.text(
-                        y_here, 
-                        xplc,  
-                        " %s" % label, 
-                        verticalalignment=va, 
-                        horizontalalignment=ha, 
+                        y_here,
+                        xplc,
+                        " %s" % label,
+                        verticalalignment=va,
+                        horizontalalignment=ha,
                         color=get_label_color(label),
                         rotation=90
-                        )
-                    
+                    )
+
             # Add label above the branch (optional)
             if draw_labels:
                 conf_label = format_branch_label(clade)
@@ -604,103 +604,100 @@ def draw(
                 # Draw descendents
                 for child in clade:
                     draw_clade(child, x_here, color, lw)
-    
-    
+
     def draw_clade_polar(clade, color, lw, x_start=0, y_start=0):
-        
+
         try:
             import numpy as np
         except ImportError:
-                raise MissingPythonDependencyError(
-                    "Install numpy if you want to draw a circular tree."
-                ) from None
-        
+            raise MissingPythonDependencyError(
+                "Install numpy if you want to draw a circular tree."
+            ) from None
+
         try:
             from scipy.interpolate import interp1d
         except ImportError:
-                raise MissingPythonDependencyError(
-                    "Install scipy if you want to draw a circular tree."
-                ) from None
-        
-        #get the maximum y value and divide this by the circular span defined to give the angle that each y value is associated with
+            raise MissingPythonDependencyError(
+                "Install scipy if you want to draw a circular tree."
+            ) from None
+
+        # get the maximum y value and divide this by the circular span defined to give the angle that each y value is associated with
         ymax = max(y_posns.values())
-        yang = circular_span/ymax
-        xmax = max(x_posns.values())+max(x_posns.values())/30
-        
-        #convert the circular span from degrees to radians
-        rad = (circular_span*np.pi/180)/ymax
-    
+        yang = circular_span / ymax
+        xmax = max(x_posns.values()) + max(x_posns.values()) / 30
+
+        # convert the circular span from degrees to radians
+        rad = ( circular_span * np.pi / 180 ) / ymax
+
         x_here = x_posns[clade]
         y_here = y_posns[clade]*rad
-        
-        #if x_here != 0: 
+
+        # if x_here != 0:
         axes.plot([y_start, y_here], [x_start, x_here], color=color, lw=lw)
-        #if this is one of the terminal branches and we want to align the 
-        #labels then add a dashed line going from the end of the branch to
-        #the start of the label
+        # if this is one of the terminal branches and we want to align the
+        # labels then add a dashed line going from the end of the branch to
+        # the start of the label
         if clade in tree.get_terminals() and align_labels:
-            axes.plot([y_start, y_here], [x_here, xmax], color=color, lw=lw-1, linestyle='-.')
-        
-        #plot the labels on branches and rotate them appropriately
-        rot = y_here*(180/np.pi)
+            axes.plot([y_start, y_here], [x_here, xmax], color=color, lw=( lw - 1 ), linestyle="-.")
+
+        # plot the labels on branches and rotate them appropriately
+        rot = y_here * ( 180 / np.pi )
         label = label_func(clade)
         if clade.name not in (None, clade.__class__.__name__):
-            if align_labels and clade in tree.get_terminals(): 
+            if align_labels and clade in tree.get_terminals():
                 xplc = xmax
-            else: 
+            else:
                 xplc = x_here
-            
-            if rot <= 90: 
+
+            if rot <= 90:
                 va, ha = "center", "left"
-            elif rot <= 180: 
-                va, ha, rot = "center", "right", rot-180
-            elif rot <= 270: 
-                va, ha, rot = "center", "right", rot-180
-            else: 
+            elif rot <= 180:
+                va, ha, rot = "center", "right", rot - 180
+            elif rot <= 270:
+                va, ha, rot = "center", "right", rot - 180
+            else:
                 va, ha = "center", "left"
-            
-            if draw_labels: 
-                axes.text(y_here, xplc, label, color='k', rotation=rot, rotation_mode='anchor', va=va, ha=ha)
-            
+
+            if draw_labels:
+                axes.text(y_here, xplc, label, color="k", rotation=rot, rotation_mode="anchor", va=va, ha=ha)
 
         if clade.clades:
-            
-            #multiply the y values by the angle needed and convert this to radians
-            y_top = y_posns[clade.clades[0]]*yang*np.pi/180
-            y_bot = y_posns[clade.clades[-1]]*yang*np.pi/180
-            
-            #plot a curve between this angle and the previous angle along the x axis
+
+            # multiply the y values by the angle needed and convert this to radians
+            y_top = y_posns[clade.clades[0]] * yang * np.pi / 180
+            y_bot = y_posns[clade.clades[-1]] * yang * np.pi / 180
+
+            # plot a curve between this angle and the previous angle along the x axis
             curve = [[y_bot, y_top], [x_here, x_here]]
-            
+
             x = np.linspace(curve[0][0], curve[0][1], 500)
             y = interp1d(curve[0], curve[1])(x)
             axes.plot(x, y, color=color, lw=lw)
-            
-            #calculate the distance between each branch coming from this x line
+
+            # calculate the distance between each branch coming from this x line
             ymin, ymax = min(x), max(x)
-            ydiff = ymax-ymin
+            ydiff = ymax - ymin
             c1 = [1 for child in clade]
-            c1 = sum(c1)-2
-            
+            c1 = sum(c1) - 2
+
             locs = [ymin]
             for a in range(c1):
-                locs.append(ydiff/(c1+1)+ymin)
+                locs.append( ydiff / ( c1 + 1 ) + ymin )
             locs.append(ymax)
-            
-            #plot the children, ensuring that they start on one of the x locations
-            #along the branch that we've calculated
+
+            # plot the children, ensuring that they start on one of the x locations
+            # along the branch that we've calculated
             count = 0
             for child in clade:
-                if child in tree.get_terminals(): 
-                    y_start = y_posns[child]*rad
+                if child in tree.get_terminals():
+                    y_start = y_posns[child] * rad
                 else:
                     y_start = locs[count]
                 draw_clade_polar(child, color, lw, x_start=x_here, y_start=y_start)
                 count += 1
-        
-        
+
         return
-    
+
     if orient_tree in ["horizontal", "vertical"]:
         draw_clade(tree.root, 0, "k", plt.rcParams["lines.linewidth"])
         # If line collections were used to create clade lines, here they are added
@@ -709,7 +706,7 @@ def draw(
             axes.add_collection(i)
         for i in vertical_linecollections:
             axes.add_collection(i)
-        
+
         if orient_tree == "vertical":
             axes.set_xlabel("branch length")
             axes.set_ylabel("taxa")
@@ -737,18 +734,16 @@ def draw(
                 axes.set_ylim(-0.05 * xmax, 1.6 * xmax)
             else:
                 axes.set_ylim(-0.05 * xmax, 1.25 * xmax)
-            
-        
+
     elif orient_tree == "circular":
         draw_clade_polar(tree.root, "k", plt.rcParams["lines.linewidth"])
         xmax = max(x_posns.values())
         if draw_labels and align_labels:
-            axes.set_ylim([0, 1.5*xmax])
+            axes.set_ylim([0, 1.5 * xmax])
         elif draw_labels:
-            axes.set_ylim([0, 1.25*xmax])
+            axes.set_ylim([0, 1.25 * xmax])
         else:
             axes.set_ylim([0, xmax])
-
 
     # Aesthetics
 
@@ -759,7 +754,6 @@ def draw(
     else:
         if name:
             axes.set_title(name)
-    
 
     # Parse and process key word arguments as pyplot options
     for key, value in kwargs.items():

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -248,6 +248,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Richard Neher <https://github.com/rneher>
 - Rob Miller <https://github.com/rob-miller>
 - Robert Ernst <https://github.com/rernst>
+- Robyn Wright <https://github.com/R-Wright-1>
 - Rodrigo Dorantes-Gilardi <https://github.com/rodogi>
 - Rona Costello <https://github.com/RonaCostello>
 - Sacha Laurent <https://github.com/Cashalow>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -30,6 +30,7 @@ possible, especially the following contributors:
 - Aziz Khan
 - Chenghao Zhu
 - Fabian Egli
+- Robyn Wright
 
 
 3 June 2021: Biopython 1.79


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

I added some functionality to tree drawing for myself, and thought it might be useful to others. If you don't want to add it in then I thought just having it here might be useful to someone else looking to expand on the existing tree drawing capabilities. Let me know if there's anything you'd like me to change.

The updates give the options to draw the default vertical trees facing either left or right, to draw horizontal trees (facing either up or down), to draw circular trees (this also requires numpy [numpy.pi and numpy.linspace] and scipy [scipy.interpolate.interp1d]) and also to align the terminal leaf labels. This is using the following options:
**orient_tree** - this gives the option to have the tree be either vertical (default), horizontal or circular
**vertical_direction** - the option for a vertical tree to be facing left or right
**horizontal_direction** - the option for a horizontal tree to be facing up or down
**circular_span** - how much of a circle (i.e. 360 degrees) a circular tree should take up
**draw_labels** - whether to draw any labels on the tree
**align_labels** - whether all labels should be drawn in line with eachother, connected from the end of the branch by a dotted line

![](https://github.com/R-Wright-1/peptides/blob/master/test_trees.png?raw=true)
This is an example made with the following code:
```
from Bio import Phylo
import matplotlib.pyplot as plt

tree = Phylo.read('test_tree_2.txt', "newick")
fig = plt.figure(figsize=(20,30))
ax1 = plt.subplot2grid((5,1), (0,0))
Phylo.draw(tree, orient_tree='horizontal', horizontal_direction='up', axes=ax1, draw_labels=True, align_labels=True, show_confidence=False, do_show=False)

ax2 = plt.subplot2grid((5,2), (1,0), rowspan=2)
Phylo.draw(tree, orient_tree='vertical', vertical_direction='left', axes=ax2, draw_labels=True, show_confidence=False, do_show=False)

ax3 = plt.subplot2grid((5,2), (1,1), rowspan=2)
Phylo.draw(tree, axes=ax3, do_show=False)

ax4 = plt.subplot2grid((5,4), (3,0), colspan=2, rowspan=2, projection='polar')
Phylo.draw(tree, orient_tree='circular', vertical_direction='left', axes=ax4, draw_labels=True, align_labels=True, show_confidence=False, do_show=False)

ax5 = plt.subplot2grid((5,4), (3,2), frameon=False, colspan=2, rowspan=2, projection='polar')
Phylo.draw(tree, orient_tree='circular', vertical_direction='left', axes=ax5, draw_labels=True, show_confidence=False, do_show=False, circular_span=280)
ax5.yaxis.grid(False), ax5.set_xticks([]), ax5.set_yticklabels([])

ax1.set_title('Horizontal tree facing up with aligned labels', fontweight='bold'), ax2.set_title('Vertical tree facing left without aligned labels', fontweight='bold'), ax3.set_title('Default tree', fontweight='bold'), ax4.set_title('Circular tree with aligned labels and default span (355)', fontweight='bold'), ax5.set_title('Circular tree with span 280 and no frame, grid lines, x ticks or y ticks', fontweight='bold')
plt.subplots_adjust(hspace=0.2)
plt.savefig('test_trees.png', bbox_inches='tight', dpi=300)
```
