### PR TITLE
More f-strings mainly on sequence code, using flynt 0.69

### DIFF
--- a/Bio/AlignIO/ClustalIO.py
+++ b/Bio/AlignIO/ClustalIO.py
@@ -36,10 +36,10 @@ class ClustalWriter(SequentialAlignmentWriter):
             version = "1.81"
         if version.startswith("2."):
             # e.g. 2.0.x
-            output = "CLUSTAL %s multiple sequence alignment\n\n\n" % version
+            output = f"CLUSTAL {version} multiple sequence alignment\n\n\n"
         else:
             # e.g. 1.81 or 1.83
-            output = "CLUSTAL X (%s) multiple sequence alignment\n\n\n" % version
+            output = f"CLUSTAL X ({version}) multiple sequence alignment\n\n\n"
 
         cur_char = 0
         max_length = len(alignment[0])
@@ -155,7 +155,7 @@ class ClustalIterator(AlignmentIterator):
                 # We expect there to be two fields, there can be an optional
                 # "sequence number" field containing the letter count.
                 if len(fields) < 2 or len(fields) > 3:
-                    raise ValueError("Could not parse line:\n%s" % line)
+                    raise ValueError(f"Could not parse line:\n{line}")
 
                 ids.append(fields[0])
                 seqs.append(fields[1])
@@ -174,11 +174,11 @@ class ClustalIterator(AlignmentIterator):
                         letters = int(fields[2])
                     except ValueError:
                         raise ValueError(
-                            "Could not parse line, bad sequence number:\n%s" % line
+                            f"Could not parse line, bad sequence number:\n{line}"
                         ) from None
                     if len(fields[1].replace("-", "")) != letters:
                         raise ValueError(
-                            "Could not parse line, invalid sequence number:\n%s" % line
+                            f"Could not parse line, invalid sequence number:\n{line}"
                         )
             elif line[0] == " ":
                 # Sequence consensus line...
@@ -228,13 +228,13 @@ class ClustalIterator(AlignmentIterator):
 
             for i in range(len(ids)):
                 if line[0] == " ":
-                    raise ValueError("Unexpected line:\n%r" % line)
+                    raise ValueError(f"Unexpected line:\n{line!r}")
                 fields = line.rstrip().split()
 
                 # We expect there to be two fields, there can be an optional
                 # "sequence number" field containing the letter count.
                 if len(fields) < 2 or len(fields) > 3:
-                    raise ValueError("Could not parse line:\n%r" % line)
+                    raise ValueError(f"Could not parse line:\n{line!r}")
 
                 if fields[0] != ids[i]:
                     raise ValueError(
@@ -260,11 +260,11 @@ class ClustalIterator(AlignmentIterator):
                         letters = int(fields[2])
                     except ValueError:
                         raise ValueError(
-                            "Could not parse line, bad sequence number:\n%s" % line
+                            f"Could not parse line, bad sequence number:\n{line}"
                         ) from None
                     if len(seqs[i].replace("-", "")) != letters:
                         raise ValueError(
-                            "Could not parse line, invalid sequence number:\n%s" % line
+                            f"Could not parse line, invalid sequence number:\n{line}"
                         )
 
                 # Read in the next line

--- a/Bio/AlignIO/EmbossIO.py
+++ b/Bio/AlignIO/EmbossIO.py
@@ -181,7 +181,7 @@ class EmbossIterator(AlignmentIterator):
                 # Just a spacer?
                 pass
             else:
-                raise ValueError("Unrecognised EMBOSS pairwise line: %r\n" % line)
+                raise ValueError(f"Unrecognised EMBOSS pairwise line: {line!r}\n")
 
             line = handle.readline()
             if (

--- a/Bio/AlignIO/FastaIO.py
+++ b/Bio/AlignIO/FastaIO.py
@@ -309,12 +309,12 @@ handle.name: {handle.name}
                 # Seen in lalign36, specifically version 36.3.4 Apr, 2011
                 # Fixed in version 36.3.5b Oct, 2011(preload8)
                 warnings.warn(
-                    "Missing colon in line: %r" % line, BiopythonParserWarning
+                    f"Missing colon in line: {line!r}", BiopythonParserWarning
                 )
                 try:
                     key, value = (s.strip() for s in line[2:].split(" ", 1))
                 except ValueError:
-                    raise ValueError("Bad line: %r" % line) from None
+                    raise ValueError(f"Bad line: {line!r}") from None
             if state == state_QUERY_HEADER:
                 header_tags[key] = value
             elif state == state_ALIGN_HEADER:

--- a/Bio/AlignIO/MafIO.py
+++ b/Bio/AlignIO/MafIO.py
@@ -76,7 +76,7 @@ class MafWriter(SequentialAlignmentWriter):
             "%15s" % record.annotations.get("srcSize", 0),
             str(record.seq),
         ]
-        self.handle.write("%s\n" % " ".join(fields))
+        self.handle.write(f"{' '.join(fields)}\n")
 
     def write_alignment(self, alignment):
         """Write a complete alignment to a MAF block.
@@ -313,8 +313,7 @@ class MafIndex:
             if tmp_mafpath != os.path.abspath(self._maf_file):
                 # Original and given absolute paths differ.
                 raise ValueError(
-                    "Index uses a different file (%s != %s)"
-                    % (filename, self._maf_file)
+                    f"Index uses a different file ({filename} != {self._maf_file})"
                 )
 
             db_target = self._con.execute(
@@ -346,7 +345,7 @@ class MafIndex:
             return records_found
 
         except (dbapi2.OperationalError, dbapi2.DatabaseError) as err:
-            raise ValueError("Problem with SQLite database: %s" % err) from None
+            raise ValueError(f"Problem with SQLite database: {err}") from None
 
     def __make_new_index(self):
         """Read MAF file and generate SQLite index (PRIVATE)."""
@@ -423,8 +422,7 @@ class MafIndex:
         self._con.execute("CREATE INDEX IF NOT EXISTS end_index ON offset_data(end);")
 
         self._con.execute(
-            "UPDATE meta_data SET value = '%s' WHERE key = 'record_count'"
-            % (insert_count,)
+            f"UPDATE meta_data SET value = '{insert_count}' WHERE key = 'record_count'"
         )
 
         self._con.commit()
@@ -643,7 +641,7 @@ class MafIndex:
         """
         # validate strand
         if strand not in (1, -1):
-            raise ValueError("Strand must be 1 or -1, got %s" % strand)
+            raise ValueError(f"Strand must be 1 or -1, got {strand}")
 
         # pull all alignments that span the desired intervals
         fetched = list(self.search(starts, ends))

--- a/Bio/AlignIO/MauveIO.py
+++ b/Bio/AlignIO/MauveIO.py
@@ -159,14 +159,8 @@ class MauveWriter(SequentialAlignmentWriter):
         # We remove the "/{start}-{end}" before writing, as it cannot be part
         # of the produced XMFA file.
         if "start" in record.annotations and "end" in record.annotations:
-            suffix0 = "/%s-%s" % (
-                record.annotations["start"],
-                record.annotations["end"],
-            )
-            suffix1 = "/%s-%s" % (
-                record.annotations["start"] + 1,
-                record.annotations["end"],
-            )
+            suffix0 = f"/{record.annotations['start']}-{record.annotations['end']}"
+            suffix1 = f"/{record.annotations['start'] + 1}-{record.annotations['end']}"
             if seq_name[-len(suffix0) :] == suffix0:
                 seq_name = seq_name[: -len(suffix0)]
             if seq_name[-len(suffix1) :] == suffix1:
@@ -223,7 +217,7 @@ class MauveWriter(SequentialAlignmentWriter):
             id_line = id_line.replace("\n", " ").replace("\r", " ")
             self.handle.write(id_line + "\n")
             for i in range(0, len(record.seq), 80):
-                self.handle.write("%s\n" % record.seq[i : i + 80])
+                self.handle.write(f"{record.seq[i:i + 80]}\n")
 
 
 class MauveIterator(AlignmentIterator):

--- a/Bio/AlignIO/MsfIO.py
+++ b/Bio/AlignIO/MsfIO.py
@@ -170,16 +170,16 @@ class MsfIterator(AlignmentIterator):
                         # T-COFFEE oddity, ignore this
                         name = name[:-3]
                     if name in ids:
-                        raise ValueError("Duplicated ID of %r" % name)
+                        raise ValueError(f"Duplicated ID of {name!r}")
                     if " " in name:
-                        raise NotImplementedError("Space in ID %r" % name)
+                        raise NotImplementedError(f"Space in ID {name!r}")
                     ids.append(name)
                     # Expect aln_length <= int(length.strip()), see below
                     lengths.append(int(length.strip()))
                     checks.append(int(check.strip()))
                     weights.append(float(weight.strip()))
                 else:
-                    raise ValueError("Malformed GCG MSF name line: %r" % line)
+                    raise ValueError(f"Malformed GCG MSF name line: {line!r}")
         if not line:
             raise ValueError("End of file while looking for end of header // line.")
 
@@ -277,7 +277,7 @@ class MsfIterator(AlignmentIterator):
             completed_length += 50
             line = handle.readline()
             if line.strip():
-                raise ValueError("Expected blank line, got: %r" % line)
+                raise ValueError(f"Expected blank line, got: {line!r}")
 
         # Skip over any whitespace at the end...
         while True:
@@ -293,7 +293,7 @@ class MsfIterator(AlignmentIterator):
                 self._header = line
                 break
             else:
-                raise ValueError("Unexpected line after GCG MSF alignment: %r" % line)
+                raise ValueError(f"Unexpected line after GCG MSF alignment: {line!r}")
 
         # Combine list of strings into single string, remap gaps
         seqs = ["".join(s).replace("~", "-").replace(".", "-") for s in seqs]

--- a/Bio/AlignIO/PhylipIO.py
+++ b/Bio/AlignIO/PhylipIO.py
@@ -131,7 +131,7 @@ class PhylipWriter(SequentialAlignmentWriter):
                     seq_segment = sequence[i : i + 10]
                     # TODO - Force any gaps to be '-' character?
                     # TODO - How to cope with '?' or '.' in the sequence?
-                    handle.write(" %s" % seq_segment)
+                    handle.write(f" {seq_segment}")
                     if i + 10 > length_of_seqs:
                         break
                 handle.write("\n")
@@ -275,7 +275,7 @@ class RelaxedPhylipWriter(PhylipWriter):
         # Check inputs
         for name in (s.id.strip() for s in alignment):
             if any(c in name for c in string.whitespace):
-                raise ValueError("Whitespace not allowed in identifier: %s" % name)
+                raise ValueError(f"Whitespace not allowed in identifier: {name}")
 
         # Calculate a truncation length - maximum length of sequence ID plus a
         # single character for padding

--- a/Bio/AlignIO/StockholmIO.py
+++ b/Bio/AlignIO/StockholmIO.py
@@ -229,7 +229,7 @@ class StockholmWriter(SequentialAlignmentWriter):
         seq_name = seq_name.replace(" ", "_")
 
         if "start" in record.annotations and "end" in record.annotations:
-            suffix = "/%s-%s" % (record.annotations["start"], record.annotations["end"])
+            suffix = f"/{record.annotations['start']}-{record.annotations['end']}"
             if seq_name[-len(suffix) :] != suffix:
                 seq_name = "%s/%s-%s" % (
                     seq_name,
@@ -238,7 +238,7 @@ class StockholmWriter(SequentialAlignmentWriter):
                 )
 
         if seq_name in self._ids_written:
-            raise ValueError("Duplicate record identifier: %s" % seq_name)
+            raise ValueError(f"Duplicate record identifier: {seq_name}")
         self._ids_written.append(seq_name)
         self.handle.write(f"{seq_name} {record.seq}\n")
 
@@ -256,8 +256,7 @@ class StockholmWriter(SequentialAlignmentWriter):
         # AC = Accession
         if "accession" in record.annotations:
             self.handle.write(
-                "#=GS %s AC %s\n"
-                % (seq_name, self.clean(record.annotations["accession"]))
+                f"#=GS {seq_name} AC {self.clean(record.annotations['accession'])}\n"
             )
         elif record.id:
             self.handle.write(f"#=GS {seq_name} AC {self.clean(record.id)}\n")

--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -201,7 +201,7 @@ def write(alignments, handle, format):
     if not format:
         raise ValueError("Format required (lower case string)")
     if format != format.lower():
-        raise ValueError("Format string '%s' should be lower case" % format)
+        raise ValueError(f"Format string '{format}' should be lower case")
 
     if isinstance(alignments, MultipleSeqAlignment):
         # This raised an exception in older versions of Biopython
@@ -225,11 +225,9 @@ def write(alignments, handle, format):
                 SeqIO.write(alignment, fp, format)
                 count += 1
         elif format in _FormatToIterator or format in SeqIO._FormatToIterator:
-            raise ValueError(
-                "Reading format '%s' is supported, but not writing" % format
-            )
+            raise ValueError(f"Reading format '{format}' is supported, but not writing")
         else:
-            raise ValueError("Unknown format '%s'" % format)
+            raise ValueError(f"Unknown format '{format}'")
 
     if not isinstance(count, int):
         raise RuntimeError(
@@ -256,7 +254,7 @@ def _SeqIO_to_alignment_iterator(handle, format, seq_count=None):
     from Bio import SeqIO
 
     if format not in SeqIO._FormatToIterator:
-        raise ValueError("Unknown format '%s'" % format)
+        raise ValueError(f"Unknown format '{format}'")
 
     if seq_count:
         # Use the count to split the records into batches.
@@ -317,7 +315,7 @@ def parse(handle, format, seq_count=None):
     if not format:
         raise ValueError("Format required (lower case string)")
     if format != format.lower():
-        raise ValueError("Format string '%s' should be lower case" % format)
+        raise ValueError(f"Format string '{format}' should be lower case")
     if seq_count is not None and not isinstance(seq_count, int):
         raise TypeError("Need integer for seq_count (sequences per alignment)")
 
@@ -331,7 +329,7 @@ def parse(handle, format, seq_count=None):
             # Exploit the existing SeqIO parser to the dirty work!
             i = _SeqIO_to_alignment_iterator(fp, format, seq_count=seq_count)
         else:
-            raise ValueError("Unknown format '%s'" % format)
+            raise ValueError(f"Unknown format '{format}'")
 
         yield from i
 
@@ -445,7 +443,7 @@ def convert(in_file, in_format, out_file, out_format, molecule_type=None):
     """
     if molecule_type:
         if not isinstance(molecule_type, str):
-            raise TypeError("Molecule type should be a string, not %r" % molecule_type)
+            raise TypeError(f"Molecule type should be a string, not {molecule_type!r}")
         elif (
             "DNA" in molecule_type
             or "RNA" in molecule_type
@@ -453,7 +451,7 @@ def convert(in_file, in_format, out_file, out_format, molecule_type=None):
         ):
             pass
         else:
-            raise ValueError("Unexpected molecule type, %r" % molecule_type)
+            raise ValueError(f"Unexpected molecule type, {molecule_type!r}")
 
     # TODO - Add optimised versions of important conversions
     # For now just off load the work to SeqIO parse/write

--- a/Bio/File.py
+++ b/Bio/File.py
@@ -196,7 +196,7 @@ class _IndexedSeqFileDict(collections.abc.Mapping):
             #       % (key, offset, length, filename, format)
             if key in offsets:
                 self._proxy._handle.close()
-                raise ValueError("Duplicate key '%s'" % key)
+                raise ValueError(f"Duplicate key '{key}'")
             else:
                 offsets[key] = offset
         self._offsets = offsets
@@ -408,11 +408,11 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
                 # Filenames are equal (after imposing abspath)
         except sqlite3.OperationalError as err:
             con.close()
-            raise ValueError("Not a Biopython index database? %s" % err) from None
+            raise ValueError(f"Not a Biopython index database? {err}") from None
         # Now we have the format (from the DB if not given to us),
         if not proxy_factory(self._format):
             con.close()
-            raise ValueError("Unsupported format '%s'" % self._format)
+            raise ValueError(f"Unsupported format '{self._format}'")
 
     def _build_index(self):
         """Call from __init__ to create a new index (PRIVATE)."""
@@ -427,10 +427,10 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
 
         if not fmt or not filenames:
             raise ValueError(
-                "Filenames to index and format required to build %r" % index_filename
+                f"Filenames to index and format required to build {index_filename!r}"
             )
         if not proxy_factory(fmt):
-            raise ValueError("Unsupported format '%s'" % fmt)
+            raise ValueError(f"Unsupported format '{fmt}'")
         # Create the index
         con = sqlite3.dbapi2.connect(index_filename)
         self._con = con
@@ -509,7 +509,7 @@ class _SQLiteManySeqFilesDict(_IndexedSeqFileDict):
             self._proxies = random_access_proxies
             self.close()
             con.close()
-            raise ValueError("Duplicate key? %s" % err) from None
+            raise ValueError(f"Duplicate key? {err}") from None
         con.execute("PRAGMA locking_mode=NORMAL")
         con.execute("UPDATE meta_data SET value = ? WHERE key = ?;", (count, "count"))
         con.commit()

--- a/Bio/GenBank/Record.py
+++ b/Bio/GenBank/Record.py
@@ -287,7 +287,7 @@ class Record:
 
             acc_info = ""
             for accession in self.accession:
-                acc_info += "%s " % accession
+                acc_info += f"{accession} "
             # strip off an extra space at the end
             acc_info = acc_info.rstrip()
             output += _wrapped_genbank(acc_info, Record.GB_BASE_INDENT)
@@ -302,7 +302,7 @@ class Record:
             output = Record.BASE_FORMAT % "VERSION"
             output += self.version
             output += "  GI:"
-            output += "%s\n" % self.gi
+            output += f"{self.gi}\n"
         else:
             output = ""
         return output
@@ -311,7 +311,7 @@ class Record:
         output = ""
         if len(self.projects) > 0:
             output = Record.BASE_FORMAT % "PROJECT"
-            output += "%s\n" % "  ".join(self.projects)
+            output += f"{'  '.join(self.projects)}\n"
         return output
 
     def _dblink_line(self):
@@ -326,7 +326,7 @@ class Record:
         """Output for the NID line. Use of NID is obsolete in GenBank files (PRIVATE)."""
         if self.nid:
             output = Record.BASE_FORMAT % "NID"
-            output += "%s\n" % self.nid
+            output += f"{self.nid}\n"
         else:
             output = ""
         return output
@@ -335,7 +335,7 @@ class Record:
         """Output for PID line. Presumedly, PID usage is also obsolete (PRIVATE)."""
         if self.pid:
             output = Record.BASE_FORMAT % "PID"
-            output += "%s\n" % self.pid
+            output += f"{self.pid}\n"
         else:
             output = ""
         return output
@@ -347,7 +347,7 @@ class Record:
             output += Record.BASE_FORMAT % "KEYWORDS"
             keyword_info = ""
             for keyword in self.keywords:
-                keyword_info += "%s; " % keyword
+                keyword_info += f"{keyword}; "
             # replace the ; at the end with a period
             keyword_info = keyword_info[:-2]
             keyword_info += "."
@@ -360,7 +360,7 @@ class Record:
         """Output for DBSOURCE line (PRIVATE)."""
         if self.db_source:
             output = Record.BASE_FORMAT % "DBSOURCE"
-            output += "%s\n" % self.db_source
+            output += f"{self.db_source}\n"
         else:
             output = ""
         return output
@@ -387,7 +387,7 @@ class Record:
         output += " " * Record.GB_BASE_INDENT
         taxonomy_info = ""
         for tax in self.taxonomy:
-            taxonomy_info += "%s; " % tax
+            taxonomy_info += f"{tax}; "
         # replace the ; at the end with a period
         taxonomy_info = taxonomy_info[:-2]
         taxonomy_info += "."
@@ -460,7 +460,7 @@ class Record:
                     start_pos = cur_seq_pos + section * 10
                     end_pos = start_pos + 10
                     seq_section = self.sequence[start_pos:end_pos]
-                    output += " %s" % seq_section.lower()
+                    output += f" {seq_section.lower()}"
 
                     # stop looping if we are out of sequence
                     if end_pos > len(self.sequence):
@@ -542,9 +542,9 @@ class Reference:
         if self.number:
             if self.bases:
                 output += "%-3s" % self.number
-                output += "%s" % self.bases
+                output += f"{self.bases}"
             else:
-                output += "%s" % self.number
+                output += f"{self.number}"
 
         output += "\n"
         return output

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -186,7 +186,7 @@ class InsdcScanner:
                 continue
             if len(line) < self.FEATURE_QUALIFIER_INDENT:
                 warnings.warn(
-                    "line too short to contain a feature: %r" % line,
+                    f"line too short to contain a feature: {line!r}",
                     BiopythonParserWarning,
                 )
                 line = self.handle.readline()
@@ -211,7 +211,7 @@ class InsdcScanner:
                     feature_key, line = line[2:].strip().split(None, 1)
                     feature_lines = [line]
                     warnings.warn(
-                        "Over indented %s feature?" % feature_key,
+                        f"Over indented {feature_key} feature?",
                         BiopythonParserWarning,
                     )
                 else:
@@ -637,7 +637,7 @@ class EmblScanner(InsdcScanner):
     def parse_footer(self):
         """Return a tuple containing a list of any misc strings, and the sequence."""
         if self.line[: self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
-            raise ValueError("Footer format unexpected: '%s'" % self.line)
+            raise ValueError(f"Footer format unexpected: '{self.line}'")
 
         # Note that the SQ line can be split into several lines...
         misc_lines = []
@@ -652,7 +652,7 @@ class EmblScanner(InsdcScanner):
             self.line[: self.HEADER_WIDTH] == " " * self.HEADER_WIDTH
             or self.line.strip() == "//"
         ):
-            raise ValueError("Unexpected content after SQ or CO line: %r" % self.line)
+            raise ValueError(f"Unexpected content after SQ or CO line: {self.line!r}")
 
         seq_lines = []
         line = self.line
@@ -835,7 +835,7 @@ class EmblScanner(InsdcScanner):
     @staticmethod
     def _feed_seq_length(consumer, text):
         length_parts = text.split()
-        assert len(length_parts) == 2, "Invalid sequence length string %r" % text
+        assert len(length_parts) == 2, f"Invalid sequence length string {text!r}"
         assert length_parts[1].upper() in ["BP", "BP.", "AA", "AA."]
         consumer.size(length_parts[0])
 
@@ -885,7 +885,7 @@ class EmblScanner(InsdcScanner):
                         for bases in data.split(",")
                         if bases.strip()
                     ]
-                    consumer.reference_bases("(bases %s)" % "; ".join(parts))
+                    consumer.reference_bases(f"(bases {'; '.join(parts)})")
             elif line_type == "RT":
                 # Remove the enclosing quotes and trailing semi colon.
                 # Note the title can be split over multiple lines.
@@ -966,7 +966,7 @@ class EmblScanner(InsdcScanner):
                 getattr(consumer, consumer_dict[line_type])(data)
             else:
                 if self.debug:
-                    print("Ignoring EMBL header line:\n%s" % line)
+                    print(f"Ignoring EMBL header line:\n{line}")
 
     def _feed_misc_lines(self, consumer, lines):
         # TODO - Should we do something with the information on the SQ line(s)?
@@ -1193,7 +1193,7 @@ class GenBankScanner(InsdcScanner):
     def parse_footer(self):
         """Return a tuple containing a list of any misc strings, and the sequence."""
         if self.line[: self.HEADER_WIDTH].rstrip() not in self.SEQUENCE_HEADERS:
-            raise ValueError("Footer format unexpected:  '%s'" % self.line)
+            raise ValueError(f"Footer format unexpected:  '{self.line}'")
 
         misc_lines = []
         while (
@@ -1207,7 +1207,7 @@ class GenBankScanner(InsdcScanner):
                 raise ValueError("Premature end of file")
 
         if self.line[: self.HEADER_WIDTH].rstrip() in self.SEQUENCE_HEADERS:
-            raise ValueError("Eh? '%s'" % self.line)
+            raise ValueError(f"Eh? '{self.line}'")
 
         # Now just consume the sequence lines until reach the // marker
         # or a CONTIG line
@@ -1237,7 +1237,7 @@ class GenBankScanner(InsdcScanner):
                 )
                 line = line[1:]
                 if len(line) > 9 and line[9:10] != " ":
-                    raise ValueError("Sequence line mal-formed, '%s'" % line)
+                    raise ValueError(f"Sequence line mal-formed, '{line}'")
             seq_lines.append(line[10:])  # remove spaces later
             line = self.handle.readline()
 
@@ -1389,7 +1389,7 @@ class GenBankScanner(InsdcScanner):
                 # See issue #1656 e.g.
                 # LOCUS       pEH010                  5743 bp    DNA     circular
                 warnings.warn(
-                    "Truncated LOCUS line found - is this correct?\n:%r" % line,
+                    f"Truncated LOCUS line found - is this correct?\n:{line!r}",
                     BiopythonParserWarning,
                 )
                 padding_len = 79 - len(line)
@@ -1495,7 +1495,7 @@ class GenBankScanner(InsdcScanner):
                 # Must just have just "LOCUS       ", is this even legitimate?
                 # We should be able to continue parsing... we need real world testcases!
                 warnings.warn(
-                    "Minimal LOCUS line found - is this correct?\n:%r" % line,
+                    f"Minimal LOCUS line found - is this correct?\n:{line!r}",
                     BiopythonParserWarning,
                 )
         elif (
@@ -1552,7 +1552,7 @@ class GenBankScanner(InsdcScanner):
             # Cope with EMBOSS seqret output where it seems the locus id can cause
             # the other fields to overflow.  We just IGNORE the other fields!
             warnings.warn(
-                "Malformed LOCUS line found - is this correct?\n:%r" % line,
+                f"Malformed LOCUS line found - is this correct?\n:{line!r}",
                 BiopythonParserWarning,
             )
             consumer.locus(line.split()[1])
@@ -1562,7 +1562,7 @@ class GenBankScanner(InsdcScanner):
             #   "LOCUS       RNA5 complete       1718 bp"
             # Treat everything between LOCUS and the size as the identifier.
             warnings.warn(
-                "Malformed LOCUS line found - is this correct?\n:%r" % line,
+                f"Malformed LOCUS line found - is this correct?\n:{line!r}",
                 BiopythonParserWarning,
             )
             consumer.locus(line[5:].rsplit(None, 2)[0].strip())

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -337,7 +337,7 @@ def _loc(loc_str, expected_seq_length, strand, seq_type=None):
             elif int(s) == expected_seq_length and e == "1":
                 pos = _pos(s)
             else:
-                raise ValueError("Invalid between location %r" % loc_str) from None
+                raise ValueError(f"Invalid between location {loc_str!r}") from None
             return SeqFeature.FeatureLocation(pos, pos, strand, ref=ref)
         else:
             # e.g. "123"
@@ -730,7 +730,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         if topology:
             if topology not in ["linear", "circular"]:
                 raise ParserFailureError(
-                    "Unexpected topology %r should be linear or circular" % topology
+                    f"Unexpected topology {topology!r} should be linear or circular"
                 )
             self.data.annotations["topology"] = topology
 
@@ -739,7 +739,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         if mol_type:
             if "circular" in mol_type or "linear" in mol_type:
                 raise ParserFailureError(
-                    "Molecule type %r should not include topology" % mol_type
+                    f"Molecule type {mol_type!r} should not include topology"
                 )
 
             # Writing out records will fail if we have a lower case DNA
@@ -749,7 +749,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
             # so we need to index from the back
             if mol_type[-3:].upper() in ("DNA", "RNA") and not mol_type[-3:].isupper():
                 warnings.warn(
-                    "Non-upper case molecule type in LOCUS line: %s" % mol_type,
+                    f"Non-upper case molecule type in LOCUS line: {mol_type}",
                     BiopythonParserWarning,
                 )
 
@@ -983,8 +983,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         # otherwise raise an error
         else:
             raise ValueError(
-                "Could not parse base info %s in record %s"
-                % (ref_base_info, self.data.id)
+                f"Could not parse base info {ref_base_info} in record {self.data.id}"
             )
 
         self._cur_reference.location = all_locations
@@ -1264,7 +1263,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
         cur_feature.location = None
         warnings.warn(
             BiopythonParserWarning(
-                "Couldn't parse feature location: %r" % location_line
+                f"Couldn't parse feature location: {location_line!r}"
             )
         )
 
@@ -1404,7 +1403,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
             # we have a bug if we get here
             else:
                 raise ValueError(
-                    "Could not determine molecule_type for seq_type %s" % self._seq_type
+                    f"Could not determine molecule_type for seq_type {self._seq_type}"
                 )
         # Don't overwrite molecule_type
         if molecule_type is not None:
@@ -1453,7 +1452,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
         # Be lenient about parsing, but technically lowercase residue types are malformed.
         if "dna" in content or "rna" in content:
             warnings.warn(
-                "Invalid seq_type (%s): DNA/RNA should be uppercase." % content,
+                f"Invalid seq_type ({content}): DNA/RNA should be uppercase.",
                 BiopythonParserWarning,
             )
         self.data.residue_type = content
@@ -1477,7 +1476,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
         if mol_type:
             if "circular" in mol_type or "linear" in mol_type:
                 raise ParserFailureError(
-                    "Molecule type %r should not include topology" % mol_type
+                    f"Molecule type {mol_type!r} should not include topology"
                 )
 
             # Writing out records will fail if we have a lower case DNA
@@ -1487,7 +1486,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
             # so we need to index from the back
             if mol_type[-3:].upper() in ("DNA", "RNA") and not mol_type[-3:].isupper():
                 warnings.warn(
-                    "Non-upper case molecule type in LOCUS line: %s" % mol_type,
+                    f"Non-upper case molecule type in LOCUS line: {mol_type}",
                     BiopythonParserWarning,
                 )
 
@@ -1501,7 +1500,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
         if topology:
             if topology not in ["linear", "circular"]:
                 raise ParserFailureError(
-                    "Unexpected topology %r should be linear or circular" % topology
+                    f"Unexpected topology {topology!r} should be linear or circular"
                 )
             self.data.topology = topology
 
@@ -1650,7 +1649,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
         for content in content_list:
             # the record parser keeps the /s -- add them if we don't have 'em
             if not content.startswith("/"):
-                content = "/%s" % content
+                content = f"/{content}"
             # add on a qualifier if we've got one
             if self._cur_qualifier is not None:
                 self._cur_feature.qualifiers.append(self._cur_qualifier)
@@ -1661,7 +1660,7 @@ class _RecordConsumer(_BaseGenBankConsumer):
     def feature_qualifier_description(self, content):
         # if we have info then the qualifier key should have a ='s
         if "=" not in self._cur_qualifier.key:
-            self._cur_qualifier.key = "%s=" % self._cur_qualifier.key
+            self._cur_qualifier.key = f"{self._cur_qualifier.key}="
         cur_content = self._remove_newlines(content)
         # remove all spaces from the value if it is a type where spaces
         # are not important

--- a/Bio/GenBank/utils.py
+++ b/Bio/GenBank/utils.py
@@ -48,11 +48,9 @@ class FeatureValueCleaner:
         """
         if key_name in self._to_process:
             try:
-                cleaner = getattr(self, "_clean_%s" % key_name)
+                cleaner = getattr(self, f"_clean_{key_name}")
             except AttributeError:
-                raise AssertionError(
-                    "No function to clean key: %s" % key_name
-                ) from None
+                raise AssertionError(f"No function to clean key: {key_name}") from None
             value = cleaner(value)
         return value
 

--- a/Bio/MarkovModel.py
+++ b/Bio/MarkovModel.py
@@ -113,21 +113,21 @@ def load(handle):
     mm.p_initial = numpy.zeros(N)
     line = _readline_and_check_start(handle, "INITIAL:")
     for i in range(len(states)):
-        line = _readline_and_check_start(handle, "  %s:" % states[i])
+        line = _readline_and_check_start(handle, f"  {states[i]}:")
         mm.p_initial[i] = float(line.split()[-1])
 
     # Load the transition.
     mm.p_transition = numpy.zeros((N, N))
     line = _readline_and_check_start(handle, "TRANSITION:")
     for i in range(len(states)):
-        line = _readline_and_check_start(handle, "  %s:" % states[i])
+        line = _readline_and_check_start(handle, f"  {states[i]}:")
         mm.p_transition[i, :] = [float(v) for v in line.split()[1:]]
 
     # Load the emission.
     mm.p_emission = numpy.zeros((N, M))
     line = _readline_and_check_start(handle, "EMISSION:")
     for i in range(len(states)):
-        line = _readline_and_check_start(handle, "  %s:" % states[i])
+        line = _readline_and_check_start(handle, f"  {states[i]}:")
         mm.p_emission[i, :] = [float(v) for v in line.split()[1:]]
 
     return mm
@@ -137,17 +137,17 @@ def save(mm, handle):
     """Save MarkovModel object into handle."""
     # This will fail if there are spaces in the states or alphabet.
     w = handle.write
-    w("STATES: %s\n" % " ".join(mm.states))
-    w("ALPHABET: %s\n" % " ".join(mm.alphabet))
+    w(f"STATES: {' '.join(mm.states)}\n")
+    w(f"ALPHABET: {' '.join(mm.alphabet)}\n")
     w("INITIAL:\n")
     for i in range(len(mm.p_initial)):
-        w("  %s: %g\n" % (mm.states[i], mm.p_initial[i]))
+        w(f"  {mm.states[i]}: {mm.p_initial[i]:g}\n")
     w("TRANSITION:\n")
     for i in range(len(mm.p_transition)):
-        w("  %s: %s\n" % (mm.states[i], " ".join(str(x) for x in mm.p_transition[i])))
+        w(f"  {mm.states[i]}: {' '.join(str(x) for x in mm.p_transition[i])}\n")
     w("EMISSION:\n")
     for i in range(len(mm.p_emission)):
-        w("  %s: %s\n" % (mm.states[i], " ".join(str(x) for x in mm.p_emission[i])))
+        w(f"  {mm.states[i]}: {' '.join(str(x) for x in mm.p_emission[i])}\n")
 
 
 # XXX allow them to specify starting points

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2263,7 +2263,7 @@ class UnknownSeq(Seq):
             sub = str(sub)
         elif not isinstance(sub, str):
             raise TypeError(
-                "a Seq, MutableSeq, or string object is required, not '%s'" % type(sub)
+                f"a Seq, MutableSeq, or string object is required, not '{type(sub)}'"
             )
         # Handling case where subsequence not in self
         if set(sub) != set(self._character):
@@ -2314,7 +2314,7 @@ class UnknownSeq(Seq):
             sub = str(sub)
         elif not isinstance(sub, str):
             raise TypeError(
-                "a Seq, MutableSeq, or string object is required, not '%s'" % type(sub)
+                f"a Seq, MutableSeq, or string object is required, not '{type(sub)}'"
             )
         # Handling case where subsequence not in self
         if set(sub) != set(self._character):
@@ -2691,7 +2691,7 @@ class MutableSeq(_SeqAbstractBaseClass):
             elif isinstance(value, str):
                 self._data[index] = value.encode("ASCII")
             else:
-                raise TypeError("received unexpected type '%s'" % type(value).__name__)
+                raise TypeError(f"received unexpected type '{type(value).__name__}'")
 
     def __delitem__(self, index):
         """Delete a subsequence of single letter.

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -274,10 +274,10 @@ class SeqFeature:
                 self.location.operator = value
             elif self.location is None:
                 raise ValueError(
-                    "Location is None so can't set its operator (to %r)" % value
+                    f"Location is None so can't set its operator (to {value!r})"
                 )
             else:
-                raise ValueError("Only CompoundLocation gets an operator (%r)" % value)
+                raise ValueError(f"Only CompoundLocation gets an operator ({value!r})")
 
     location_operator = property(
         fget=_get_location_operator,
@@ -289,26 +289,26 @@ class SeqFeature:
         """Represent the feature as a string for debugging."""
         answer = f"{self.__class__.__name__}({self.location!r}"
         if self.type:
-            answer += ", type=%r" % self.type
+            answer += f", type={self.type!r}"
         if self.location_operator:
-            answer += ", location_operator=%r" % self.location_operator
+            answer += f", location_operator={self.location_operator!r}"
         if self.id and self.id != "<unknown id>":
-            answer += ", id=%r" % self.id
+            answer += f", id={self.id!r}"
         if self.qualifiers:
             answer += ", qualifiers=..."
         if self.ref:
-            answer += ", ref=%r" % self.ref
+            answer += f", ref={self.ref!r}"
         if self.ref_db:
-            answer += ", ref_db=%r" % self.ref_db
+            answer += f", ref_db={self.ref_db!r}"
         answer += ")"
         return answer
 
     def __str__(self):
         """Return the full feature as a python string."""
-        out = "type: %s\n" % self.type
-        out += "location: %s\n" % self.location
+        out = f"type: {self.type}\n"
+        out += f"location: {self.location}\n"
         if self.id and self.id != "<unknown id>":
-            out += "id: %s\n" % self.id
+            out += f"id: {self.id}\n"
         out += "qualifiers:\n"
         for qual_key in sorted(self.qualifiers):
             out += f"    Key: {qual_key}, Value: {self.qualifiers[qual_key]}\n"
@@ -639,15 +639,15 @@ class Reference:
         """Return the full Reference object as a python string."""
         out = ""
         for single_location in self.location:
-            out += "location: %s\n" % single_location
-        out += "authors: %s\n" % self.authors
+            out += f"location: {single_location}\n"
+        out += f"authors: {self.authors}\n"
         if self.consrtm:
-            out += "consrtm: %s\n" % self.consrtm
-        out += "title: %s\n" % self.title
-        out += "journal: %s\n" % self.journal
-        out += "medline id: %s\n" % self.medline_id
-        out += "pubmed id: %s\n" % self.pubmed_id
-        out += "comment: %s\n" % self.comment
+            out += f"consrtm: {self.consrtm}\n"
+        out += f"title: {self.title}\n"
+        out += f"journal: {self.journal}\n"
+        out += f"medline id: {self.medline_id}\n"
+        out += f"pubmed id: {self.pubmed_id}\n"
+        out += f"comment: {self.comment}\n"
         return out
 
     def __repr__(self):
@@ -828,7 +828,7 @@ class FeatureLocation:
     def _set_strand(self, value):
         """Set function for the strand property (PRIVATE)."""
         if value not in [+1, -1, 0, None]:
-            raise ValueError("Strand should be +1, -1, 0 or None, not %r" % value)
+            raise ValueError(f"Strand should be +1, -1, 0 or None, not {value!r}")
         self._strand = value
 
     strand = property(
@@ -864,17 +864,12 @@ class FeatureLocation:
         """Represent the FeatureLocation object as a string for debugging."""
         optional = ""
         if self.strand is not None:
-            optional += ", strand=%r" % self.strand
+            optional += f", strand={self.strand!r}"
         if self.ref is not None:
-            optional += ", ref=%r" % self.ref
+            optional += f", ref={self.ref!r}"
         if self.ref_db is not None:
-            optional += ", ref_db=%r" % self.ref_db
-        return "%s(%r, %r%s)" % (
-            self.__class__.__name__,
-            self.start,
-            self.end,
-            optional,
-        )
+            optional += f", ref_db={self.ref_db!r}"
+        return f"{self.__class__.__name__}({self.start!r}, {self.end!r}{optional})"
 
     def __add__(self, other):
         """Combine location with another FeatureLocation object, or shift it.
@@ -1237,7 +1232,7 @@ class CompoundLocation:
                 )
         if len(parts) < 2:
             raise ValueError(
-                "CompoundLocation should have at least 2 parts, not %r" % parts
+                f"CompoundLocation should have at least 2 parts, not {parts!r}"
             )
 
     def __str__(self):
@@ -1579,7 +1574,7 @@ class AbstractPosition:
 
     def __repr__(self):
         """Represent the AbstractPosition object as a string for debugging."""
-        return "%s(...)" % (self.__class__.__name__)
+        return f"{self.__class__.__name__}(...)"
 
 
 class ExactPosition(int, AbstractPosition):
@@ -1620,9 +1615,7 @@ class ExactPosition(int, AbstractPosition):
     def __new__(cls, position, extension=0):
         """Create an ExactPosition object."""
         if extension != 0:
-            raise AttributeError(
-                "Non-zero extension %s for exact position." % extension
-            )
+            raise AttributeError(f"Non-zero extension {extension} for exact position.")
         return int.__new__(cls, position)
 
     # Must define this on Python 3.8 onwards because we redefine __repr__
@@ -1673,7 +1666,7 @@ class UnknownPosition(AbstractPosition):
 
     def __repr__(self):
         """Represent the UnknownPosition object as a string for debugging."""
-        return "%s()" % self.__class__.__name__
+        return f"{self.__class__.__name__}()"
 
     def __hash__(self):
         """Return the hash value of the UnknownPosition object."""
@@ -1993,9 +1986,7 @@ class BeforePosition(int, AbstractPosition):
     def __new__(cls, position, extension=0):
         """Create a new instance in BeforePosition object."""
         if extension != 0:
-            raise AttributeError(
-                "Non-zero extension %s for exact position." % extension
-            )
+            raise AttributeError(f"Non-zero extension {extension} for exact position.")
         return int.__new__(cls, position)
 
     @property
@@ -2014,7 +2005,7 @@ class BeforePosition(int, AbstractPosition):
 
     def __str__(self):
         """Return a representation of the BeforePosition object (with python counting)."""
-        return "<%s" % self.position
+        return f"<{self.position}"
 
     def _shift(self, offset):
         """Return a copy of the position object with its location shifted (PRIVATE)."""
@@ -2069,9 +2060,7 @@ class AfterPosition(int, AbstractPosition):
     def __new__(cls, position, extension=0):
         """Create a new instance of the AfterPosition object."""
         if extension != 0:
-            raise AttributeError(
-                "Non-zero extension %s for exact position." % extension
-            )
+            raise AttributeError(f"Non-zero extension {extension} for exact position.")
         return int.__new__(cls, position)
 
     @property
@@ -2090,7 +2079,7 @@ class AfterPosition(int, AbstractPosition):
 
     def __str__(self):
         """Return a representation of the AfterPosition object (with python counting)."""
-        return ">%s" % self.position
+        return f">{self.position}"
 
     def _shift(self, offset):
         """Return a copy of the position object with its location shifted (PRIVATE)."""
@@ -2198,7 +2187,7 @@ class OneOfPosition(int, AbstractPosition):
         """Return a representation of the OneOfPosition object (with python counting)."""
         out = "one-of("
         for position in self.position_choices:
-            out += "%s," % position
+            out += f"{position},"
         # replace the last comma with the closing parenthesis
         return out[:-1] + ")"
 
@@ -2228,7 +2217,7 @@ class PositionGap:
 
     def __str__(self):
         """Return a representation of the PositionGap object (with python counting)."""
-        return "gap(%s)" % self.gap_size
+        return f"gap({self.gap_size})"
 
 
 if __name__ == "__main__":

--- a/Bio/SeqIO/AbiIO.py
+++ b/Bio/SeqIO/AbiIO.py
@@ -361,7 +361,7 @@ class AbiIterator(SequenceIterator):
             raise ValueError("Empty file.")
 
         if marker != b"ABIF":
-            raise OSError("File should start ABIF, not %r" % marker)
+            raise OSError(f"File should start ABIF, not {marker!r}")
         records = self.iterate(handle)
         return records
 
@@ -404,8 +404,8 @@ class AbiIterator(SequenceIterator):
                     annot[_EXTRACT[key]] = tag_data
 
         # set time annotations
-        annot["run_start"] = "%s %s" % (times["RUND1"], times["RUNT1"])
-        annot["run_finish"] = "%s %s" % (times["RUND2"], times["RUNT2"])
+        annot["run_start"] = f"{times['RUND1']} {times['RUNT1']}"
+        annot["run_finish"] = f"{times['RUND2']} {times['RUNT2']}"
 
         # raw data (for advanced end users benefit)
         annot["abif_raw"] = raw

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -308,7 +308,7 @@ class FastaWriter(SequenceWriter):
 
         assert "\n" not in title
         assert "\r" not in title
-        self.handle.write(">%s\n" % title)
+        self.handle.write(f">{title}\n")
 
         data = _get_seq_string(record)  # Catches sequence being None
 
@@ -384,7 +384,7 @@ def as_fasta(record):
         title = id
     assert "\n" not in title
     assert "\r" not in title
-    lines = [">%s\n" % title]
+    lines = [f">{title}\n"]
 
     data = _get_seq_string(record)  # Catches sequence being None
     assert "\n" not in data

--- a/Bio/SeqIO/IgIO.py
+++ b/Bio/SeqIO/IgIO.py
@@ -77,7 +77,7 @@ class IgIterator(SequenceIterator):
             return
 
         if line[0] != ";":
-            raise ValueError("Records should start with ';' and not:\n%r" % line)
+            raise ValueError(f"Records should start with ';' and not:\n{line!r}")
         while line:
             # Now iterate over the records
 

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -1027,7 +1027,7 @@ class GenBankWriter(_InsdcWriter):
         if gi != ".":
             self._write_single_line("VERSION", f"{acc_with_version}  GI:{gi}")
         else:
-            self._write_single_line("VERSION", "%s" % acc_with_version)
+            self._write_single_line("VERSION", acc_with_version)
 
         # The NCBI initially expected two types of link,
         # e.g. "Project:28471" and "Trace Assembly Archive:123456"

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -249,7 +249,7 @@ def _insdc_feature_position_string(pos, offset=0):
 
 def _insdc_location_string_ignoring_strand_and_subfeatures(location, rec_length):
     if location.ref:
-        ref = "%s:" % location.ref
+        ref = f"{location.ref}:"
     else:
         ref = ""
     assert not location.ref_db
@@ -345,7 +345,7 @@ def _insdc_location_string(location, rec_length):
             location, rec_length
         )
         if location.strand == -1:
-            return "complement(%s)" % loc
+            return f"complement({loc})"
         else:
             return loc
 
@@ -425,7 +425,7 @@ class _InsdcWriter(SequenceWriter):
         index = location[:length].rfind(",")
         if index == -1:
             # No good place to split (!)
-            warnings.warn("Couldn't split location:\n%s" % location, BiopythonWarning)
+            warnings.warn(f"Couldn't split location:\n{location}", BiopythonWarning)
             return location
         return (
             location[: index + 1]
@@ -550,7 +550,7 @@ class GenBankWriter(_InsdcWriter):
                 )
             else:
                 # Can't give such a precise warning
-                warnings.warn("Annotation %r too long" % text, BiopythonWarning)
+                warnings.warn(f"Annotation {text!r} too long", BiopythonWarning)
         self.handle.write(
             "%s%s\n" % (tag.ljust(self.HEADER_WIDTH), text.replace("\n", " "))
         )
@@ -731,7 +731,7 @@ class GenBankWriter(_InsdcWriter):
                 )
 
         if len(locus.split()) > 1:
-            raise ValueError("Invalid whitespace in %r for LOCUS line" % locus)
+            raise ValueError(f"Invalid whitespace in {locus!r} for LOCUS line")
         if len(record) > 99999999999:
             # As of the GenBank release notes 229.0, the locus line can be
             # any length. However, long locus lines may not be compatible
