### PR TITLE
Tweaks to doctest syntax/style in Tutorial

### DIFF
--- a/Doc/Tutorial/chapter_blast.tex
+++ b/Doc/Tutorial/chapter_blast.tex
@@ -35,7 +35,7 @@ available at \url{https://blast.ncbi.nlm.nih.gov/Blast.cgi}.
 Currently \verb|qblast| only works with blastn, blastp, blastx, tblast
 and tblastx.
 \item The second argument specifies the databases to search against. Again,
-the options for this are available on the NCBI Guide to BLAST 
+the options for this are available on the NCBI Guide to BLAST
 \url{ftp://ftp.ncbi.nlm.nih.gov/pub/factsheets/HowTo_BLASTGuide.pdf}.
 \item The third argument is a string containing your query sequence.  This
 can either be the sequence itself, the sequence in fasta format,
@@ -355,7 +355,8 @@ StopIteration
 Or, you can use a \verb|for|-loop:
 \begin{minted}{pycon}
 >>> for blast_record in blast_records:
-...     # Do something with blast_record
+...     pass  # Do something with blast_record
+...
 \end{minted}
 
 Note though that you can step through the BLAST records only once.

--- a/Doc/Tutorial/chapter_cluster.tex
+++ b/Doc/Tutorial/chapter_cluster.tex
@@ -189,14 +189,11 @@ The number of columns in each row is equal to the row number. Hence, the first r
 \begin{minted}{pycon}
 >>> from numpy import array
 >>> from Bio.Cluster import distancematrix
->>> data = array(
-...     [
-...         [0, 1, 2, 3],
-...         [4, 5, 6, 7],
-...         [8, 9, 10, 11],
-...         [1, 2, 3, 4],
-...     ]
-... )
+>>> data = array([[0, 1,  2 , 3],
+...               [4, 5,  6,  7],
+...               [8, 9, 10, 11],
+...               [1, 2,  3,  4]])  # fmt: skip
+...
 >>> distances = distancematrix(data, dist="e")
 \end{minted}
 yields a distance matrix

--- a/Doc/Tutorial/chapter_cluster.tex
+++ b/Doc/Tutorial/chapter_cluster.tex
@@ -189,11 +189,15 @@ The number of columns in each row is equal to the row number. Hence, the first r
 \begin{minted}{pycon}
 >>> from numpy import array
 >>> from Bio.Cluster import distancematrix
->>> data = array([[0, 1,  2,  3],
-...               [4, 5,  6,  7],
-...               [8, 9, 10, 11],
-...               [1, 2,  3,  4]])
->>> distances = distancematrix(data, dist='e')
+>>> data = array(
+...     [
+...         [0, 1, 2, 3],
+...         [4, 5, 6, 7],
+...         [8, 9, 10, 11],
+...         [1, 2, 3, 4],
+...     ]
+... )
+>>> distances = distancematrix(data, dist="e")
 \end{minted}
 yields a distance matrix
 \begin{minted}{pycon}
@@ -700,14 +704,15 @@ This two-step process gives you some flexibility in the source of the data.
 For example, you can use
 
 \begin{minted}{pycon}
->>> import gzip # Python standard library
+>>> import gzip  # Python standard library
 >>> handle = gzip.open("mydatafile.txt.gz", "rt")
 \end{minted}
 to open a gzipped file, or
 \begin{minted}{pycon}
 >>> from urllib.request import urlopen
 >>> from io import TextIOWrapper
->>> handle = TextIOWrapper(urlopen("https://raw.githubusercontent.com/biopython/biopython/master/Tests/Cluster/cyano.txt"))
+>>> url = "https://raw.githubusercontent.com/biopython/biopython/master/Tests/Cluster/cyano.txt"
+>>> handle = TextIOWrapper(urlopen(url))
 \end{minted}
 to open a file stored on the Internet before calling \verb|read|.
 
@@ -951,7 +956,7 @@ This is an example of a hierarchical clustering calculation, using single linkag
 
 The example data \verb|cyano.txt| can be found in Biopython's \verb|Tests/Cluster| subdirectory and is from the paper \cite[Hihara \textit{et al.}, 2001]{hihara2001}.
 
-%all cyano_result* files created here during the run of test_Tutorial.py are 
+%all cyano_result* files created here during the run of test_Tutorial.py are
 %after automatically deleted at the end of the test run.
 
 %doctest ../Tests/Cluster lib:numpy

--- a/Doc/Tutorial/chapter_cluster.tex
+++ b/Doc/Tutorial/chapter_cluster.tex
@@ -189,7 +189,7 @@ The number of columns in each row is equal to the row number. Hence, the first r
 \begin{minted}{pycon}
 >>> from numpy import array
 >>> from Bio.Cluster import distancematrix
->>> data = array([[0, 1,  2 , 3],
+>>> data = array([[0, 1,  2,  3],
 ...               [4, 5,  6,  7],
 ...               [8, 9, 10, 11],
 ...               [1, 2,  3,  4]])  # fmt: skip

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -1165,7 +1165,7 @@ First, we use EGQuery to find out the number of results we will get before actua
 4457
 \end{minted}
 
-So, we expect to find 4457 Entrez Nucleotide records (this increased from 814 records in 2008; it is likely to continue to increase in the future). If you find some ridiculously high number of hits, you may want to reconsider if you really want to download all of them, which is our next step. 
+So, we expect to find 4457 Entrez Nucleotide records (this increased from 814 records in 2008; it is likely to continue to increase in the future). If you find some ridiculously high number of hits, you may want to reconsider if you really want to download all of them, which is our next step.
 Let's use the \verb+retmax+ argument to restrict the maximum number of records retrieved to the number available in 2008:
 
 %doctest . internet
@@ -1187,7 +1187,7 @@ First, let's check how many results were found:
 >>> print(record["Count"])
 '4457'
 \end{minted}
-You might have expected this to be 814, the maximum number of records we asked to retrieve. 
+You might have expected this to be 814, the maximum number of records we asked to retrieve.
 However, \verb+Count+ represents the total number of records available for that search, not how many were retrieved.
 The retrieved records are stored in \verb+record['IdList']+, which should contain the total number we asked for:
 \begin{minted}{pycon}
@@ -1309,8 +1309,8 @@ In this case, we are just getting the raw records. To get the records in a more 
 \noindent We can now step through the records and look at the information we are interested in:
 \begin{minted}{pycon}
 >>> for record in records:
->>> ...    print("%s, length %i, with %i features"
->>> ...           % (record.name, len(record), len(record.features)))
+...    print(f"{record.name}, length {len(record)}, with {len(record.features)} features")
+...
 AY851612, length 892, with 3 features
 AY851611, length 881, with 3 features
 AF191661, length 895, with 3 features

--- a/Doc/Tutorial/chapter_learning.tex
+++ b/Doc/Tutorial/chapter_learning.tex
@@ -131,7 +131,8 @@ The function \verb+train+ has two optional arguments: \verb+update_fn+ and \verb
 
 \begin{minted}{pycon}
 >>> def show_progress(iteration, loglikelihood):
-        print("Iteration:", iteration, "Log-likelihood function:", loglikelihood)
+...     print(f"Iteration: {iteration} Log-likelihood function: {loglikelihood}")
+...
 >>>
 >>> model = LogisticRegression.train(xs, ys, update_fn=show_progress)
 Iteration: 0 Log-likelihood function: -11.7835020695
@@ -225,7 +226,8 @@ class OP: probability = 0.000321211251817 class NOP: probability = 0.99967878874
 To get some idea of the prediction accuracy of the logistic regression model, we can apply it to the training data:
 \begin{minted}{pycon}
 >>> for i in range(len(ys)):
-        print("True:", ys[i], "Predicted:", LogisticRegression.classify(model, xs[i]))
+...     print(f"True: {ys[i]} Predicted: {LogisticRegression.classify(model, xs[i])}")
+...
 True: 1 Predicted: 1
 True: 1 Predicted: 0
 True: 1 Predicted: 1
@@ -247,8 +249,9 @@ True: 0 Predicted: 0
 showing that the prediction is correct for all but one of the gene pairs. A more reliable estimate of the prediction accuracy can be found from a leave-one-out analysis, in which the model is recalculated from the training data after removing the gene to be predicted:
 \begin{minted}{pycon}
 >>> for i in range(len(ys)):
-        model = LogisticRegression.train(xs[:i]+xs[i+1:], ys[:i]+ys[i+1:])
-        print("True:", ys[i], "Predicted:", LogisticRegression.classify(model, xs[i]))
+...     model = LogisticRegression.train(xs[:i]+xs[i+1:], ys[:i]+ys[i+1:])
+...     print(f"True: {ys[i]} Predicted: {LogisticRegression.classify(model, xs[i])}")
+...
 True: 1 Predicted: 1
 True: 1 Predicted: 0
 True: 1 Predicted: 1
@@ -360,7 +363,8 @@ which means that two neighbors are operon pairs and one neighbor is a non-operon
 To get some idea of the prediction accuracy of the $k$-nearest neighbors approach, we can apply it to the training data:
 \begin{minted}{pycon}
 >>> for i in range(len(ys)):
-        print("True:", ys[i], "Predicted:", kNN.classify(model, xs[i]))
+...     print(f"True: {ys[i]} Predicted: {kNN.classify(model, xs[i])}")
+...
 True: 1 Predicted: 1
 True: 1 Predicted: 0
 True: 1 Predicted: 1
@@ -383,8 +387,9 @@ showing that the prediction is correct for all but two of the gene pairs. A more
 \begin{minted}{pycon}
 >>> k = 3
 >>> for i in range(len(ys)):
-        model = kNN.train(xs[:i]+xs[i+1:], ys[:i]+ys[i+1:], k)
-        print("True:", ys[i], "Predicted:", kNN.classify(model, xs[i]))
+...     model = kNN.train(xs[:i]+xs[i+1:], ys[:i]+ys[i+1:], k)
+...     print(f"True: {ys[i]} Predicted: {kNN.classify(model, xs[i])}")
+...
 True: 1 Predicted: 1
 True: 1 Predicted: 0
 True: 1 Predicted: 1

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -366,8 +366,9 @@ T  [ 7 58  0 55 49 52 21 56  0  2 ]
 The motifs are read as follows:
 \begin{minted}{pycon}
 >>> fh = open("jaspar_motifs.txt")
->>> for m in motifs.parse(fh, "jaspar"))
+>>> for m in motifs.parse(fh, "jaspar"):
 ...     print(m)
+...
 TF name	 Arnt
 Matrix ID	MA0004.1
 Matrix:
@@ -408,10 +409,10 @@ In addition to parsing these flat file formats, we can also retrieve motifs from
 \begin{minted}{pycon}
 >>> from Bio.motifs.jaspar.db import JASPAR5
 >>>
->>> JASPAR_DB_HOST = <hostname>
->>> JASPAR_DB_NAME = <db_name>
->>> JASPAR_DB_USER = <user>
->>> JASPAR_DB_PASS = <password>
+>>> JASPAR_DB_HOST = ""  # <hostname>
+>>> JASPAR_DB_NAME = ""  # <db_name>
+>>> JASPAR_DB_USER = ""  # <user>
+>>> JASPAR_DB_PASS = ""  # <password>
 >>>
 >>> jdb = JASPAR5(
 ...     host=JASPAR_DB_HOST,
@@ -522,11 +523,9 @@ For example, using the Arnt motif before, let's search a sequence with a relativ
 >>> max_score = pssm.max
 >>> min_score = pssm.min
 >>> abs_score_threshold = (max_score - min_score) * 0.8 + min_score
->>> for position, score in pssm.search(test_seq,
-                                       threshold=abs_score_threshold):
+>>> for pos, score in pssm.search(test_seq, threshold=abs_score_threshold):
 ...     rel_score = (score - min_score) / (max_score - min_score)
-...     print("Position %d: score = %5.3f, rel. score = %5.3f" % (
-            position, score, rel_score))
+...     print(f"Position {pos}: score = {score:5.3f}, rel. score = {rel_score:5.3f}")
 ...
 Position 2: score = 5.362, rel. score = 0.801
 Position 8: score = 6.112, rel. score = 0.831

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -409,10 +409,10 @@ In addition to parsing these flat file formats, we can also retrieve motifs from
 \begin{minted}{pycon}
 >>> from Bio.motifs.jaspar.db import JASPAR5
 >>>
->>> JASPAR_DB_HOST = ""  # <hostname>
->>> JASPAR_DB_NAME = ""  # <db_name>
->>> JASPAR_DB_USER = ""  # <user>
->>> JASPAR_DB_PASS = ""  # <password>
+>>> JASPAR_DB_HOST = "yourhostname"  # fill in these values
+>>> JASPAR_DB_NAME = "yourdatabase"
+>>> JASPAR_DB_USER = "yourusername"
+>>> JASPAR_DB_PASS = "yourpassword"
 >>>
 >>> jdb = JASPAR5(
 ...     host=JASPAR_DB_HOST,

--- a/Doc/Tutorial/chapter_phenotype.tex
+++ b/Doc/Tutorial/chapter_phenotype.tex
@@ -59,9 +59,11 @@ There are several ways to access WellRecord objects from a PlateRecord objects:
 \begin{description}
   \item[Well identifier]
     If you know the well identifier (row + column identifiers) you can access the desired well directly.
+%cont-doctest
 \begin{minted}{pycon}
-    >>> record["A02"]
-    \end{minted}
+>>> record["A02"]
+WellRecord('(0.0, 12.0), (0.25, 18.0), (0.5, 27.0), (0.75, 35.0), (1.0, 37.0), ..., (71.75, 143.0)')
+\end{minted}
 
   \item[Well plate coordinates]
     The same well can be retrieved by using the row and columns numbers (0-based index).
@@ -151,7 +153,7 @@ indexing; the default time interval is therefore one hour.
 
 %cont-doctest
 \begin{minted}{pycon}
->>> well[:10]  
+>>> well[:10]
 [12.0, 37.0, 44.0, 44.0, 44.0, 44.0, 44.0, 44.0, 44.0, 44.0]
 \end{minted}
 

--- a/Doc/Tutorial/chapter_uniprot.tex
+++ b/Doc/Tutorial/chapter_uniprot.tex
@@ -17,7 +17,7 @@ To parse a Swiss-Prot record, we first get a handle to a Swiss-Prot record. Ther
 \item Open a Swiss-Prot file locally:
 \begin{minted}{pycon}
 >>> handle = open("myswissprotfile.dat")
-\end{minted} 
+\end{minted}
 
 \item Open a gzipped Swiss-Prot file:
 \begin{minted}{pycon}
@@ -451,8 +451,10 @@ CRAFQYHSKEQQCVIMAENRKSSIIIRMRDVVLFEKKVYLSECKTGNGKNYRGTMSKTKN
 you can use the following code:
 
 \begin{minted}{pycon}
->>> sequence = "MEHKEVVLLLLLFLKSGQGEPLDDYVNTQGASLFSVTKKQLGAGSIEECAAKCEEDEEFT
-CRAFQYHSKEQQCVIMAENRKSSIIIRMRDVVLFEKKVYLSECKTGNGKNYRGTMSKTKN"
+>>> sequence = (
+...     "MEHKEVVLLLLLFLKSGQGEPLDDYVNTQGASLFSVTKKQLGAGSIEECAAKCEEDEEFT"
+...     "CRAFQYHSKEQQCVIMAENRKSSIIIRMRDVVLFEKKVYLSECKTGNGKNYRGTMSKTKN"
+... )
 >>> from Bio.ExPASy import ScanProsite
 >>> handle = ScanProsite.scan(seq=sequence)
 \end{minted}


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This is intended allow the use of blacken-docs v1.11.0 which included asottile/blacken-docs#112 from me to support ``\begin{minted}{pycon}`` specifically for the Biopython documentation.

These commits either address syntax issues blocking automated use of blacken-docs as seen in #3758 (and https://github.com/asottile/blacken-docs/issues/121), or tweak the examples to work better after black formatting.