### PR TITLE
f-strings in Bio.Seq*, Bio.GenBank, and Bio.PDB using pyupgrade 2.25.0

### DIFF
--- a/Bio/GenBank/Record.py
+++ b/Bio/GenBank/Record.py
@@ -427,7 +427,7 @@ class Record:
                     count_info = count_parts.pop(0)
                     count_type = count_parts.pop(0)
 
-                    output += "%7s %s" % (count_info, count_type)
+                    output += f"{count_info:>7} {count_type}"
             # deal with ugly ORIGIN lines like:
             # 1311257 a2224835 c2190093 g1309889 t
             # by just outputting the raw information
@@ -624,7 +624,7 @@ class Feature:
 
     def __repr__(self):
         """Representation of the object for debugging or logging."""
-        return "Feature(key=%r, location=%r)" % (self.key, self.location)
+        return f"Feature(key={self.key!r}, location={self.location!r})"
 
     def __str__(self):
         """Return feature as a GenBank format string."""
@@ -653,7 +653,7 @@ class Qualifier:
 
     def __repr__(self):
         """Representation of the object for debugging or logging."""
-        return "Qualifier(key=%r, value=%r)" % (self.key, self.value)
+        return f"Qualifier(key={self.key!r}, value={self.value!r})"
 
     def __str__(self):
         """Return feature qualifier as a GenBank format string."""

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -337,7 +337,7 @@ class InsdcScanner:
                     elif value == '"':
                         # One single quote
                         if self.debug:
-                            print("Single quote %s:%s" % (key, value))
+                            print(f"Single quote {key}:{value}")
                         # DO NOT remove the quote...
                         qualifiers.append((key, value))
                     elif value[0] == '"':
@@ -936,7 +936,7 @@ class EmblScanner(InsdcScanner):
                         "Malformed DR line in EMBL file.", BiopythonParserWarning
                     )
                 else:
-                    consumer.dblink("%s:%s" % (parts[0].strip(), parts[1].strip()))
+                    consumer.dblink(f"{parts[0].strip()}:{parts[1].strip()}")
             elif line_type == "RA":
                 # Remove trailing ; at end of authors list
                 consumer.authors(data.rstrip(";"))

--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -453,7 +453,7 @@ class DSSP(AbstractResiduePropertyMap):
 
         def resid2code(res_id):
             """Serialize a residue's resseq and icode for easy comparison."""
-            return "%s%s" % (res_id[1], res_id[2])
+            return f"{res_id[1]}{res_id[2]}"
 
         # DSSP outputs label_asym_id from the mmCIF file as the chain ID
         # But MMCIFParser reads in the auth_asym_id

--- a/Bio/PDB/Dice.py
+++ b/Bio/PDB/Dice.py
@@ -54,7 +54,7 @@ class ChainSelector:
             return 0
         if icode != " ":
             warnings.warn(
-                "WARNING: Icode %s at position %s" % (icode, resseq), BiopythonWarning
+                f"WARNING: Icode {icode} at position {resseq}", BiopythonWarning
             )
         if self.start <= resseq <= self.end:
             return 1

--- a/Bio/PDB/HSExposure.py
+++ b/Bio/PDB/HSExposure.py
@@ -225,12 +225,12 @@ class HSExposureCA(_AbstractHSExposure):
             fp.write("from pymol import cmd\n")
             fp.write("obj=[\n")
             fp.write("BEGIN, LINES,\n")
-            fp.write("COLOR, %.2f, %.2f, %.2f,\n" % (1.0, 1.0, 1.0))
+            fp.write(f"COLOR, {1.0:.2f}, {1.0:.2f}, {1.0:.2f},\n")
             for (ca, cb) in self.ca_cb_list:
                 x, y, z = ca.get_array()
-                fp.write("VERTEX, %.2f, %.2f, %.2f,\n" % (x, y, z))
+                fp.write(f"VERTEX, {x:.2f}, {y:.2f}, {z:.2f},\n")
                 x, y, z = cb.get_array()
