### PR TITLE
Use https://pre-commit.ci/ for style checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,30 +16,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Combine precommit config and python versions for caching
-          command: |
-            cat .pre-commit-config.yaml > pre-commit-deps.txt
-            python -VV >> pre-commit-deps.txt
-      - restore_cache:
-          keys:
-          - v1-precommit-deps-{{ checksum "pre-commit-deps.txt" }}
-      - run:
-          name: Style install
-          command: |
-            python --version
-            pip install pre-commit
-            pre-commit install
-            pre-commit install-hooks
-      - save_cache:
-          paths:
-            - ~/.cache/pre-commit
-            - ./venv
-          key: v1-precommit-deps-{{ checksum "pre-commit-deps.txt" }}
-      - run:
-          name: Style checks
-          command: |
-            pre-commit run -a
-      - run:
           name: Dependencies
           command: |
             python --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
   # since it is used in most actions.
   # Adapted from: https://medium.com/ai2-blog/python-caching-in-github-actions-e9452698e98d
   linux_prep:
-    needs: [style]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -69,7 +68,6 @@ jobs:
         python setup.py sdist --formats=gztar,zip
 
   build_wheels:
-    needs: [style]
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -113,13 +111,13 @@ jobs:
   # tests install only numpy (lightweight version).
   # NOTE: PyPy only runs on Linux with minimal dependencies because it's running slowly.
   #
-  # Tests trigger only of the style and build steps succeed.
+  # Tests trigger only if the build steps succeed.
   #
 
   # Linux is where the thorough tests run. Install all dependencies and run all (offline) tests.
   test_linux:
     timeout-minutes: 15
-    needs: [style, build, build_wheels, linux_prep]
+    needs: [build, build_wheels, linux_prep]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -169,7 +167,7 @@ jobs:
 
   test_macos:
     timeout-minutes: 15
-    needs: [style, build, build_wheels]
+    needs: [build, build_wheels]
     runs-on: macos-latest
     strategy:
       matrix:
@@ -202,7 +200,7 @@ jobs:
 
   test_windows:
     timeout-minutes: 15
-    needs: [style, build, build_wheels]
+    needs: [build, build_wheels]
     runs-on: windows-latest
     strategy:
       matrix:
@@ -235,7 +233,7 @@ jobs:
 
   test_pypy:
     timeout-minutes: 20  # a little more time
-    needs: [style, build, build_wheels]
+    needs: [build, build_wheels]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -303,18 +301,6 @@ jobs:
   #   - name: Debug Info
   #     run: |
   #       pip freeze
-
-  #   - name: Check RST formatting
-  #     run: |
-  #       # Check sort order (bash call work around for pipe character)
-  #       bash -c \' grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f \'
-  #       # Check copyright date
-  #       bash -c \' grep "1999-`date +'%Y'`" LICENSE.rst \'
-  #       # Check no __docformat__ lines
-  #       bash -c "if grep --include '*.py' -rn '^__docformat__ ' Bio BioSQL Tests Scripts Doc ; then echo 'Remove __docformat__ line(s), we assume restructuredtext.'; false; fi"
-  #       # Black style check:
-  #       black --check --diff .
-  #     shell: bash
 
   docs:
     needs: [check_tests]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
   # - tarball on Linux
   # - wheels on all supported OSes and Linux, MacOS, and Windows
   build:
-    needs: [style]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,50 @@ on:
       - master
 
 jobs:
+  # Style Checking: Linux and Python version only.
+  style:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Check for changes only on files changed by the PR/push
+    - uses: trilom/file-changes-action@v1.2.4
+      with:
+        # Creates 'files.txt' by default
+        output: ' '
+        fileOutput: ' '
+
+    # Cache CI packages
+    - uses: actions/cache@v2
+      id: cache-precommit
+      with:
+        path: ~/.cache/pre-commit
+        key: ${{ runner.os }}-precommit-hooks-v2-${{ hashFiles('**/.pre-commit-config.yaml') }}
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Installing pre-commit
+      run: |
+        python -m pip install pre-commit
+
+    - name: Installing pre-commit hooks (cached)
+      if: steps.cache-precommit.outputs.cache-hit != 'true'
+      run: |
+        pre-commit install --install-hooks
+
+    - name: Run style checking via pre-commit
+      run: |
+        pre-commit run --files $( cat ${HOME}/files.txt )
+
   # Cache pip & python dependencies for Linux runner
   # since it is used in most actions.
   # Adapted from: https://medium.com/ai2-blog/python-caching-in-github-actions-e9452698e98d
   linux_prep:
