### PR TITLE
use defined_ranges to simplify code

### DIFF
--- a/Bio/Align/maf.py
+++ b/Bio/Align/maf.py
@@ -317,7 +317,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
     def create_alignment(
         records,
         aligned_sequences,
-        starts,
         strands,
         annotations,
         column_annotations,
@@ -325,9 +324,10 @@ class AlignmentIterator(interfaces.AlignmentIterator):
     ):
         """Create the Alignment object from the collected alignment data."""
         coordinates = Alignment.infer_coordinates(aligned_sequences)
-        for start, strand, row in zip(starts, strands, coordinates):
+        for record, strand, row in zip(records, strands, coordinates):
             if strand == "-":
                 row[:] = row[-1] - row[0] - row
+            start = record.seq.defined_ranges[0][0]
             row += start
         alignment = Alignment(records, coordinates)
         if annotations is not None:
@@ -352,7 +352,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         records = None
         for line in lines:
             if line.startswith("a"):
-                starts = []
                 strands = []
                 annotations = {}
                 column_annotations = {}
@@ -400,7 +399,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 seq = Seq({start: sequence}, length=srcSize)
                 record = SeqRecord(seq, id=src)
                 records.append(record)
-                starts.append(start)
                 strands.append(strand)
             elif line.startswith("i "):
                 words = line.strip().split()
@@ -450,7 +448,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 yield AlignmentIterator.create_alignment(
                     records,
                     aligned_sequences,
-                    starts,
                     strands,
                     annotations,
                     column_annotations,
@@ -464,7 +461,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         yield AlignmentIterator.create_alignment(
             records,
             aligned_sequences,
-            starts,
             strands,
             annotations,
             column_annotations,


### PR DESCRIPTION
Use the new `defined_ranges` property to simplify the MAF parsing code.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