-                fp.write("VERTEX, %.2f, %.2f, %.2f,\n" % (x, y, z))
+                fp.write(f"VERTEX, {x:.2f}, {y:.2f}, {z:.2f},\n")
             fp.write("END]\n")
             fp.write("cmd.load_cgo(obj, 'HS')\n")
 

--- a/Bio/PDB/Polypeptide.py
+++ b/Bio/PDB/Polypeptide.py
@@ -311,7 +311,7 @@ class Polypeptide(list):
         """
         start = self[0].get_id()[1]
         end = self[-1].get_id()[1]
-        return "<Polypeptide start=%s end=%s>" % (start, end)
+        return f"<Polypeptide start={start} end={end}>"
 
 
 class _PPBuilder:

--- a/Bio/PDB/Residue.py
+++ b/Bio/PDB/Residue.py
@@ -46,7 +46,7 @@ class Residue(Entity):
         atom_id = atom.get_id()
         if self.has_id(atom_id):
             raise PDBConstructionException(
-                "Atom %s defined twice in residue %s" % (atom_id, self)
+                f"Atom {atom_id} defined twice in residue {self}"
             )
         Entity.add(self, atom)
 

--- a/Bio/PDB/internal_coords.py
+++ b/Bio/PDB/internal_coords.py
@@ -2701,7 +2701,7 @@ class Edron:
             else:
                 acs.append(ac)
         if estr != "":
-            raise MissingAtomError("%s missing coordinates for %s" % (self, estr))
+            raise MissingAtomError(f"{self} missing coordinates for {estr}")
         return tuple(acs)
 
     def is_backbone(self) -> bool:
@@ -2916,7 +2916,7 @@ class Hedron(Edron):
         elif all(ak in self.aks[1:] for ak in ak_tpl):
             self.lal[2] = newLength  # len23
         else:
-            raise TypeError("%s not found in %s" % (str(ak_tpl), self))
+            raise TypeError(f"{str(ak_tpl)} not found in {self}")
 
         self.cic.hAtoms_needs_update[self.cic.hedraNdx[self.aks]] = True
 
@@ -3037,14 +3037,14 @@ class Dihedron(Edron):
 
         if not hedron1:
             raise HedronMatchError(
-                "can't find 1st hedron for key %s dihedron %s" % (h1key, self)
+                f"can't find 1st hedron for key {h1key} dihedron {self}"
             )
 
         hedron2 = Dihedron._get_hedron(res, h2key)
 
         if not hedron2:
             raise HedronMatchError(
-                "can't find 2nd hedron for key %s dihedron %s" % (h2key, self)
+                f"can't find 2nd hedron for key {h2key} dihedron {self}"
             )
 
         self.hedron1 = hedron1

--- a/Bio/PDB/vectors.py
+++ b/Bio/PDB/vectors.py
@@ -266,7 +266,7 @@ class Vector:
     def __repr__(self):
         """Return vector 3D coordinates."""
         x, y, z = self._ar
-        return "<Vector %.2f, %.2f, %.2f>" % (x, y, z)
+        return f"<Vector {x:.2f}, {y:.2f}, {z:.2f}>"
 
     def __neg__(self):
         """Return Vector(-x, -y, -z)."""

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -326,7 +326,7 @@ class _SeqAbstractBaseClass(ABC):
                 if len(seq) > 60:
                     start = seq[:54].decode("ASCII")
                     end = seq[-3:].decode("ASCII")
-                    seq = "%s...%s" % (start, end)
+                    seq = f"{start}...{end}"
                 else:
                     seq = seq.decode("ASCII")
                 d[position] = seq

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -287,7 +287,7 @@ class SeqFeature:
 
     def __repr__(self):
         """Represent the feature as a string for debugging."""
-        answer = "%s(%r" % (self.__class__.__name__, self.location)
+        answer = f"{self.__class__.__name__}({self.location!r}"
         if self.type:
             answer += ", type=%r" % self.type
         if self.location_operator:
@@ -311,7 +311,7 @@ class SeqFeature:
             out += "id: %s\n" % self.id
         out += "qualifiers:\n"
         for qual_key in sorted(self.qualifiers):
-            out += "    Key: %s, Value: %s\n" % (qual_key, self.qualifiers[qual_key])
+            out += f"    Key: {qual_key}, Value: {self.qualifiers[qual_key]}\n"
         return out
 
     def _shift(self, offset):
@@ -653,7 +653,7 @@ class Reference:
     def __repr__(self):
         """Represent the Reference object as a string for debugging."""
         # TODO - Update this is __init__ later accepts values
-        return "%s(title=%r, ...)" % (self.__class__.__name__, self.title)
+        return f"{self.__class__.__name__}(title={self.title!r}, ...)"
 
     def __eq__(self, other):
         """Check if two Reference objects should be considered equal.
