### PR TITLE
Code style fixes from pyupgrade 2.25.0

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -895,7 +895,7 @@ class MultipleSeqAlignment:
             ('A', 'C') : 0.8 * 1.0 = 0.8
 
         """
-        letters = set.union(*[set(record.seq) for record in self])
+        letters = set.union(*(set(record.seq) for record in self))
         try:
             letters.remove("-")
         except KeyError:
@@ -2587,7 +2587,7 @@ class Alignment:
         is 3.5 + 3.5 = 7.
         """
         sequences = self.sequences
-        letters = set.union(*[set(sequence) for sequence in sequences])
+        letters = set.union(*(set(sequence) for sequence in sequences))
         letters = "".join(sorted(letters))
         m = substitution_matrices.Array(letters, dims=2)
         n = len(sequences)

--- a/Bio/AlignIO/FastaIO.py
+++ b/Bio/AlignIO/FastaIO.py
@@ -301,7 +301,7 @@ handle.name: {handle.name}
             # Next line(s) should be consensus seq...
         elif line.startswith("; "):
             if ": " in line:
-                key, value = [s.strip() for s in line[2:].split(": ", 1)]
+                key, value = (s.strip() for s in line[2:].split(": ", 1))
             else:
                 import warnings
                 from Bio import BiopythonParserWarning
@@ -312,7 +312,7 @@ handle.name: {handle.name}
                     "Missing colon in line: %r" % line, BiopythonParserWarning
                 )
                 try:
-                    key, value = [s.strip() for s in line[2:].split(" ", 1)]
+                    key, value = (s.strip() for s in line[2:].split(" ", 1))
                 except ValueError:
                     raise ValueError("Bad line: %r" % line) from None
             if state == state_QUERY_HEADER:

--- a/Bio/ExPASy/Prosite.py
+++ b/Bio/ExPASy/Prosite.py
@@ -203,7 +203,7 @@ def __read(handle):
             for col in cols:
                 if not col:
                     continue
-                qual, data = [word.lstrip() for word in col.split("=")]
+                qual, data = (word.lstrip() for word in col.split("="))
                 if qual == "/RELEASE":
                     release, seqs = data.split(",")
                     record.nr_sp_release = release
@@ -247,7 +247,7 @@ def __read(handle):
                     # For example, from Bug 2403, in PS50293 have:
                     # CC /AUTHOR=K_Hofmann; N_Hulo
                     continue
-                qual, data = [word.lstrip() for word in col.split("=")]
+                qual, data = (word.lstrip() for word in col.split("="))
                 if qual == "/TAXO-RANGE":
                     record.cc_taxo_range = data
                 elif qual == "/MAX-REPEAT":
@@ -278,7 +278,7 @@ def __read(handle):
             for ref in refs:
                 if not ref:
                     continue
-                acc, name, type = [word.strip() for word in ref.split(",")]
+                acc, name, type = (word.strip() for word in ref.split(","))
                 if type == "T":
                     record.dr_positive.append((acc, name))
                 elif type == "F":

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -1972,9 +1972,9 @@ class Nexus:
             return cm
         undelete = [t for t in self.taxlabels if t in cm]
         if seqobjects:
-            sitesm = list(zip(*[str(cm[t]) for t in undelete]))
+            sitesm = list(zip(*(str(cm[t]) for t in undelete)))
         else:
-            sitesm = list(zip(*[cm[t] for t in undelete]))
+            sitesm = list(zip(*(cm[t] for t in undelete)))
         bootstrapsitesm = [
             sitesm[random.randint(0, len(sitesm) - 1)] for _ in range(len(sitesm))
         ]
@@ -2043,7 +2043,7 @@ class Nexus:
             raise NexusError("Illegal gap position: %d" % pos)
         if n == 0:
             return
-        sitesm = list(zip(*[str(self.matrix[t]) for t in self.taxlabels]))
+        sitesm = list(zip(*(str(self.matrix[t]) for t in self.taxlabels)))
         sitesm[pos:pos] = [["-"] * len(self.taxlabels)] * n
         mapped = ["".join(x) for x in zip(*sitesm)]
         listed = [(taxon, Seq(mapped[i])) for i, taxon in enumerate(self.taxlabels)]
@@ -2097,7 +2097,7 @@ class Nexus:
         gap = set(self.gap)
         if include_missing:
             gap.add(self.missing)
-        sitesm = zip(*[str(self.matrix[t]) for t in self.taxlabels])
+        sitesm = zip(*(str(self.matrix[t]) for t in self.taxlabels))
         return [i for i, site in enumerate(sitesm) if set(site).issubset(gap)]
 
     def terminal_gap_to_missing(self, missing=None, skip_n=True):

--- a/Bio/PDB/Polypeptide.py
+++ b/Bio/PDB/Polypeptide.py
@@ -270,7 +270,7 @@ class Polypeptide(list):
         tau_list = []
         for i in range(0, len(ca_list) - 3):
             atom_list = (ca_list[i], ca_list[i + 1], ca_list[i + 2], ca_list[i + 3])
