### PR TITLE
Try replacing any CircleCI SSH key for deployment

### DIFF
--- a/.github/deploy_docs.sh
+++ b/.github/deploy_docs.sh
@@ -103,15 +103,7 @@ if [ `grep -c "^\-\-\-\-\-" $HOME/.biopython_doc_deploy.key` -ne 2 ]; then
     false
 fi
 chmod 600 $HOME/.biopython_doc_deploy.key
-export GIT_SSH=${TRAVIS_BUILD_DIR:-$PWD}/.github/ssh_via_deploy_key.sh
-
-if ! [[ -f "$GIT_SSH" ]]; then
-    echo "Error, set GIT_SSH="$GIT_SSH" but does not exist"
-    false
-elif ! [[ -x "$GIT_SSH" ]]; then
-    echo "Error, set GIT_SSH="$GIT_SSH" but not executable"
-    false
-fi;
+mv $HOME/.biopython_doc_deploy.key $HOME/.ssh/id_rsa
 
 echo "Setting up clone of $DEST_SLUG locally at $WORKING_DIR"
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Continues from #3678 which got CircleCI to build the docs, but deployment never worked.

Despite setting a brand new key with read/write permissions on the docs/ repository, CircleCI still fails:

```
Finally, pushing to biopython/docs gh-pages branch
ERROR: The key you are authenticating with has been marked as read only.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

Exited with code exit status 128
```

It seems to do things a little differently from TravisCI, and perhaps is using its own key?

Note: This won't actually deploy unless on the master branch, which makes testing tricky.