### PR TITLE
Assorted spelling fixes via Codespell

### DIFF
--- a/Bio/Align/Applications/_Mafft.py
+++ b/Bio/Align/Applications/_Mafft.py
@@ -256,7 +256,7 @@ class MafftCommandline(AbstractCommandline):
                 equate=False,
             ),
             # Offset value, which works like gap extension penalty, for group-to-
-            # group alignment. Deafult: 0.123
+            # group alignment. Default: 0.123
             _Option(
                 ["--ep", "ep"],
                 "Offset value, which works like gap extension penalty, "
@@ -394,12 +394,12 @@ class MafftCommandline(AbstractCommandline):
                 "Do not report progress (True) or not (False, default).",
             ),
             # **** Input ****
-            # Assume the sequences are nucleotide. Deafult: auto
+            # Assume the sequences are nucleotide. Default: auto
             _Switch(
                 ["--nuc", "nuc"],
                 "Assume the sequences are nucleotide (True/False). Default: auto",
             ),
-            # Assume the sequences are amino acid. Deafult: auto
+            # Assume the sequences are amino acid. Default: auto
             _Switch(
                 ["--amino", "amino"],
                 "Assume the sequences are amino acid (True/False). Default: auto",

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -2798,7 +2798,7 @@ class PairwiseAligner(_aligners.PairwiseAligner):
     <BLANKLINE>
 
     You can also set the value of attributes directly during construction
-    of the PairwiseAligner object by providing them as keyword arguemnts:
+    of the PairwiseAligner object by providing them as keyword arguments:
 
     >>> aligner = Align.PairwiseAligner(mode='global', match_score=2, mismatch_score=-1)
     >>> for alignment in aligner.align("TACCG", "ACG"):

--- a/Bio/Application/__init__.py
+++ b/Bio/Application/__init__.py
@@ -21,7 +21,7 @@ construct command line strings by setting the values of each parameter.
 The finished command line strings are then normally invoked via the built-in
 Python module subprocess.
 
-Due to the on going maintainance burden or keeping command line application
+Due to the on going maintenance burden or keeping command line application
 wrappers up to date, we have decided to deprecate and eventually remove them.
 We instead now recommend building your command line and invoking it directly
 with the subprocess module.

--- a/Bio/Data/CodonTable.py
+++ b/Bio/Data/CodonTable.py
@@ -268,7 +268,7 @@ def list_possible_proteins(codon, forward_table, ambiguous_nucleotide_values):
 
 
 def list_ambiguous_codons(codons, ambiguous_nucleotide_values):
-    """Extend a codon list to include all possible ambigous codons.
+    """Extend a codon list to include all possible ambiguous codons.
 
     e.g.::
 

--- a/Bio/GenBank/Record.py
+++ b/Bio/GenBank/Record.py
@@ -610,7 +610,7 @@ class Feature:
     """Hold information about a Feature in the Feature Table of GenBank record.
 
     Attributes:
-     - key - The key name of the featue (ie. source)
+     - key - The key name of the feature (ie. source)
      - location - The string specifying the location of the feature.
      - qualfiers - A list of Qualifier objects in the feature.
 

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -391,7 +391,7 @@ class InsdcScanner:
         return [], ""  # Dummy values!
 
     def _feed_first_line(self, consumer, line):
-        """Handle the LOCUS/ID line, passing data to the comsumer (PRIVATE).
+        """Handle the LOCUS/ID line, passing data to the consumer (PRIVATE).
 
         This should be implemented by the EMBL / GenBank specific subclass
 
@@ -400,7 +400,7 @@ class InsdcScanner:
         pass
 
     def _feed_header_lines(self, consumer, lines):
-        """Handle the header lines (list of strings), passing data to the comsumer (PRIVATE).
+        """Handle the header lines (list of strings), passing data to the consumer (PRIVATE).
 
         This should be implemented by the EMBL / GenBank specific subclass
 
@@ -410,7 +410,7 @@ class InsdcScanner:
 
     @staticmethod
     def _feed_feature_table(consumer, feature_tuples):
-        """Handle the feature table (list of tuples), passing data to the comsumer (PRIVATE).
+        """Handle the feature table (list of tuples), passing data to the consumer (PRIVATE).
 
         Used by the parse_records() and parse() methods.
         """
@@ -537,7 +537,7 @@ class InsdcScanner:
 
         Arguments:
          - alphabet - Obsolete, should be left as None.
-         - tags2id  - Tupple of three strings, the feature keys to use
+         - tags2id  - Tuple of three strings, the feature keys to use
            for the record id, name and description,
 
         This method is intended for use in Bio.SeqIO
@@ -982,7 +982,7 @@ class EmblScanner(InsdcScanner):
                         if not line:
                             break
                         elif line.startswith("CO   "):
-                            # Don't need to preseve the whitespace here.
+                            # Don't need to preserve the whitespace here.
                             contig_location += line[5:].strip()
                         else:
                             raise ValueError(
@@ -1883,7 +1883,7 @@ class GenBankScanner(InsdcScanner):
                         if not line:
                             break
                         elif line[: self.GENBANK_INDENT] == self.GENBANK_SPACER:
-                            # Don't need to preseve the whitespace here.
+                            # Don't need to preserve the whitespace here.
                             contig_location += line[self.GENBANK_INDENT :].rstrip()
                         elif line.startswith("ORIGIN"):
                             # Strange, seen this in GenPept files via Entrez gbwithparts

--- a/Bio/Graphics/BasicChromosome.py
+++ b/Bio/Graphics/BasicChromosome.py
@@ -512,10 +512,10 @@ class ChromosomeSegment(_ChromosomeComponent):
 
 
 def _spring_layout(desired, minimum, maximum, gap=0):
-    """Try to layout label co-ordinates or other floats (PRIVATE).
+    """Try to layout label coordinates or other floats (PRIVATE).
 
     Originally written for the y-axis vertical positioning of labels on a
-    chromosome diagram (where the minimum gap between y-axis co-ordinates is
+    chromosome diagram (where the minimum gap between y-axis coordinates is
     the label height), it could also potentially be used for x-axis placement,
     or indeed radial placement for circular chromosomes within GenomeDiagram.
 

--- a/Bio/Graphics/BasicChromosome.py
+++ b/Bio/Graphics/BasicChromosome.py
@@ -209,7 +209,7 @@ class Chromosome(_ChromosomeComponent):
          - scale_num - A number of scale the drawing by. This is useful if
            you want to draw multiple chromosomes of different sizes at the
            same scale. If this is not set, then the chromosome drawing will
-           be scaled by the number of segements in the chromosome (so each
+           be scaled by the number of segments in the chromosome (so each
            chromosome will be the exact same final size).
 
         """
@@ -641,13 +641,13 @@ class AnnotatedChromosomeSegment(ChromosomeSegment):
         ReportLab color (string or object), and optional ReportLab fill color.
 
         Note we require 0 <= start <= end <= bp_length, and within the vertical
-        space allocated to this segmenet lines will be places according to the
+        space allocated to this segment lines will be places according to the
         start/end coordinates (starting from the top).
 
         Positive stand features are drawn on the right, negative on the left,
         otherwise all the way across.
 
-        We recommend using consisent units for all the segment's scale values
+        We recommend using consistent units for all the segment's scale values
         (e.g. their length in base pairs).
 
         When providing features as SeqFeature objects, the default color

--- a/Bio/Graphics/ColorSpiral.py
+++ b/Bio/Graphics/ColorSpiral.py
@@ -97,7 +97,7 @@ class ColorSpiral:
                 log(n + (k * offset)) - log((1 + offset) * k * self._a)
             )
             # Put 0 <= h <= 2*pi, where h is the angular part of the polar
-            # co-ordinates for this point on the spiral
+            # coordinates for this point on the spiral
             h = t
             while h < 0:
                 h += 2 * pi

--- a/Bio/Graphics/DisplayRepresentation.py
+++ b/Bio/Graphics/DisplayRepresentation.py
@@ -120,7 +120,7 @@ class ChromosomeCounts:
     def get_segment_info(self):
         """Retrieve the color and label info about the segments.
 
-        Returns a list consiting of two tuples specifying the counts and
+        Returns a list consisting of two tuples specifying the counts and
         label name for each segment. The list is ordered according to the
         original listing of names. Labels are set as None if no label
         was specified.

--- a/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_AbstractDrawer.py
@@ -18,7 +18,7 @@ Provides:
  - page_sizes - Method that returns a ReportLab pagesize when passed
    a valid ISO size
  - draw_box - Method that returns a closed path object when passed
-   the proper co-ordinates.  For HORIZONTAL boxes only.
+   the proper coordinates.  For HORIZONTAL boxes only.
  - angle2trig - Method that returns a tuple of values that are the
    vector for rotating a point through a passed angle,
    about an origin
@@ -252,7 +252,7 @@ def draw_arrow(
 
     # Depending on the orientation, we define the bottom left (x1, y1) and
     # top right (x2, y2) coordinates differently, but still draw the box
-    # using the same relative co-ordinates:
+    # using the same relative coordinates:
     xmin, ymin = min(x1, x2), min(y1, y2)
     xmax, ymax = max(x1, x2), max(y1, y2)
     if orientation == "right":

--- a/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
@@ -304,7 +304,7 @@ class CircularDrawer(AbstractDrawer):
          - locend        The end position of the feature
 
         """
-        # Establish the co-ordinates for the sigil
+        # Establish the coordinates for the sigil
         btm, ctr, top = self.track_radii[self.current_track_level]
 
         startangle, startcos, startsin = self.canvas_angle(locstart)
@@ -904,7 +904,7 @@ class CircularDrawer(AbstractDrawer):
          - draw_label    Boolean, write the tick label?
 
         """
-        # Calculate tick co-ordinates
+        # Calculate tick coordinates
         tickangle, tickcos, ticksin = self.canvas_angle(tickpos)
         x0, y0 = self.xcenter + ctr * ticksin, self.ycenter + ctr * tickcos
         x1, y1 = (

--- a/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
@@ -381,7 +381,7 @@ class LinearDrawer(AbstractDrawer):
                 "Tick at %i, but showing %r to %r for track"
                 % (tickpos, track.start, track.end)
             )
-        fragment, tickx = self.canvas_location(tickpos)  # Tick co-ordinates
+        fragment, tickx = self.canvas_location(tickpos)  # Tick coordinates
         assert fragment >= 0, "Fragment %i, tickpos %i" % (fragment, tickpos)
         tctr = ctr + self.fragment_lines[fragment][0]  # Center line of the track
         tickx += self.x0  # Tick X co-ord
@@ -1049,14 +1049,14 @@ class LinearDrawer(AbstractDrawer):
 
         Arguments:
          - feature       Feature object
-         - x0            Start X co-ordinate on diagram
-         - x1            End X co-ordinate on diagram
+         - x0            Start X coordinate on diagram
+         - x1            End X coordinate on diagram
          - fragment      The fragment on which the feature appears
 
         Returns a drawable indicator of the feature, and any required label
         for it.
         """
-        # Establish co-ordinates for drawing
+        # Establish coordinates for drawing
         x0, x1 = self.x0 + x0, self.x0 + x1
         btm, ctr, top = self.track_offsets[self.current_track_level]
         try:

--- a/Bio/Graphics/KGML_vis.py
+++ b/Bio/Graphics/KGML_vis.py
@@ -236,7 +236,7 @@ class KGMLCanvas:
             self.drawing.drawPath(p)
             self.drawing.setLineWidth(1)  # Return to default
         # KGML defines the (x, y) coordinates as the centre of the circle/
-        # rectangle/roundrectangle, but Reportlab uses the co-ordinates of the
+        # rectangle/roundrectangle, but Reportlab uses the coordinates of the
         # lower-left corner for rectangle/elif.
         if graphics.type == "circle":
             self.drawing.circle(
@@ -402,7 +402,7 @@ class KGMLCanvas:
         Draws an arrow from the g_from Entry object to the g_to
         Entry object; both must have Graphics objects.
         """
-        # Centre and bound co-ordinates for the from and two objects
+        # Centre and bound coordinates for the from and two objects
         bounds_from, bounds_to = g_from.bounds, g_to.bounds
         centre_from = (
             0.5 * (bounds_from[0][0] + bounds_from[1][0]),

--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -577,7 +577,7 @@ class HiddenMarkovModel:
         pred_state_seq = {}
 
         # --- recursion
-        # loop over the training squence (i = 1 .. L)
+        # loop over the training sequence (i = 1 .. L)
         # NOTE: My index numbers are one less than what is given in Durbin
         # et al, since we are indexing the sequence going from 0 to
         # (Length - 1) not 1 to Length, like in Durbin et al.

--- a/Bio/KEGG/Compound/__init__.py
+++ b/Bio/KEGG/Compound/__init__.py
@@ -30,7 +30,7 @@ class Record:
 
     Attributes:
      - entry       The entry identifier.
-     - name        A list of the compund names.
+     - name        A list of the compound names.
      - formula     The chemical formula for the compound
      - mass        The molecular weight for the compound
      - pathway     A list of 3-tuples: ('PATH', pathway id, pathway)

--- a/Bio/KEGG/Enzyme/__init__.py
+++ b/Bio/KEGG/Enzyme/__init__.py
@@ -35,7 +35,7 @@ class Record:
     """Holds info from a KEGG Enzyme record.
 
     Attributes:
-     - entry       The EC number (withou the 'EC ').
+     - entry       The EC number (without the 'EC ').
      - name        A list of the enzyme names.
      - classname   A list of the classification terms.
      - sysname     The systematic name of the enzyme.

--- a/Bio/KEGG/KGML/KGML_pathway.py
+++ b/Bio/KEGG/KGML/KGML_pathway.py
@@ -399,7 +399,7 @@ class Entry:
     def bounds(self):
         """Coordinate bounds for all Graphics elements in the Entry.
 
-        Return the [(xmin, ymin), (xmax, ymax)] co-ordinates for the Entry
+        Return the [(xmin, ymin), (xmax, ymax)] coordinates for the Entry
         Graphics elements.
         """
         xlist, ylist = [], []
@@ -466,7 +466,7 @@ class Graphics:
      - name         Label for the graphics object
      - x            X-axis position of the object (int)
      - y            Y-axis position of the object (int)
-     - coords       polyline co-ordinates, list of (int, int) tuples
+     - coords       polyline coordinates, list of (int, int) tuples
      - type         object shape
      - width        object width (int)
      - height       object height (int)
@@ -543,7 +543,7 @@ class Graphics:
         _getheight, _setheight, _delheight, "The height of the graphics element."
     )
 
-    # We make sure that the polyline co-ordinates are integers, too
+    # We make sure that the polyline coordinates are integers, too
     def _getcoords(self):
         return self._coords
 
@@ -628,7 +628,7 @@ class Graphics:
         """Coordinate bounds for the Graphics element.
 
         Return the bounds of the Graphics object as an [(xmin, ymin),
-        (xmax, ymax)] tuple.  Co-ordinates give the centre of the
+        (xmax, ymax)] tuple.  Coordinates give the centre of the
         circle, rectangle, roundrectangle elements, so we have to
         adjust for the relevant width/height.
         """

--- a/Bio/KEGG/REST.py
+++ b/Bio/KEGG/REST.py
@@ -66,7 +66,7 @@ def kegg_info(database):
 
     """
     # TODO - return a string (rather than the handle?)
-    # TODO - chache and validate the organism code / T numbers?
+    # TODO - cache and validate the organism code / T numbers?
     # TODO - can we parse the somewhat formatted output?
     #
     # http://rest.kegg.jp/info/<database>

--- a/Bio/MarkovModel.py
+++ b/Bio/MarkovModel.py
@@ -540,7 +540,7 @@ def _mle(
 
 
 def _argmaxes(vector, allowance=None):
-    """Return indeces of the maximum values aong the vector (PRIVATE)."""
+    """Return indices of the maximum values aong the vector (PRIVATE)."""
     return [numpy.argmax(vector)]
 
 

--- a/Bio/NMR/xpktools.py
+++ b/Bio/NMR/xpktools.py
@@ -9,7 +9,7 @@ HEADERLEN = 6
 
 
 class XpkEntry:
-    """Provide dictonary access to single entry from nmrview .xpk file.
+    """Provide dictionary access to single entry from nmrview .xpk file.
 
     This class is suited for handling single lines of non-header data
     from an nmrview .xpk file. This class provides methods for extracting

--- a/Bio/Nexus/Trees.py
+++ b/Bio/Nexus/Trees.py
@@ -565,7 +565,7 @@ class Tree(Nodes.Chain):
         elif not taxon_list and ntax:
             taxon_list = ["taxon" + str(i + 1) for i in range(ntax)]
         elif not ntax and not taxon_list:
-            raise TreeError("Either numer of taxa or list of taxa must be specified.")
+            raise TreeError("Either number of taxa or list of taxa must be specified.")
         elif ntax != len(taxon_list):
             raise TreeError("Length of taxon list must correspond to ntax.")
         # initiate self with empty root
@@ -667,13 +667,13 @@ class Tree(Nodes.Chain):
                     info_string = ":0.00"
             elif self.branchlengths_only:  # write only branchlengths, ignore support
                 info_string = ":%1.5f" % (data.branchlength)
-            else:  # write suport and branchlengths (e.g. .con tree of mrbayes)
+            else:  # write support and branchlengths (e.g. .con tree of mrbayes)
                 if terminal:
                     info_string = ":%1.5f" % (data.branchlength)
                 else:
                     if (
                         data.branchlength is not None and data.support is not None
-                    ):  # we have blen and suppport
+                    ):  # we have blen and support
                         info_string = "%1.2f:%1.5f" % (data.support, data.branchlength)
                     elif data.branchlength is not None:  # we have only blen
                         info_string = "0.00000:%1.5f" % (data.branchlength)
@@ -849,7 +849,7 @@ class Tree(Nodes.Chain):
         )  # add branch to outgroup to unrooted tree
         _connect_subtree(root.id, ingroup_node)  # add ingroup
         _connect_subtree(root.id, outgroup_node)  # add outgroup
-        # if theres still a lonely node in self.chain, then it's the old root, and we delete it
+        # if there's still a lonely node in self.chain, then it's the old root, and we delete it
         oldroot = [
             i for i in self.all_ids() if self.node(i).prev is None and i != self.root
         ]

--- a/Bio/Nexus/cnexus.c
+++ b/Bio/Nexus/cnexus.c
@@ -77,7 +77,7 @@ static PyObject * cnexus_scanfile(PyObject *self, PyObject *args)
             /* we replace the ; at the end of command lines with special
              * character to make subsequent parsing of blocks easier */
             if (t==';' && !(quotelevel || speciallevel))
-                /* need an ascii code thats not part of a nexus file, used as
+                /* need an ascii code that's not part of a nexus file, used as
                  * separator */
                 *(scanned++)=7;
             else

--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -18,7 +18,7 @@ from Bio.PDB.PDBExceptions import PDBConstructionException
 
 
 class Entity:
-    """Basic container object for PDB heirachy.
+    """Basic container object for PDB hierarchy.
 
     Structure, Model, Chain and Residue are subclasses of Entity.
     It deals with storage and lookup.

--- a/Bio/PDB/FragmentMapper.py
+++ b/Bio/PDB/FragmentMapper.py
@@ -148,7 +148,7 @@ class Fragment:
         :param resname: residue name (eg. GLY).
         :type resname: string
 
-        :param ca_coord: the c-alpha coorinates of the residues
+        :param ca_coord: the c-alpha coordinates of the residues
         :type ca_coord: Numeric array with length 3
         """
         if self.counter >= self.length:
@@ -158,7 +158,7 @@ class Fragment:
         self.counter = self.counter + 1
 
     def __len__(self):
-        """Return lengt of the fragment."""
+        """Return length of the fragment."""
         return self.length
 
     def __sub__(self, other):

--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -24,7 +24,7 @@ class MMCIFParser:
         """Create a PDBParser object.
 
         The mmCIF parser calls a number of standard methods in an aggregated
-        StructureBuilder object. Normally this object is instanciated by the
+        StructureBuilder object. Normally this object is instantiated by the
         MMCIParser object itself, but if the user provides his/her own
         StructureBuilder object, the latter is used instead.
 
@@ -309,7 +309,7 @@ class FastMMCIFParser:
         """Create a FastMMCIFParser object.
 
         The mmCIF parser calls a number of standard methods in an aggregated
-        StructureBuilder object. Normally this object is instanciated by the
+        StructureBuilder object. Normally this object is instantiated by the
         parser object itself, but if the user provides his/her own
         StructureBuilder object, the latter is used instead.
 

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -421,7 +421,7 @@ class PDBList:
             Has a meaning only for obsolete structures.
             If True, download the obsolete structure
             to 'obsolete' folder, otherwise download won't be performed.
-            This option doesn't work for mmtf format as obsoleted structures are not availbe as mmtf.
+            This option doesn't work for mmtf format as obsoleted structures are not available as mmtf.
             (default: False)
 
         :type obsolete: bool

--- a/Bio/PDB/QCPSuperimposer/__init__.py
+++ b/Bio/PDB/QCPSuperimposer/__init__.py
@@ -110,7 +110,7 @@ class QCPSuperimposer:
         """
         # clear everything from previous runs
         self._clear()
-        # store cordinates
+        # store coordinates
         self.reference_coords = reference_coords
         self.coords = coords
         n = reference_coords.shape

--- a/Bio/PDB/SCADIO.py
+++ b/Bio/PDB/SCADIO.py
@@ -224,7 +224,7 @@ peptide_scad = """
 //    You may wish to modify it here to adjust the appearance of the model in terms of atom sphere
 //    or bond cylinder diameter, however the bond lengths are fixed with the supplied value when
 //    the data matrices are generated.  Atom sphere and bond cylinder radii may be individually
-//    adusted below as well.
+//    adjusted below as well.
 //
 //  $fn (fragment number) is an OpenSCAD parameter controlling the smoothness of the model surface.
 //    Smaller values will render faster, but yield more 'blocky' models.
@@ -411,7 +411,7 @@ module joiner(bondlen, scal, male=0, ver=0, supportSelect=0) {  // ver = differe
 //  bl : bond length
 //  br : bond radius
 //  scal : protein_scale
-//  key : option symbols dfined below
+//  key : option symbols defined below
 //  atm : atomic element symbol, used for color and radius by atom() routine above
 //  ver : make rotatable bonds slightly different based on value; currently unused
 //  supporSel : enable print-in-place support for rotatable bonds
@@ -657,7 +657,7 @@ amideOnly = false; // make only the first amide
                 }
             }
         } else if (h[h_residue] == "P") {
-            color("darkgray")   // hightlight Prolines in OpenSCAD renderer
+            color("darkgray")   // highlight Prolines in OpenSCAD renderer
                 hedron(h, rev, scal);
         } else {
             echo("unrecognised hedron", h[h_class]);
@@ -701,7 +701,7 @@ module dihedron(d,hedra,scal)
 /*
 //
 // Generate a residue consisting of the set of dihedra in the parameter 'r', referring to hedra the
-//   table speicified in the parameter 'hedra'.
+//   table specified in the parameter 'hedra'.
 //
 */
 module residue(r,hedra, scal)

--- a/Bio/PDB/mmtf/DefaultParser.py
+++ b/Bio/PDB/mmtf/DefaultParser.py
@@ -61,7 +61,7 @@ class StructureDecoder:
         :param atom_name: the atom name, e.g. CA for this atom
         :param serial_number: the serial id of the atom (e.g. 1)
         :param alternative_location_id: the alternative location id for the atom, if present
-        :param x: the x coordiante of the atom
+        :param x: the x coordinate of the atom
         :param y: the y coordinate of the atom
         :param z: the z coordinate of the atom
         :param occupancy: the occupancy of the atom

--- a/Bio/Phylo/Applications/_Fasttree.py
+++ b/Bio/Phylo/Applications/_Fasttree.py
@@ -514,7 +514,7 @@ class FastTreeCommandline(AbstractCommandline):
             ),
             _Option(
                 ["-constraintWeight", "constraintWeight"],
-                """Weight strength of contraints in topology searching.
+                """Weight strength of constraints in topology searching.
 
                     Constrained topology search options:
                     -constraintWeight -- how strongly to weight the constraints. A value of 1

--- a/Bio/Phylo/Applications/_Raxml.py
+++ b/Bio/Phylo/Applications/_Raxml.py
@@ -101,7 +101,7 @@ class RaxmlCommandline(AbstractCommandline):
 
                         b: Draw bipartition information on a tree provided with '-t'
                         based on multiple trees (e.g. form a bootstrap) in a file
-                        specifed by '-z'.
+                        specified by '-z'.
 
                         c: Check if the alignment can be properly read by RAxML.
 
@@ -121,7 +121,7 @@ class RaxmlCommandline(AbstractCommandline):
                         bootstrap tree under GAMMA and a more exhaustive algorithm.
 
                         j: Generate a bunch of bootstrapped alignment files from an
-                        original alignemnt file.
+                        original alignment file.
 
                         m: Compare bipartitions between two bunches of trees passed
                         via '-t' and '-z' respectively. This will return the

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -1088,7 +1088,7 @@ class Clade(TreeElement, TreeMixin):
         return iter(self.clades)
 
     def __len__(self):
-        """Return the number of clades directy under the root."""
+        """Return the number of clades directly under the root."""
         return len(self.clades)
 
     def __bool__(self):

--- a/Bio/Phylo/Consensus.py
+++ b/Bio/Phylo/Consensus.py
@@ -208,7 +208,7 @@ class _BitString(str):
         """Check if current bitstr1 is compatible with another bitstr2.
 
         Two conditions are considered as compatible:
-         1. bitstr1.contain(bitstr2) or vise versa;
+         1. bitstr1.contain(bitstr2) or vice versa;
          2. bitstr1.independent(bitstr2).
 
         """

--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -67,7 +67,7 @@ class _Matrix:
     >>> m[0,1]
     7
 
-    Also you can delete or insert a column&row of elemets by index.
+    Also you can delete or insert a column&row of elements by index.
 
     >>> m
     _Matrix(names=['Alpha', 'Beta', 'Gamma', 'Delta'], matrix=[[0], [7, 0], [8, 4, 0], [9, 5, 6, 0]])
@@ -914,7 +914,7 @@ class NNITreeSearcher(TreeSearcher):
                     left_right = left.clades[1]
                     right_left = right.clades[0]
                     right_right = right.clades[1]
-                    # neightbor 1 (left_left + right_right)
+                    # neighbor 1 (left_left + right_right)
                     del left.clades[1]
                     del right.clades[1]
                     left.clades.append(right_right)

--- a/Bio/PopGen/GenePop/Controller.py
+++ b/Bio/PopGen/GenePop/Controller.py
@@ -171,7 +171,7 @@ class _GenePopCommandline(AbstractCommandline):
     def __init__(self, genepop_dir=None, cmd="Genepop", **kwargs):
         self.parameters = [
             _Argument(["command"], "GenePop option to be called", is_required=True),
-            _Argument(["mode"], "Should allways be batch", is_required=True),
+            _Argument(["mode"], "Should always be batch", is_required=True),
             _Argument(["input"], "Input file", is_required=True),
             _Argument(["Dememorization"], "Dememorization step"),
             _Argument(["BatchNumber"], "Number of MCMC batches"),

--- a/Bio/SCOP/Dom.py
+++ b/Bio/SCOP/Dom.py
@@ -18,7 +18,7 @@ from .Residues import Residues
 class Record:
     """Holds information for one SCOP domain.
 
-    Attribues:
+    Attributes:
      - sid - The SCOP ID of the entry, e.g. d1anu1
      - residues - The domain definition as a Residues object
      - hierarchy - A string specifying where this domain is in the hierarchy.

--- a/Bio/SVDSuperimposer/__init__.py
+++ b/Bio/SVDSuperimposer/__init__.py
@@ -133,7 +133,7 @@ class SVDSuperimposer:
         """
         # clear everything from previous runs
         self._clear()
-        # store cordinates
+        # store coordinates
         self.reference_coords = reference_coords
         self.coords = coords
         n = reference_coords.shape

--- a/Bio/SearchIO/BlastIO/__init__.py
+++ b/Bio/SearchIO/BlastIO/__init__.py
@@ -20,7 +20,7 @@ Bio.SearchIO.BlastIO was tested on the following BLAST+ flavors and versions:
 You should also be able to parse outputs from a local BLAST+ search or from
 NCBI's web interface. Although the module was not tested against all BLAST+,
 it should still be able to parse these other versions' outputs. Please submit
-a bug report if you stumble upon an unparseable file.
+a bug report if you stumble upon an unparsable file.
 
 Some output formats from the BLAST legacy suite (BLAST+'s predecessor) may
 still be parsed by this module. However, results are not guaranteed. You may

--- a/Bio/SearchIO/ExonerateIO/__init__.py
+++ b/Bio/SearchIO/ExonerateIO/__init__.py
@@ -22,7 +22,7 @@ models:
 
 Although model testing were not exhaustive, ExonerateIO should be able to cope
 with all Exonerate models. Please file a bug report if you stumble upon an
-unparseable file.
+unparsable file.
 
 More information on Exonerate is available on its home page at
 www.ebi.ac.uk/~guy/exonerate/

--- a/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
+++ b/Bio/SearchIO/HHsuiteIO/hhsuite2_text.py
@@ -33,7 +33,7 @@ _END_OF_FILE_MARKER = "Done!"
 _PROGRAM = "HHSUITE"
 
 # Maximum number of lines to read before expecting a hit block
-# This determines the maximum numnber of hits that would be allowed in
+# This determines the maximum number of hits that would be allowed in
 # the initial hit table.
 MAX_READ_UNTIL = 5000
 

--- a/Bio/SearchIO/InterproscanIO/interproscan_xml.py
+++ b/Bio/SearchIO/InterproscanIO/interproscan_xml.py
@@ -84,7 +84,7 @@ class InterproscanXmlParser:
                     else:
                         hit_list.append(hit_new)
 
-                # create qresult and assing attributes
+                # create qresult and assign attributes
                 qresult = QueryResult(hit_list, query_id)
                 setattr(qresult, "description", query_desc)
                 for key, value in self._meta.items():

--- a/Bio/SearchIO/_model/hit.py
+++ b/Bio/SearchIO/_model/hit.py
@@ -441,7 +441,7 @@ class Hit(_BaseSearchObject):
         :param in_place: whether to do in-place sorting or no
         :type in_place: bool
 
-        ``sort`` defaults to sorting in-place, to mimick Python's ``list.sort``
+        ``sort`` defaults to sorting in-place, to mimic Python's ``list.sort``
         method. If you set the ``in_place`` argument to False, it will treat
         return a new, sorted Hit object and keep the initial one unsorted
 

--- a/Bio/SearchIO/_model/hsp.py
+++ b/Bio/SearchIO/_model/hsp.py
@@ -185,7 +185,7 @@ class HSP(_BaseHSP):
     +----------------------+---------------------+-----------------------------+
 
     For all types of HSP objects, the property will return the values in a list.
-    Shorcuts are only applicable for HSPs with one fragment. Except the ones
+    Shortcuts are only applicable for HSPs with one fragment. Except the ones
     noted, if they are used on an HSP with more than one fragments, an exception
     will be raised.
 

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -698,7 +698,7 @@ class QueryResult(_BaseSearchObject):
         :param in_place: whether to do in-place sorting or no
         :type in_place: bool
 
-        ``sort`` defaults to sorting in-place, to mimick Python's ``list.sort``
+        ``sort`` defaults to sorting in-place, to mimic Python's ``list.sort``
         method. If you set the ``in_place`` argument to False, it will treat
         return a new, sorted QueryResult object and keep the initial one
         unsorted.

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -2202,7 +2202,7 @@ class PositionGap:
     """Simple class to hold information about a gap between positions."""
 
     def __init__(self, gap_size):
-        """Intialize with a position object containing the gap information."""
+        """Initialize with a position object containing the gap information."""
         self.gap_size = gap_size
 
     def __repr__(self):

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1308,7 +1308,7 @@ class CompoundLocation:
         join{[15:17], [20:30], [40:50], [60:70]}
 
         Also, as with the FeatureLocation, adding an integer shifts the
-        location's co-ordinates by that offset:
+        location's coordinates by that offset:
 
         >>> print(f1 + 100)
         join{[115:117], [120:130]}

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -44,7 +44,7 @@ def AtomIterator(pdb_id, structure):
     module may be used by SeqIO modules wishing to parse sequences from lists
     of residues.
 
-    Calling funtions must pass a Bio.PDB.Structure.Structure object.
+    Calling functions must pass a Bio.PDB.Structure.Structure object.
 
 
     See Bio.SeqIO.PdbIO.PdbAtomIterator and Bio.SeqIO.PdbIO.CifAtomIterator for

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -381,7 +381,7 @@ SOLEXA_SCORE_OFFSET = 64
 
 
 def solexa_quality_from_phred(phred_quality):
-    """Covert a PHRED quality (range 0 to about 90) to a Solexa quality.
+    """Convert a PHRED quality (range 0 to about 90) to a Solexa quality.
 
     PHRED and Solexa quality scores are both log transformations of a
     probality of error (high score = low probability of error). This function

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -475,12 +475,12 @@ def _sff_find_roche_index(handle):
     data = handle.read(fmt_size)
     if not data:
         raise ValueError(
-            "Premature end of file? Expected index of size %i at offest %i, found nothing"
+            "Premature end of file? Expected index of size %i at offset %i, found nothing"
             % (index_length, index_offset)
         )
     if len(data) < fmt_size:
         raise ValueError(
-            "Premature end of file? Expected index of size %i at offest %i, found %r"
+            "Premature end of file? Expected index of size %i at offset %i, found %r"
             % (index_length, index_offset, data)
         )
     magic_number, ver0, ver1, ver2, ver3 = struct.unpack(fmt, data)
@@ -595,7 +595,7 @@ def _sff_read_roche_index(handle):
 
     Note that since only four bytes are used for the read offset, this is
     limited to 255^4 bytes (nearly 4GB). If you try to use the Roche sfffile
-    tool to combine SFF files beyound this limit, they issue a warning and
+    tool to combine SFF files beyond this limit, they issue a warning and
     omit the index (and manifest).
     """
     (

--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -133,7 +133,7 @@ def _read_feature(handle, record):
 
     # Assemble the feature
     # Shift start by -1 as XDNA feature coordinates are 1-based
-    # while Biopython uses 0-based couting.
+    # while Biopython uses 0-based counting.
     location = FeatureLocation(start - 1, end, strand=strand)
     qualifiers = {}
     if name:

--- a/Bio/SeqIO/_index.py
+++ b/Bio/SeqIO/_index.py
@@ -79,7 +79,7 @@ class SffRandomAccess(SeqFileRandomAccess):
         """Load any index block in the file, or build it the slow way (PRIVATE)."""
         handle = self._handle
         handle.seek(0)
-        # Alread did this in __init__ but need handle in right place
+        # Already did this in __init__ but need handle in right place
         (
             header_length,
             index_offset,

--- a/Bio/SeqIO/_twoBitIO.c
+++ b/Bio/SeqIO/_twoBitIO.c
@@ -360,7 +360,7 @@ blocks_converter(PyObject* object, void* pointer)
     }
     if (view->shape[1] != 2) {
         PyErr_Format(PyExc_RuntimeError,
-                     "blocks should have two colums (found %zd)",
+                     "blocks should have two columns (found %zd)",
                      view->shape[1]);
         goto exit;
     }

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -620,7 +620,7 @@ class SeqRecord:
         Number of features: 0
         Seq('MKQHKAMIVALIVICITAVVAALVTRKDLCEVHIRTGQTEVAVF')
 
-        In this example you don't actually need to call str explicity, as the
+        In this example you don't actually need to call str explicitly, as the
         print command does this automatically:
 
         >>> print(record)

--- a/Bio/SeqUtils/CodonUsageIndices.py
+++ b/Bio/SeqUtils/CodonUsageIndices.py
@@ -3,7 +3,7 @@
 # choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
 # Please see the LICENSE file that should have been included as part of this
 # package.
-"""Codon adaption indxes, including Sharp and Li (1987) E. coli index.
+"""Codon adaption indexes, including Sharp and Li (1987) E. coli index.
 
 Currently this module only defines a single codon adaption index from
 Sharp & Li, Nucleic Acids Res. 1987.

--- a/Bio/Sequencing/Ace.py
+++ b/Bio/Sequencing/Ace.py
@@ -40,7 +40,7 @@ sorted into the right place.
 see _RecordConsumer for details.
 
 The second option is to  iterate over the contigs of an ace file one by one
-in the ususal way::
+in the usual way::
 
     from Bio.Sequencing import Ace
     contigs = Ace.parse(open('my_ace_file.ace'))

--- a/Bio/SubsMat/__init__.py
+++ b/Bio/SubsMat/__init__.py
@@ -387,7 +387,7 @@ def _build_obs_freq_mat(acc_rep_mat):
 
 
 def _exp_freq_table_from_obs_freq(obs_freq_mat):
-    """Build expected frequence table from observed frequences (PRIVATE)."""
+    """Build expected frequence table from observed frequencies (PRIVATE)."""
     exp_freq_table = {}
     for i in obs_freq_mat.alphabet:
         exp_freq_table[i] = 0.0

--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -532,7 +532,7 @@ def _read_dt(record, line):
         date = cols[0].rstrip(",")
 
         # Re-use the historical property names, even though
-        # the meaning has changed slighty:
+        # the meaning has changed slightly:
         if "INTEGRATED" in uprline:
             record.created = date, version
         elif "SEQUENCE VERSION" in uprline:

--- a/Bio/UniProt/GOA.py
+++ b/Bio/UniProt/GOA.py
@@ -405,7 +405,7 @@ def gafiterator(handle):
 
     Example: open, read, interat and filter results.
 
-    Original data file has been trimed to ~600 rows.
+    Original data file has been trimmed to ~600 rows.
 
     Original source ftp://ftp.ebi.ac.uk/pub/databases/GO/goa/YEAST/goa_yeast.gaf.gz
 

--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -762,7 +762,7 @@ class BgzfWriter:
     """Define a BGZFWriter object."""
 
     def __init__(self, filename=None, mode="w", fileobj=None, compresslevel=6):
-        """Initilize the class."""
+        """Initialize the class."""
         if fileobj:
             assert filename is None
             handle = fileobj

--- a/Bio/kNN.py
+++ b/Bio/kNN.py
@@ -34,7 +34,7 @@ import numpy
 class kNN:
     """Holds information necessary to do nearest neighbors classification.
 
-    Attribues:
+    Attributes:
      - classes  Set of the possible classes.
      - xs       List of the neighbors.
      - ys       List of the classes that the neighbors belong to.

--- a/Bio/motifs/jaspar/db.py
+++ b/Bio/motifs/jaspar/db.py
@@ -534,7 +534,7 @@ class JASPAR5:
             """
             if all_versions:
                 for id in matrix_id:
-                    # ignore vesion here, this is a stupidity filter
+                    # ignore version here, this is a stupidity filter
                     (base_id, version) = jaspar.split_jaspar_id(id)
                     cur.execute("select ID from MATRIX where BASE_ID = %s", (base_id,))
 
@@ -542,7 +542,7 @@ class JASPAR5:
                     for row in rows:
                         int_ids.append(row[0])
             else:
-                # only the lastest version, or the requested version
+                # only the latest version, or the requested version
                 for id in matrix_id:
                     (base_id, version) = jaspar.split_jaspar_id(id)
 
@@ -753,7 +753,7 @@ class JASPAR5:
 
         if len(int_ids) < 1:
             warnings.warn(
-                "Zero motifs returned with current select critera", BiopythonWarning
+                "Zero motifs returned with current select criteria", BiopythonWarning
             )
 
         return int_ids

--- a/Bio/motifs/minimal.py
+++ b/Bio/motifs/minimal.py
@@ -38,7 +38,7 @@ def read(handle):
     >>> print(motif.name)
     IFXA
 
-    This function wont retrieve instances, as there are none in minimal meme format.
+    This function won't retrieve instances, as there are none in minimal meme format.
 
     """
     motif_number = 0

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -1311,7 +1311,7 @@ class affine_penalty:
 
 
 def calc_affine_penalty(length, open, extend, penalize_extend_when_opening):
-    """Calculate a penality score for the gap function."""
+    """Calculate a penalty score for the gap function."""
     if length <= 0:
         return 0.0
     penalty = open + extend * length

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -152,7 +152,7 @@ def open_database(driver="MySQLdb", **kwargs):
 
 
 class DBServer:
-    """Represents a BioSQL database continaing namespaces (sub-databases).
+    """Represents a BioSQL database containing namespaces (sub-databases).
 
     This acts like a Python dictionary, giving access to each namespace
     (defined by a row in the biodatabase table) as a BioSeqDatabase object.

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -1007,7 +1007,7 @@ class DatabaseLoader:
         # TODO - Record the location_operator (e.g. "join" or "order")
         # using the location_qualifier_value table (which we and BioPerl
         # have historically left empty).
-        # Note this will need an ontology term for the location qualifer
+        # Note this will need an ontology term for the location qualifier
         # (location_qualifier_value.term_id) for which oddly the schema
         # does not allow NULL.
         if feature.location_operator:

--- a/Doc/examples/ACT_example.py
+++ b/Doc/examples/ACT_example.py
@@ -105,7 +105,7 @@ for i, crunch_file in enumerate(comparisons):
             )
             gd_diagram.cross_track_links.append(CrossLink(q_feature, s_feature, c, b))
             # NOTE: We are using the same colour for all the matches,
-            # with transparency. This means overlayed matches will appear darker.
+            # with transparency. This means overlaid matches will appear darker.
             # It also means the drawing order not very important.
             # Note ACT puts long hits at the back, and colours by hit score
 

--- a/Doc/examples/getgene.py
+++ b/Doc/examples/getgene.py
@@ -170,7 +170,7 @@ class DB_Index:
             return "U"
 
     def Get_Gene(self, id):
-        """Retreive the gene name (GN)."""
+        """Retrieve the gene name (GN)."""
         entry = self.Get(id)
         if not entry:
             return None
@@ -209,7 +209,7 @@ class DB_Index:
         return OS, OC, GN
 
     def Get_OS_OC_OG(self, id):
-        """Retreive organism species + classification and organelle."""
+        """Retrieve organism species + classification and organelle."""
         entry = self.Get(id)
         if not entry:
             return None, None, None

--- a/Scripts/xbbtools/README
+++ b/Scripts/xbbtools/README
@@ -8,7 +8,7 @@ BioWish. This is the start of a pure python re-implementation of xbbtools with
 biopython.
 Usage: xbbtools test.fas
 
-Whats available:
+What's available:
       * open FASTA file
       * display 1 or 6 frame translations ala DNA Strider
       * all operations work on selection or complete sequence

--- a/Scripts/xbbtools/nextorf.py
+++ b/Scripts/xbbtools/nextorf.py
@@ -221,7 +221,7 @@ def help():
     print("")
     print("Options:                                                       default")
     print("--start       Start position in sequence                             0")
-    print("--stop        Stop position in sequence            (end of seqence)")
+    print("--stop        Stop position in sequence            (end of sequence)")
     print("--minlength   Minimum length of orf in bp                          100")
     print("--maxlength   Maximum length of orf in bp, default           100000000")
     print("--strand      Strand to analyse [both, plus, minus]               both")

--- a/Scripts/xbbtools/xbb_blast.py
+++ b/Scripts/xbbtools/xbb_blast.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2000 by Thomas Sicheritz-Ponten.
-# Copyrigth 2016 by Markus Piotrowski.
+# Copyright 2016 by Markus Piotrowski.
 # All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included

--- a/Scripts/xbbtools/xbb_blastbg.py
+++ b/Scripts/xbbtools/xbb_blastbg.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2000 by Thomas Sicheritz-Ponten.
-# Copyrigth 2016 by Markus Piotrowski.
+# Copyright 2016 by Markus Piotrowski.
 # All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
@@ -103,7 +103,7 @@ class BlastDisplayer:
                 self.tid.insert("end", txt)
                 self.tid.update()
             except Exception:
-                # text widget is detroyed, we assume the search
+                # text widget is destroyed, we assume the search
                 # has been cancelled
                 pass
         self.Exit()

--- a/Scripts/xbbtools/xbb_help.py
+++ b/Scripts/xbbtools/xbb_help.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2000 by Thomas Sicheritz-Ponten.
-# Copyrigth 2016 by Markus Piotrowski.
+# Copyright 2016 by Markus Piotrowski.
 # All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included

--- a/Scripts/xbbtools/xbb_search.py
+++ b/Scripts/xbbtools/xbb_search.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2000 by Thomas Sicheritz-Ponten.
-# Copyrigth 2016 by Markus Piotrowski.
+# Copyright 2016 by Markus Piotrowski.
 # All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included

--- a/Scripts/xbbtools/xbb_translations.py
+++ b/Scripts/xbbtools/xbb_translations.py
@@ -96,7 +96,7 @@ class xbb_translations:
         return GC(seq)
 
     def gcframe(self, seq, translation_table=1, direction="both"):
-        """Print a pretty print tranlation in several frames."""
+        """Print a pretty print translation in several frames."""
         # always use uppercase nt-sequence !!
         comp = self.complement(seq)
         anti = self.reverse(comp)

--- a/Scripts/xbbtools/xbbtools.py
+++ b/Scripts/xbbtools/xbbtools.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2000 by Thomas Sicheritz-Ponten.
-# Copyrigth 2016 by Markus Piotrowski.
+# Copyright 2016 by Markus Piotrowski.
 # All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included

--- a/Tests/test_ColorSpiral.py
+++ b/Tests/test_ColorSpiral.py
@@ -35,7 +35,7 @@ class SpiralTest(unittest.TestCase):
         """Set up canvas for drawing."""
         output_filename = os.path.join("Graphics", "spiral_test.pdf")
         self.c = Canvas(output_filename, pagesize=A4)
-        # co-ordinates of the centre of the canvas
+        # coordinates of the centre of the canvas
         self.x_0, self.y_0 = 0.5 * A4[0], 0.5 * A4[1]
 
     def test_colorlist(self):

--- a/Tests/test_Nexus.py
+++ b/Tests/test_Nexus.py
@@ -877,7 +877,7 @@ Root:  16
         with self.assertRaises(Exception) as context:
             tree.randomize()
         self.assertIn(
-            "Either numer of taxa or list of taxa must be specified.",
+            "Either number of taxa or list of taxa must be specified.",
             str(context.exception),
         )
         tree_rand = Trees.Tree(ts1c)

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -1174,7 +1174,7 @@ class NC_005816(NC_000932):
         self.assertEqual(len(fa_records), len(features))
         # This assumes they are in the same order...
         for fa_record, f in zip(fa_records, features):
-            # TODO - check the FASTA ID line against the co-ordinates?
+            # TODO - check the FASTA ID line against the coordinates?
             f_seq = f.extract(gb_record.seq)
             self.assertEqual(fa_record.seq, f_seq)
             self.assertEqual(len(f_seq), len(f))


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Ran codespell https://github.com/codespell-project/codespell and manually screened these as harmless fixes.

Using the tool more in depth will require putting together a list of biological works like Ser and OTU (which are currently otherwise changed to Set and OUT).

Changes are almost all in comments or docstrings, a couple are in our exception messages.