+    needs: [style]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,6 +89,7 @@ jobs:
   # - tarball on Linux
   # - wheels on all supported OSes and Linux, MacOS, and Windows
   build:
+    needs: [style]
     runs-on: ubuntu-latest
 
     steps:
@@ -68,6 +109,7 @@ jobs:
         python setup.py sdist --formats=gztar,zip
 
   build_wheels:
+    needs: [style]
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -111,13 +153,13 @@ jobs:
   # tests install only numpy (lightweight version).
   # NOTE: PyPy only runs on Linux with minimal dependencies because it's running slowly.
   #
-  # Tests trigger only if the build steps succeed.
+  # Tests trigger only of the style and build steps succeed.
   #
 
   # Linux is where the thorough tests run. Install all dependencies and run all (offline) tests.
   test_linux:
     timeout-minutes: 15
-    needs: [build, build_wheels, linux_prep]
+    needs: [style, build, build_wheels, linux_prep]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -167,7 +209,7 @@ jobs:
 
   test_macos:
     timeout-minutes: 15
-    needs: [build, build_wheels]
+    needs: [style, build, build_wheels]
     runs-on: macos-latest
     strategy:
       matrix:
@@ -200,7 +242,7 @@ jobs:
 
   test_windows:
     timeout-minutes: 15
-    needs: [build, build_wheels]
+    needs: [style, build, build_wheels]
     runs-on: windows-latest
     strategy:
       matrix:
@@ -233,7 +275,7 @@ jobs:
 
   test_pypy:
     timeout-minutes: 20  # a little more time
-    needs: [build, build_wheels]
+    needs: [style, build, build_wheels]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -301,6 +343,18 @@ jobs:
   #   - name: Debug Info
   #     run: |
   #       pip freeze
+
+  #   - name: Check RST formatting
+  #     run: |
+  #       # Check sort order (bash call work around for pipe character)
+  #       bash -c \' grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f \'
+  #       # Check copyright date
+  #       bash -c \' grep "1999-`date +'%Y'`" LICENSE.rst \'
+  #       # Check no __docformat__ lines
+  #       bash -c "if grep --include '*.py' -rn '^__docformat__ ' Bio BioSQL Tests Scripts Doc ; then echo 'Remove __docformat__ line(s), we assume restructuredtext.'; false; fi"
+  #       # Black style check:
+  #       black --check --diff .
+  #     shell: bash
 
   docs:
     needs: [check_tests]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,45 +16,6 @@ on:
       - master
 
 jobs:
-  # Style Checking: Linux and Python version only.
-  style:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    # Check for changes only on files changed by the PR/push
-    - uses: trilom/file-changes-action@v1.2.4
-      with:
-        # Creates 'files.txt' by default
-        output: ' '
-        fileOutput: ' '
-
-    # Cache CI packages
-    - uses: actions/cache@v2
-      id: cache-precommit
-      with:
-        path: ~/.cache/pre-commit
-        key: ${{ runner.os }}-precommit-hooks-v2-${{ hashFiles('**/.pre-commit-config.yaml') }}
-
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-
-    - name: Installing pre-commit
-      run: |
-        python -m pip install pre-commit
-
-    - name: Installing pre-commit hooks (cached)
-      if: steps.cache-precommit.outputs.cache-hit != 'true'
-      run: |
-        pre-commit install --install-hooks
-
-    - name: Run style checking via pre-commit
-      run: |
-        pre-commit run --files $( cat ${HOME}/files.txt )
-
   # Cache pip & python dependencies for Linux runner
   # since it is used in most actions.
   # Adapted from: https://medium.com/ai2-blog/python-caching-in-github-actions-e9452698e98d

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@
 .. image:: https://img.shields.io/conda/vn/conda-forge/biopython.svg?logo=conda-forge
    :alt: Biopython on the Conda package conda-forge channel
    :target: https://anaconda.org/conda-forge/biopython
+.. image:: https://results.pre-commit.ci/badge/github/biopython/biopython/master.svg
+   :target: https://results.pre-commit.ci/latest/github/biopython/biopython/master
+   :alt: pre-commit.ci status
 .. image:: https://img.shields.io/circleci/build/github/biopython/biopython.svg?logo=circleci
    :alt: Linux testing with CircleCI
    :target: https://app.circleci.com/pipelines/github/biopython/biopython


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This pull request drops calling the tool ``pre-commit`` from our existing CI setups.

Separately we would enable Biopython on https://pre-commit.ci/ instead.

(Potential followup to enable their bot for applying changes including potentially black to pull requests, currently via 9c2be2db7e317a8ea8c3438b9b9324eb86b1ece4 that is off)