### PR TITLE
reverse_complement not in-situ

### DIFF
--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -721,7 +721,7 @@ MutableSeq('GCCACGTAATGGGCCGCTGAAAGGGTGCCCGA')
 MutableSeq('AGCCCGTGGGAAAGTCGCCGGGTAATGCACCG')
 \end{minted}
 
-Do note that unlike the \verb|Seq| object, the \verb|MutableSeq| object's methods like \verb|reverse_complement()| and \verb|reverse()| act in-situ!
+Note that the \verb|MutableSeq| object's \verb|reverse()| method, like the \verb|reverse()| method of a Python list, reverses the sequence in place.
 
 An important technical difference between mutable and immutable objects in Python means that you can't use a \verb|MutableSeq| object as a dictionary key, but you can use a Python string or a \verb|Seq| object in this way.
 


### PR DESCRIPTION
This PR updates a sentence in the tutorial that was saying that `reverse_complement` acts in-situ for `MutableSeq` objects.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
