### PR TITLE
Drop experimental warnings on Bio.phenotype

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,9 @@ Tests/test_AlignIO* @peterjc
 Bio/bgzf.py @peterjc
 Tests/test_bgzf*.py @peterjc
 
+Bio/phenotype/* @mgalardini
+Tests/test_phenotype*.py @mgalardini
+
 Bio/Cluster/* @mdehoon
 Tests/test_Cluster*.py @mdehoon
 

--- a/Bio/phenotype/__init__.py
+++ b/Bio/phenotype/__init__.py
@@ -83,18 +83,9 @@ Note that while Bio.phenotype can read the above file formats, it can only
 write in JSON format.
 """
 
-from Bio import BiopythonExperimentalWarning
 from Bio.File import as_handle
 from . import phen_micro
 
-import warnings
-
-
-warnings.warn(
-    "Bio.phenotype is an experimental submodule which may undergo "
-    "significant changes prior to its future official release.",
-    BiopythonExperimentalWarning,
-)
 
 # Convention for format names is "mainname-format" in lower case.
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -25,6 +25,9 @@ The Local Composition Complexity functions from ``Bio.SeqUtils`` now uses
 base 4 log instead of 2 as stated in the original reference Konopka (2005),
 Sequence Complexity and Composition. https://doi.org/10.1038/npg.els.0005260
 
+The experimental warning was dropped from ``Bio.phenotype`` (which was new in
+Biopython 1.67).
+
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite.
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Both modules have been in place and stable for some time, this is probably overdue.

CC: @mgalardini and @zruan