@@ -801,13 +801,13 @@ class FeatureLocation:
         elif isinstance(start, int):
             self._start = ExactPosition(start)
         else:
-            raise TypeError("start=%r %s" % (start, type(start)))
+            raise TypeError(f"start={start!r} {type(start)}")
         if isinstance(end, AbstractPosition):
             self._end = end
         elif isinstance(end, int):
             self._end = ExactPosition(end)
         else:
-            raise TypeError("end=%r %s" % (end, type(end)))
+            raise TypeError(f"end={end!r} {type(end)}")
         if (
             isinstance(self.start.position, int)
             and isinstance(self.end.position, int)
@@ -844,9 +844,9 @@ class FeatureLocation:
         (zero based counting) which GenBank would call 123..150 (one based
         counting).
         """
-        answer = "[%s:%s]" % (self._start, self._end)
+        answer = f"[{self._start}:{self._end}]"
         if self.ref and self.ref_db:
-            answer = "%s:%s%s" % (self.ref_db, self.ref, answer)
+            answer = f"{self.ref_db}:{self.ref}{answer}"
         elif self.ref:
             answer = self.ref + answer
         # Is ref_db without ref meaningful?
@@ -1246,7 +1246,7 @@ class CompoundLocation:
 
     def __repr__(self):
         """Represent the CompoundLocation object as string for debugging."""
-        return "%s(%r, %r)" % (self.__class__.__name__, self.parts, self.operator)
+        return f"{self.__class__.__name__}({self.parts!r}, {self.operator!r})"
 
     def _get_strand(self):
         """Get function for the strand property (PRIVATE)."""
@@ -1340,7 +1340,7 @@ class CompoundLocation:
             if self.operator != other.operator:
                 # Handle join+order -> order as a special case?
                 raise ValueError(
-                    "Mixed operators %s and %s" % (self.operator, other.operator)
+                    f"Mixed operators {self.operator} and {other.operator}"
                 )
             return CompoundLocation(self.parts + other.parts, self.operator)
         elif isinstance(other, int):
@@ -1813,7 +1813,7 @@ class WithinPosition(int, AbstractPosition):
 
     def __str__(self):
         """Return a representation of the WithinPosition object (with python counting)."""
-        return "(%s.%s)" % (self._left, self._right)
+        return f"({self._left}.{self._right})"
 
     @property
     def position(self):
@@ -1931,7 +1931,7 @@ class BetweenPosition(int, AbstractPosition):
 
     def __str__(self):
         """Return a representation of the BetweenPosition object (with python counting)."""
-        return "(%s^%s)" % (self._left, self._right)
+        return f"({self._left}^{self._right})"
 
     @property
     def position(self):
@@ -2162,7 +2162,7 @@ class OneOfPosition(int, AbstractPosition):
         """
         if position not in choices:
             raise ValueError(
-                "OneOfPosition: %r should match one of %r" % (position, choices)
+                f"OneOfPosition: {position!r} should match one of {choices!r}"
             )
         obj = int.__new__(cls, position)
         obj.position_choices = choices
@@ -2224,7 +2224,7 @@ class PositionGap:
 
     def __repr__(self):
         """Represent the position gap as a string for debugging."""
-        return "%s(%r)" % (self.__class__.__name__, self.gap_size)
+        return f"{self.__class__.__name__}({self.gap_size!r})"
 
     def __str__(self):
         """Return a representation of the PositionGap object (with python counting)."""

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -302,7 +302,7 @@ class FastaWriter(SequenceWriter):
                 # The description includes the id at the start
                 title = description
             elif description:
-                title = "%s %s" % (id, description)
+                title = f"{id} {description}"
             else:
                 title = id
 
@@ -379,7 +379,7 @@ def as_fasta(record):
         # The description includes the id at the start
         title = description
     elif description:
-        title = "%s %s" % (id, description)
+        title = f"{id} {description}"
     else:
         title = id
     assert "\n" not in title
@@ -407,7 +407,7 @@ def as_fasta_2line(record):
         # The description includes the id at the start
         title = description
     elif description:
-        title = "%s %s" % (id, description)
+        title = f"{id} {description}"
     else:
         title = id
     assert "\n" not in title
@@ -417,7 +417,7 @@ def as_fasta_2line(record):
     assert "\n" not in data
     assert "\r" not in data
 
-    return ">%s\n%s\n" % (title, data)
+    return f">{title}\n{data}\n"
 
 
 if __name__ == "__main__":

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -376,7 +376,7 @@ class _InsdcWriter(SequenceWriter):
     def _write_feature_qualifier(self, key, value=None, quote=None):
         if value is None:
             # Value-less entry like /pseudo
-            self.handle.write("%s/%s\n" % (self.QUALIFIER_INDENT_STR, key))
+            self.handle.write(f"{self.QUALIFIER_INDENT_STR}/{key}\n")
             return
 
         if type(value) == str:
@@ -393,9 +393,9 @@ class _InsdcWriter(SequenceWriter):
             else:
                 quote = True
         if quote:
-            line = '%s/%s="%s"' % (self.QUALIFIER_INDENT_STR, key, value)
+            line = f'{self.QUALIFIER_INDENT_STR}/{key}="{value}"'
         else:
-            line = "%s/%s=%s" % (self.QUALIFIER_INDENT_STR, key, value)
+            line = f"{self.QUALIFIER_INDENT_STR}/{key}={value}"
         if len(line) <= self.MAX_WIDTH:
             self.handle.write(line + "\n")
             return
@@ -546,7 +546,7 @@ class GenBankWriter(_InsdcWriter):
         if len(text) > self.MAX_WIDTH - self.HEADER_WIDTH:
             if tag:
                 warnings.warn(
-                    "Annotation %r too long for %r line" % (text, tag), BiopythonWarning
+                    f"Annotation {text!r} too long for {tag!r} line", BiopythonWarning
                 )
             else:
                 # Can't give such a precise warning
@@ -1025,7 +1025,7 @@ class GenBankWriter(_InsdcWriter):
 
         self._write_single_line("ACCESSION", accession)
         if gi != ".":
-            self._write_single_line("VERSION", "%s  GI:%s" % (acc_with_version, gi))
+            self._write_single_line("VERSION", f"{acc_with_version}  GI:{gi}")
         else:
             self._write_single_line("VERSION", "%s" % acc_with_version)
 

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -92,7 +92,7 @@ def AtomIterator(pdb_id, structure):
         else:
             # No gaps
             res_out = [_res2aacode(x) for x in residues]
-        record_id = "%s:%s" % (pdb_id, chn_id)
+        record_id = f"{pdb_id}:{chn_id}"
         # ENH - model number in SeqRecord id if multiple models?
         # id = "Chain%s" % str(chain.id)
         # if len(structure) > 1 :

--- a/Bio/SeqIO/PhdIO.py
+++ b/Bio/SeqIO/PhdIO.py
@@ -125,7 +125,7 @@ class PhdWriter(SequenceWriter):
         if record.description.startswith("%s " % record.id):
             title = record.description
         else:
-            title = "%s %s" % (record.id, record.description)
+            title = f"{record.id} {record.description}"
         self.handle.write("BEGIN_SEQUENCE %s\nBEGIN_COMMENT\n" % self.clean(title))
         for annot in [k.lower() for k in Phd.CKEYWORDS]:
             value = None
@@ -138,7 +138,7 @@ class PhdWriter(SequenceWriter):
             else:
                 value = record.annotations.get(annot)
             if value or value == 0:
-                self.handle.write("%s: %s\n" % (annot.upper(), value))
+                self.handle.write(f"{annot.upper()}: {value}\n")
 
         self.handle.write("END_COMMENT\nBEGIN_DNA\n")
         for i, site in enumerate(record.seq):

--- a/Bio/SeqIO/PirIO.py
+++ b/Bio/SeqIO/PirIO.py
@@ -269,7 +269,7 @@ class PirWriter(SequenceWriter):
         assert "\n" not in title
         assert "\r" not in description
 
-        self.handle.write(">%s;%s\n%s\n" % (code, title, description))
+        self.handle.write(f">{code};{title}\n{description}\n")
 
         data = _get_seq_string(record)  # Catches sequence being None
 

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -1509,11 +1509,11 @@ class FastqPhredWriter(SequenceWriter):
             # The description includes the id at the start
             title = description
         elif description:
-            title = "%s %s" % (id, description)
+            title = f"{id} {description}"
         else:
             title = id
 
-        self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq, qualities_str))
+        self.handle.write(f"@{title}\n{seq}\n+\n{qualities_str}\n")
 
 
 def as_fastq(record):
