### PR TITLE
adjust test_GraphicsBitmaps.py for newer renderpm

### DIFF
--- a/Tests/test_GraphicsBitmaps.py
+++ b/Tests/test_GraphicsBitmaps.py
@@ -102,8 +102,9 @@ def real_test():
         else:
             raise
     except RenderPMError as err:
-        if (str(err).startswith("Can't setFont(")
-                or str(err).startswith("Error in setFont(")):
+        if str(err).startswith("Can't setFont(") or str(err).startswith(
+            "Error in setFont("
+        ):
             # TODO - can we raise the error BEFORE the unit test function
             # is run? That way it can be skipped in run_tests.py
             raise MissingExternalDependencyError(


### PR DESCRIPTION
Greetings,

Starting with reportlab 3.6, the RenderPM error message relative to
missing fonts does not start with "Can't setFont(" any more, but
"Error in setFont(" instead.  This breaks the test suite in case
the font is indeed missing, while it used to be skipped instead.
The main symptom is the test suite failing with error:

```
Traceback (most recent call last):
  File "/tmp/autopkgtest-lxc.czuqoy9m/downtmp/autopkgtest_tmp/Tests/run_tests.py", line 275, in runTest
    suite = loader.loadTestsFromName(name)
  File "/usr/lib/python3.9/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/tmp/autopkgtest-lxc.czuqoy9m/downtmp/autopkgtest_tmp/Tests/test_GraphicsBitmaps.py", line 119, in <module>
    real_test()
  File "/tmp/autopkgtest-lxc.czuqoy9m/downtmp/autopkgtest_tmp/Tests/test_GraphicsBitmaps.py", line 92, in real_test
    compare_plot.draw_to_file(output_file, "Testing Scatter Plots")
  File "/usr/lib/python3/dist-packages/Bio/Graphics/Comparative.py", line 96, in draw_to_file
    return _write(cur_drawing, output_file, self.output_format)
  File "/usr/lib/python3/dist-packages/Bio/Graphics/__init__.py", line 88, in _write
    return drawmethod.drawToFile(drawing, output_file, format, dpi=dpi)
  File "/usr/lib/python3/dist-packages/reportlab/graphics/renderPM.py", line 692, in drawToFile
    c = drawToPMCanvas(d, dpi=dpi, bg=bg, configPIL=configPIL, showBoundary=showBoundary,backend=backend)
  File "/usr/lib/python3/dist-packages/reportlab/graphics/renderPM.py", line 678, in drawToPMCanvas
    draw(d, c, 0, 0, showBoundary=showBoundary)
  File "/usr/lib/python3/dist-packages/reportlab/graphics/renderPM.py", line 49, in draw
    R.draw(renderScaledDrawing(drawing), canvas, x, y, showBoundary=showBoundary)
  File "/usr/lib/python3/dist-packages/reportlab/graphics/renderbase.py", line 185, in draw
    self.initState(x,y)  #this is the push()
  File "/usr/lib/python3/dist-packages/reportlab/graphics/renderPM.py", line 96, in initState
    self.applyState()
  File "/usr/lib/python3/dist-packages/reportlab/graphics/renderPM.py", line 90, in applyState
    self._canvas.setFont(s['fontName'], s['fontSize'])
  File "/usr/lib/python3/dist-packages/reportlab/graphics/renderPM.py", line 406, in setFont
    _setFont(self._gs,fontName,fontSize)
  File "/usr/lib/python3/dist-packages/reportlab/graphics/utils.py", line 42, in setFont
    _errorDump(fontName,fontSize)
  File "/usr/lib/python3/dist-packages/reportlab/graphics/utils.py", line 29, in _errorDump
    rl_exec(code,dict(RenderPMError=RenderPMError))
  File "<string>", line 1, in <module>
reportlab.graphics.utils.RenderPMError: Error in setFont('Times-Roman',10) missing the T1 files?
Originally <class 'TypeError'>: makeT1Font() argument 2 must be str, not None
```

A [full log](https://ci.debian.net/data/autopkgtest/testing/arm64/p/python-biopython/16089190/log.gz) is available on Debian continous integration platform.

This patch adds a pattern to match for the new error message as well.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
