### PR TITLE
Add __iter__ method to Seq objects to improve list performance #3772

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -428,6 +428,10 @@ class _SeqAbstractBaseClass(ABC):
         """Return the length of the sequence."""
         return len(self._data)
 
+    def __iter__(self):
+        """Return an iterable of the sequence."""
+        return self._data.decode("ASCII").__iter__()
+
     def __getitem__(self, index):
         """Return a subsequence as a single letter or as a sequence object.
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -89,6 +89,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Damien Goutte-Gattat <https://github.com/gouttegd>
 - Dan Vogel <dmv at domain andrew.cmu.edu>
 - Darcy Mason <https://github.com/darcymason>
+- David Born <https://github.com/hypostulate>
 - David Cain <gmail, david joseph cain>
 - David Koppstein <https://github.com/dkoppstein>
 - David Nicholson <https://github.com/danich1>

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -130,6 +130,9 @@ class TestSeq(unittest.TestCase):
     def test_replace(self):
         self.assertEqual("ATCCCA", Seq.Seq("ATC-CCA").replace("-", ""))
 
+    def test_cast_to_list(self):
+        self.assertEqual(list("ATC"), list(Seq.Seq("ATC")))
+
 
 class TestSeqStringMethods(unittest.TestCase):
     def setUp(self):

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -132,6 +132,13 @@ class TestSeq(unittest.TestCase):
 
     def test_cast_to_list(self):
         self.assertEqual(list("ATC"), list(Seq.Seq("ATC")))
+        self.assertEqual(list("ATC"), list(Seq.MutableSeq("ATC")))
+        self.assertEqual(list(""), list(Seq.MutableSeq("")))
+        self.assertEqual(list(""), list(Seq.Seq("")))
+        with self.assertRaises(Seq.UndefinedSequenceError):
+            list(Seq.Seq(None, length=3))
+        with self.assertRaises(Seq.UndefinedSequenceError):
+            list(Seq.Seq({3: "ACGT"}, length=10))
 
 
 class TestSeqStringMethods(unittest.TestCase):


### PR DESCRIPTION
This dramatically improves performance when calling `list(Seq(...))`

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3772 by adding __iter__ to _SeqAbstractBaseClass