@@ -1535,10 +1535,10 @@ def as_fastq(record):
     if description and description.split(None, 1)[0] == id:
         title = description
     elif description:
-        title = "%s %s" % (id, description)
+        title = f"{id} {description}"
     else:
         title = id
-    return "@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str)
+    return f"@{title}\n{seq_str}\n+\n{qualities_str}\n"
 
 
 class QualPhredWriter(SequenceWriter):
@@ -1612,7 +1612,7 @@ class QualPhredWriter(SequenceWriter):
                 # The description includes the id at the start
                 title = description
             elif description:
-                title = "%s %s" % (id, description)
+                title = f"{id} {description}"
             else:
                 title = id
         handle.write(">%s\n" % title)
@@ -1665,7 +1665,7 @@ def as_qual(record):
     if description and description.split(None, 1)[0] == id:
         title = description
     elif description:
-        title = "%s %s" % (id, description)
+        title = f"{id} {description}"
     else:
         title = id
     lines = [">%s\n" % title]
@@ -1765,11 +1765,11 @@ class FastqSolexaWriter(SequenceWriter):
             # The description includes the id at the start
             title = description
         elif description:
-            title = "%s %s" % (id, description)
+            title = f"{id} {description}"
         else:
             title = id
 
-        self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq, qualities_str))
+        self.handle.write(f"@{title}\n{seq}\n+\n{qualities_str}\n")
 
 
 def as_fastq_solexa(record):
