### PR TITLE
Fix parsing BGZF files with internal empty block

### DIFF
--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -669,7 +669,7 @@ class BgzfReader:
             raise NotImplementedError("Don't be greedy, that could be massive!")
 
         result = "" if self._text else b""
-        while size and self._buffer:
+        while size and self._block_raw_length:
             if self._within_block_offset + size <= len(self._buffer):
                 # This may leave us right at the end of a block
                 # (lazy loading, don't load the next block unless we have too)
@@ -684,8 +684,6 @@ class BgzfReader:
                 data = self._buffer[self._within_block_offset :]
                 size -= len(data)
                 self._load_block()  # will reset offsets
-                # TODO - Test with corner case of an empty block followed by
-                # a non-empty block
                 result += data
 
         return result
@@ -693,7 +691,7 @@ class BgzfReader:
     def readline(self):
         """Read a single line for the BGZF file."""
         result = "" if self._text else b""
-        while self._buffer:
+        while self._block_raw_length:
             i = self._buffer.find(self._newline, self._within_block_offset)
             # Three cases to consider,
             if i == -1:

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -266,6 +266,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Thomas Sicheritz-Ponten <thomas at domain cbs.dtu.dk>
 - Tiago Antao <https://github.com/tiagoantao>
 - Tianyi Shi <https://github.com/TianyiShi2001>
+- Tim Burke <https://github.com/tipabu>
 - Tyghe Vallard <https://github.com/necrolyte2>
 - Uri Laserson <https://github.com/laserson>
 - Uwe Schmitt <https://github.com/uweschmitt>

--- a/Tests/test_bgzf.py
+++ b/Tests/test_bgzf.py
@@ -387,6 +387,27 @@ class BgzfTests(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             bgzf.open(self.temp_file, "ab")
 
+    def test_double_flush(self):
+        with bgzf.open(self.temp_file, "wb") as h:
+            h.write(b">hello\n")
+            h.write(b"aaaaaaaaaaaaaaaaaa\n")
+            h.flush()
+            pos = h.tell()
+            h.flush()
+            self.assertGreater(h.tell(), pos)  # sanity check
+            h.write(b">there\n")
+            h.write(b"cccccccccccccccccc\n")
+        with bgzf.open(self.temp_file, "rb") as h:
+            self.assertEqual(
+                list(h),
+                [
+                    b">hello\n",
+                    b"aaaaaaaaaaaaaaaaaa\n",
+                    b">there\n",
+                    b"cccccccccccccccccc\n",
+                ],
+            )
+
     def test_many_blocks_in_single_read(self):
         n = 1000
 


### PR DESCRIPTION
Extracted from @tipabu's #2166 in aid of supporting append mode, where he had agreed to the licensing:

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Removes a TODO comment, adds a test which demonstrated the bug the TODO comment suspected existed, and fixes the bug.