### PR TITLE
Add codespell for documentation to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
-# pre-commit run --all-files
+# See CONTRIBUTING.rst, we expect this to be run via a git pre-commit hook.
+# You can also run the checks directly at the terminal, e.g.
+#
+# $ pre-commit run --all-files
+#
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
@@ -54,3 +58,10 @@ repos:
         entry: '(?i)(doi:|dx\.doi\.org|http://doi\.org)'
         language: pygrep
         files: \.(rst|tex)$
+ci:
+    # Settings for the https://pre-commit.ci/ continuous integration service
+    autofix_prs: false
+    # Default message is more verbose
+    autoupdate_commit_msg: '[pre-commit.ci] autoupdate'
+    # Default is weekly
+    autoupdate_schedule: quarterly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,6 @@ repos:
             'flake8-comprehensions',
             'flake8-docstrings',
             'flake8-implicit-str-concat',
-            'flake8-quotes',
             'flake8-rst-docstrings>=0.2.3',
             'pydocstyle>=6.0.0',
         ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,17 @@ repos:
     -   id: doc8
         additional_dependencies: [pygments]
         args: [--quiet,--ignore-path=Doc/examples/ec_*.txt, --ignore=D004]
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+    -   id: codespell
+        files: \.(rst|md|tex)$
+        args: [
+            --ignore-regex,
+            '(^|\W)([A-Z]{2,3})(\W|$)',
+            -L,
+            'ser,hsa,hist,fpr'
+        ]
 -   repo: local
     hooks:
     -   id: doi-link-style


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Builds on recent work using codespell to catch and fix various typos in Biopython. By adding codespell to the pre-commit checks on the documentation (only, for now) we should reduce the number of new typos added.

This is configured to check ``*.rst``, ``*.md`` and ``*.tex`` files only (hard to do directly with codespell, easy in pre-commit), uses a regex to ignore 2 and 3 letter upper case acronyms, and ignores a handful of words.

Note there are still plenty of typos in the code, but also many more false positives from codespell.