### PR TITLE
Fix Exonerate text parser to correctly determine strand from ':[revcomp]'

### DIFF
--- a/Bio/SearchIO/ExonerateIO/_base.py
+++ b/Bio/SearchIO/ExonerateIO/_base.py
@@ -311,6 +311,35 @@ def _parse_hit_or_query_line(line):
     return id, desc
 
 
+def _get_strand_from_desc(desc, is_protein, modify_desc=True):
+    """Determine the strand from the description (PRIVATE).
+
+    Exonerate appends ``:[revcomp]`` (versions <= 2.2) or ``[revcomp]``
+    (versions > 2.2) to the query and/or hit description string. This function
+    outputs '-' if the description has such modifications or '+' if not. If the
+    query and/or hit is a protein sequence, a '.' is output instead.
+
+    Aside from the strand, the input description value is also returned. It is
+    returned unmodified if ``modify_desc`` is ``False``. Otherwise, the appended
+    ``:[revcomp]`` or ``[revcomp]`` is removed.
+
+    """
+    if is_protein:
+        return ".", desc
+
+    suffix = ""
+    if desc.endswith("[revcomp]"):
+        suffix = ":[revcomp]" if desc.endswith(":[revcomp]") else "[revcomp]"
+
+    if not suffix:
+        return "+", desc
+
+    if modify_desc:
+        return "-", desc[:-len(suffix)]
+
+    return "-", desc
+
+
 class _BaseExonerateParser(ABC):
     """Abstract base class iterator for exonerate format."""
 
@@ -389,20 +418,21 @@ class _BaseExonerateParser(ABC):
                 hsp["hit_start"], hsp["hit_end"] = line.split(" ", 4)[2:5:2]
 
         # determine strand
-        if qresult["description"].endswith(":[revcomp]"):
-            hsp["query_strand"] = "-"
-            qresult["description"] = qresult["description"].replace(":[revcomp]", "")
-        elif "protein2" in qresult["model"]:
-            hsp["query_strand"] = "."
-        else:
-            hsp["query_strand"] = "+"
-        if hit["description"].endswith(":[revcomp]"):
-            hsp["hit_strand"] = "-"
-            hit["description"] = hit["description"].replace(":[revcomp]", "")
-        elif "2protein" in qresult["model"]:
-            hsp["hit_strand"] = "."
-        else:
-            hsp["hit_strand"] = "+"
+        qresult_strand, qresult_desc = _get_strand_from_desc(
+            desc=qresult["description"],
+            is_protein="protein2" in qresult["model"],
+            modify_desc=True,
+        )
+        hsp["query_strand"] = qresult_strand
+        qresult["description"] = qresult_desc
+
+        hit_strand, hit_desc = _get_strand_from_desc(
+            desc=hit["description"],
+            is_protein="2protein" in qresult["model"],
+            modify_desc=True,
+        )
+        hsp["hit_strand"] = hit_strand
+        hit["description"] = hit_desc
 
         # NOTE: we haven't processed the coordinates types
         # and the strands are not yet Biopython's standard (1 / -1 / 0)

--- a/Bio/SearchIO/ExonerateIO/_base.py
+++ b/Bio/SearchIO/ExonerateIO/_base.py
@@ -335,7 +335,7 @@ def _get_strand_from_desc(desc, is_protein, modify_desc=True):
         return "+", desc
 
     if modify_desc:
-        return "-", desc[:-len(suffix)]
+        return "-", desc[: -len(suffix)]
 
     return "-", desc
 


### PR DESCRIPTION
This PR resolves #3757, where the `exonerate-text` parser does not correctly determine when a hit or query sequence lies on the negative strand.

Thanks to  @chrisjackson-pellicle , the root cause was determined to be the `:[revcomp]`, which was appended by Exonerate to the query / hit description. In more recent versions of Exonerate, the string has been updated to `[revcomp]` but this has not been followed by the parser, resulting in the negative strand always being set incorrectly as the positive strand.

In addition to the fix, this PR also refactored the functionality into a separate function.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3757
