### PR TITLE
More f-string conversion using pyupgrade 2.25.0 

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -219,7 +219,7 @@ class MultipleSeqAlignment:
         """
         if record.seq.__class__.__name__ == "CodonSeq":
             if len(record.seq) <= length:
-                return "%s %s" % (record.seq, record.id)
+                return f"{record.seq} {record.id}"
             else:
                 return "%s...%s %s" % (
                     record.seq[: length - 3],
@@ -228,7 +228,7 @@ class MultipleSeqAlignment:
                 )
         else:
             if len(record.seq) <= length:
-                return "%s %s" % (record.seq, record.id)
+                return f"{record.seq} {record.id}"
             else:
                 return "%s...%s %s" % (
                     record.seq[: length - 6],
@@ -1713,7 +1713,7 @@ class Alignment:
             start2 = end2
         aligned_seq1 += seq1[end1:]
         aligned_seq2 += seq2[end2:]
-        return "%s\n%s\n%s\n" % (aligned_seq1, pattern, aligned_seq2)
+        return f"{aligned_seq1}\n{pattern}\n{aligned_seq2}\n"
 
     def _format_generalized(self):
         """Return generalized string representation (PRIVATE).
@@ -1786,7 +1786,7 @@ class Alignment:
         aligned_seq1 = " ".join(aligned_seq1)
         aligned_seq2 = " ".join(aligned_seq2)
         pattern = " ".join(pattern)
-        return "%s\n%s\n%s\n" % (aligned_seq1, pattern, aligned_seq2)
+        return f"{aligned_seq1}\n{pattern}\n{aligned_seq2}\n"
 
     def _format_bed(self):
         """Return BED file format string representation (PRIVATE).

--- a/Bio/Align/clustal.py
+++ b/Bio/Align/clustal.py
@@ -32,7 +32,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
                 version = alignments.version
             except AttributeError:
                 version = ""
-        line = "%s %s multiple sequence alignment\n" % (program, version)
+        line = f"{program} {version} multiple sequence alignment\n"
         stream.write(line)
         stream.write("\n")
         stream.write("\n")
@@ -78,7 +78,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
                 stop = length
 
             for name, gapped_sequence in zip(names, gapped_sequences):
-                line = "%s%s\n" % (name, gapped_sequence[start:stop])
+                line = f"{name}{gapped_sequence[start:stop]}\n"
                 stream.write(line)
 
             # now we need to print out the star info, if we've got it

--- a/Bio/AlignIO/FastaIO.py
+++ b/Bio/AlignIO/FastaIO.py
@@ -99,7 +99,7 @@ def FastaM10Iterator(handle, seq_count=None):
 
     def build_hsp():
         if not query_tags and not match_tags:
-            raise ValueError("No data for query %r, match %r" % (query_id, match_id))
+            raise ValueError(f"No data for query {query_id!r}, match {match_id!r}")
         assert query_tags, query_tags
         assert match_tags, match_tags
         evalue = align_tags.get("fa_expect")
@@ -324,7 +324,7 @@ handle.name: {handle.name}
             elif state == state_ALIGN_MATCH:
                 match_tags[key] = value
             else:
-                raise RuntimeError("Unexpected state %r, %r" % (state, line))
+                raise RuntimeError(f"Unexpected state {state!r}, {line!r}")
         elif state == state_ALIGN_QUERY:
             query_seq += line.strip()
         elif state == state_ALIGN_MATCH:

--- a/Bio/AlignIO/MafIO.py
+++ b/Bio/AlignIO/MafIO.py
@@ -355,15 +355,15 @@ class MafIndex:
         # make the tables
         self._con.execute("CREATE TABLE meta_data (key TEXT, value TEXT);")
         self._con.execute(
-            "INSERT INTO meta_data (key, value) VALUES ('version', %s);"
-            % MAFINDEX_VERSION
+            "INSERT INTO meta_data (key, value) VALUES (?, ?);",
+            ("version", MAFINDEX_VERSION),
         )
         self._con.execute(
             "INSERT INTO meta_data (key, value) VALUES ('record_count', -1);"
         )
         self._con.execute(
-            "INSERT INTO meta_data (key, value) VALUES ('target_seqname', '%s');"
-            % (self._target_seqname,)
+            "INSERT INTO meta_data (key, value) VALUES (?, ?);",
+            ("target_seqname", self._target_seqname),
         )
         # Determine whether to store maf file as relative to the index or absolute
         # See https://github.com/biopython/biopython/pull/381
@@ -391,7 +391,8 @@ class MafIndex:
             # example: /home/bli/src/biopython/Tests/MAF/ucsc_mm9_chr10.maf
             mafpath = os.path.abspath(self._maf_file)
         self._con.execute(
-            "INSERT INTO meta_data (key, value) VALUES ('filename', '%s');" % (mafpath,)
+            "INSERT INTO meta_data (key, value) VALUES (?, ?);",
+            ("filename", mafpath),
         )
         self._con.execute(
             "CREATE TABLE offset_data (bin INTEGER, start INTEGER, end INTEGER, offset INTEGER);"

--- a/Bio/AlignIO/MafIO.py
+++ b/Bio/AlignIO/MafIO.py
@@ -98,7 +98,7 @@ class MafWriter(SequentialAlignmentWriter):
         try:
             anno = " ".join(
                 [
-                    "%s=%s" % (x, y)
+                    f"{x}={y}"
                     for x, y in alignment._annotations.items()
                     if x in ("score", "pass")
                 ]
@@ -106,7 +106,7 @@ class MafWriter(SequentialAlignmentWriter):
         except AttributeError:
             anno = "score=0.00"
 
-        self.handle.write("a %s\n" % (anno,))
+        self.handle.write(f"a {anno}\n")
 
         recs_out = 0
 
@@ -231,9 +231,7 @@ def MafIterator(handle, seq_count=None):
                 annotations = []
                 records = []
             else:
-                raise ValueError(
-                    "Error parsing alignment - unexpected line:\n%s" % (line,)
-                )
+                raise ValueError(f"Error parsing alignment - unexpected line:\n{line}")
         elif line.startswith("a"):
             # start a bundle of records
             in_a_bundle = True
@@ -720,7 +718,7 @@ class MafIndex:
             # https://docs.python.org/2/tutorial/controlflow.html#break-and-continue-statements-and-else-clauses-on-loops
             else:
                 raise ValueError(
-                    "Did not find %s in alignment bundle" % (self._target_seqname,)
+                    f"Did not find {self._target_seqname} in alignment bundle"
                 )
 
             # the true, chromosome/contig/etc position in the target seqname

--- a/Bio/AlignIO/MauveIO.py
+++ b/Bio/AlignIO/MauveIO.py
@@ -139,7 +139,7 @@ class MauveWriter(SequentialAlignmentWriter):
             # Sequence1Entry	1
             # Sequence1Format	FastA
             for i in range(1, count + 1):
-                self.handle.write("#Sequence%sEntry\t%s\n" % (i, i))
+                self.handle.write(f"#Sequence{i}Entry\t{i}\n")
 
         for idx, record in enumerate(alignment):
             self._write_record(record, record_idx=idx)

--- a/Bio/AlignIO/MsfIO.py
+++ b/Bio/AlignIO/MsfIO.py
@@ -265,15 +265,13 @@ class MsfIterator(AlignmentIterator):
                         # expect a line with name and a block of trailing ~ here.
                         pass
                     else:
-                        raise ValueError(
-                            "Expected sequence for %s, got: %r" % (name, line)
-                        )
+                        raise ValueError(f"Expected sequence for {name}, got: {line!r}")
                 elif words[0] == name:
                     assert len(words) > 1, line
                     # print(i, name, repr(words))
                     seqs[idx].extend(words[1:])
                 else:
-                    raise ValueError("Expected sequence for %r, got: %r" % (name, line))
+                    raise ValueError(f"Expected sequence for {name!r}, got: {line!r}")
             # TODO - check the sequence lengths thus far are consistent
             # with blocks of 50?
             completed_length += 50

--- a/Bio/AlignIO/StockholmIO.py
+++ b/Bio/AlignIO/StockholmIO.py
@@ -204,11 +204,9 @@ class StockholmWriter(SequentialAlignmentWriter):
         if alignment.column_annotations:
             for k, v in sorted(alignment.column_annotations.items()):
                 if k in self.pfam_gc_mapping:
-                    self.handle.write("#=GC %s %s\n" % (self.pfam_gc_mapping[k], v))
+                    self.handle.write(f"#=GC {self.pfam_gc_mapping[k]} {v}\n")
                 elif k in self.pfam_gr_mapping:
-                    self.handle.write(
-                        "#=GC %s %s\n" % (self.pfam_gr_mapping[k] + "_cons", v)
-                    )
+                    self.handle.write(f"#=GC {self.pfam_gr_mapping[k]}_cons {v}\n")
                 else:
                     # It doesn't follow the PFAM standards, but should we record
                     # this data anyway?
@@ -242,7 +240,7 @@ class StockholmWriter(SequentialAlignmentWriter):
         if seq_name in self._ids_written:
             raise ValueError("Duplicate record identifier: %s" % seq_name)
         self._ids_written.append(seq_name)
-        self.handle.write("%s %s\n" % (seq_name, record.seq))
+        self.handle.write(f"{seq_name} {record.seq}\n")
 
         # The recommended placement for GS lines (per sequence annotation)
         # is above the alignment (as a header block) or just below the
@@ -262,17 +260,15 @@ class StockholmWriter(SequentialAlignmentWriter):
                 % (seq_name, self.clean(record.annotations["accession"]))
             )
         elif record.id:
-            self.handle.write("#=GS %s AC %s\n" % (seq_name, self.clean(record.id)))
+            self.handle.write(f"#=GS {seq_name} AC {self.clean(record.id)}\n")
 
         # DE = description
         if record.description:
-            self.handle.write(
-                "#=GS %s DE %s\n" % (seq_name, self.clean(record.description))
-            )
+            self.handle.write(f"#=GS {seq_name} DE {self.clean(record.description)}\n")
 
         # DE = database links
         for xref in record.dbxrefs:
-            self.handle.write("#=GS %s DR %s\n" % (seq_name, self.clean(xref)))
+            self.handle.write(f"#=GS {seq_name} DR {self.clean(xref)}\n")
 
         # GS = other per sequence annotation
         for key, value in record.annotations.items():

--- a/Bio/Application/__init__.py
+++ b/Bio/Application/__init__.py
@@ -351,13 +351,13 @@ class AbstractCommandline:
         >>> cline
         WaterCommandline(cmd='water', outfile='temp_water.txt', asequence='asis:ACCCGGGCGCGGT', bsequence='asis:ACCCGAGCGCGGT', gapopen=10, gapextend=0.5)
         """