@@ -1791,10 +1791,10 @@ def as_fastq_solexa(record):
         # The description includes the id at the start
         title = description
     elif description:
-        title = "%s %s" % (id, description)
+        title = f"{id} {description}"
     else:
         title = id
-    return "@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str)
+    return f"@{title}\n{seq_str}\n+\n{qualities_str}\n"
 
 
 class FastqIlluminaWriter(SequenceWriter):
@@ -1849,11 +1849,11 @@ class FastqIlluminaWriter(SequenceWriter):
             # The description includes the id at the start
             title = description
         elif description:
-            title = "%s %s" % (id, description)
+            title = f"{id} {description}"
         else:
             title = id
 
-        self.handle.write("@%s\n%s\n+\n%s\n" % (title, seq, qualities_str))
+        self.handle.write(f"@{title}\n{seq}\n+\n{qualities_str}\n")
 
 
 def as_fastq_illumina(record):
@@ -1874,10 +1874,10 @@ def as_fastq_illumina(record):
     if description and description.split(None, 1)[0] == id:
         title = description
     elif description:
-        title = "%s %s" % (id, description)
+        title = f"{id} {description}"
     else:
         title = id
-    return "@%s\n%s\n+\n%s\n" % (title, seq_str, qualities_str)
+    return f"@{title}\n{seq_str}\n+\n{qualities_str}\n"
 
 
 def PairedFastaQualIterator(fasta_source, qual_source, alphabet=None, title2ids=None):
