### PR TITLE
encoding alignments on the reverse strand

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1348,8 +1348,7 @@ class Alignment:
         coordinates = self.coordinates.copy()
         for i, sequence in enumerate(sequences):
             if coordinates[i, 0] > coordinates[i, -1]:  # mapped to reverse strand
-                n = len(sequences[i])
-                coordinates[i, :] = n - coordinates[i, :]
+                coordinates[i, :] = coordinates[i, ::-1]
                 try:  # reverse_complement function does not work on SeqRecord
                     sequences[i] = sequences[i].reverse_complement()
                 except AttributeError:  # for str
@@ -1530,7 +1529,7 @@ class Alignment:
                             if self.coordinates[i, 0] > self.coordinates[i, -1]:
                                 # mapped to reverse strand
                                 n = len(sequence)
-                                coordinates[i, :] = n - coordinates[i, :]
+                                coordinates[i, :] = coordinates[i, ::-1]
                         sequences = self.sequences
                         alignment = Alignment(sequences, coordinates)
                         if numpy.array_equal(coordinates, self.coordinates):
@@ -1678,7 +1677,7 @@ class Alignment:
         coordinates = self.coordinates
         if coordinates[1, 0] > coordinates[1, -1]:  # mapped to reverse strand
             coordinates = coordinates.copy()
-            coordinates[1, :] = n2 - coordinates[1, :]
+            coordinates[1, :] = coordinates[1, ::-1]
             seq2 = reverse_complement(seq2)
         coordinates = coordinates.transpose()
         end1, end2 = coordinates[0, :]
@@ -1809,9 +1808,8 @@ class Alignment:
             strand = "+"
         else:  # mapped to reverse strand
             strand = "-"
-            n = len(query)
             coordinates = coordinates.copy()
-            coordinates[1, :] = n - coordinates[1, :]
+            coordinates[1, :] = coordinates[1, ::-1]
         score = self.score
         blockSizes = []
         tStarts = []
@@ -1895,7 +1893,7 @@ class Alignment:
             strand = "-"
             seq2 = reverse_complement(query)
             coordinates = coordinates.copy()
-            coordinates[1, :] = n2 - coordinates[1, :]
+            coordinates[1, :] = coordinates[1, ::-1]
         try:
             seq2 = bytes(seq2)
         except TypeError:  # string
@@ -2047,7 +2045,7 @@ class Alignment:
             flag = 16
             seq = reverse_complement(query)
             coordinates = coordinates.copy()
-            coordinates[1, :] = n2 - coordinates[1, :]
+            coordinates[1, :] = coordinates[1, ::-1]
         try:
             seq = bytes(seq)
         except TypeError:  # string
@@ -2204,8 +2202,7 @@ class Alignment:
         n = len(coordinates)
         for i in range(n):
             if coordinates[i, 0] > coordinates[i, -1]:  # mapped to reverse strand
-                k = len(self.sequences[i])
-                coordinates[i, :] = k - coordinates[i, :]
+                coordinates[i, :] = coordinates[i, ::-1]
         steps = numpy.diff(coordinates, 1).max(0)
         m = sum(steps)
         return (n, m)
@@ -2297,8 +2294,7 @@ class Alignment:
         coordinates = self.coordinates.copy()
         for i, sequence in enumerate(self.sequences):
             if coordinates[i, 0] > coordinates[i, -1]:  # mapped to reverse strand
-                n = len(sequence)
-                coordinates[i, :] = n - coordinates[i, :]
+                coordinates[i, :] = coordinates[i, ::-1]
         coordinates = coordinates.transpose()
         steps = numpy.diff(coordinates, axis=0).min(1)
         indices = numpy.flatnonzero(steps)
@@ -2455,16 +2451,16 @@ class Alignment:
         if strand1 == "+":
             if strand2 == "-":  # mapped to reverse strand
                 coordinates2 = coordinates2.copy()
-                coordinates2[1, :] = n2 - coordinates2[1, :]
+                coordinates2[1, :] = coordinates2[1, ::-1]
         else:  # mapped to reverse strand
             coordinates1 = coordinates1.copy()