-            v1, v2, v3, v4 = [a.get_vector() for a in atom_list]
+            v1, v2, v3, v4 = (a.get_vector() for a in atom_list)
             tau = calc_dihedral(v1, v2, v3, v4)
             tau_list.append(tau)
             # Put tau in xtra dict of residue
@@ -284,7 +284,7 @@ class Polypeptide(list):
         ca_list = self.get_ca_list()
         for i in range(0, len(ca_list) - 2):
             atom_list = (ca_list[i], ca_list[i + 1], ca_list[i + 2])
-            v1, v2, v3 = [a.get_vector() for a in atom_list]
+            v1, v2, v3 = (a.get_vector() for a in atom_list)
             theta = calc_angle(v1, v2, v3)
             theta_list.append(theta)
             # Put tau in xtra dict of residue

--- a/Bio/PDB/internal_coords.py
+++ b/Bio/PDB/internal_coords.py
@@ -2226,7 +2226,7 @@ class IC_Residue:
             s += "\n"
         for d in sorted(self.dihedra.values()):
             try:
-                s += base + d.id + " " + "{:9.5f}".format(set_accuracy_95(d.angle))
+                s += base + d.id + " " + f"{set_accuracy_95(d.angle):9.5f}"
             except KeyError:
                 pass
             s += "\n"

--- a/Bio/PDB/internal_coords.py
+++ b/Bio/PDB/internal_coords.py
@@ -2226,7 +2226,7 @@ class IC_Residue:
             s += "\n"
         for d in sorted(self.dihedra.values()):
             try:
-                s += base + d.id + " " + f"{set_accuracy_95(d.angle):9.5f}"
+                s += f"{base}{d.id} {set_accuracy_95(d.angle):9.5f}"
             except KeyError:
                 pass
             s += "\n"

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -1202,7 +1202,7 @@ class BranchColor:
         ), "need a 24-bit hexadecimal string, e.g. #000000"
 
         RGB = hexstr[1:3], hexstr[3:5], hexstr[5:]
-        return cls(*[int("0x" + cc, base=16) for cc in RGB])
+        return cls(*(int("0x" + cc, base=16) for cc in RGB))
 
     @classmethod
     def from_name(cls, colorname):

--- a/Bio/SeqIO/SnapGeneIO.py
+++ b/Bio/SeqIO/SnapGeneIO.py
@@ -169,7 +169,7 @@ def _parse_features_packet(length, data, record):
             if strand == -1:
                 # Reverse segment indexes and order for reverse-strand features
                 subparts = reversed([[n_parts - i + 1, name] for i, name in subparts])
-            quals["parts"] = [";".join("{}:{}".format(i, name) for i, name in subparts)]
+            quals["parts"] = [";".join(f"{i}:{name}" for i, name in subparts)]
 
         if not location:
             raise ValueError("Missing feature location")

--- a/Bio/SeqIO/SnapGeneIO.py
+++ b/Bio/SeqIO/SnapGeneIO.py
@@ -110,7 +110,7 @@ def _parse_cookie_packet(length, data, record):
 
 
 def _parse_location(rangespec, strand, record):
-    start, end = [int(x) for x in rangespec.split("-")]
+    start, end = (int(x) for x in rangespec.split("-"))
     # Account for SnapGene's 1-based coordinates
     start = start - 1
     if start > end:

--- a/Doc/examples/getgene.py
+++ b/Doc/examples/getgene.py
@@ -108,7 +108,7 @@ class DB_Index:
             values = self.db[id]
         except Exception:
             return None
-        start, stop = [int(x) for x in values.split()]
+        start, stop = (int(x) for x in values.split())
         self.fid.seek(start)
         txt = self.fid.read(stop - start)
         return txt

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -407,7 +407,7 @@ class DictionaryBuilder:
             #   Now select the right type for the enzyme.
             #
             bases = cls.bases
-            clsbases = tuple([eval(x) for x in bases])  # noqa: C407
+            clsbases = tuple(eval(x) for x in bases)
             typestuff = ""
             for t in tdct.values():
                 #

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -470,7 +470,7 @@ class SeqInterfaceTest(unittest.TestCase):
         test_seq = self.item.seq
         string_rep = str(test_seq)
         self.assertEqual(string_rep, str(test_seq))  # check __str__ too
-        self.assertEqual(type(string_rep), type(""))
+        self.assertEqual(type(string_rep), str)
         self.assertEqual(len(test_seq), 880)
         self.assertEqual(test_seq[879], "A")
         self.assertEqual(test_seq[-1], "A")

--- a/Tests/test_Affy.py
+++ b/Tests/test_Affy.py
@@ -266,7 +266,7 @@ class AffyTest(unittest.TestCase):
 
     def testAffyWrongModeReadV4(self):
         with self.assertRaises(ValueError):
-            with open(self.affy4, "rt") as f:
+            with open(self.affy4) as f:
                 record = CelFile.read(f, version=4)
 
     # Writes a small example Affymetrix V4 CEL File

