### PR TITLE
defaultdict default_factory receives no arguments

### DIFF
--- a/Bio/PDB/SASA.py
+++ b/Bio/PDB/SASA.py
@@ -41,7 +41,7 @@ _ENTITY_HIERARCHY = {
 # References:
 # A. Bondi (1964). "van der Waals Volumes and Radii".
 # M. Mantina, A.C. et al., J. Phys. Chem. 2009, 113, 5806.
-ATOMIC_RADII = collections.defaultdict(lambda x: 2.0)
+ATOMIC_RADII = collections.defaultdict(lambda: 2.0)
 ATOMIC_RADII.update(
     {
         "H": 1.200,


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

There's a small bug in the SASA implementation. `ATOMIC_RADII` is a `defaultdict`, which is meant to handle KeyErrors from unspecified atomic radii. The problem is that defaultdicts do not pass any arguments to their `default_factory` function, so the `SharkeRupley.compute` call fails if it ever actually encounters a KeyError. The fix is trivial.

See the Python docs for more info: https://docs.python.org/3/library/collections.html#collections.defaultdict.default_factory