@@ -751,7 +751,7 @@ class GenBankWriter(_InsdcWriter):
             # Deal with common cases from EMBL to GenBank
             mol_type = mol_type.replace("unassigned ", "").replace("genomic ", "")
             if len(mol_type) > 7:
-                warnings.warn("Molecule type %r too long" % mol_type, BiopythonWarning)
+                warnings.warn(f"Molecule type {mol_type!r} too long", BiopythonWarning)
                 mol_type = "DNA"
         if mol_type in ["protein", "PROTEIN"]:
             mol_type = ""
@@ -985,7 +985,7 @@ class GenBankWriter(_InsdcWriter):
             for words in range(
                 line_number, min(line_number + self.LETTERS_PER_LINE, seq_len), 10
             ):
-                self.handle.write(" %s" % data[words : words + 10])
+                self.handle.write(f" {data[words:words + 10]}")
             self.handle.write("\n")
 
     def write_record(self, record):
@@ -1189,7 +1189,7 @@ class EmblWriter(_InsdcWriter):
                 index = (
                     self.LETTERS_PER_LINE * line_number + self.LETTERS_PER_BLOCK * block
                 )
-                handle.write(" %s" % data[index : index + self.LETTERS_PER_BLOCK])
+                handle.write(f" {data[index:index + self.LETTERS_PER_BLOCK]}")
             handle.write(
                 str((line_number + 1) * self.LETTERS_PER_LINE).rjust(
                     self.POSITION_PADDING
@@ -1204,9 +1204,7 @@ class EmblWriter(_InsdcWriter):
                 index = (
                     self.LETTERS_PER_LINE * line_number + self.LETTERS_PER_BLOCK * block
                 )
-                handle.write(
-                    (" %s" % data[index : index + self.LETTERS_PER_BLOCK]).ljust(11)
-                )
+                handle.write(f" {data[index:index + self.LETTERS_PER_BLOCK]}".ljust(11))
             handle.write(str(seq_len).rjust(self.POSITION_PADDING))
             handle.write("\n")
 
@@ -1214,7 +1212,7 @@ class EmblWriter(_InsdcWriter):
         assert len(tag) == 2
         line = tag + "   " + text
         if len(text) > self.MAX_WIDTH:
-            warnings.warn("Line %r too long" % line, BiopythonWarning)
+            warnings.warn(f"Line {line!r} too long", BiopythonWarning)
         self.handle.write(line + "\n")
 
     def _write_multi_line(self, tag, text):
@@ -1237,12 +1235,10 @@ class EmblWriter(_InsdcWriter):
             )
 
         if ";" in accession:
-            raise ValueError(
-                "Cannot have semi-colon in EMBL accession, '%s'" % accession
-            )
+            raise ValueError(f"Cannot have semi-colon in EMBL accession, '{accession}'")
         if " " in accession:
             # This is out of practicality... might it be allowed?
-            raise ValueError("Cannot have spaces in EMBL accession, '%s'" % accession)
+            raise ValueError(f"Cannot have spaces in EMBL accession, '{accession}'")
 
         topology = self._get_annotation_str(record, "topology", default="")
 
@@ -1253,7 +1249,7 @@ class EmblWriter(_InsdcWriter):
         if mol_type is None:
             raise ValueError("missing molecule_type in annotations")
         if mol_type not in ("DNA", "RNA", "protein"):
-            warnings.warn("Non-standard molecule type: %s" % mol_type, BiopythonWarning)
+            warnings.warn(f"Non-standard molecule type: {mol_type}", BiopythonWarning)
         mol_type_upper = mol_type.upper()
         if "DNA" in mol_type_upper:
             units = "BP"
@@ -1263,7 +1259,7 @@ class EmblWriter(_InsdcWriter):
             mol_type = "PROTEIN"
             units = "AA"
         else:
-            raise ValueError("failed to understand molecule_type '%s'" % mol_type)
+            raise ValueError(f"failed to understand molecule_type '{mol_type}'")
 
         # Get the taxonomy division
         division = self._get_data_division(record)
@@ -1373,15 +1369,15 @@ class EmblWriter(_InsdcWriter):
                 )
             # TODO - record any DOI or AGRICOLA identifier in the reference object?
             if ref.pubmed_id:
-                self._write_single_line("RX", "PUBMED; %s." % ref.pubmed_id)
+                self._write_single_line("RX", f"PUBMED; {ref.pubmed_id}.")
             if ref.consrtm:
-                self._write_single_line("RG", "%s" % ref.consrtm)
+                self._write_single_line("RG", f"{ref.consrtm}")
             if ref.authors:
                 # We store the AUTHORS data as a single string
                 self._write_multi_line("RA", ref.authors + ";")
             if ref.title:
                 # We store the title as a single string
-                self._write_multi_line("RT", '"%s";' % ref.title)
+                self._write_multi_line("RT", f'"{ref.title}";')
             if ref.journal:
                 # We store this as a single string - holds the journal name,
                 # volume, year, and page numbers of the citation

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -48,15 +48,15 @@ class SequenceIterator(ABC):
             if mode == "t":
                 if source.read(0) != "":
                     raise StreamModeError(
-                        "%s files must be opened in text mode." % fmt
+                        f"{fmt} files must be opened in text mode."
                     ) from None
             elif mode == "b":
                 if source.read(0) != b"":
                     raise StreamModeError(
-                        "%s files must be opened in binary mode." % fmt
+                        f"{fmt} files must be opened in binary mode."
                     ) from None
             else:
-                raise ValueError("Unknown mode '%s'" % mode) from None
+                raise ValueError(f"Unknown mode '{mode}'") from None
             self.stream = source
             self.should_close_stream = False
         try:
@@ -102,9 +102,9 @@ def _get_seq_string(record):
     if not isinstance(record, SeqRecord):
         raise TypeError("Expected a SeqRecord object")
     if record.seq is None:
-        raise TypeError("SeqRecord (id=%s) has None for its sequence." % record.id)
+        raise TypeError(f"SeqRecord (id={record.id}) has None for its sequence.")
     elif not isinstance(record.seq, (Seq, MutableSeq)):
-        raise TypeError("SeqRecord (id=%s) has an invalid sequence." % record.id)
+        raise TypeError(f"SeqRecord (id={record.id}) has an invalid sequence.")
     return str(record.seq)
 
 
@@ -157,7 +157,7 @@ class SequenceWriter:
             else:
                 handle = target
         else:
-            raise RuntimeError("Unknown mode '%s'" % mode)
+            raise RuntimeError(f"Unknown mode '{mode}'")
 
         self._target = target
         self.handle = handle

--- a/Bio/SeqIO/NibIO.py
+++ b/Bio/SeqIO/NibIO.py
@@ -139,7 +139,7 @@ class NibWriter(SequenceWriter):
         elif byteorder == "big":  # big-endian
             signature = "6be93d3a"
         else:
-            raise RuntimeError("unexpected system byte order %s" % byteorder)
+            raise RuntimeError(f"unexpected system byte order {byteorder}")
         handle.write(bytes.fromhex(signature))
 
     def write_record(self, record):

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -228,17 +228,13 @@ class PdbSeqresIterator(SequenceIterator):
             record.annotations["molecule_type"] = "protein"
             if chn_id in metadata:
                 m = metadata[chn_id][0]
-                record.id = record.name = "%s:%s" % (m["pdb_id"], chn_id)
-                record.description = "%s:%s %s" % (
-                    m["database"],
-                    m["db_acc"],
-                    m["db_id_code"],
-                )
+                record.id = record.name = f"{m['pdb_id']}:{chn_id}"
+                record.description = f"{m['database']}:{m['db_acc']} {m['db_id_code']}"
                 for melem in metadata[chn_id]:
                     record.dbxrefs.extend(
                         [
-                            "%s:%s" % (melem["database"], melem["db_acc"]),
-                            "%s:%s" % (melem["database"], melem["db_id_code"]),
+                            f"{melem['database']}:{melem['db_acc']}",
+                            f"{melem['database']}:{melem['db_id_code']}",
                         ]
                     )
             else:
@@ -432,17 +428,13 @@ def CifSeqresIterator(source):
         record.annotations["molecule_type"] = "protein"
         if chn_id in metadata:
             m = metadata[chn_id][0]
-            record.id = record.name = "%s:%s" % (m["pdb_id"], chn_id)
-            record.description = "%s:%s %s" % (
-                m["database"],
-                m["db_acc"],
-                m["db_id_code"],
-            )
+            record.id = record.name = f"{m['pdb_id']}:{chn_id}"
+            record.description = f"{m['database']}:{m['db_acc']} {m['db_id_code']}"
             for melem in metadata[chn_id]:
                 record.dbxrefs.extend(
                     [
-                        "%s:%s" % (melem["database"], melem["db_acc"]),
-                        "%s:%s" % (melem["database"], melem["db_id_code"]),
+                        f"{melem['database']}:{melem['db_acc']}",
+                        f"{melem['database']}:{melem['db_id_code']}",
                     ]
                 )
         else:

--- a/Bio/SeqIO/PhdIO.py
+++ b/Bio/SeqIO/PhdIO.py
@@ -122,11 +122,11 @@ class PhdWriter(SequenceWriter):
                 )
         if None in phred_qualities:
             raise ValueError("A quality value of None was found")
-        if record.description.startswith("%s " % record.id):
+        if record.description.startswith(f"{record.id} "):
             title = record.description
         else:
             title = f"{record.id} {record.description}"
-        self.handle.write("BEGIN_SEQUENCE %s\nBEGIN_COMMENT\n" % self.clean(title))
+        self.handle.write(f"BEGIN_SEQUENCE {self.clean(title)}\nBEGIN_COMMENT\n")
         for annot in [k.lower() for k in Phd.CKEYWORDS]:
             value = None
             if annot == "trim":
@@ -134,7 +134,7 @@ class PhdWriter(SequenceWriter):
                     value = "%s %s %.4f" % record.annotations["trim"]
             elif annot == "trace_peak_area_ratio":
                 if record.annotations.get("trace_peak_area_ratio"):
-                    value = "%.4f" % record.annotations["trace_peak_area_ratio"]
+                    value = f"{record.annotations['trace_peak_area_ratio']:.4f}"
             else:
                 value = record.annotations.get(annot)
             if value or value == 0:

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -470,7 +470,7 @@ def solexa_quality_from_phred(phred_quality):
         return -5.0
     else:
         raise ValueError(
-            "PHRED qualities must be positive (or zero), not %r" % phred_quality
+            f"PHRED qualities must be positive (or zero), not {phred_quality!r}"
         )
 
 
@@ -517,7 +517,7 @@ def phred_quality_from_solexa(solexa_quality):
         return None
     if solexa_quality < -5:
         warnings.warn(
-            "Solexa quality less than -5 passed, %r" % solexa_quality, BiopythonWarning
+            f"Solexa quality less than -5 passed, {solexa_quality!r}", BiopythonWarning
         )
     return 10 * log(10 ** (solexa_quality / 10.0) + 1, 10)
 
@@ -1493,7 +1493,7 @@ class FastqPhredWriter(SequenceWriter):
         # TODO - Is an empty sequence allowed in FASTQ format?
         seq = record.seq
         if seq is None:
-            raise ValueError("No sequence for record %s" % record.id)
+            raise ValueError(f"No sequence for record {record.id}")
         qualities_str = _get_sanger_quality_str(record)
         if len(qualities_str) != len(seq):
             raise ValueError(
@@ -1615,7 +1615,7 @@ class QualPhredWriter(SequenceWriter):
                 title = f"{id} {description}"
             else:
                 title = id
-        handle.write(">%s\n" % title)
+        handle.write(f">{title}\n")
 
         qualities = _get_phred_quality(record)
         try:
@@ -1668,7 +1668,7 @@ def as_qual(record):
         title = f"{id} {description}"
     else:
         title = id
-    lines = [">%s\n" % title]
+    lines = [f">{title}\n"]
 
     qualities = _get_phred_quality(record)
     try:
@@ -1749,7 +1749,7 @@ class FastqSolexaWriter(SequenceWriter):
         # TODO - Is an empty sequence allowed in FASTQ format?
         seq = record.seq
         if seq is None:
-            raise ValueError("No sequence for record %s" % record.id)
+            raise ValueError(f"No sequence for record {record.id}")
         qualities_str = _get_solexa_quality_str(record)
         if len(qualities_str) != len(seq):
             raise ValueError(
@@ -1833,7 +1833,7 @@ class FastqIlluminaWriter(SequenceWriter):
         # TODO - Is an empty sequence allowed in FASTQ format?
         seq = record.seq
         if seq is None:
-            raise ValueError("No sequence for record %s" % record.id)
+            raise ValueError(f"No sequence for record {record.id}")
         qualities_str = _get_illumina_quality_str(record)
         if len(qualities_str) != len(seq):
             raise ValueError(
@@ -1975,8 +1975,7 @@ def PairedFastaQualIterator(fasta_source, qual_source, alphabet=None, title2ids=
             )
         if len(f_rec) != len(q_rec.letter_annotations["phred_quality"]):
             raise ValueError(
-                "Sequence length and number of quality scores disagree for %s"
-                % f_rec.id
+                f"Sequence length and number of quality scores disagree for {f_rec.id}"
             )
         # Merge the data....
         f_rec.letter_annotations["phred_quality"] = q_rec.letter_annotations[
@@ -2210,7 +2209,7 @@ def _fastq_convert_fasta(in_file, out_file):
     with as_handle(out_file, "w") as out_handle:
         for title, seq, qual in FastqGeneralIterator(in_file):
             count += 1
-            out_handle.write(">%s\n" % title)
+            out_handle.write(f">{title}\n")
             # Do line wrapping
             for i in range(0, len(seq), 60):
                 out_handle.write(seq[i : i + 60] + "\n")
@@ -2246,7 +2245,7 @@ def _fastq_convert_qual(in_file, out_file, mapping):
     with as_handle(out_file, "w") as out_handle:
         for title, seq, qual in FastqGeneralIterator(in_file):
             count += 1
-            out_handle.write(">%s\n" % title)
+            out_handle.write(f">{title}\n")
             # map the qual... note even with Sanger encoding max 2 digits
             try:
                 qualities_strs = [mapping[ascii] for ascii in qual]

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -76,11 +76,11 @@ class ContentHandler(handler.ContentHandler):
                     raise ValueError("Unexpected attribute for XML Schema in namespace")
             else:
                 raise ValueError(
-                    "Unexpected namespace '%s' for seqXML attribute" % namespace
+                    f"Unexpected namespace '{namespace}' for seqXML attribute"
                 )
         if self.seqXMLversion is None:
             raise ValueError("Failed to find seqXMLversion")
-        url = "http://www.seqxml.org/%s/seqxml.xsd" % self.seqXMLversion
+        url = f"http://www.seqxml.org/{self.seqXMLversion}/seqxml.xsd"
         if schema != url:
             raise ValueError(
                 "XML Schema '%s' found not consistent with reported seqXML version %s"
@@ -93,9 +93,9 @@ class ContentHandler(handler.ContentHandler):
         """Handle end of the seqXML element."""
         namespace, localname = name
         if namespace is not None:
-            raise RuntimeError("Unexpected namespace '%s' for seqXML end" % namespace)
+            raise RuntimeError(f"Unexpected namespace '{namespace}' for seqXML end")
         if qname is not None:
-            raise RuntimeError("Unexpected qname '%s' for seqXML end" % qname)
+            raise RuntimeError(f"Unexpected qname '{qname}' for seqXML end")
         if localname != "seqXML":
             raise RuntimeError("Failed to find end of seqXML element")
         self.startElementNS = None
@@ -122,11 +122,11 @@ class ContentHandler(handler.ContentHandler):
                     record.annotations["source"] = value
                 else:
                     raise ValueError(
-                        "Unexpected attribute %s in entry element" % localname
+                        f"Unexpected attribute {localname} in entry element"
                     )
             else:
                 raise ValueError(
-                    "Unexpected namespace '%s' for entry attribute" % namespace
+                    f"Unexpected namespace '{namespace}' for entry attribute"
                 )
         if record.id is None:
             raise ValueError("Failed to find entry ID")
@@ -162,7 +162,7 @@ class ContentHandler(handler.ContentHandler):
             return self.startDBRefElement(attrs)
         if localname == "property":
             return self.startPropertyElement(attrs)
-        raise ValueError("Unexpected field %s in entry" % localname)
+        raise ValueError(f"Unexpected field {localname} in entry")
 
     def startSpeciesElement(self, attrs):
         """Parse the species information."""
@@ -179,11 +179,11 @@ class ContentHandler(handler.ContentHandler):
                     ncbiTaxID = value
                 else:
                     raise ValueError(
-                        "Unexpected attribute '%s' found in species tag" % key
+                        f"Unexpected attribute '{key}' found in species tag"
                     )
             else:
                 raise ValueError(
-                    "Unexpected namespace '%s' for species attribute" % namespace
+                    f"Unexpected namespace '{namespace}' for species attribute"
                 )
         # The attributes "name" and "ncbiTaxID" are required:
         if name is None:
@@ -201,9 +201,9 @@ class ContentHandler(handler.ContentHandler):
         """Handle end of a species element."""
         namespace, localname = name
         if namespace is not None:
-            raise RuntimeError("Unexpected namespace '%s' for species end" % namespace)
+            raise RuntimeError(f"Unexpected namespace '{namespace}' for species end")
         if qname is not None:
-            raise RuntimeError("Unexpected qname '%s' for species end" % qname)
+            raise RuntimeError(f"Unexpected qname '{qname}' for species end")
         if localname != "species":
             raise RuntimeError("Failed to find end of species element")
         self.endElementNS = self.endEntryElement
@@ -213,7 +213,7 @@ class ContentHandler(handler.ContentHandler):
         if attrs:
             raise ValueError("Unexpected attributes found in description element")
         if self.data is not None:
-            raise RuntimeError("Unexpected data found: '%s'" % self.data)
+            raise RuntimeError(f"Unexpected data found: '{self.data}'")
         self.data = ""
         self.endElementNS = self.endDescriptionElement
 
@@ -222,10 +222,10 @@ class ContentHandler(handler.ContentHandler):
         namespace, localname = name
         if namespace is not None:
             raise RuntimeError(
-                "Unexpected namespace '%s' for description end" % namespace
+                f"Unexpected namespace '{namespace}' for description end"
             )
         if qname is not None:
-            raise RuntimeError("Unexpected qname '%s' for description end" % qname)
+            raise RuntimeError(f"Unexpected qname '{qname}' for description end")
         if localname != "description":
             raise RuntimeError("Failed to find end of description element")
         record = self.records[-1]
@@ -240,7 +240,7 @@ class ContentHandler(handler.ContentHandler):
         if attrs:
             raise ValueError("Unexpected attributes found in sequence element")
         if self.data is not None:
-            raise RuntimeError("Unexpected data found: '%s'" % self.data)
+            raise RuntimeError(f"Unexpected data found: '{self.data}'")
         self.data = ""
         self.endElementNS = self.endSequenceElement
 
@@ -248,9 +248,9 @@ class ContentHandler(handler.ContentHandler):
         """Handle the end of a sequence element."""
         namespace, localname = name
         if namespace is not None:
-            raise RuntimeError("Unexpected namespace '%s' for sequence end" % namespace)
+            raise RuntimeError(f"Unexpected namespace '{namespace}' for sequence end")
         if qname is not None:
-            raise RuntimeError("Unexpected qname '%s' for sequence end" % qname)
+            raise RuntimeError(f"Unexpected qname '{qname}' for sequence end")
         record = self.records[-1]
         if localname == "DNAseq":
             record.annotations["molecule_type"] = "DNA"
@@ -260,7 +260,7 @@ class ContentHandler(handler.ContentHandler):
             record.annotations["molecule_type"] = "protein"
         else:
             raise RuntimeError(
-                "Failed to find end of sequence (localname = %s)" % localname
+                f"Failed to find end of sequence (localname = {localname})"
             )
         record.seq = Seq(self.data)
         self.data = None
@@ -279,11 +279,11 @@ class ContentHandler(handler.ContentHandler):
                     ID = value
                 else:
                     raise ValueError(
-                        "Unexpected attribute '%s' found for DBRef element" % key
+                        f"Unexpected attribute '{key}' found for DBRef element"
                     )
             else:
                 raise ValueError(
-                    "Unexpected namespace '%s' for DBRef attribute" % namespace
+                    f"Unexpected namespace '{namespace}' for DBRef attribute"
                 )
         # The attributes "source" and "id" are required:
         if source is None:
@@ -291,7 +291,7 @@ class ContentHandler(handler.ContentHandler):
         if ID is None:
             raise ValueError("Failed to find id for DBRef element")
         if self.data is not None:
-            raise RuntimeError("Unexpected data found: '%s'" % self.data)
+            raise RuntimeError(f"Unexpected data found: '{self.data}'")
         self.data = ""
         record = self.records[-1]
         dbxref = f"{source}:{ID}"
@@ -303,18 +303,14 @@ class ContentHandler(handler.ContentHandler):
         """Handle the end of a DBRef element."""
         namespace, localname = name
         if namespace is not None:
-            raise RuntimeError(
-                "Unexpected namespace '%s' for DBRef element" % namespace
-            )
+            raise RuntimeError(f"Unexpected namespace '{namespace}' for DBRef element")
         if qname is not None:
-            raise RuntimeError("Unexpected qname '%s' for DBRef element" % qname)
+            raise RuntimeError(f"Unexpected qname '{qname}' for DBRef element")
         if localname != "DBRef":
-            raise RuntimeError(
-                "Unexpected localname '%s' for DBRef element" % localname
-            )
+            raise RuntimeError(f"Unexpected localname '{localname}' for DBRef element")
         if self.data:
             raise RuntimeError(
-                "Unexpected data received for DBRef element: '%s'" % self.data
+                f"Unexpected data received for DBRef element: '{self.data}'"
             )
         self.data = None
         self.endElementNS = self.endEntryElement
@@ -336,7 +332,7 @@ class ContentHandler(handler.ContentHandler):
                     )
             else:
                 raise ValueError(
-                    "Unexpected namespace '%s' for property attribute" % namespace
+                    f"Unexpected namespace '{namespace}' for property attribute"
                 )
         # The attribute "name" is required:
         if property_name is None:
@@ -359,13 +355,13 @@ class ContentHandler(handler.ContentHandler):
         namespace, localname = name
         if namespace is not None:
             raise RuntimeError(
-                "Unexpected namespace '%s' for property element" % namespace
+                f"Unexpected namespace '{namespace}' for property element"
             )
         if qname is not None:
-            raise RuntimeError("Unexpected qname '%s' for property element" % qname)
+            raise RuntimeError(f"Unexpected qname '{qname}' for property element")
         if localname != "property":
             raise RuntimeError(
-                "Unexpected localname '%s' for property element" % localname
+                f"Unexpected localname '{localname}' for property element"
             )
         self.endElementNS = self.endEntryElement
 
@@ -611,7 +607,7 @@ class SeqXmlWriter(SequenceWriter):
         elif "protein" in molecule_type:
             seqElem = "AAseq"
         else:
-            raise ValueError("unknown molecule_type '%s'" % molecule_type)
+            raise ValueError(f"unknown molecule_type '{molecule_type}'")
 
         self.xml_generator.startElement(seqElem, AttributesImpl({}))
         self.xml_generator.characters(seq)

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -314,7 +314,7 @@ def _sff_file_header(handle):
         # Probably user error, calling Bio.SeqIO.parse() twice!
         raise ValueError("Handle seems to be at SFF index block, not start")
     if magic_number != _sff:  # 779314790
-        raise ValueError("SFF file did not start '.sff', but %r" % magic_number)
+        raise ValueError(f"SFF file did not start '.sff', but {magic_number!r}")
     if (ver0, ver1, ver2, ver3) != (0, 0, 0, 1):
         raise ValueError(
             "Unsupported SFF version in header, %i.%i.%i.%i" % (ver0, ver1, ver2, ver3)
@@ -1229,7 +1229,7 @@ class SffWriter(SequenceWriter):
         else:
             from Bio import __version__
 
-            xml = "<!-- This file was output with Biopython %s -->\n" % __version__
+            xml = f"<!-- This file was output with Biopython {__version__} -->\n"
             xml += (
                 "<!-- This XML and index block attempts to mimic Roche SFF files -->\n"
             )
@@ -1368,7 +1368,7 @@ class SffWriter(SequenceWriter):
             quals = record.letter_annotations["phred_quality"]
         except KeyError:
             raise ValueError(
-                "Missing PHRED qualities information for %s" % record.id
+                f"Missing PHRED qualities information for {record.id}"
             ) from None
         # Flow
         try:
@@ -1380,38 +1380,34 @@ class SffWriter(SequenceWriter):
             ):
                 raise ValueError("Records have inconsistent SFF flow data")
         except KeyError:
-            raise ValueError(
-                "Missing SFF flow information for %s" % record.id
-            ) from None
+            raise ValueError(f"Missing SFF flow information for {record.id}") from None
         except AttributeError:
             raise ValueError("Header not written yet?") from None
         # Clipping
         try:
             clip_qual_left = record.annotations["clip_qual_left"]
             if clip_qual_left < 0:
-                raise ValueError("Negative SFF clip_qual_left value for %s" % record.id)
+                raise ValueError(f"Negative SFF clip_qual_left value for {record.id}")
             if clip_qual_left:
                 clip_qual_left += 1
             clip_qual_right = record.annotations["clip_qual_right"]
             if clip_qual_right < 0:
-                raise ValueError(
-                    "Negative SFF clip_qual_right value for %s" % record.id
-                )
+                raise ValueError(f"Negative SFF clip_qual_right value for {record.id}")
             clip_adapter_left = record.annotations["clip_adapter_left"]
             if clip_adapter_left < 0:
                 raise ValueError(
-                    "Negative SFF clip_adapter_left value for %s" % record.id
+                    f"Negative SFF clip_adapter_left value for {record.id}"
                 )
             if clip_adapter_left:
                 clip_adapter_left += 1
             clip_adapter_right = record.annotations["clip_adapter_right"]
             if clip_adapter_right < 0:
                 raise ValueError(
-                    "Negative SFF clip_adapter_right value for %s" % record.id
+                    f"Negative SFF clip_adapter_right value for {record.id}"
                 )
         except KeyError:
             raise ValueError(
-                "Missing SFF clipping information for %s" % record.id
+                f"Missing SFF clipping information for {record.id}"
             ) from None
 
         # Capture information for index

--- a/Bio/SeqIO/SwissIO.py
+++ b/Bio/SeqIO/SwissIO.py
@@ -49,7 +49,7 @@ def _make_position(location_string, offset=0):
             )
         except ValueError:
             pass
-    raise NotImplementedError("Cannot parse location '%s'" % location_string)
+    raise NotImplementedError(f"Cannot parse location '{location_string}'")
 
 
 def SwissIterator(source):
@@ -132,7 +132,7 @@ def SwissIterator(source):
                     elif key == "AGRICOLA":
                         pass
                     else:
-                        raise ValueError("Unknown key %s found in references" % key)
+                        raise ValueError(f"Unknown key {key} found in references")
                 feature.authors = reference.authors
                 feature.title = reference.title
                 feature.journal = reference.location

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -243,7 +243,7 @@ class Parser:
             ]
 
             if element.attrib["type"] in simple_comments:
-                ann_key = "comment_%s" % element.attrib["type"].replace(" ", "")
+                ann_key = f"comment_{element.attrib['type'].replace(' ', '')}"
                 for text_element in element.iter(NS + "text"):
                     if text_element.text:
                         append_to_annotations(ann_key, text_element.text)
@@ -258,7 +258,7 @@ class Parser:
                             append_to_annotations(ann_key, el.text)
             elif element.attrib["type"] == "interaction":
                 for interact_element in element.iter(NS + "interactant"):
-                    ann_key = "comment_%s_intactId" % element.attrib["type"]
+                    ann_key = f"comment_{element.attrib['type']}_intactId"
                     append_to_annotations(ann_key, interact_element.attrib["intactId"])
             elif element.attrib["type"] == "alternative products":
                 for alt_element in element.iter(NS + "isoform"):
@@ -268,7 +268,7 @@ class Parser:
                     for id_element in alt_element.iter(NS + "id"):
                         append_to_annotations(ann_key, id_element.text)
             elif element.attrib["type"] == "mass spectrometry":
-                ann_key = "comment_%s" % element.attrib["type"].replace(" ", "")
+                ann_key = f"comment_{element.attrib['type'].replace(' ', '')}"
                 start = end = 0
                 for el in element.iter(NS + "location"):
                     pos_els = list(el.iter(NS + "position"))
@@ -294,17 +294,16 @@ class Parser:
                 pass  # not parsed: few information, complex structure
             elif element.attrib["type"] == "online information":
                 for link_element in element.iter(NS + "link"):
-                    ann_key = "comment_%s" % element.attrib["type"].replace(" ", "")
+                    ann_key = f"comment_{element.attrib['type'].replace(' ', '')}"
                     for id_element in link_element.iter(NS + "link"):
                         append_to_annotations(
                             ann_key,
-                            "%s@%s"
-                            % (element.attrib["name"], link_element.attrib["uri"]),
+                            f"{element.attrib['name']}@{link_element.attrib['uri']}",
                         )
 
             # return raw XML comments if needed
             if self.return_raw_comments:
-                ann_key = "comment_%s_xml" % element.attrib["type"].replace(" ", "")
+                ann_key = f"comment_{element.attrib['type'].replace(' ', '')}_xml"
                 append_to_annotations(ann_key, ElementTree.tostring(element))
 
         def _parse_dbReference(element):
@@ -444,7 +443,7 @@ class Parser:
             elif status == "uncertain":
                 return SeqFeature.UncertainPosition(position)
             else:
-                raise NotImplementedError("Position status %r" % status)
+                raise NotImplementedError(f"Position status {status!r}")
 
         def _parse_feature(element):
             feature = SeqFeature.SeqFeature()
@@ -488,9 +487,9 @@ class Parser:
         def _parse_sequence(element):
             for k, v in element.attrib.items():
                 if k in ("length", "mass", "version"):
-                    self.ParsedSeqRecord.annotations["sequence_%s" % k] = int(v)
+                    self.ParsedSeqRecord.annotations[f"sequence_{k}"] = int(v)
                 else:
-                    self.ParsedSeqRecord.annotations["sequence_%s" % k] = v
+                    self.ParsedSeqRecord.annotations[f"sequence_{k}"] = v
             self.ParsedSeqRecord.seq = Seq("".join(element.text.split()))
             self.ParsedSeqRecord.annotations["molecule_type"] = "protein"
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -497,7 +497,7 @@ def write(sequences, handle, format):
     if not format:
         raise ValueError("Format required (lower case string)")
     if not format.islower():
-        raise ValueError("Format string '%s' should be lower case" % format)
+        raise ValueError(f"Format string '{format}' should be lower case")
 
     if isinstance(handle, SeqRecord):
         raise TypeError("Check arguments, handle should NOT be a SeqRecord")
@@ -543,9 +543,9 @@ def write(sequences, handle, format):
         return count
 
     if format in _FormatToIterator or format in AlignIO._FormatToIterator:
-        raise ValueError("Reading format '%s' is supported, but not writing" % format)
+        raise ValueError(f"Reading format '{format}' is supported, but not writing")
 
-    raise ValueError("Unknown format '%s'" % format)
+    raise ValueError(f"Unknown format '{format}'")
 
 
 def parse(handle, format, alphabet=None):
@@ -596,7 +596,7 @@ def parse(handle, format, alphabet=None):
     if not format:
         raise ValueError("Format required (lower case string)")
     if not format.islower():
-        raise ValueError("Format string '%s' should be lower case" % format)
+        raise ValueError(f"Format string '{format}' should be lower case")
     if alphabet is not None:
         raise ValueError("The alphabet argument is no longer supported")
 
@@ -606,7 +606,7 @@ def parse(handle, format, alphabet=None):
     if format in AlignIO._FormatToIterator:
         # Use Bio.AlignIO to read in the alignments
         return (r for alignment in AlignIO.parse(handle, format) for r in alignment)
-    raise ValueError("Unknown format '%s'" % format)
+    raise ValueError(f"Unknown format '{format}'")
 
 
 def read(handle, format, alphabet=None):
@@ -731,7 +731,7 @@ def to_dict(sequences, key_function=None):
     for record in sequences:
         key = key_function(record)
         if key in d:
-            raise ValueError("Duplicate key '%s'" % key)
+            raise ValueError(f"Duplicate key '{key}'")
         d[key] = record
     return d
 
@@ -851,7 +851,7 @@ def index(filename, format, alphabet=None, key_function=None):
     if not format:
         raise ValueError("Format required (lower case string)")
     if not format.islower():
-        raise ValueError("Format string '%s' should be lower case" % format)
+        raise ValueError(f"Format string '{format}' should be lower case")
     if alphabet is not None:
         raise ValueError("The alphabet argument is no longer supported")
 
@@ -862,7 +862,7 @@ def index(filename, format, alphabet=None, key_function=None):
     try:
         proxy_class = _FormatToRandomAccess[format]
     except KeyError:
-        raise ValueError("Unsupported format %r" % format) from None
+        raise ValueError(f"Unsupported format {format!r}") from None
     repr = "SeqIO.index(%r, %r, alphabet=%r, key_function=%r)" % (
         filename,
         format,
@@ -935,7 +935,7 @@ def index_db(
     if format is not None and not isinstance(format, str):
         raise TypeError("Need a string for the file format (lower case)")
     if format and not format.islower():
-        raise ValueError("Format string '%s' should be lower case" % format)
+        raise ValueError(f"Format string '{format}' should be lower case")
     if alphabet is not None:
         raise ValueError("The alphabet argument is no longer supported")
 
@@ -1056,7 +1056,7 @@ def convert(in_file, in_format, out_file, out_format, molecule_type=None):
     """
     if molecule_type:
         if not isinstance(molecule_type, str):
-            raise TypeError("Molecule type should be a string, not %r" % molecule_type)
+            raise TypeError(f"Molecule type should be a string, not {molecule_type!r}")
         elif (
             "DNA" in molecule_type
             or "RNA" in molecule_type
@@ -1064,7 +1064,7 @@ def convert(in_file, in_format, out_file, out_format, molecule_type=None):
         ):
             pass
         else:
-            raise ValueError("Unexpected molecule type, %r" % molecule_type)
+            raise ValueError(f"Unexpected molecule type, {molecule_type!r}")
     f = _converter.get((in_format, out_format))
     if f:
         count = f(in_file, out_file)

--- a/Bio/SeqIO/_index.py
+++ b/Bio/SeqIO/_index.py
@@ -108,7 +108,7 @@ class SffRandomAccess(SeqFileRandomAccess):
                 from Bio import BiopythonParserWarning
 
                 warnings.warn(
-                    "Could not parse the SFF index: %s" % err, BiopythonParserWarning
+                    f"Could not parse the SFF index: {err}", BiopythonParserWarning
                 )
                 assert count == 0, "Partially populated index"
                 handle.seek(0)
@@ -346,7 +346,7 @@ class EmblRandomAccess(SequentialSeqFileRandomAccess):
                 if key.endswith(b";"):
                     key = key[:-1]
             else:
-                raise ValueError("Did not recognise the ID line layout:\n%r" % line)
+                raise ValueError(f"Did not recognise the ID line layout:\n{line!r}")
             while True:
                 line = handle.readline()
                 if marker_re.match(line) or not line:
@@ -516,7 +516,7 @@ class IntelliGeneticsRandomAccess(SeqFileRandomAccess):
             length = 0
             assert offset + len(line) == handle.tell()
             if not line.startswith(b";"):
-                raise ValueError("Records should start with ';' and not:\n%r" % line)
+                raise ValueError(f"Records should start with ';' and not:\n{line!r}")
             while line.startswith(b";"):
                 length += len(line)
                 line = handle.readline()
@@ -599,7 +599,7 @@ class FastqRandomAccess(SeqFileRandomAccess):
             # Empty file!
             return
         if line[0:1] != b"@":
-            raise ValueError("Problem with FASTQ @ line:\n%r" % line)
+            raise ValueError(f"Problem with FASTQ @ line:\n{line!r}")
         while line:
             # assert line[0]=="@"
             # This record seems OK (so far)
@@ -625,14 +625,14 @@ class FastqRandomAccess(SeqFileRandomAccess):
                         line = handle.readline()
                         if line.strip():
                             raise ValueError(
-                                "Expected blank quality line, not %r" % line
+                                f"Expected blank quality line, not {line!r}"
                             )
                         length += len(line)  # Need to include the blank ling
                     # Should be end of record...
                     end_offset = handle.tell()
                     line = handle.readline()
                     if line and line[0:1] != b"@":
-                        raise ValueError("Problem with line %r" % line)
+                        raise ValueError(f"Problem with line {line!r}")
                     break
                 else:
                     line = handle.readline()
@@ -652,7 +652,7 @@ class FastqRandomAccess(SeqFileRandomAccess):
         line = handle.readline()
         data = line
         if line[0:1] != b"@":
-            raise ValueError("Problem with FASTQ @ line:\n%r" % line)
+            raise ValueError(f"Problem with FASTQ @ line:\n{line!r}")
         # Find the seq line(s)
         seq_len = 0
         while line:
@@ -672,12 +672,12 @@ class FastqRandomAccess(SeqFileRandomAccess):
                     # Special case, quality line should be just "\n"
                     line = handle.readline()
                     if line.strip():
-                        raise ValueError("Expected blank quality line, not %r" % line)
+                        raise ValueError(f"Expected blank quality line, not {line!r}")
                     data += line
                 # Should be end of record...
                 line = handle.readline()
                 if line and line[0:1] != b"@":
-                    raise ValueError("Problem with line %r" % line)
+                    raise ValueError(f"Problem with line {line!r}")
                 break
             else:
                 line = handle.readline()

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -1348,7 +1348,7 @@ class SeqRecord:
             answer.features = features
         elif features:
             # Does not make sense to copy old features as locations wrong
-            raise TypeError("Unexpected features argument %r" % features)
+            raise TypeError(f"Unexpected features argument {features!r}")
         if isinstance(annotations, dict):
             answer.annotations = annotations
         elif annotations:
@@ -1361,7 +1361,7 @@ class SeqRecord:
         elif letter_annotations:
             # Does not make sense to copy these as length now wrong
             raise TypeError(
-                "Unexpected letter_annotations argument %r" % letter_annotations
+                f"Unexpected letter_annotations argument {letter_annotations!r}"
             )
         return answer
 

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -833,7 +833,7 @@ def _key_error(neighbors, strict):
     """Throw an error or a warning if there is no data for the neighbors (PRIVATE)."""
     # We haven't found the key in the tables
     if strict:
-        raise ValueError("no thermodynamic data for neighbors %r available" % neighbors)
+        raise ValueError(f"no thermodynamic data for neighbors {neighbors!r} available")
     else:
         warnings.warn(
             "no themodynamic data for neighbors %r available. "

--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -294,9 +294,7 @@ class ProteinAnalysis:
             if middle in param_dict:
                 score += param_dict[middle]
             else:
-                sys.stderr.write(
-                    "warning: %s  is not a standard amino acid.\n" % middle
-                )
+                sys.stderr.write(f"warning: {middle} is not a standard amino acid.\n")
 
             scores.append(score / sum_of_weights)
 

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -134,7 +134,7 @@ def xGC_skew(seq, window=1000, zoom=100, r=300, px=100, py=100):
     ty = Y0
     canvas.create_text(X0, ty, text="%s...%s (%d nt)" % (seq[:7], seq[-7:], len(seq)))
     ty += 20
-    canvas.create_text(X0, ty, text="GC %3.2f%%" % (GC(seq)))
+    canvas.create_text(X0, ty, text=f"GC {GC(seq):3.2f}%")
     ty += 20
     canvas.create_text(X0, ty, text="GC Skew", fill="blue")
     ty += 20
@@ -182,7 +182,7 @@ def nt_search(seq, subseq):
         if len(value) == 1:
             pattern += value
         else:
-            pattern += "[%s]" % value
+            pattern += f"[{value}]"
 
     pos = -1
     result = [pattern]
@@ -364,7 +364,7 @@ def molecular_weight(
         else:
             weight_table = IUPACData.protein_weights
     else:
-        raise ValueError("Allowed seq_types are DNA, RNA or protein, not %r" % seq_type)
+        raise ValueError(f"Allowed seq_types are DNA, RNA or protein, not {seq_type!r}")
 
     if monoisotopic:
         water = 18.010565

--- a/Bio/Sequencing/Applications/_Novoalign.py
+++ b/Bio/Sequencing/Applications/_Novoalign.py
@@ -54,7 +54,7 @@ class NovoalignCommandline(AbstractCommandline):
             _Option(["-f", "readfile"], "read file", filename=True, equate=False),
             _Option(
                 ["-F", "format"],
-                "Format of read files.\n\nAllowed values: %s" % ", ".join(READ_FORMAT),
+                f"Format of read files.\n\nAllowed values: {', '.join(READ_FORMAT)}",
                 checker_function=lambda x: x in READ_FORMAT,
                 equate=False,
             ),

--- a/Bio/_utils.py
+++ b/Bio/_utils.py
@@ -42,7 +42,7 @@ def find_test_dir(start_dir=None):
             break
         target = new
     raise ValueError(
-        "Not within Biopython source tree: %r" % os.path.abspath(start_dir)
+        f"Not within Biopython source tree: {os.path.abspath(start_dir)!r}"
     )
 
 

--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -274,7 +274,7 @@ def open(filename, mode="rb"):
     elif "w" in mode.lower() or "a" in mode.lower():
         return BgzfWriter(filename, mode)
     else:
-        raise ValueError("Bad mode %r" % mode)
+        raise ValueError(f"Bad mode {mode!r}")
 
 
 def make_virtual_offset(block_start_offset, within_block_offset):
@@ -768,7 +768,7 @@ class BgzfWriter:
             handle = fileobj
         else:
             if "w" not in mode.lower() and "a" not in mode.lower():
-                raise ValueError("Must use write or append mode, not %r" % mode)
+                raise ValueError(f"Must use write or append mode, not {mode!r}")
             if "a" in mode.lower():
                 raise NotImplementedError("Append mode is not implemented yet")
                 # handle = _open(filename, "ab")

--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -363,11 +363,11 @@ class align:
             try:
                 match_args, match_doc = self.match2args[match_type]
             except KeyError:
-                raise AttributeError("unknown match type %r" % match_type)
+                raise AttributeError(f"unknown match type {match_type!r}")
             try:
                 penalty_args, penalty_doc = self.penalty2args[penalty_type]
             except KeyError:
-                raise AttributeError("unknown penalty type %r" % penalty_type)
+                raise AttributeError(f"unknown penalty type {penalty_type!r}")
 
             # Now get the names of the parameters to this function.
             param_names = ["sequenceA", "sequenceB"]
@@ -379,10 +379,7 @@ class align:
 
             self.__name__ = self.function_name
             # Set the doc string.
-            doc = "%s(%s) -> alignments\n" % (
-                self.__name__,
-                ", ".join(self.param_names),
-            )
+            doc = f"{self.__name__}({', '.join(self.param_names)}) -> alignments\n"
             doc += """\
 \nThe following parameters can also be used with optional
 keywords of the same name.\n\n
@@ -390,9 +387,9 @@ sequenceA and sequenceB must be of the same type, either
 strings, lists or Biopython sequence objects.\n
 """
             if match_doc:
-                doc += "\n%s\n" % match_doc
+                doc += f"\n{match_doc}\n"
             if penalty_doc:
-                doc += "\n%s\n" % penalty_doc
+                doc += f"\n{penalty_doc}\n"
             doc += """\
 \nalignments is a list of named tuples (seqA, seqB, score,
 begin, end). seqA and seqB are strings showing the alignment
@@ -459,7 +456,7 @@ where the alignment occurs.
                     keywds["gap_B_fn"] = affine_penalty(openB, extendB, pe)
                     i += 4
                 else:
-                    raise ValueError("unknown parameter %r" % self.param_names[i])
+                    raise ValueError(f"unknown parameter {self.param_names[i]!r}")
 
             # Here are the default parameters for _align.  Assign
             # these to keywds, unless already specified.
@@ -1403,7 +1400,7 @@ def format_alignment(align1, align2, score, begin, end, full_sequences=False):
         else:
             m_line.append("{:^{width}}".format(".", width=m_len))  # mismatch
 
-    s2_line.append("\n  Score=%g\n" % score)
+    s2_line.append(f"\n  Score={score:g}\n")
     return "\n".join(["".join(s1_line), "".join(m_line), "".join(s2_line)])
 
 

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -185,7 +185,7 @@ class DBServer:
 
     def __repr__(self):
         """Return a short description of the class name and database connection."""
-        return self.__class__.__name__ + "(%r)" % self.adaptor.conn
+        return f"{self.__class__.__name__}({self.adaptor.conn!r})"
 
     def __getitem__(self, name):
         """Return a BioSeqDatabase object.
@@ -279,9 +279,7 @@ class DBServer:
             for sql_line in sql_parts[:-1]:
                 self.adaptor.cursor.execute(sql_line)
         else:
-            raise ValueError(
-                "Module %s not supported by the loader." % (self.module_name)
-            )
+            raise ValueError(f"Module {self.module_name} not supported by the loader.")
 
     def commit(self):
         """Commit the current transaction to the database."""
@@ -385,7 +383,7 @@ class Adaptor:
         )
         rv = self.cursor.fetchall()
         if not rv:
-            raise KeyError("Cannot find biodatabase with name %r" % dbname)
+            raise KeyError(f"Cannot find biodatabase with name {dbname!r}")
         return rv[0][0]
 
     def fetch_seqid_by_display_id(self, dbid, name):
@@ -405,9 +403,9 @@ class Adaptor:
         self.execute(sql, fields)
         rv = self.cursor.fetchall()
         if not rv:
-            raise IndexError("Cannot find display id %r" % name)
+            raise IndexError(f"Cannot find display id {name!r}")
         if len(rv) > 1:
-            raise IndexError("More than one entry with display id %r" % name)
+            raise IndexError(f"More than one entry with display id {name!r}")
         return rv[0][0]
 
     def fetch_seqid_by_accession(self, dbid, name):
@@ -427,9 +425,9 @@ class Adaptor:
         self.execute(sql, fields)
         rv = self.cursor.fetchall()
         if not rv:
-            raise IndexError("Cannot find accession %r" % name)
+            raise IndexError(f"Cannot find accession {name!r}")
         if len(rv) > 1:
-            raise IndexError("More than one entry with accession %r" % name)
+            raise IndexError(f"More than one entry with accession {name!r}")
         return rv[0][0]
 
     def fetch_seqids_by_accession(self, dbid, name):
@@ -459,7 +457,7 @@ class Adaptor:
         """
         acc_version = name.split(".")
         if len(acc_version) > 2:
-            raise IndexError("Bad version %r" % name)
+            raise IndexError(f"Bad version {name!r}")
         acc = acc_version[0]
         if len(acc_version) == 2:
             version = acc_version[1]
@@ -473,9 +471,9 @@ class Adaptor:
         self.execute(sql, fields)
         rv = self.cursor.fetchall()
         if not rv:
-            raise IndexError("Cannot find version %r" % name)
+            raise IndexError(f"Cannot find version {name!r}")
         if len(rv) > 1:
-            raise IndexError("More than one entry with version %r" % name)
+            raise IndexError(f"More than one entry with version {name!r}")
         return rv[0][0]
 
     def fetch_seqid_by_identifier(self, dbid, identifier):
@@ -496,7 +494,7 @@ class Adaptor:
         self.execute(sql, fields)
         rv = self.cursor.fetchall()
         if not rv:
-            raise IndexError("Cannot find display id %r" % identifier)
+            raise IndexError(f"Cannot find display id {identifier!r}")
         return rv[0][0]
 
     def list_biodatabase_names(self):
@@ -713,14 +711,14 @@ class BioSeqDatabase:
         """
         record = BioSeq.DBSeqRecord(self.adaptor, key)
         if record._biodatabase_id != self.dbid:
-            raise KeyError("Entry %r does exist, but not in current name space" % key)
+            raise KeyError(f"Entry {key!r} does exist, but not in current name space")
         return record
 
     def __delitem__(self, key):
         """Remove an entry and all its annotation."""
         if key not in self:
             raise KeyError(
-                "Entry %r cannot be deleted. It was not found or is invalid" % key
+                f"Entry {key!r} cannot be deleted. It was not found or is invalid"
             )
         # Assuming this will automatically cascade to the other tables...
         sql = "DELETE FROM bioentry WHERE biodatabase_id=%s AND bioentry_id=%s;"
@@ -779,8 +777,7 @@ class BioSeqDatabase:
         k, v = list(kwargs.items())[0]
         if k not in _allowed_lookups:
             raise TypeError(
-                "lookup() expects one of %r, not %r"
-                % (list(_allowed_lookups.keys()), k)
+                f"lookup() expects one of {list(_allowed_lookups.keys())!r}, not {k!r}"
             )
         lookup_name = _allowed_lookups[k]
         lookup_func = getattr(self.adaptor, lookup_name)

--- a/BioSQL/DBUtils.py
+++ b/BioSQL/DBUtils.py
@@ -104,14 +104,14 @@ class _PostgreSQL_dbutils(Generic_dbutils):
 
     def next_id(self, cursor, table):
         table = self.tname(table)
-        sql = "SELECT nextval('%s_pk_seq')" % table
+        sql = f"SELECT nextval('{table}_pk_seq')"
         cursor.execute(sql)
         rv = cursor.fetchone()
         return rv[0]
 
     def last_id(self, cursor, table):
         table = self.tname(table)
-        sql = "SELECT currval('%s_pk_seq')" % table
+        sql = f"SELECT currval('{table}_pk_seq')"
         cursor.execute(sql)
         rv = cursor.fetchone()
         return rv[0]

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -106,7 +106,7 @@ class DatabaseLoader:
         id_results = self.adaptor.execute_and_fetchall(sql, fields)
         # something is wrong
         if len(id_results) > 1:
-            raise ValueError("Multiple term ids for %s: %r" % (name, id_results))
+            raise ValueError(f"Multiple term ids for {name}: {id_results!r}")
         elif len(id_results) == 1:
             return id_results[0][0]
         else:
@@ -1097,7 +1097,7 @@ class DatabaseLoader:
                 db = dbxref_data[0]
                 accessions = dbxref_data[1:]
             except Exception:
-                raise ValueError("Parsing of db_xref failed: '%s'" % value) from None
+                raise ValueError(f"Parsing of db_xref failed: '{value}'") from None
             # Loop over all the grabbed accessions, and attempt to fill the
             # table
             for accession in accessions:
@@ -1179,9 +1179,7 @@ class DatabaseLoader:
                 db = db.strip()
                 accession = accession.strip()
             except Exception:
-                raise ValueError(
-                    "Parsing of dbxrefs list failed: '%s'" % value
-                ) from None
+                raise ValueError(f"Parsing of dbxrefs list failed: '{value}'") from None
             # Get the dbxref_id value for the dbxref data
             dbxref_id = self._get_dbxref_id(db, accession)
             # Insert the bioentry_dbxref  data


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Progress on #2510 using the latest version of ``flynt`` (default settings), which is more aggressive than ``pyupgrade`` and does not use the ``.format(...)`` method.

I have tried not to touch too many files in this PR, and have eyeballed all the changes. In a couple of places I made a manual tweak as well (e.g. combine string addition with percent formatting into a single f-string).