### PR TITLE
Add KEGG.Compound.Record.raw

### DIFF
--- a/Bio/KEGG/Compound/__init__.py
+++ b/Bio/KEGG/Compound/__init__.py
@@ -37,6 +37,8 @@ class Record:
      - enzyme      A list of the EC numbers.
      - structures  A list of 2-tuples: (database, list of struct ids)
      - dblinks     A list of 2-tuples: (database, list of link ids)
+     - raw         A dictionary of lists with all attributes which are
+                   not explicitly handled by this class
 
     """
 
@@ -50,6 +52,7 @@ class Record:
         self.enzyme = []
         self.structures = []
         self.dblinks = []
+        self.raw = {}
 
     def __str__(self):
         """Return a string representation of this Record."""
@@ -62,6 +65,7 @@ class Record:
             + self._enzyme()
             + self._structures()
             + self._dblinks()
+            + self._raw()
             + "///"
         )
 
@@ -103,6 +107,9 @@ class Record:
         for entry in self.dblinks:
             s.append(entry[0] + ": " + " ".join(entry[1]))
         return _write_kegg("DBLINKS", [_wrap_kegg(l, wrap_rule=id_wrap(9)) for l in s])
+
+    def _raw(self):
+        return "".join(_write_kegg(key, value) for (key, value) in self.raw.items())
 
 
 def parse(handle):
@@ -167,6 +174,8 @@ def parse(handle):
                 values.extend(data.split())
                 row = key, values
                 record.dblinks[-1] = row
+        else:
+            record.raw.setdefault(keyword.rstrip(), []).append(data)
 
 
 if __name__ == "__main__":

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -31,6 +31,9 @@ files with an internal empty block fixed).
 The experimental warning was dropped from ``Bio.phenotype`` (which was new in
 Biopython 1.67).
 
+The ``KEGG.Compound.Record`` class now has a ``raw`` attribute which makes all
+fields available which have not already been explicitly handled by the parser.
+
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite.
 

--- a/Tests/test_KEGG.py
+++ b/Tests/test_KEGG.py
@@ -144,6 +144,18 @@ class CompoundTests(unittest.TestCase):
         self.assertEqual(records[1].enzyme[0], ("2.3.2.6"))
         self.assertEqual(records[1].structures, [])
         self.assertEqual(records[1].dblinks[0], ("PubChem", ["3319"]))
+        # check the "raw" dictionary
+        self.assertEqual(records[0].raw["EXACT_MASS"], ["55.9349"])
+        self.assertEqual(
+            records[0].raw["ATOM"],
+            [
+                "1",
+                "1   Z   Fe   22.1200  -16.1700",
+            ],
+        )
+        # keys with dedicated fields are not available from "raw"
+        with self.assertRaises(KeyError):
+            records[0].raw["FORMULA"]
         self.assertEqual(
             str(records[-1]).replace(" ", "").split("\n")[:10],
             [


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Add a `raw` dictionary to `KEGG.Compound.Record` for all fields which are not explicitly handled.

Example:

```python
In [18]: r = next(Bio.KEGG.Compound.parse(Bio.KEGG.REST.kegg_get("D03257")))

In [19]: r.raw["SEQUENCE"]
Out[19]: 
['(Heavy chain)',
 'EVQLVESGGG LVQPGGSLRL SCAASGFNIK DTYIHWVRQA PGKGLEWVAR IYPTNGYTRY',
 'ADSVKGRFTI SADTSKNTAY LQMNSLRAED TAVYYCSRWG GDGFYAMDYW GQGTLVTVSS',
 'ASTKGPSVFP LAPSSKSTSG GTAALGCLVK DYFPEPVTVS WNSGALTSGV HTFPAVLQSS',
 'GLYSLSSVVT VPSSSLGTQT YICNVNHKPS NTKVDKKVEP KSCDKTHTCP PCPAPELLGG',
 'PSVFLFPPKP KDTLMISRTP EVTCVVVDVS HEDPEVKFNW YVDGVEVHNA KTKPREEQYN',
 'STYRVVSVLT VLHQDWLNGK EYKCKVSNKA LPAPIEKTIS KAKGQPREPQ VYTLPPSREE',
 'MTKNQVSLTC LVKGFYPSDI AVEWESNGQP ENNYKTTPPV LDSDGSFFLY SKLTVDKSRW',
 'QQGNVFSCSV MHEALHNHYT QKSLSLSPG',
 '(Light chain)',
 'DIQMTQSPSS LSASVGDRVT ITCRASQDVN TAVAWYQQKP GKAPKLLIYS ASFLYSGVPS',
 'RFSGSRSGTD FTLTISSLQP EDFATYYCQQ HYTTPPTFGQ GTKVEIKRTV AAPSVFIFPP',
 'SDEQLKSGTA SVVCLLNNFY PREAKVQWKV DNALQSGNSQ ESVTEQDSKD STYSLSSTLT',
 'LSKADYEKHK VYACEVTHQG LSSPVTKSFN RGEC',
 "(Disulfide bridge: H22-H96, H147-H203, H264-H324, H370-H428, H229-H'229, H232-H'232, L23-L88, L134-L194, H223-L214)"]
```