### PR TITLE
Fix flake8/pydocstyle D412 regression

### DIFF
--- a/Bio/PDB/SASA.py
+++ b/Bio/PDB/SASA.py
@@ -89,8 +89,6 @@ class ShrakeRupley:
             default ATOMIC_RADII dictionary.
         :type radii_dict: dict
 
-        Examples:
-
         >>> sr = ShrakeRupley()
         >>> sr = ShrakeRupley(n_points=960)
         >>> sr = ShrakeRupley(radii_dict={"O": 3.1415})
@@ -158,8 +156,6 @@ class ShrakeRupley:
             "S" (Structure). The ASA value of an entity is the sum of all ASA
             values of its children. Defaults to "A".
         :type entity: Bio.PDB.Entity
-
-        Example:
 
         >>> from Bio.PDB import PDBParser
         >>> p = PDBParser(QUIET=1)


### PR DESCRIPTION
I had rashly skipped CI testing of the previous commit, and it triggered flake8/pydocstyle:

D412 No blank lines allowed between a section header and its content

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
