### PR TITLE
Add defined attribute to Seq

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2062,9 +2062,9 @@ class Seq(_SeqAbstractBaseClass):
             return True
         elif isinstance(self, UnknownSeq):
             return False
-        elif isinstance(self._data, _UndefinedSequenceData):
-            return False
-        elif isinstance(self._data, _PartiallyDefinedSequenceData):
+        elif isinstance(
+            self._data, (_UndefinedSequenceData, _PartiallyDefinedSequenceData)
+        ):
             return False
         return True
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1922,7 +1922,7 @@ class Seq(_SeqAbstractBaseClass):
 
         Arguments:
          - data - Sequence, required (string)
-         - length - Sequence length, used only if data is None (integer)
+         - length - Sequence length, used only if data is None or a dictionary (integer)
 
         You will typically use Bio.SeqIO to read in sequences from files as
         SeqRecord objects, whose sequence will be exposed as a Seq object via
@@ -1977,7 +1977,7 @@ class Seq(_SeqAbstractBaseClass):
         elif isinstance(data, (bytes, SequenceDataAbstractBaseClass)):
             self._data = data
         elif isinstance(data, (bytearray, _SeqAbstractBaseClass)):
-            self._data = data = bytes(data)
+            self._data = bytes(data)
         elif isinstance(data, str):
             self._data = bytes(data, encoding="ASCII")
         elif isinstance(data, dict):
@@ -2051,6 +2051,22 @@ class Seq(_SeqAbstractBaseClass):
         elif len(gap) != 1 or not isinstance(gap, str):
             raise ValueError(f"Unexpected gap character, {gap!r}")
         return self.replace(gap, b"")
+
+    @property
+    def defined(self):
+        """Return true if the sequence is defined, false if undefined or partially defined.
+
+        Zero-length sequences are always considered to be defined.
+        """
+        if len(self) == 0:
+            return True
+        elif isinstance(self, UnknownSeq):
+            return False
+        elif isinstance(self._data, _UndefinedSequenceData):
+            return False
+        elif isinstance(self._data, _PartiallyDefinedSequenceData):
+            return False
+        return True
 
 
 class UnknownSeq(Seq):

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -226,6 +226,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Nader Morshed <https://github.com/naderm>
 - Nate Sutton <https://github.com/nmsutton>
 - Nathan J. Edwards <nje5 at edu domain georgetown>
+- Neil P. <https://github.com/npars>
 - Nick Negretti <https://github.com/nimne>
 - Nicolas Fontrodona <https://github.com/NFontrodona>
 - Nigel Delaney <https://github.com/evolvedmicrobe>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -31,6 +31,9 @@ files with an internal empty block fixed).
 The experimental warning was dropped from ``Bio.phenotype`` (which was new in
 Biopython 1.67).
 
+Sequences now have a ``defined`` attribute that returns a boolean indicating
+if the underlying data is defined or not.
+
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite.
 
@@ -46,6 +49,7 @@ possible, especially the following contributors:
 - Michiel de Hoon
 - Peter Cock
 - Erik  Whiting
+- Neil P. (first contribution)
 
 3 June 2021: Biopython 1.79
 ===========================

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -151,7 +151,7 @@ def main(argv):
     source_path = os.path.abspath(f"{test_path}/..")
     sys.path.insert(1, source_path)
     build_path = os.path.abspath(
-        f"{test_path}/../build/lib.{distutils.util.get_platform()}-{sys.version[:3]}"
+        f"{test_path}/../build/lib.{distutils.util.get_platform()}-{sys.version_info.major}.{sys.version_info.minor}"
     )
     if os.access(build_path, os.F_OK):
         sys.path.insert(1, build_path)

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -1461,6 +1461,33 @@ class TestAttributes(unittest.TestCase):
         self.assertNotIn("dog", dir(s))
 
 
+class TestSeqDefined(unittest.TestCase):
+    def test_zero_length(self):
+        zero_length_seqs = [
+            Seq.Seq(""),
+            Seq.Seq(None, length=0),
+            Seq.Seq({}, length=0),
+            Seq.UnknownSeq(length=0),
+        ]
+
+        for seq in zero_length_seqs:
+            self.assertTrue(seq.defined)
+
+    def test_undefined(self):
+        undefined_seqs = [
+            Seq.Seq(None, length=1),
+            Seq.Seq({3: "ACGT"}, length=10),
+            Seq.UnknownSeq(length=1),
+        ]
+
+        for seq in undefined_seqs:
+            self.assertFalse(seq.defined)
+
+    def test_defined(self):
+        seq = Seq.Seq("T")
+        self.assertTrue(seq.defined)
+
+
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)
     unittest.main(testRunner=runner)

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -1484,8 +1484,14 @@ class TestSeqDefined(unittest.TestCase):
             self.assertFalse(seq.defined)
 
     def test_defined(self):
-        seq = Seq.Seq("T")
-        self.assertTrue(seq.defined)
+        seqs = [
+            Seq.Seq("T"),
+            Seq.Seq({0: "A"}, length=1),
+            Seq.Seq({0: "A", 1: "C"}, length=2),
+        ]
+
+        for seq in seqs:
+            self.assertTrue(seq.defined)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3667

Add "defined" attribute to Seq object that returns true if the Seq contains a 
fully defined sequence and false if it is unknown or partial.