@@ -1971,7 +1971,7 @@ def PairedFastaQualIterator(fasta_source, qual_source, alphabet=None, title2ids=
             raise ValueError("QUAL file has more entries than the FASTA file.")
         if f_rec.id != q_rec.id:
             raise ValueError(
-                "FASTA and QUAL entries do not match (%s vs %s)." % (f_rec.id, q_rec.id)
+                f"FASTA and QUAL entries do not match ({f_rec.id} vs {q_rec.id})."
             )
         if len(f_rec) != len(q_rec.letter_annotations["phred_quality"]):
             raise ValueError(
@@ -1998,7 +1998,7 @@ def _fastq_generic(in_file, out_file, mapping):
             qual = old_qual.translate(mapping)
             if null in qual:
                 raise ValueError("Invalid character in quality string")
-            out_handle.write("@%s\n%s\n+\n%s\n" % (title, seq, qual))
+            out_handle.write(f"@{title}\n{seq}\n+\n{qual}\n")
     return count
 
 
@@ -2017,7 +2017,7 @@ def _fastq_generic2(in_file, out_file, mapping, truncate_char, truncate_msg):
             if truncate_char in qual:
                 qual = qual.replace(truncate_char, chr(126))
                 warnings.warn(truncate_msg, BiopythonWarning)
-            out_handle.write("@%s\n%s\n+\n%s\n" % (title, seq, qual))
+            out_handle.write(f"@{title}\n{seq}\n+\n{qual}\n")
     return count
 
 
@@ -2231,7 +2231,7 @@ def _fastq_convert_tab(in_file, out_file):
     with as_handle(out_file, "w") as out_handle:
         for title, seq, qual in FastqGeneralIterator(in_file):
             count += 1
-            out_handle.write("%s\t%s\n" % (title.split(None, 1)[0], seq))
+            out_handle.write(f"{title.split(None, 1)[0]}\t{seq}\n")
     return count
 
 

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -148,12 +148,10 @@ class ContentHandler(handler.ContentHandler):
         namespace, localname = name
         if namespace is not None:
             raise ValueError(
-                "Unexpected namespace '%s' for %s element" % (namespace, localname)
+                f"Unexpected namespace '{namespace}' for {localname} element"
             )
         if qname is not None:
-            raise RuntimeError(
-                "Unexpected qname '%s' for %s element" % (qname, localname)
-            )
+            raise RuntimeError(f"Unexpected qname '{qname}' for {localname} element")
         if localname == "species":
             return self.startSpeciesElement(attrs)
         if localname == "description":
@@ -296,7 +294,7 @@ class ContentHandler(handler.ContentHandler):
             raise RuntimeError("Unexpected data found: '%s'" % self.data)
         self.data = ""
         record = self.records[-1]
-        dbxref = "%s:%s" % (source, ID)
+        dbxref = f"{source}:{ID}"
         if dbxref not in record.dbxrefs:
             record.dbxrefs.append(dbxref)
         self.endElementNS = self.endDBRefElement

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -541,7 +541,7 @@ def _sff_find_roche_index(handle):
         )
     else:
         raise ValueError(
-            "Unknown magic number %r in SFF index header:\n%r" % (magic_number, data)
+            f"Unknown magic number {magic_number!r} in SFF index header:\n{data!r}"
         )
 
 

--- a/Bio/SeqIO/SwissIO.py
+++ b/Bio/SeqIO/SwissIO.py
@@ -86,7 +86,7 @@ def SwissIterator(source):
             if len(cross_reference) < 2:
                 continue
             database, accession = cross_reference[:2]
-            dbxref = "%s:%s" % (database, accession)
+            dbxref = f"{database}:{accession}"
             if dbxref not in record.dbxrefs:
                 record.dbxrefs.append(dbxref)
         annotations = record.annotations

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -130,7 +130,7 @@ def as_tab(record):
     assert "\t" not in seq
     assert "\n" not in seq
     assert "\r" not in seq
-    return "%s\t%s\n" % (title, seq)
+    return f"{title}\t{seq}\n"
 
 
 if __name__ == "__main__":

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -158,7 +158,7 @@ class Parser:
                         if taxon_element.tag == NS + "taxon":
                             append_to_annotations("taxonomy", taxon_element.text)
             if sci_name and com_name:
-                organism_name = "%s (%s)" % (sci_name, com_name)
+                organism_name = f"{sci_name} ({com_name})"
             elif sci_name:
                 organism_name = sci_name
             elif com_name:
@@ -287,11 +287,9 @@ class Parser:
                 mass = element.attrib["mass"]
                 method = element.attrib["method"]
                 if start == end == 0:
-                    append_to_annotations(ann_key, "undefined:%s|%s" % (mass, method))
+                    append_to_annotations(ann_key, f"undefined:{mass}|{method}")
                 else:
-                    append_to_annotations(
-                        ann_key, "%s..%s:%s|%s" % (start, end, mass, method)
-                    )
+                    append_to_annotations(ann_key, f"{start}..{end}:{mass}|{method}")
             elif element.attrib["type"] == "sequence caution":
                 pass  # not parsed: few information, complex structure
             elif element.attrib["type"] == "online information":

--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -333,7 +333,7 @@ class XdnaWriter(SequenceWriter):
                 for val in feature.qualifiers[qname]:
                     if len(description) > 0:
                         description = description + "\x0D"
-                    description = description + '%s="%s"' % (qname, val)
+                    description = description + f'{qname}="{val}"'
             self._write_pstring(description)
 
             self._write_pstring(feature.type)

--- a/Bio/SeqUtils/CheckSum.py
+++ b/Bio/SeqUtils/CheckSum.py
@@ -76,7 +76,7 @@ def crc64(s):
         crch = temp1h ^ _table_h[idx]
         crcl = temp1l
 
-    return "CRC-%08X%08X" % (crch, crcl)
+    return f"CRC-{crch:08X}{crcl:08X}"
 
 
 def gcg(seq):

--- a/Bio/SeqUtils/CodonUsage.py
+++ b/Bio/SeqUtils/CodonUsage.py
@@ -150,9 +150,7 @@ class CodonAdaptationIndex:
                     cai_length += 1
             # some indices may not include stop codons:
             elif codon not in ["TGA", "TAA", "TAG"]:
-                raise TypeError(
-                    "illegal codon in sequence: %s.\n%s" % (codon, self.index)
-                )
+                raise TypeError(f"illegal codon in sequence: {codon}.\n{self.index}")
 
         return math.exp(cai_value / (cai_length - 1.0))
 
@@ -175,7 +173,7 @@ class CodonAdaptationIndex:
                         self.codon_count[codon] += 1
                     else:
                         raise TypeError(
-                            "illegal codon %s in gene: %s" % (codon, cur_record.id)
+                            f"illegal codon {codon} in gene: {cur_record.id}"
                         )
 
     def print_index(self):
@@ -184,4 +182,4 @@ class CodonAdaptationIndex:
         This just gives the index when the objects is printed.
         """
         for i in sorted(self.index):
-            print("%s\t%.3f" % (i, self.index[i]))
+            print(f"{i}\t{self.index[i]:.3f}")

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -377,7 +377,7 @@ def molecular_weight(
             weight -= water
     except KeyError as e:
         raise ValueError(
-            "%s is not a valid unambiguous letter for %s" % (e, seq_type)
+            f"{e} is not a valid unambiguous letter for {seq_type}"
         ) from None
 
     if double_stranded:
@@ -435,7 +435,7 @@ def six_frame_translations(seq, genetic_code=1):
 
     # create header
     if length > 20:
-        short = "%s ... %s" % (seq[:10], seq[-10:])
+        short = f"{seq[:10]} ... {seq[-10:]}"
     else:
         short = seq
     header = "GC_Frame:"


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Progress on #2510, work originally done on top of #3722 but rebased and submitting separately.

Note that in multiple cases pyupgrade would replace a % string example with a string format method, and I reverted these. In general I still find those less readable than either % style or f-strings.

This is similar to my past experience using flynt for automated f-string conversion, where again I would frequently not like the changes it proposed.

i.e. I would prefer not to use either tool in automated mode right now.