-        answer = "%s(cmd=%r" % (self.__class__.__name__, self.program_name)
+        answer = f"{self.__class__.__name__}(cmd={self.program_name!r}"
         for parameter in self.parameters:
             if parameter.is_set:
                 if isinstance(parameter, _Switch):
                     answer += ", %s=True" % parameter.names[-1]
                 else:
-                    answer += ", %s=%r" % (parameter.names[-1], parameter.value)
+                    answer += f", {parameter.names[-1]}={parameter.value!r}"
         answer += ")"
         return answer
 
@@ -432,7 +432,7 @@ class AbstractCommandline:
                 )
             if not is_good:
                 raise ValueError(
-                    "Invalid parameter value %r for parameter %s" % (value, name)
+                    f"Invalid parameter value {value!r} for parameter {name}"
                 )
 
     def __setattr__(self, name, value):
@@ -634,7 +634,7 @@ class _Option(_AbstractParameter):
     ):
         self.names = names
         if not isinstance(description, str):
-            raise TypeError("Should be a string: %r for %s" % (description, names[-1]))
+            raise TypeError(f"Should be a string: {description!r} for {names[-1]}")
         # Note 'filename' is for any string with spaces that needs quoting
         self.is_filename = filename
         self.checker_function = checker_function
@@ -661,9 +661,9 @@ class _Option(_AbstractParameter):
         else:
             v = str(self.value)
         if self.equate:
-            return "%s=%s " % (self.names[0], v)
+            return f"{self.names[0]}={v} "
         else:
-            return "%s %s " % (self.names[0], v)
+            return f"{self.names[0]} {v} "
 
 
 class _Switch(_AbstractParameter):
@@ -730,7 +730,7 @@ class _Argument(_AbstractParameter):
         #                     "single entry list with a PEP8 property name.")
         self.names = names
         if not isinstance(description, str):
-            raise TypeError("Should be a string: %r for %s" % (description, names[-1]))
+            raise TypeError(f"Should be a string: {description!r} for {names[-1]}")
         # Note 'filename' is for any string with spaces that needs quoting
         self.is_filename = filename
         self.checker_function = checker_function

--- a/Bio/Blast/Applications.py
+++ b/Bio/Blast/Applications.py
@@ -126,7 +126,7 @@ class _NcbibaseblastCommandline(AbstractCommandline):
             if self._get_parameter(a):
                 for b in incompatibles[a]:
                     if self._get_parameter(b):
-                        raise ValueError("Options %s and %s are incompatible." % (a, b))
+                        raise ValueError(f"Options {a} and {b} are incompatible.")
 
 
 class _NcbiblastCommandline(_NcbibaseblastCommandline):
@@ -1573,7 +1573,7 @@ class NcbimakeblastdbCommandline(AbstractCommandline):
             if self._get_parameter(a):
                 for b in incompatibles[a]:
                     if self._get_parameter(b):
-                        raise ValueError("Options %s and %s are incompatible." % (a, b))
+                        raise ValueError(f"Options {a} and {b} are incompatible.")
 
         if self.mask_id and not self.mask_data:
             raise ValueError("Option mask_id requires mask_data to be set.")

--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -75,7 +75,7 @@ class _XMLparser(ContentHandler):
         # but that white space doesn't belong to child tags like Hsp_midline
         if self._value.strip():
             raise ValueError(
-                "What should we do with %s before the %r tag?" % (self._value, name)
+                f"What should we do with {self._value} before the {name!r} tag?"
             )
         self._value = ""
 
@@ -105,11 +105,11 @@ class _XMLparser(ContentHandler):
         if method in self._method_map:
             self._method_map[method]()
             if self._debug > 2:
-                print("NCBIXML: Parsed:  %s %s" % (method, self._value))
+                print(f"NCBIXML: Parsed:  {method} {self._value}")
         elif self._debug > 1:
             # Doesn't exist (yet) and may want to warn about it
             if method not in self._debug_ignore_list:
-                print("NCBIXML: Ignored: %s %s" % (method, self._value))
+                print(f"NCBIXML: Ignored: {method} {self._value}")
                 self._debug_ignore_list.append(method)
 
         # Reset character buffer

--- a/Bio/Blast/Record.py
+++ b/Bio/Blast/Record.py
@@ -87,7 +87,7 @@ class Description:
 
     def __str__(self):
         """Return the description as a string."""
-        return "%-66s %5s  %s" % (self.title, self.score, self.e)
+        return f"{self.title:<66} {self.score:>5}  {self.e}"
 
 
 class DescriptionExt(Description):
@@ -128,7 +128,7 @@ class DescriptionExtItem:
 
     def __str__(self):
         """Return the description identifier and title as a string."""
-        return "%s %s" % (self.id, self.title)
+        return f"{self.id} {self.title}"
 
 
 class Alignment:
@@ -242,19 +242,15 @@ class HSP:
         if self.align_length is None:
             return "\n".join(lines)
         if self.align_length < 50:
-            lines.append(
-                "Query:%8s %s %s" % (self.query_start, self.query, self.query_end)
-            )
+            lines.append(f"Query:{self.query_start:>8} {self.query} {self.query_end}")
             lines.append("               %s" % self.match)
-            lines.append(
-                "Sbjct:%8s %s %s" % (self.sbjct_start, self.sbjct, self.sbjct_end)
-            )
+            lines.append(f"Sbjct:{self.sbjct_start:>8} {self.sbjct} {self.sbjct_end}")
         else:
             lines.append(
                 "Query:%8s %s...%s %s"
                 % (self.query_start, self.query[:45], self.query[-3:], self.query_end)
             )
