### PR TITLE
Add Support for DSSP v4.0

### DIFF
--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -435,7 +435,7 @@ class DSSP(AbstractResiduePropertyMap):
 
     """
 
-    def __init__(self, model, in_file, dssp="dssp", acc_array="Sander", file_type="", dssp_version="3.9.9"):
+    def __init__(self, model, in_file, dssp="dssp", acc_array="Sander", file_type=""):
         """Create a DSSP object.
 
         Parameters
@@ -453,9 +453,6 @@ class DSSP(AbstractResiduePropertyMap):
         file_type: string
             File type switch: either PDB, MMCIF or DSSP. Inferred from the
             file extension by default.
-        dssp_version: string
-            Version of DSSP used to generate in_file if in_file is of DSSP
-            format. Else version will be automatically detected.
 
         """
         self.residue_max_acc = residue_max_acc[acc_array]

--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -204,7 +204,9 @@ residue_max_acc = {
     },
 }
 
+
 def version(version_string):
+    """Parse semantic version scheme."""
     return tuple(map(int, (version_string.split("."))))
 
 
@@ -234,7 +236,7 @@ def dssp_dict_from_pdb_file(in_file, DSSP="dssp", dssp_version="3.9.9"):
 
     DSSP : string
         DSSP executable (argument to subprocess)
-    
+
     dssp_version : string
         Version of DSSP excutable
 
@@ -474,9 +476,13 @@ class DSSP(AbstractResiduePropertyMap):
             # calling 'dssp' will not work in some operating systems
             # (Debian distribution of DSSP includes a symlink for 'dssp' argument)
             try:
-                version_string= subprocess.check_output([dssp, "--version"], universal_newlines=True)
+                version_string = subprocess.check_output(
+                    [dssp, "--version"], universal_newlines=True
+                )
                 dssp_version = re.search(r"\s*([\d.]+)", version_string).group(1)
-                dssp_dict, dssp_keys = dssp_dict_from_pdb_file(in_file, dssp, dssp_version)
+                dssp_dict, dssp_keys = dssp_dict_from_pdb_file(
+                    in_file, dssp, dssp_version
+                )
             except FileNotFoundError:
                 if dssp == "dssp":
                     dssp = "mkdssp"
@@ -484,9 +490,13 @@ class DSSP(AbstractResiduePropertyMap):
                     dssp = "dssp"
                 else:
                     raise
-                version_string= subprocess.check_output([dssp, "--version"], universal_newlines=True)
+                version_string = subprocess.check_output(
+                    [dssp, "--version"], universal_newlines=True
+                )
                 dssp_version = re.search(r"\s*([\d.]+)", version_string).group(1)
-                dssp_dict, dssp_keys = dssp_dict_from_pdb_file(in_file, dssp, dssp_version)
+                dssp_dict, dssp_keys = dssp_dict_from_pdb_file(
+                    in_file, dssp, dssp_version
+                )
         # If the input file is a DSSP file just parse it directly:
         elif file_type == "DSSP":
             dssp_dict, dssp_keys = make_dssp_dict(in_file)

--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -249,7 +249,7 @@ def dssp_dict_from_pdb_file(in_file, DSSP="dssp", dssp_version="3.9.9"):
 
     Examples
     --------
-    How dssp_dict_frompdb_file could be used::
+    How dssp_dict_from_pdb_file could be used::
 
         from Bio.PDB.DSSP import dssp_dict_from_pdb_file
         dssp_tuple = dssp_dict_from_pdb_file("/local-pdb/1fat.pdb")

--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -206,7 +206,7 @@ residue_max_acc = {
 
 
 def version(version_string):
-    """Parse semantic version scheme."""
+    """Parse semantic version scheme for easy comparison."""
     return tuple(map(int, (version_string.split("."))))
 
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -74,6 +74,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Chaitanya Gupta <https://github.com/iCHAIT>
 - Cheng Soon Ong <chengsoon.ong at tuebingen.mpg.de>
 - Chenghao Zhu <zhuchcn@gmail.com>
+- Christian Balbin <christian at domain balbin.com>
 - Chris Daley <https://github.com/chebizarro>
 - Chris Jackson <https://github.com/chrisjackson-pellicle>
 - Chris Lasher <chris.lasher at gmail.com>


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3763 #3433

This is a patch to the current DSSP parser to support DSSP v4.0 . The DSSP parser currently only handles up to v3.x.x. I think supporting v4.0 is important as that is what is install by default when using apt on Ubuntu 21.04 or greater. Currently it is not mentioned in the documentation that v4.0 is not supported and this could be undesirable to some users.

DSSP v4.0 shifts to a mmCIF format by default. You can output a DSSP v3.0 style report using the flag --output-format=dssp. While I am a big fan of mmCIFs gain in popularity. DSSP 4.0 s mmCIF out is missing some critical items such as accessibility; [see comment](https://github.com/biopython/biopython/issues/3433#issuecomment-739473781).
Thus I think it is better to stick with the classic DSSP format output.

DSSP v4.0 also now uses auth_asym_id for the chain IDs instead of label_asym_id when ran on mmCIF files [see comment](https://github.com/biopython/biopython/issues/3763#issuecomment-954334393). For older versions of DSSP, a mapping had to be done from the label to auth chain ID f85e4d91b27f72849f1288040519d6a3dd6537ab. This is now disabled when a DSSP v4.0 or higher executable is detected.

In order to enable the expected experience for the most users, whether using PDB or mmCIF format files, or DSSP v3 vs v4 I added a version check to the initializer of the DSSP class. This check uses code similar to that found the the DSSP unit test. If it is found that the executable has a version greater than or equal to '4.0.0' the flag --output-format=dssp is added to the dssp command. Also if the user is found to be using v4.0.0 or greater with an mmCIF file. The label to auth chain ID mapping is disabled as the results already contain the auth chain ID instead.

Thanks for your time,

Christian