--- a/Tests/test_Affy.py
+++ b/Tests/test_Affy.py
@@ -317,7 +317,7 @@ class AffyTest(unittest.TestCase):
         preHeadersOrder = ["magic", "version", "columns", "rows", "cellNo", "headerLen"]
         headersEncoded = struct.pack(
             "<" + "i" * len(preHeadersOrder),
-            *[preHeaders[header] for header in preHeadersOrder]
+            *(preHeaders[header] for header in preHeadersOrder)
         )
 
         def packData(intensity, sdev, pixel):

--- a/Tests/test_CAPS.py
+++ b/Tests/test_CAPS.py
@@ -17,10 +17,7 @@ from Bio.Align import MultipleSeqAlignment
 def createAlignment(sequences):
     """Create an Alignment object from a list of sequences."""
     return MultipleSeqAlignment(
-        (
-            SeqRecord(Seq(s), id="sequence%i" % (i + 1))
-            for (i, s) in enumerate(sequences)
-        )
+        SeqRecord(Seq(s), id="sequence%i" % (i + 1)) for (i, s) in enumerate(sequences)
     )
 
 

--- a/Tests/test_Entrez_parser.py
+++ b/Tests/test_Entrez_parser.py
@@ -44,14 +44,14 @@ class GeneralTests(unittest.TestCase):
     def test_read_text_handle(self):
         """Test reading a handle opened in text mode."""
         message = "^file should be opened in binary mode$"
-        with open("Entrez/pubmed1.xml", "rt") as handle:
+        with open("Entrez/pubmed1.xml") as handle:
             with self.assertRaisesRegex(TypeError, message):
                 Entrez.read(handle)
 
     def test_parse_text_handle(self):
         """Test parsing a handle opened in text mode."""
         message = "^file should be opened in binary mode$"
-        with open("Entrez/einfo1.xml", "rt") as handle:
+        with open("Entrez/einfo1.xml") as handle:
             records = Entrez.parse(handle)
             with self.assertRaisesRegex(TypeError, message):
                 next(records)

--- a/Tests/test_SearchIO_blast_xml.py
+++ b/Tests/test_SearchIO_blast_xml.py
@@ -3997,7 +3997,7 @@ class BlastXmlSpecialCases(unittest.TestCase):
             self.assertEqual(
                 exp_warning,
                 len(w),
-                "Expected {0} warning(s), got {1}".format(exp_warning, len(w)),
+                f"Expected {exp_warning} warning(s), got {len(w)}",
             )
 
         self.assertEqual(qresult.blast_id, "Query_1")
@@ -4027,7 +4027,7 @@ class BlastXmlSpecialCases(unittest.TestCase):
             self.assertEqual(
                 exp_warning,
                 len(w),
-                "Expected {0} warning(s), got {1}".format(exp_warning, len(w)),
+                f"Expected {exp_warning} warning(s), got {len(w)}",
             )
 
         self.assertEqual(qresult.blast_id, "Query_1")
@@ -4057,7 +4057,7 @@ class BlastXmlSpecialCases(unittest.TestCase):
             self.assertEqual(
                 exp_warning,
                 len(w),
-                "Expected {0} warning(s), got {1}".format(exp_warning, len(w)),
+                f"Expected {exp_warning} warning(s), got {len(w)}",
             )
 
         self.assertEqual(qresult.id, "Query_1")

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -257,12 +257,12 @@ class TestExtract(unittest.TestCase):
         parent_record = SeqRecord.SeqRecord(seq=Seq.Seq("actg"))
         another_record = SeqRecord.SeqRecord(seq=Seq.Seq("gtcagctac"))
         location = FeatureLocation(5, 8, ref="ANOTHER.7")
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError,
             r"Feature references another sequence \(ANOTHER\.7\), references mandatory",
         ):
             location.extract(parent_record)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError,
             r"Feature references another sequence \(ANOTHER\.7\), not found in references",
         ):
@@ -289,12 +289,12 @@ class TestExtract(unittest.TestCase):
         parent_record = SeqRecord.SeqRecord(Seq.Seq("aaccaaccaaccaaccaa"))
         another_record = SeqRecord.SeqRecord(Seq.Seq("ttggttggttggttggtt"))
         location = FeatureLocation(2, 6) + FeatureLocation(5, 8, ref="ANOTHER.7")
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError,
             r"Feature references another sequence \(ANOTHER\.7\), references mandatory",
         ):
             location.extract(parent_record)
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             ValueError,
             r"Feature references another sequence \(ANOTHER\.7\), not found in references",
         ):

--- a/Tests/test_SffIO.py
+++ b/Tests/test_SffIO.py
@@ -77,7 +77,7 @@ class TestUAN(unittest.TestCase):
                 region = int(fields[-1])
                 self.test_annotations[current_name]["region"] = region
             elif "XY" in line:
-                x, y = [int(v) for v in fields[-1].split("_")]
+                x, y = (int(v) for v in fields[-1].split("_"))
                 self.test_annotations[current_name]["coords"] = (x, y)
 
     def test_time(self):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

A repeat of #2480 and #3463, using ``pyupgrade --py37-plus --keep-percent-format`` on the code base, with changes broken up by type for the commit history.

We may want to include this as a hook in our pre-commit configuration too...