-            lines.append("               %s...%s" % (self.match[:45], self.match[-3:]))
+            lines.append(f"               {self.match[:45]}...{self.match[-3:]}")
             lines.append(
                 "Sbjct:%8s %s...%s %s"
                 % (self.sbjct_start, self.sbjct[:45], self.sbjct[-3:], self.sbjct_end)

--- a/Bio/Blast/Record.py
+++ b/Bio/Blast/Record.py
@@ -242,9 +242,13 @@ class HSP:
         if self.align_length is None:
             return "\n".join(lines)
         if self.align_length < 50:
-            lines.append(f"Query:{self.query_start:>8} {self.query} {self.query_end}")
+            lines.append(
+                "Query:%8s %s %s" % (self.query_start, self.query, self.query_end)
+            )
             lines.append("               %s" % self.match)
-            lines.append(f"Sbjct:{self.sbjct_start:>8} {self.sbjct} {self.sbjct_end}")
+            lines.append(
+                "Sbjct:%8s %s %s" % (self.sbjct_start, self.sbjct, self.sbjct_end)
+            )
         else:
             lines.append(
                 "Query:%8s %s...%s %s"

--- a/Bio/Cluster/__init__.py
+++ b/Bio/Cluster/__init__.py
@@ -1131,7 +1131,7 @@ class Record:
             while counter < n:
                 for j in index:
                     if clusterids[j] == cluster:
-                        outputfile.write("%s\t%s\n" % (names[j], cluster))
+                        outputfile.write(f"{names[j]}\t{cluster}\n")
                         sortedindex[counter] = j
                         counter += 1
                 cluster += 1
@@ -1183,9 +1183,7 @@ class Record:
             for i in geneindex:
                 if gid:
                     outputfile.write("GENE%dX\t" % i)
-                outputfile.write(
-                    "%s\t%s\t%f" % (self.geneid[i], genename[i], gweight[i])
-                )
+                outputfile.write(f"{self.geneid[i]}\t{genename[i]}\t{gweight[i]:f}")
                 for j in expindex:
                     outputfile.write("\t")
                     if mask[i, j]:

--- a/Bio/Emboss/PrimerSearch.py
+++ b/Bio/Emboss/PrimerSearch.py
@@ -23,7 +23,7 @@ class InputRecord:
         """Summarize the primersearch input record as a string."""
         output = ""
         for name, primer1, primer2 in self.primer_info:
-            output += "%s %s %s\n" % (name, primer1, primer2)
+            output += f"{name} {primer1} {primer2}\n"
         return output
 
     def add_primer_set(self, primer_name, first_primer_seq, second_primer_seq):

--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -108,7 +108,7 @@ class IntegerElement(int):
             attributes = self.attributes
         except AttributeError:
             return text
-        return "IntegerElement(%s, attributes=%r)" % (text, attributes)
+        return f"IntegerElement({text}, attributes={attributes!r})"
 
 
 class StringElement(str):
@@ -130,7 +130,7 @@ class StringElement(str):
         attributes = self.attributes
         if not attributes:
             return text
-        return "StringElement(%s, attributes=%r)" % (text, attributes)
+        return f"StringElement({text}, attributes={attributes!r})"
 
 
 class ListElement(list):
@@ -152,7 +152,7 @@ class ListElement(list):
         attributes = self.attributes
         if not attributes:
             return text
-        return "ListElement(%s, attributes=%r)" % (text, attributes)
+        return f"ListElement({text}, attributes={attributes!r})"
 
     def store(self, value):
         """Append an element to the list, checking tags."""
@@ -185,7 +185,7 @@ class DictionaryElement(dict):
         attributes = self.attributes
         if not attributes:
             return text
-        return "DictElement(%s, attributes=%r)" % (text, attributes)
+        return f"DictElement({text}, attributes={attributes!r})"
 
     def store(self, value):
         """Add an entry to the dictionary, checking tags."""
@@ -463,7 +463,7 @@ class DataHandler(metaclass=DataHandlerMeta):
             elif prefix == "xlink":
                 assert uri == "http://www.w3.org/1999/xlink"
             else:
-                raise ValueError("Unknown prefix '%s' with uri '%s'" % (prefix, uri))
+                raise ValueError(f"Unknown prefix '{prefix}' with uri '{uri}'")
             self.namespace_level[prefix] += 1
             self.namespace_prefix[uri] = prefix
 
@@ -630,14 +630,14 @@ class DataHandler(metaclass=DataHandlerMeta):
                 if self.namespace_level[prefix] == 1:
                     attrs = {"xmlns": uri}
         if prefix:
-            key = "%s:%s" % (prefix, name)
+            key = f"{prefix}:{name}"
         else:
             key = name
         # self.allowed_tags is ignored for now. Anyway we know what to do
         # with this tag.
         tag = "<%s" % name
         for key, value in attrs.items():
-            tag += ' %s="%s"' % (key, value)
+            tag += f' {key}="{value}"'
         tag += ">"
         self.data.append(tag)
         self.parser.EndElementHandler = self.endRawElementHandler
@@ -933,7 +933,7 @@ class DataHandler(metaclass=DataHandlerMeta):
         try:
             handle = open(path, "wb")
         except OSError:
-            warnings.warn("Failed to save %s at %s" % (filename, path))
+            warnings.warn(f"Failed to save {filename} at {path}")
         else:
             handle.write(text)
             handle.close()
@@ -944,7 +944,7 @@ class DataHandler(metaclass=DataHandlerMeta):
         try:
             handle = open(path, "wb")
         except OSError:
-            warnings.warn("Failed to save %s at %s" % (filename, path))
+            warnings.warn(f"Failed to save {filename} at {path}")
         else:
             handle.write(text)
             handle.close()
@@ -987,9 +987,7 @@ class DataHandler(metaclass=DataHandlerMeta):
             try:
                 handle = urlopen(url)
             except OSError:
-                raise RuntimeError(
-                    "Failed to access %s at %s" % (filename, url)
-                ) from None
+                raise RuntimeError(f"Failed to access {filename} at {url}") from None
             text = handle.read()
             handle.close()
             self.save_dtd_file(filename, text)

--- a/Bio/ExPASy/Prosite.py
+++ b/Bio/ExPASy/Prosite.py
@@ -215,9 +215,7 @@ def __read(handle):
                 elif qual in ["/TOTAL", "/POSITIVE", "/UNKNOWN", "/FALSE_POS"]:
                     m = re.match(r"(\d+)\((\d+)\)", data)
                     if not m:
-                        raise Exception(
-                            "Broken data %s in comment line\n%r" % (data, line)
-                        )
+                        raise Exception(f"Broken data {data} in comment line\n{line!r}")
                     hits = tuple(map(int, m.groups()))
                     if qual == "/TOTAL":
                         record.nr_total = hits
@@ -228,9 +226,7 @@ def __read(handle):
                     elif qual == "/FALSE_POS":
                         record.nr_false_pos = hits
                 else:
-                    raise ValueError(
-                        "Unknown qual %s in comment line\n%r" % (qual, line)
-                    )
+                    raise ValueError(f"Unknown qual {qual} in comment line\n{line!r}")
         elif keyword == "CC":
             # Expect CC lines like this:
             # CC   /TAXO-RANGE=??EPV; /MAX-REPEAT=2;
@@ -270,9 +266,7 @@ def __read(handle):
                 elif qual == "/VERSION":
                     record.cc_version = data
                 else:
-                    raise ValueError(
-                        "Unknown qual %s in comment line\n%r" % (qual, line)
-                    )
+                    raise ValueError(f"Unknown qual {qual} in comment line\n{line!r}")
         elif keyword == "DR":
             refs = value.split(";")
             for ref in refs:

--- a/Bio/ExPASy/ScanProsite.py
+++ b/Bio/ExPASy/ScanProsite.py
@@ -55,7 +55,7 @@ def scan(seq="", mirror="https://www.expasy.org", output="xml", **keywords):
         if value is not None:
             parameters[key] = value
     command = urlencode(parameters)
-    url = "%s/cgi-bin/prosite/PSScan.cgi?%s" % (mirror, command)
+    url = f"{mirror}/cgi-bin/prosite/PSScan.cgi?{command}"
     handle = urlopen(url)
     return handle
 

--- a/Bio/ExPASy/__init__.py
+++ b/Bio/ExPASy/__init__.py
@@ -39,7 +39,7 @@ def get_prodoc_entry(
     For a non-existing key XXX, ExPASy returns an HTML-formatted page
     containing this text: 'There is currently no PROSITE entry for'
     """
-    return _open("%s?%s" % (cgi, id))
+    return _open(f"{cgi}?{id}")
 
 
 def get_prosite_entry(
@@ -60,7 +60,7 @@ def get_prosite_entry(
     For a non-existing key XXX, ExPASy returns an HTML-formatted page
     containing this text: 'There is currently no PROSITE entry for'
     """
-    return _open("%s?%s" % (cgi, id))
+    return _open(f"{cgi}?{id}")
 
 
 def get_prosite_raw(id, cgi=None):

--- a/Bio/File.py
+++ b/Bio/File.py
@@ -209,7 +209,7 @@ class _IndexedSeqFileDict(collections.abc.Mapping):
         """Create a string representation of the File object."""
         # TODO - How best to handle the __str__ for SeqIO and SearchIO?
         if self:
-            return "{%r : %s(...), ...}" % (list(self.keys())[0], self._obj_repr)
+            return f"{{{list(self.keys())[0]!r} : {self._obj_repr}(...), ...}}"
         else:
             return "{}"
 
@@ -230,7 +230,7 @@ class _IndexedSeqFileDict(collections.abc.Mapping):
         else:
             key2 = record.id
         if key != key2:
-            raise ValueError("Key did not match (%s vs %s)" % (key, key2))
+            raise ValueError(f"Key did not match ({key} vs {key2})")
         return record
 
     def get_raw(self, key):
@@ -347,7 +347,7 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
             if fmt and fmt != self._format:
                 con.close()
                 raise ValueError(
-                    "Index file says format %s, not %s" % (self._format, fmt)
+                    f"Index file says format {self._format}, not {fmt}"
                 ) from None
             try:
                 (filenames_relative_to_index,) = con.execute(
@@ -562,7 +562,7 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
         else:
             key2 = record.id
         if key != key2:
-            raise ValueError("Key did not match (%s vs %s)" % (key, key2))
+            raise ValueError(f"Key did not match ({key} vs {key2})")
         return record
 
     def get_raw(self, key):

--- a/Bio/Geo/Record.py
+++ b/Bio/Geo/Record.py
@@ -47,22 +47,22 @@ class Record:
             if isinstance(contents, list):
                 for item in contents:
                     try:
-                        output += "%s: %s\n" % (key, item[:40])
+                        output += f"{key}: {item[:40]}\n"
                         output += out_block(item[40:])
                     except Exception:  # TODO: IndexError?
                         pass
             elif isinstance(contents, str):
-                output += "%s: %s\n" % (key, contents[:40])
+                output += f"{key}: {contents[:40]}\n"
                 output += out_block(contents[40:])
             else:
                 print(contents)
-                output += "%s: %s\n" % (key, contents[:40])
+                output += f"{key}: {contents[:40]}\n"
                 output += out_block(contents[40:])
         col_keys = sorted(self.col_defs)
         output += "Column Header Definitions\n"
         for key in col_keys:
             val = self.col_defs[key]
-            output += "    %s: %s\n" % (key, val[:40])
+            output += f"    {key}: {val[:40]}\n"
             output += out_block(val[40:], "    ")
         # May have to display VERY large tables,
         # so only show the first 20 lines of data
@@ -87,6 +87,6 @@ def out_block(text, prefix=""):
     """Format text in blocks of 80 chars with an additional optional prefix."""
     output = ""
     for j in range(0, len(text), 80):
-        output += "%s%s\n" % (prefix, text[j : j + 80])
+        output += f"{prefix}{text[j : j + 80]}\n"
     output += "\n"
     return output

--- a/Bio/Graphics/BasicChromosome.py
+++ b/Bio/Graphics/BasicChromosome.py
@@ -534,7 +534,7 @@ def _spring_layout(desired, minimum, maximum, gap=0):
     if count <= 1:
         return desired  # Easy!
     if minimum >= maximum:
-        raise ValueError("Bad min/max %f and %f" % (minimum, maximum))
+        raise ValueError(f"Bad min/max {minimum:f} and {maximum:f}")
     if min(desired) < minimum or max(desired) > maximum:
         raise ValueError(
             "Data %f to %f out of bounds (%f to %f)"

--- a/Bio/Graphics/GenomeDiagram/_Diagram.py
+++ b/Bio/Graphics/GenomeDiagram/_Diagram.py
@@ -403,7 +403,7 @@ class Diagram:
 
     def __str__(self):
         """Return a formatted string describing the diagram."""
-        outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
+        outstr = [f"\n<{self.__class__}: {self.name}>"]
         outstr.append("%d tracks" % len(self.tracks))
         for level in self.get_levels():
             outstr.append("Track %d: %s\n" % (level, self.tracks[level]))

--- a/Bio/Graphics/GenomeDiagram/_FeatureSet.py
+++ b/Bio/Graphics/GenomeDiagram/_FeatureSet.py
@@ -188,7 +188,7 @@ class FeatureSet:
         if not verbose:  # Short account only required
             return "%s" % self
         else:  # Long account desired
-            outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
+            outstr = [f"\n<{self.__class__}: {self.name}>"]
             outstr.append("%d features" % len(self.features))
             for key in self.features:
                 outstr.append("feature: %s" % self.features[key])

--- a/Bio/Graphics/GenomeDiagram/_Graph.py
+++ b/Bio/Graphics/GenomeDiagram/_Graph.py
@@ -184,7 +184,7 @@ class GraphData:
 
     def __str__(self):
         """Return a string describing the graph data."""
-        outstr = ["\nGraphData: %s, ID: %s" % (self.name, self.id)]
+        outstr = [f"\nGraphData: {self.name}, ID: {self.id}"]
         outstr.append("Number of points: %d" % len(self.data))
         outstr.append("Mean data value: %s" % self.mean())
         outstr.append("Sample SD: %.3f" % self.stdev())

--- a/Bio/Graphics/GenomeDiagram/_GraphSet.py
+++ b/Bio/Graphics/GenomeDiagram/_GraphSet.py
@@ -149,7 +149,7 @@ class GraphSet:
         if not verbose:
             return "%s" % self
         else:
-            outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
+            outstr = [f"\n<{self.__class__}: {self.name}>"]
             outstr.append("%d graphs" % len(self._graphs))
             for key in self._graphs:
                 outstr.append("%s" % self._graphs[key])
@@ -165,7 +165,7 @@ class GraphSet:
 
     def __str__(self):
         """Return a formatted string with information about the feature set."""
-        outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
+        outstr = [f"\n<{self.__class__}: {self.name}>"]
         outstr.append("%d graphs" % len(self._graphs))
         outstr = "\n".join(outstr)
         return outstr

--- a/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_LinearDrawer.py
@@ -1065,9 +1065,9 @@ class LinearDrawer(AbstractDrawer):
             top += self.fragment_lines[fragment][0]
         except Exception:  # Only called if the method screws up big time
             print("We've got a screw-up")
-            print("%s %s" % (self.start, self.end))
+            print(f"{self.start} {self.end}")
             print(self.fragment_bases)
-            print("%r %r" % (x0, x1))
+            print(f"{x0!r} {x1!r}")
             for locstart, locend in feature.locations:
                 print(self.canvas_location(locstart))
                 print(self.canvas_location(locend))
@@ -1104,7 +1104,7 @@ class LinearDrawer(AbstractDrawer):
             strand=feature.strand,
             color=feature.color,
             border=feature.border,
-            **kwargs
+            **kwargs,
         )
 
         if feature.label_strand:
@@ -1552,7 +1552,7 @@ class LinearDrawer(AbstractDrawer):
             strokeWidth=1,
             strokeLineJoin=1,  # 1=round
             fillColor=color,
-            **kwargs
+            **kwargs,
         )
 
     def _draw_sigil_arrow(self, bottom, center, top, x1, x2, strand, **kwargs):

--- a/Bio/Graphics/GenomeDiagram/_Track.py
+++ b/Bio/Graphics/GenomeDiagram/_Track.py
@@ -268,7 +268,7 @@ class Track:
         if not verbose:  # Return the short description
             return "%s" % self  # Use __str__ method instead
         else:  # Return the long description
-            outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
+            outstr = [f"\n<{self.__class__}: {self.name}>"]
             outstr.append("%d sets" % len(self._sets))
             for key in self._sets:
                 outstr.append("set: %s" % self._sets[key])
@@ -280,6 +280,6 @@ class Track:
 
     def __str__(self):
         """Return a formatted string with information about the Track."""
-        outstr = ["\n<%s: %s>" % (self.__class__, self.name)]
+        outstr = [f"\n<{self.__class__}: {self.name}>"]
         outstr.append("%d sets" % len(self._sets))
         return "\n".join(outstr)

--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -362,7 +362,7 @@ class MarkovModelBuilder:
             self.transition_pseudo[(from_state, to_state)] = pseudocount
         else:
             raise KeyError(
-                "Transition from %s to %s is already allowed." % (from_state, to_state)
+                f"Transition from {from_state} to {to_state} is already allowed."
             )
 
     def destroy_transition(self, from_state, to_state):
@@ -392,7 +392,7 @@ class MarkovModelBuilder:
             self.transition_prob[(from_state, to_state)] = probability
         else:
             raise KeyError(
-                "Transition from %s to %s is not allowed." % (from_state, to_state)
+                f"Transition from {from_state} to {to_state} is not allowed."
             )
 
     def set_transition_pseudocount(self, from_state, to_state, count):
@@ -412,7 +412,7 @@ class MarkovModelBuilder:
             self.transition_pseudo[(from_state, to_state)] = count
         else:
             raise KeyError(
-                "Transition from %s to %s is not allowed." % (from_state, to_state)
+                f"Transition from {from_state} to {to_state} is not allowed."
             )
 
     # --- functions to deal with emissions from the sequence
@@ -428,7 +428,7 @@ class MarkovModelBuilder:
             self.emission_prob[(seq_state, emission_state)] = probability
         else:
             raise KeyError(
-                "Emission of %s from %s is not allowed." % (emission_state, seq_state)
+                f"Emission of {emission_state} from {seq_state} is not allowed."
             )
 
     def set_emission_pseudocount(self, seq_state, emission_state, count):
@@ -448,7 +448,7 @@ class MarkovModelBuilder:
             self.emission_pseudo[(seq_state, emission_state)] = count
         else:
             raise KeyError(
-                "Emission of %s from %s is not allowed." % (emission_state, seq_state)
+                f"Emission of {emission_state} from {seq_state} is not allowed."
             )
 
 

--- a/Bio/HMM/Trainer.py
+++ b/Bio/HMM/Trainer.py
@@ -402,9 +402,7 @@ class KnownStateTrainer(AbstractTrainer):
             try:
                 emission_counts[(cur_state, cur_emission)] += 1
             except KeyError:
-                raise KeyError(
-                    "Unexpected emission (%s, %s)" % (cur_state, cur_emission)
-                )
+                raise KeyError(f"Unexpected emission ({cur_state}, {cur_emission})")
         return emission_counts
 
     def _count_transitions(self, state_seq, transition_counts):
@@ -423,8 +421,6 @@ class KnownStateTrainer(AbstractTrainer):
             try:
                 transition_counts[(cur_state, next_state)] += 1
             except KeyError:
-                raise KeyError(
-                    "Unexpected transition (%s, %s)" % (cur_state, next_state)
-                )
+                raise KeyError(f"Unexpected transition ({cur_state}, {next_state})")
 
         return transition_counts

--- a/Bio/HMM/Utilities.py
+++ b/Bio/HMM/Utilities.py
@@ -51,9 +51,7 @@ def pretty_print_prediction(
             "%s%s"
             % (emission_title, emissions[cur_position : cur_position + seq_length])
         )
-        print(
-            "%s%s" % (real_title, real_state[cur_position : cur_position + seq_length])
-        )
+        print(f"{real_title}{real_state[cur_position : cur_position + seq_length]}")
         print(
             "%s%s\n"
             % (

--- a/Bio/KEGG/KGML/KGML_pathway.py
+++ b/Bio/KEGG/KGML/KGML_pathway.py
@@ -94,7 +94,7 @@ class Pathway:
         # We insist that the node ID is an integer
         if not isinstance(entry.id, int):
             raise TypeError(
-                "Node ID must be an integer, got %s (%s)" % (type(entry.id), entry.id)
+                f"Node ID must be an integer, got {type(entry.id)} ({entry.id})"
             )
         entry._pathway = self  # Let the entry know about the pathway
         self.entries[entry.id] = entry
@@ -103,7 +103,7 @@ class Pathway:
         """Remove an Entry element from the pathway."""
         if not isinstance(entry.id, int):
             raise TypeError(
-                "Node ID must be an integer, got %s (%s)" % (type(entry.id), entry.id)
+                f"Node ID must be an integer, got {type(entry.id)} ({entry.id})"
             )
         # We need to remove the entry from any other elements that may
         # contain it, which means removing those elements

--- a/Bio/KEGG/REST.py
+++ b/Bio/KEGG/REST.py
@@ -36,11 +36,11 @@ from urllib.request import urlopen
 def _q(op, arg1, arg2=None, arg3=None):
     URL = "http://rest.kegg.jp/%s"
     if arg2 and arg3:
-        args = "%s/%s/%s/%s" % (op, arg1, arg2, arg3)
+        args = f"{op}/{arg1}/{arg2}/{arg3}"
     elif arg2:
-        args = "%s/%s/%s" % (op, arg1, arg2)
+        args = f"{op}/{arg1}/{arg2}"
     else:
-        args = "%s/%s" % (op, arg1)
+        args = f"{op}/{arg1}"
     resp = urlopen(URL % (args))
 
     if "image" == arg2:

--- a/Bio/MarkovModel.py
+++ b/Bio/MarkovModel.py
@@ -92,7 +92,7 @@ def _readline_and_check_start(handle, start):
     """Read the first line and evaluate that begisn with the correct start (PRIVATE)."""
     line = handle.readline()
     if not line.startswith(start):
-        raise ValueError("I expected %r but got %r" % (start, line))
+        raise ValueError(f"I expected {start!r} but got {line!r}")
     return line
 
 

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -399,10 +399,10 @@ def combine(matrices):
 
     # rename taxon sets and character sets and name them with prefix
     for cn, cs in combined.charsets.items():
-        combined.charsets["%s.%s" % (name, cn)] = cs
+        combined.charsets[f"{name}.{cn}"] = cs
         del combined.charsets[cn]
     for tn, ts in combined.taxsets.items():
-        combined.taxsets["%s.%s" % (name, tn)] = ts
+        combined.taxsets[f"{name}.{tn}"] = ts
         del combined.taxsets[tn]
     # previous partitions usually don't make much sense in combined matrix
     # just initiate one new partition parted by single matrices
@@ -429,14 +429,12 @@ def combine(matrices):
             )
         combined.taxlabels.extend(m_only)  # new taxon list
         for cn, cs in m.charsets.items():  # adjust character sets for new matrix
-            combined.charsets["%s.%s" % (n, cn)] = [x + combined.nchar for x in cs]
+            combined.charsets[f"{n}.{cn}"] = [x + combined.nchar for x in cs]
         if m.taxsets:
             if not combined.taxsets:
                 combined.taxsets = {}
             # update taxon sets
-            combined.taxsets.update(
-                {"%s.%s" % (n, tn): ts for tn, ts in m.taxsets.items()}
-            )
+            combined.taxsets.update({f"{n}.{tn}": ts for tn, ts in m.taxsets.items()})
         # update new charpartition
         combined.charpartitions["combined"][n] = list(
             range(combined.nchar, combined.nchar + m.nchar)
@@ -1315,7 +1313,7 @@ class Nexus:
             if qualifier.lower() == "vector":
                 raise NexusError("Unsupported VECTOR format in line %s" % (opts))
             elif qualifier.lower() != "standard":
-                raise NexusError("Unknown qualifier %s in line %s" % (qualifier, opts))
+                raise NexusError(f"Unknown qualifier {qualifier} in line {opts}")
         if opts.next_nonwhitespace() != separator:
             raise NexusError("Formatting error in line: %s " % rest)
         return name
@@ -1615,9 +1613,7 @@ class Nexus:
                 clkeys = sorted(newcharlabels)
                 fh.write(
                     "charlabels "
-                    + ", ".join(
-                        "%s %s" % (k + 1, safename(newcharlabels[k])) for k in clkeys
-                    )
+                    + ", ".join(f"{k + 1} {safename(newcharlabels[k])}" for k in clkeys)
                     + ";\n"
                 )
             fh.write("matrix\n")
@@ -1633,7 +1629,7 @@ class Nexus:
                 # to excluded characters
                 seek = 0
                 for p in names:
-                    fh.write("[%s: %s]\n" % (interleave_by_partition, p))
+                    fh.write(f"[{interleave_by_partition}: {p}]\n")
                     if len(newpartition[p]) > 0:
                         for taxon in undelete:
                             fh.write(
@@ -1726,9 +1722,7 @@ class Nexus:
             for n, ns in self.charsets.items():
                 cset = [offlist[c] for c in ns if c not in exclude]
                 if cset:
-                    setsb.append(
-                        "charset %s = %s" % (safename(n), _compact4nexus(cset))
-                    )
+                    setsb.append(f"charset {safename(n)} = {_compact4nexus(cset)}")
             for n, s in self.taxsets.items():
                 tset = [safename(t, mrbayes=mrbayes) for t in s if t not in delete]
                 if tset:
@@ -1758,7 +1752,7 @@ class Nexus:
                         command,
                         safename(n),
                         ", ".join(
-                            "%s: %s" % (sn, _compact4nexus(newpartition[sn]))
+                            f"{sn}: {_compact4nexus(newpartition[sn])}"
                             for sn in names
                             if sn in newpartition
                         ),
@@ -1833,7 +1827,7 @@ class Nexus:
         with open(filename, "w") as fh:
             fh.write("%d %d\n" % (self.ntax, self.nchar))
             for taxon in self.taxlabels:
-                fh.write("%s %s\n" % (safename(taxon), str(self.matrix[taxon])))
+                fh.write(f"{safename(taxon)} {str(self.matrix[taxon])}\n")
         return filename
 
     def constant(self, matrix=None, delete=(), exclude=()):

--- a/Bio/Nexus/Trees.py
+++ b/Bio/Nexus/Trees.py
@@ -391,7 +391,7 @@ class Tree(Nodes.Chain):
                 print(node)
                 print(self.node(node).succ)
                 for n in self.node(node).succ:
-                    print("%s %s" % (n, self.set_subtree(n)))
+                    print(f"{n} {self.set_subtree(n)}")
                 print([self.set_subtree(n) for n in self.node(node).succ])
                 raise
 
@@ -674,7 +674,7 @@ class Tree(Nodes.Chain):
                     if (
                         data.branchlength is not None and data.support is not None
                     ):  # we have blen and support
-                        info_string = "%1.2f:%1.5f" % (data.support, data.branchlength)
+                        info_string = f"{data.support:1.2f}:{data.branchlength:1.5f}"
                     elif data.branchlength is not None:  # we have only blen
                         info_string = "0.00000:%1.5f" % (data.branchlength)
                     elif data.support is not None:  # we have only support

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -180,9 +180,7 @@ def _object_matcher(obj):
         return _attribute_matcher(obj)
     if callable(obj):
         return _function_matcher(obj)
-    raise ValueError(
-        "%s (type %s) is not a valid type for comparison." % (obj, type(obj))
-    )
+    raise ValueError(f"{obj} (type {type(obj)}) is not a valid type for comparison.")
 
 
 def _combine_matchers(target, kwargs, require_spec):
@@ -248,8 +246,8 @@ class TreeElement:
         def pair_as_kwarg_string(key, val):
             if isinstance(val, str):
                 val = val[:57] + "..." if len(val) > 60 else val
-                return "%s='%s'" % (key, val)
-            return "%s=%s" % (key, val)
+                return f"{key}='{val}'"
+            return f"{key}={val}"
 
         return "%s(%s)" % (
             self.__class__.__name__,
@@ -289,7 +287,7 @@ class TreeMixin:
             order_func = order_opts[order]
         except KeyError:
             raise ValueError(
-                "Invalid order '%s'; must be one of: %s" % (order, tuple(order_opts))
+                f"Invalid order '{order}'; must be one of: {tuple(order_opts)}"
             ) from None
 
         if follow_attrs:
@@ -1222,7 +1220,7 @@ class BranchColor:
         '#0cc864'
 
         """
-        return "#%02x%02x%02x" % (self.red, self.green, self.blue)
+        return f"#{self.red:02x}{self.green:02x}{self.blue:02x}"
 
     def to_rgb(self):
         """Return a tuple of RGB values (0 to 255) representing this color.

--- a/Bio/Phylo/CDAOIO.py
+++ b/Bio/Phylo/CDAOIO.py
@@ -277,7 +277,7 @@ class Writer:
         tree_uri="",
         record_complete_ancestry=False,
         rooted=False,
-        **kwargs
+        **kwargs,
     ):
         """Write this instance's trees to a file handle."""
         self.rooted = rooted
@@ -291,7 +291,7 @@ class Writer:
         if tree_uri:
             handle.write("@base <%s>\n" % tree_uri)
         for k, v in self.prefixes.items():
-            handle.write("@prefix %s: <%s> .\n" % (k, v))
+            handle.write(f"@prefix {k}: <{v}> .\n")
 
         handle.write("<%s> a owl:Ontology .\n" % self.prefixes["cdao"])
 

--- a/Bio/Phylo/NeXMLIO.py
+++ b/Bio/Phylo/NeXMLIO.py
@@ -236,7 +236,7 @@ class Writer:
         """Create new labels for the NeXML writer."""
         counter = "%s_counter" % obj_type
         setattr(self, counter, getattr(self, counter) + 1)
-        return "%s%s" % (obj_type, getattr(self, counter))
+        return f"{obj_type}{getattr(self, counter)}"
 
     def write(self, handle, cdao_to_obo=True, **kwargs):
         """Write this instance's trees to a file handle."""
@@ -259,7 +259,7 @@ class Writer:
         trees = ElementTree.SubElement(
             root_node,
             "trees",
-            **{"id": "Trees", "label": "TreesBlockFromXML", "otus": "tax"}
+            **{"id": "Trees", "label": "TreesBlockFromXML", "otus": "tax"},
         )
         count = 0
         tus = set()

--- a/Bio/Phylo/PAML/_paml.py
+++ b/Bio/Phylo/PAML/_paml.py
@@ -46,7 +46,7 @@ class Paml:
     def print_options(self):
         """Print out all of the options and their current settings."""
         for option in self._options.items():
-            print("%s = %s" % (option[0], option[1]))
+            print(f"{option[0]} = {option[1]}")
 
     def set_options(self, **kwargs):
         """Set the value of an option.

--- a/Bio/Phylo/PAML/baseml.py
+++ b/Bio/Phylo/PAML/baseml.py
@@ -97,7 +97,7 @@ class Baseml(Paml):
                             % (option[1], self._options["model_options"])
                         )
                         continue
-                ctl_handle.write("%s = %s\n" % (option[0], option[1]))
+                ctl_handle.write(f"{option[0]} = {option[1]}\n")
 
     def read_ctl_file(self, ctl_file):
         """Parse a control file and load the options into the Baseml instance."""

--- a/Bio/Phylo/PAML/codeml.py
+++ b/Bio/Phylo/PAML/codeml.py
@@ -93,9 +93,9 @@ class Codeml(Paml):
                     # control file it is specified as a series of numbers
                     # separated by spaces.
                     NSsites = " ".join(str(site) for site in option[1])
-                    ctl_handle.write("%s = %s\n" % (option[0], NSsites))
+                    ctl_handle.write(f"{option[0]} = {NSsites}\n")
                 else:
-                    ctl_handle.write("%s = %s\n" % (option[0], option[1]))
+                    ctl_handle.write(f"{option[0]} = {option[1]}\n")
 
     def read_ctl_file(self, ctl_file):
         """Parse a control file and load the options into the Codeml instance."""
@@ -159,9 +159,9 @@ class Codeml(Paml):
                 # control file it is specified as a series of numbers
                 # separated by spaces.
                 NSsites = " ".join(str(site) for site in option[1])
-                print("%s = %s" % (option[0], NSsites))
+                print(f"{option[0]} = {NSsites}")
             else:
-                print("%s = %s" % (option[0], option[1]))
+                print(f"{option[0]} = {option[1]}")
 
     def _set_rel_paths(self):
         """Make all file/directory paths relative to the PWD (PRIVATE).

--- a/Bio/Phylo/PAML/yn00.py
+++ b/Bio/Phylo/PAML/yn00.py
@@ -57,7 +57,7 @@ class Yn00(Paml):
                     # to write it in the control file; it's normally just
                     # commented out.
                     continue
-                ctl_handle.write("%s = %s\n" % (option[0], option[1]))
+                ctl_handle.write(f"{option[0]} = {option[1]}\n")
 
     def read_ctl_file(self, ctl_file):
         """Parse a control file and load the options into the yn00 instance."""

--- a/Bio/Phylo/PhyloXMLIO.py
+++ b/Bio/Phylo/PhyloXMLIO.py
@@ -148,7 +148,7 @@ def _split_namespace(tag):
 
 def _ns(tag, namespace=NAMESPACES["phy"]):
     """Format an XML tag with the given namespace (PRIVATE)."""
-    return "{%s}%s" % (namespace, tag)
+    return f"{{{namespace}}}{tag}"
 
 
 def _get_child_as(parent, tag, construct):
@@ -512,7 +512,7 @@ class Parser:
             confidence=_get_child_as(elem, "confidence", self.confidence),
             properties=_get_children_as(elem, "property", self.property),
             uri=_get_child_as(elem, "uri", self.uri),
-            **elem.attrib
+            **elem.attrib,
         )
 
     def binary_characters(self, elem):

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -188,7 +188,7 @@ class FormattedSeq:
 
     def __repr__(self):
         """Represent ``FormattedSeq`` class as a string."""
-        return "FormattedSeq(%r, linear=%r)" % (self[1:], self.linear)
+        return f"FormattedSeq({self[1:]!r}, linear={self.linear!r})"
 
     def __eq__(self, other):
         """Implement equality operator for ``FormattedSeq`` object."""
@@ -2331,7 +2331,7 @@ class Analysis(RestrictionBatch, PrintFormat):
 
     def __repr__(self):
         """Represent ``Analysis`` class as a string."""
-        return "Analysis(%r,%r,%s)" % (self.rb, self.sequence, self.linear)
+        return f"Analysis({self.rb!r},{self.sequence!r},{self.linear})"
 
     def _sub_set(self, wanted):
         """Filter result for keys which are in wanted (PRIVATE).

--- a/Bio/SCOP/Residues.py
+++ b/Bio/SCOP/Residues.py
@@ -86,6 +86,6 @@ class Residues:
             if chain:
                 s.append("%s:" % chain)
             if start:
-                s.append("%s-%s" % (start, end))
+                s.append(f"{start}-{end}")
             strs.append("".join(s))
         return prefix + ",".join(strs)

--- a/Bio/SearchIO/BlastIO/blast_tab.py
+++ b/Bio/SearchIO/BlastIO/blast_tab.py
@@ -863,13 +863,13 @@ class BlastTabWriter:
         except AttributeError:
             program_line = "# %s" % program
         else:
-            program_line = "# %s %s" % (program, version)
+            program_line = f"# {program} {version}"
         comments.append(program_line)
         # description may or may not be None
         if qres.description is None:
             comments.append("# Query: %s" % qres.id)
         else:
-            comments.append("# Query: %s %s" % (qres.id, qres.description))
+            comments.append(f"# Query: {qres.id} {qres.description}")
         # try appending RID line, if present
         try:
             comments.append("# RID: %s" % qres.rid)

--- a/Bio/SearchIO/BlastIO/blast_xml.py
+++ b/Bio/SearchIO/BlastIO/blast_xml.py
@@ -346,7 +346,7 @@ class BlastXmlParser:
                             )
                             # fallback to Blast-generated IDs, if the ID is already present
                             # and restore the desc, too
-                            hit.description = "%s %s" % (hit.id, hit.description)
+                            hit.description = f"{hit.id} {hit.description}"
                             hit.id = hit.blast_id
                             # and change the hit_id of the HSPs contained
                             for hsp in hit:
@@ -803,9 +803,7 @@ class BlastXmlWriter:
             except AttributeError:
                 # ensure attrs that is not present is optional
                 if elem not in _DTD_OPT:
-                    raise ValueError(
-                        "Element %r (attribute %r) not found" % (elem, attr)
-                    )
+                    raise ValueError(f"Element {elem!r} (attribute {attr!r}) not found")
             else:
                 # custom element-attribute mapping, for fallback values
                 if elem in opt_dict:
@@ -827,12 +825,10 @@ class BlastXmlWriter:
                 content = str(getattr(qresult, attr))
             except AttributeError:
                 if elem not in _DTD_OPT:
-                    raise ValueError(
-                        "Element %s (attribute %s) not found" % (elem, attr)
-                    )
+                    raise ValueError(f"Element {elem} (attribute {attr}) not found")
             else:
                 if elem == "BlastOutput_version":
-                    content = "%s %s" % (qresult.program.upper(), qresult.version)
+                    content = f"{qresult.program.upper()} {qresult.version}"
                 elif qresult.blast_id:
                     if elem == "BlastOutput_query-ID":
                         content = qresult.blast_id
@@ -931,9 +927,7 @@ class BlastXmlWriter:
                 # in the DTD
                 except AttributeError:
                     if elem not in _DTD_OPT:
-                        raise ValueError(
-                            "Element %s (attribute %s) not found" % (elem, attr)
-                        )
+                        raise ValueError(f"Element {elem} (attribute {attr}) not found")
                 else:
                     xml.simpleElement(elem, str(content))
             self.hsp_counter += 1

--- a/Bio/SearchIO/FastaIO.py
+++ b/Bio/SearchIO/FastaIO.py
@@ -468,7 +468,7 @@ class FastaM10Parser:
                 if state == _STATE_NONE:
                     # make sure it's the correct query
                     if not query_id.startswith(line[1:].split(" ")[0]):
-                        raise ValueError("%r vs %r" % (query_id, line))
+                        raise ValueError(f"{query_id!r} vs {line!r}")
                     state = _STATE_QUERY_BLOCK
                     parsed_hsp["query"]["seq"] = ""
                 elif state == _STATE_QUERY_BLOCK:

--- a/Bio/SearchIO/__init__.py
+++ b/Bio/SearchIO/__init__.py
@@ -483,7 +483,7 @@ def index(filename, format=None, key_function=None, **kwargs):
     from Bio.File import _IndexedSeqFileDict
 
     proxy_class = get_processor(format, _INDEXER_MAP)
-    repr = "SearchIO.index(%r, %r, key_function=%r)" % (filename, format, key_function)
+    repr = f"SearchIO.index({filename!r}, {format!r}, key_function={key_function!r})"
     return _IndexedSeqFileDict(
         proxy_class(filename, **kwargs), key_function, repr, "QueryResult"
     )
@@ -556,12 +556,7 @@ def index_db(index_filename, filenames=None, format=None, key_function=None, **k
 
     from Bio.File import _SQLiteManySeqFilesDict
 
-    repr = "SearchIO.index_db(%r, filenames=%r, format=%r, key_function=%r, ...)" % (
-        index_filename,
-        filenames,
-        format,
-        key_function,
-    )
+    repr = f"SearchIO.index_db({index_filename!r}, filenames={filenames!r}, {format!r}, key_function={key_function!r})"
 
     def proxy_factory(format, filename=None):
         """Given a filename returns proxy object, else boolean if format OK."""

--- a/Bio/SearchIO/_model/_base.py
+++ b/Bio/SearchIO/_model/_base.py
@@ -41,10 +41,10 @@ class _BaseHSP(_BaseSearchObject):
         """Print the alignment header info (PRIVATE)."""
         lines = []
         # set query id line
-        qid_line = "      Query: %s %s" % (self.query_id, self.query_description)
+        qid_line = f"      Query: {self.query_id} {self.query_description}"
         qid_line = qid_line[:77] + "..." if len(qid_line) > 80 else qid_line
         # set hit id line
-        hid_line = "        Hit: %s %s" % (self.hit_id, self.hit_description)
+        hid_line = f"        Hit: {self.hit_id} {self.hit_description}"
         hid_line = hid_line[:77] + "..." if len(hid_line) > 80 else hid_line
         lines.append(qid_line)
         lines.append(hid_line)
@@ -62,7 +62,7 @@ class _BaseHSP(_BaseSearchObject):
         except ValueError:
             qstrand = self.query_strand_all[0]
             hstrand = self.hit_strand_all[0]
-        lines.append("Query range: [%s:%s] (%r)" % (query_start, query_end, qstrand))
-        lines.append("  Hit range: [%s:%s] (%r)" % (hit_start, hit_end, hstrand))
+        lines.append(f"Query range: [{query_start}:{query_end}] ({qstrand!r})")
+        lines.append(f"  Hit range: [{hit_start}:{hit_end}] ({hstrand!r})")
 
         return "\n".join(lines)

--- a/Bio/SearchIO/_model/hit.py
+++ b/Bio/SearchIO/_model/hit.py
@@ -144,7 +144,7 @@ class Hit(_BaseSearchObject):
 
     def __repr__(self):
         """Return string representation of Hit object."""
-        return "Hit(id=%r, query_id=%r, %r hsps)" % (self.id, self.query_id, len(self))
+        return f"Hit(id={self.id!r}, query_id={self.query_id!r}, {len(self)!r} hsps)"
 
     def __iter__(self):
         """Iterate over hsps."""
@@ -190,7 +190,7 @@ class Hit(_BaseSearchObject):
 
         # set attributes lines
         for key, value in sorted(self.attributes.items()):
-            lines.append(" %s: %s" % (key, value))
+            lines.append(f" {key}: {value}")
 
         # set dbxrefs line
         if self.dbxrefs:
@@ -222,7 +222,7 @@ class Hit(_BaseSearchObject):
                 # query region
                 query_start = getattr_str(hsp, "query_start")
                 query_end = getattr_str(hsp, "query_end")
-                query_range = "[%s:%s]" % (query_start, query_end)
+                query_range = f"[{query_start}:{query_end}]"
                 # max column length is 18
                 query_range = (
                     query_range[:13] + "~]" if len(query_range) > 15 else query_range
@@ -230,7 +230,7 @@ class Hit(_BaseSearchObject):
                 # hit region
                 hit_start = getattr_str(hsp, "hit_start")
                 hit_end = getattr_str(hsp, "hit_end")
-                hit_range = "[%s:%s]" % (hit_start, hit_end)
+                hit_range = f"[{hit_start}:{hit_end}]"
                 hit_range = hit_range[:19] + "~]" if len(hit_range) > 21 else hit_range
                 # append the hsp row
                 lines.append(

--- a/Bio/SearchIO/_utils.py
+++ b/Bio/SearchIO/_utils.py
@@ -153,7 +153,7 @@ def fragcascade(attr, seq_type, doc=""):
 
     """
     assert seq_type in ("hit", "query")
-    attr_name = "_%s_%s" % (seq_type, attr)
+    attr_name = f"_{seq_type}_{attr}"
 
     def getter(self):
         return getattr(self, attr_name)

--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -615,7 +615,7 @@ def _read_rc(reference, value):
             reference.comments.append(comment)
         else:
             comment = reference.comments[-1]
-            comment = "%s %s" % (comment, col)
+            comment = f"{comment} {col}"
             reference.comments[-1] = comment
     return unread
 
@@ -768,9 +768,9 @@ def _read_ft(record, line):
         # this line is a continuation of the description of the previous feature
         old_description = feature.qualifiers["description"]
         if old_description.endswith("-"):
-            description = "%s%s" % (old_description, description)
+            description = f"{old_description}{description}"
         else:
-            description = "%s %s" % (old_description, description)
+            description = f"{old_description} {description}"
 
         if feature.type in ("VARSPLIC", "VAR_SEQ"):  # special case
             # Remove unwanted spaces in sequences.
@@ -831,9 +831,9 @@ def _read_ft(record, line):
         description = value.rstrip('"')
         old_description = feature.qualifiers[key]
         if key == "evidence" or old_description.endswith("-"):
-            description = "%s%s" % (old_description, description)
+            description = f"{old_description}{description}"
         else:
-            description = "%s %s" % (old_description, description)
+            description = f"{old_description} {description}"
         if feature.type == "VAR_SEQ":  # see VARSPLIC above
             try:
                 first_seq, second_seq = description.split(" -> ")

--- a/Bio/TogoWS/__init__.py
+++ b/Bio/TogoWS/__init__.py
@@ -143,7 +143,7 @@ def entry(db, id, format=None, field=None):
 
     if isinstance(id, list):
         id = ",".join(id)
-    url = _BASE_URL + "/entry/%s/%s" % (db, quote(id))
+    url = _BASE_URL + f"/entry/{db}/{quote(id)}"
     if field:
         url += "/" + field
     if format:
@@ -174,7 +174,7 @@ def search_count(db, query):
             "TogoWS search does not officially support database '%s'. "
             "See %s/search/ for options." % (db, _BASE_URL)
         )
-    url = _BASE_URL + "/search/%s/%s/count" % (db, quote(query))
+    url = _BASE_URL + f"/search/{db}/{quote(query)}/count"
     handle = _open(url)
     data = handle.read()
     handle.close()
@@ -183,9 +183,7 @@ def search_count(db, query):
     try:
         return int(data.strip())
     except ValueError:
-        raise ValueError(
-            "Expected an integer from URL %s, got: %r" % (url, data)
-        ) from None
+        raise ValueError(f"Expected an integer from URL {url}, got: {data!r}") from None
 
 
 def search_iter(db, query, limit=None, batch=100):
@@ -279,7 +277,7 @@ def search(db, query, offset=None, limit=None, format=None):
             "TogoWS search does not explicitly support database '%s'. "
             "See %s/search/ for options." % (db, _BASE_URL)
         )
-    url = _BASE_URL + "/search/%s/%s" % (db, quote(query))
+    url = _BASE_URL + f"/search/{db}/{quote(query)}"
     if offset is not None and limit is not None:
         try:
             offset = int(offset)
@@ -326,7 +324,7 @@ def convert(data, in_format, out_format):
     if [in_format, out_format] not in _convert_formats:
         msg = "\n".join("%s -> %s" % tuple(pair) for pair in _convert_formats)
         raise ValueError("Unsupported conversion. Choose from:\n%s" % msg)
-    url = _BASE_URL + "/convert/%s.%s" % (in_format, out_format)
+    url = _BASE_URL + f"/convert/{in_format}.{out_format}"
     # TODO - Should we just accept a string not a handle? What about a filename?
     try:
         # Handle

--- a/Bio/Wise/dnal.py
+++ b/Bio/Wise/dnal.py
@@ -132,7 +132,7 @@ def align(
     mismatch=_SCORE_MISMATCH,
     gap=_SCORE_GAP_START,
     extension=_SCORE_GAP_EXTENSION,
-    **keywds
+    **keywds,
 ):
     """Align a pair of DNA files using dnal and calculate the statistics of the alignment."""
     cmdline = _build_dnal_cmdline(match, mismatch, gap, extension)
@@ -154,7 +154,7 @@ def main():
     stats = align(sys.argv[1:3])
     print(
         "\n".join(
-            "%s: %s" % (attr, getattr(stats, attr))
+            f"{attr}: {getattr(stats, attr)}"
             for attr in ("matches", "mismatches", "gaps", "extensions")
         )
     )

--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -478,7 +478,7 @@ def _load_bgzf_block(handle, text_mode=False):
     else:
         crc = struct.pack("<I", crc)
     if expected_crc != crc:
-        raise RuntimeError("CRC is %s, not %s" % (crc, expected_crc))
+        raise RuntimeError(f"CRC is {crc}, not {expected_crc}")
     if text_mode:
         # Note ISO-8859-1 aka Latin-1 preserves first 256 chars
         # (i.e. ASCII), but critically is a single byte encoding

--- a/Bio/motifs/jaspar/db.py
+++ b/Bio/motifs/jaspar/db.py
@@ -101,7 +101,7 @@ class JASPAR5:
 
     def __str__(self):
         """Return a string represention of the JASPAR5 DB connection."""
-        return r"%s\@%s:%s" % (self.user, self.host, self.name)
+        return fr"{self.user}\@{self.host}:{self.name}"
 
     def fetch_motif_by_id(self, id):
         """Fetch a single JASPAR motif from the DB by its JASPAR matrix ID.

--- a/Bio/motifs/transfac.py
+++ b/Bio/motifs/transfac.py
@@ -290,10 +290,10 @@ XX
                     if value is not None:
                         if key in multiple_value_keys:
                             for v in value:
-                                line = "%s  %s" % (key, v)
+                                line = f"{key}  {v}"
                                 lines.append(line)
                         else:
-                            line = "%s  %s" % (key, value)
+                            line = f"{key}  {value}"
                             lines.append(line)
                         blank = True
                 if key == "PV":
@@ -309,7 +309,7 @@ XX
                                 value = reference.get(key)
                                 if value is None:
                                     continue
-                                line = "%s  %s" % (key, value)
+                                line = f"{key}  {value}"
                                 lines.append(line)
                                 blank = True
             if blank:

--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -153,10 +153,10 @@ def _retrieve_dbxrefs(adaptor, primary_id):
     )
     for dbname, accession, version in dbxrefs:
         if version and version != "0":
-            v = "%s.%s" % (accession, version)
+            v = f"{accession}.{version}"
         else:
             v = accession
-        _dbxrefs.append("%s:%s" % (dbname, v))
+        _dbxrefs.append(f"{dbname}:{v}")
     return _dbxrefs
 
 
@@ -190,7 +190,7 @@ def _retrieve_features(adaptor, primary_id):
             (seqfeature_id,),
         )
         for qv_name, qv_value in qvs:
-            value = "%s:%s" % (qv_name, qv_value)
+            value = f"{qv_name}:{qv_value}"
             qualifiers.setdefault("db_xref", []).append(value)
         # Get locations
         results = adaptor.execute_and_fetchall(
@@ -244,7 +244,7 @@ def _retrieve_features(adaptor, primary_id):
         lookup = {}
         for location_id, dbname, accession, version in remote_results:
             if version and version != "0":
-                v = "%s.%s" % (accession, version)
+                v = f"{accession}.{version}"
             else:
                 v = accession
             # subfeature remote location db_ref are stored as a empty string
@@ -502,7 +502,7 @@ class DBSeqRecord(SeqRecord):
             (self._primary_id,),
         )
         if version and version != "0":
-            self.id = "%s.%s" % (accession, version)
+            self.id = f"{accession}.{version}"
         else:
             self.id = accession
         # We don't yet record any per-letter-annotations in the

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -657,7 +657,7 @@ class BioSeqDatabase:
 
     def __repr__(self):
         """Return a short summary of the BioSeqDatabase."""
-        return "BioSeqDatabase(%r, %r)" % (self.adaptor, self.name)
+        return f"BioSeqDatabase({self.adaptor!r}, {self.name!r})"
 
     def get_Seq_by_id(self, name):
         """Get a DBSeqRecord object by its name.

--- a/BioSQL/DBUtils.py
+++ b/BioSQL/DBUtils.py
@@ -36,7 +36,7 @@ class Generic_dbutils:
         """Return the last used id for a table."""
         # XXX: Unsafe without transactions isolation
         table = self.tname(table)
-        sql = "select max(%s_id) from %s" % (table, table)
+        sql = f"select max({table}_id) from {table}"
         cursor.execute(sql)
         rv = cursor.fetchone()
         return rv[0]


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Progress on #2510, follows on from #3723. With these changes about a quarter of the main code base string formatting will be f-strings:

```
$ flake8 --isolated --select SFS --statistics BioSQL Bio
...
1297  SFS101 String literal formatting using percent operator.
28    SFS201 String literal formatting using format method.
406   SFS301 String literal formatting using f-string.
```

(pyupgrade would convert about 100 more of the percent uses, but mostly to format strings - there about 30 more f-strings it would create which I missed in this manual selection)