-            coordinates1[1, :] = n1 - coordinates1[1, :]
+            coordinates1[1, :] = coordinates1[1, ::-1]
             coordinates2 = coordinates2.copy()
             coordinates2[0, :] = n1 - coordinates2[0, ::-1]
             if strand2 == "+":
                 coordinates2[1, :] = n2 - coordinates2[1, ::-1]
             else:  # mapped to reverse strand
-                coordinates2[1, :] = coordinates2[1, ::-1]
+                coordinates2[1, :] = n2 - coordinates2[1, :]
         path = []
         tEnd, qEnd = sys.maxsize, sys.maxsize
         coordinates1 = iter(coordinates1.transpose())
@@ -2513,7 +2509,7 @@ class Alignment:
             tStart2, qStart2 = tEnd2, qEnd2
         coordinates = numpy.array(path).transpose()
         if strand1 != strand2:
-            coordinates[1, :] = n2 - coordinates[1, :]
+            coordinates[1, :] = coordinates[1, ::-1]
         sequences = [target, query]
         alignment = Alignment(sequences, coordinates)
         return alignment
@@ -2666,7 +2662,7 @@ class PairwiseAlignments:
 
         path = next(self.paths)
         self.index += 1
-        coordinates = numpy.array(path).transpose()
+        coordinates = numpy.array(path)
         alignment = Alignment(self.sequences, coordinates)
         alignment.score = self.score
         self.alignment = alignment

--- a/Bio/Align/fasta_m8.py
+++ b/Bio/Align/fasta_m8.py
@@ -139,12 +139,13 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         elif self._alignment_representation == "CIGAR":
             coordinates = self.parse_cigar(columns[12])
         coordinates[0, :] += target_start
+        query_size = self._query_size
         if query_start < query_end:
             coordinates[1, :] += query_start
         else:
             # mapped to reverse strand
-            coordinates[1, :] = query_start - coordinates[1, :] + 1
-        query_size = self._query_size
+            coordinates[1, :] = coordinates[1, ::-1]
+            coordinates[1, :] += query_size - query_start - 1
         query_sequence = Seq(None, length=query_size)
         query = SeqRecord(query_sequence, id=query_id)
         if self._query_description is not None:

--- a/Tests/test_Align_Alignment.py
+++ b/Tests/test_Align_Alignment.py
@@ -306,7 +306,7 @@ A-G
         query = reverse_complement(query)
         sequences = (target, query)
         coordinates = numpy.array(
-            [[0, 1, 2, 3, 4, 6, 7, 8, 8, 9, 11], [7, 6, 6, 5, 5, 3, 3, 2, 1, 0, 0]]
+            [[0, 1, 2, 3, 4, 6, 7, 8, 8, 9, 11], [7, 7, 6, 5, 4, 4, 2, 2, 1, 1, 0]]
         )
         alignment = Align.Alignment(sequences, coordinates)
         alignment.score = 6.0
@@ -921,7 +921,7 @@ TTCTAAGGGGTCGTATGAGCAAAAATTTTTTTTAAATCATCCTTTTCATTAATTTAAATGTATTAAATTTGTTGGACG""
         self.check_indexing_slicing(alignment, msg)
         alignment.sequences[2] = alignment.sequences[2].reverse_complement()
         n = len(alignment.sequences[2])
-        alignment.coordinates[2, :] = n - alignment.coordinates[2, :]
+        alignment.coordinates[2, :] = alignment.coordinates[2, ::-1]
         msg = "reverse strand"
         self.check_indexing_slicing(alignment, msg)
 

--- a/Tests/test_Align_fasta.py
+++ b/Tests/test_Align_fasta.py
@@ -1223,7 +1223,7 @@ class TestFastaNucleotide(unittest.TestCase):
         self.assertTrue(
             numpy.array_equal(
                 alignment.coordinates,
-                numpy.array([[1499, 1511], [316, 304]]),
+                numpy.array([[1499, 1511], [353, 341]]),
             )
         )
         query = self.query
@@ -1251,7 +1251,7 @@ class TestFastaNucleotide(unittest.TestCase):
         self.assertTrue(
             numpy.array_equal(
                 alignment.coordinates,
-                numpy.array([[1499, 1511], [316, 304]]),
+                numpy.array([[1499, 1511], [353, 341]]),
             )
         )
         query = self.query
