### PR TITLE
add defined_ranges

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -326,7 +326,7 @@ class SequenceDataAbstractBaseClass(ABC):
         """
         length = len(self)
         if length > 0:
-            return ((0, length), )
+            return ((0, length),)
         else:
             return ()
 
@@ -1941,7 +1941,7 @@ class _SeqAbstractBaseClass(ABC):
         if isinstance(self._data, (bytes, bytearray)):
             length = len(self)
             if length > 0:
-                return ((0, length), )
+                return ((0, length),)
             else:
                 return ()
         else:
@@ -3285,6 +3285,7 @@ class _PartiallyDefinedSequenceData(SequenceDataAbstractBaseClass):
         The return value has the format ((start1, end1), (start2, end2), ...).
         """
         return tuple((start, start + len(seq)) for start, seq in self._data.items())
+
 
 # The transcribe, backward_transcribe, and translate functions are
 # user-friendly versions of the corresponding Seq/MutableSeq methods.

--- a/Tests/test_SeqIO_TwoBitIO.py
+++ b/Tests/test_SeqIO_TwoBitIO.py
@@ -475,6 +475,12 @@ class TestBaseClassMethods(unittest.TestCase):
         # seq.complement uses seq._data.translate
         self.assertEqual(self.seq1_twobit.complement(), self.seq1_fasta.complement())
 
+    def test_defined(self):
+        self.assertTrue(self.seq1_twobit.defined)
+        self.assertTrue(self.seq2_twobit.defined)
+        self.assertEqual(self.seq1_twobit.defined_ranges, ((0, len(self.seq1_twobit)),))
+        self.assertEqual(self.seq2_twobit.defined_ranges, ((0, len(self.seq2_twobit)),))
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -1468,20 +1468,23 @@ class TestSeqDefined(unittest.TestCase):
             Seq.Seq(None, length=0),
             Seq.Seq({}, length=0),
             Seq.UnknownSeq(length=0),
+            Seq.MutableSeq(""),
         ]
 
         for seq in zero_length_seqs:
-            self.assertTrue(seq.defined)
+            self.assertTrue(seq.defined, msg=repr(seq))
+            self.assertEqual(seq.defined_ranges, (), msg=repr(seq))
 
     def test_undefined(self):
-        undefined_seqs = [
-            Seq.Seq(None, length=1),
-            Seq.Seq({3: "ACGT"}, length=10),
-            Seq.UnknownSeq(length=1),
-        ]
-
-        for seq in undefined_seqs:
-            self.assertFalse(seq.defined)
+        seq = Seq.Seq(None, length=1)
+        self.assertFalse(seq.defined)
+        self.assertEqual(seq.defined_ranges, ())
+        seq = Seq.Seq({3: "ACGT"}, length=10)
+        self.assertFalse(seq.defined)
+        self.assertEqual(seq.defined_ranges, ((3, 7), ))
+        seq = Seq.UnknownSeq(length=1)
+        self.assertFalse(seq.defined)
+        self.assertEqual(seq.defined_ranges, ())
 
     def test_defined(self):
         seqs = [
@@ -1492,6 +1495,7 @@ class TestSeqDefined(unittest.TestCase):
 
         for seq in seqs:
             self.assertTrue(seq.defined)
+            self.assertEqual(seq.defined_ranges, ((0, len(seq)), ), msg=repr(seq))
 
 
 if __name__ == "__main__":

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -1481,7 +1481,7 @@ class TestSeqDefined(unittest.TestCase):
         self.assertEqual(seq.defined_ranges, ())
         seq = Seq.Seq({3: "ACGT"}, length=10)
         self.assertFalse(seq.defined)
-        self.assertEqual(seq.defined_ranges, ((3, 7), ))
+        self.assertEqual(seq.defined_ranges, ((3, 7),))
         seq = Seq.UnknownSeq(length=1)
         self.assertFalse(seq.defined)
         self.assertEqual(seq.defined_ranges, ())
@@ -1495,7 +1495,7 @@ class TestSeqDefined(unittest.TestCase):
 
         for seq in seqs:
             self.assertTrue(seq.defined)
-            self.assertEqual(seq.defined_ranges, ((0, len(seq)), ), msg=repr(seq))
+            self.assertEqual(seq.defined_ranges, ((0, len(seq)),), msg=repr(seq))
 
 
 if __name__ == "__main__":

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -1494,7 +1494,7 @@ class TestSeqDefined(unittest.TestCase):
         ]
 
         for seq in seqs:
-            self.assertTrue(seq.defined)
+            self.assertTrue(seq.defined, msg=repr(seq))
             self.assertEqual(seq.defined_ranges, ((0, len(seq)),), msg=repr(seq))
 
 


### PR DESCRIPTION
Add a `defined_ranges` property to `Seq` and `MutableSeq` objects, which specify for which sequence ranges the sequence is defined. For a zero-length sequence, this property is an empty tuple.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