@@ -1279,7 +1279,7 @@ class TestFastaNucleotide(unittest.TestCase):
         self.assertTrue(
             numpy.array_equal(
                 alignment.coordinates,
-                numpy.array([[490, 506], [160, 144]]),
+                numpy.array([[490, 506], [513, 497]]),
             )
         )
         query = self.query
@@ -1307,7 +1307,7 @@ class TestFastaNucleotide(unittest.TestCase):
         self.assertTrue(
             numpy.array_equal(
                 alignment.coordinates,
-                numpy.array([[1116, 1200], [242, 158]]),
+                numpy.array([[1116, 1200], [499, 415]]),
             )
         )
         query = self.query
@@ -1341,7 +1341,7 @@ class TestFastaNucleotide(unittest.TestCase):
         self.assertTrue(
             numpy.array_equal(
                 alignment.coordinates,
-                numpy.array([[792, 802], [310, 300]]),
+                numpy.array([[792, 802], [357, 347]]),
             )
         )
         query = self.query
@@ -1370,7 +1370,7 @@ class TestFastaNucleotide(unittest.TestCase):
             numpy.array_equal(
                 alignment.coordinates,
                 numpy.array(
-                    [[280, 304, 304, 312, 312, 351], [378, 354, 353, 345, 343, 304]]
+                    [[280, 304, 304, 312, 312, 351], [353, 314, 312, 304, 303, 279]]
                 ),
             )
         )
@@ -1698,7 +1698,7 @@ class TestFastaNucleotide(unittest.TestCase):
         self.assertTrue(
             numpy.array_equal(
                 alignment.coordinates,
-                numpy.array([[1499, 1511], [316, 304]]),
+                numpy.array([[1499, 1511], [353, 341]]),
             )
         )
         query = self.query
@@ -1726,7 +1726,7 @@ class TestFastaNucleotide(unittest.TestCase):
         self.assertTrue(
             numpy.array_equal(
                 alignment.coordinates,
-                numpy.array([[1499, 1511], [316, 304]]),
+                numpy.array([[1499, 1511], [353, 341]]),
             )
         )
         query = self.query
@@ -1754,7 +1754,7 @@ class TestFastaNucleotide(unittest.TestCase):
         self.assertTrue(
             numpy.array_equal(
                 alignment.coordinates,
-                numpy.array([[490, 506], [160, 144]]),
+                numpy.array([[490, 506], [513, 497]]),
             )
         )
         query = self.query
@@ -1782,7 +1782,7 @@ class TestFastaNucleotide(unittest.TestCase):
         self.assertTrue(
             numpy.array_equal(
                 alignment.coordinates,
-                numpy.array([[1116, 1200], [242, 158]]),
+                numpy.array([[1116, 1200], [499, 415]]),
             )
         )
         query = self.query
@@ -1816,7 +1816,7 @@ class TestFastaNucleotide(unittest.TestCase):
         self.assertTrue(
             numpy.array_equal(
                 alignment.coordinates,
-                numpy.array([[792, 802], [310, 300]]),
+                numpy.array([[792, 802], [357, 347]]),
             )
         )
         query = self.query
@@ -1845,7 +1845,7 @@ class TestFastaNucleotide(unittest.TestCase):
             numpy.array_equal(
                 alignment.coordinates,
                 numpy.array(
-                    [[280, 304, 304, 312, 312, 351], [378, 354, 353, 345, 343, 304]]
+                    [[280, 304, 304, 312, 312, 351], [353, 314, 312, 304, 303, 279]]
                 ),
             )
         )


### PR DESCRIPTION
If the alignment of sequence `i` in a pairwise or multiple alignment is against the reverse strand, the corresponding row in the `coordinates` matrix was replaced by `len(sequence) - coordinates[i, :]`. However, this requires the length of the sequence to be known. which is not the case for example for `.bed` files or for Mauve output. This PR encodes alignments on the reverse strand as `coordinates[::-1]`, which does not require the sequence length to be known.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #...
