### PR TITLE
Entrez internal refactoring and minor improvements

### DIFF
--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -598,7 +598,7 @@ def _open(req_or_cgi, params=None, post=None, ecitmatch=False):
     # Equivalently, at least a third of second between queries
     # Using just 0.333333334 seconds sometimes hit the NCBI rate limit,
     # the slightly longer pause of 0.37 seconds has been more reliable.
-    delay = 0.1 if api_key else 0.37
+    delay = 0.1 if _has_api_key(request) else 0.37
     current = time.time()
     wait = _open.previous + delay - current
     if wait > 0:
@@ -716,6 +716,16 @@ def _construct_params(params):
         )
 
     return params
+
+
+def _has_api_key(request):
+    """Check if a Request has the api_key parameter set, to set the rate limit.
+
+    Works with GET or POST requests.
+    """
+    if request.method == "POST":
+        return b"api_key=" in request.data
+    return "api_key=" in request.full_url
 
 
 if __name__ == "__main__":

--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -142,9 +142,8 @@ def epost(db, **keywds):
     See the online documentation for an explanation of the parameters:
     http://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.EPost
 
-    Return a handle to the results.
-
-    Raises an IOError exception if there's a network error.
+    :returns: Handle to the results.
+    :raises urllib.error.URLError: If there's a network error.
     """
     cgi = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/epost.fcgi"
     variables = {"db": db}
@@ -162,10 +161,6 @@ def efetch(db, **keywords):
     See the online documentation for an explanation of the parameters:
     http://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.EFetch
 
-    Return a handle to the results.
-
-    Raises an IOError exception if there's a network error.
-
     Short example:
 
     >>> from Bio import Entrez
@@ -180,6 +175,9 @@ def efetch(db, **keywords):
 
     **Warning:** The NCBI changed the default retmode in Feb 2012, so many
     databases which previously returned text output now give XML.
+
+    :returns: Handle to the results.
+    :raises urllib.error.URLError: If there's a network error.
     """
     cgi = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
     variables = {"db": db}
@@ -219,10 +217,6 @@ def esearch(db, term, **keywds):
     See the online documentation for an explanation of the parameters:
     http://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch
 
-    Return a handle to the results which are always in XML format.
-
-    Raises an IOError exception if there's a network error.
-
     Short example:
 
     >>> from Bio import Entrez
@@ -237,6 +231,8 @@ def esearch(db, term, **keywds):
     >>> "EF590892.1" in record["IdList"]
     True
 
+    :returns: Handle to the results, which are always in XML format.
+    :raises urllib.error.URLError: If there's a network error.
     """
     cgi = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
     variables = {"db": db, "term": term}
@@ -257,10 +253,6 @@ def elink(**keywds):
     See the online documentation for an explanation of the parameters:
     http://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ELink
 
-    Return a handle to the results, by default in XML format.
-
-    Raises an IOError exception if there's a network error.
-
     This example finds articles related to the Biopython application
     note's entry in the PubMed database:
 
@@ -277,6 +269,9 @@ def elink(**keywds):
     True
 
     This is explained in much more detail in the Biopython Tutorial.
+
+    :returns: Handle to the results, by default in XML format.
+    :raises urllib.error.URLError: If there's a network error.
     """
     cgi = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi"
     variables = {}
@@ -294,10 +289,6 @@ def einfo(**keywds):
     See the online documentation for an explanation of the parameters:
     http://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.EInfo
 
-    Return a handle to the results, by default in XML format.
-
-    Raises an IOError exception if there's a network error.
-
     Short example:
 
     >>> from Bio import Entrez
@@ -306,6 +297,8 @@ def einfo(**keywds):
     >>> 'pubmed' in record['DbList']
     True
 
+    :returns: Handle to the results, by default in XML format.
+    :raises urllib.error.URLError: If there's a network error.
     """
     cgi = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/einfo.fcgi"
     variables = {}
@@ -323,10 +316,6 @@ def esummary(**keywds):
     See the online documentation for an explanation of the parameters:
     http://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESummary
 
-    Return a handle to the results, by default in XML format.
-
-    Raises an IOError exception if there's a network error.
-
     This example discovers more about entry 19923 in the structure
     database:
 
@@ -340,6 +329,9 @@ def esummary(**keywds):
     >>> print(record[0]["PdbDescr"])
     Crystal Structure Of E. Coli Aconitase B
 
+
+    :returns: Handle to the results, by default in XML format.
+    :raises urllib.error.URLError: If there's a network error.
     """
     cgi = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi"
     variables = {}
@@ -357,10 +349,6 @@ def egquery(**keywds):
     See the online documentation for an explanation of the parameters:
     http://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.EGQuery
 
-    Return a handle to the results in XML format.
-
-    Raises an IOError exception if there's a network error.
-
     This quick example based on a longer version from the Biopython
     Tutorial just checks there are over 60 matches for 'Biopython'
     in PubMedCentral:
@@ -375,6 +363,8 @@ def egquery(**keywds):
     ...         print(int(row["Count"]) > 60)
     True
 
+    :returns: Handle to the results, by default in XML format.
+    :raises urllib.error.URLError: If there's a network error.
     """
     cgi = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/egquery.fcgi"
     variables = {}
@@ -391,10 +381,6 @@ def espell(**keywds):
     See the online documentation for an explanation of the parameters:
     http://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESpell
 
-    Return a handle to the results, by default in XML format.
-
-    Raises an IOError exception if there's a network error.
-
     Short example:
 
     >>> from Bio import Entrez
@@ -405,6 +391,8 @@ def espell(**keywds):
     >>> print(record["CorrectedQuery"])
     biopython
 
+    :returns: Handle to the results, by default in XML format.
+    :raises urllib.error.URLError: If there's a network error.
     """
     cgi = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/espell.fcgi"
     variables = {}
@@ -450,10 +438,6 @@ def ecitmatch(**keywds):
     See the online documentation for an explanation of the parameters:
     http://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ECitMatch
 
-    Return a handle to the results, by default in plain text
-
-    Raises an IOError exception if there's a network error.
-
     Short example:
 
     >>> from Bio import Entrez
@@ -466,6 +450,8 @@ def ecitmatch(**keywds):
     ['proc natl acad sci u s a', '1991', '88', '3248', 'mann bj', 'citation_1', '2014248']
     >>> handle.close()
 
+    :returns: Handle to the results, by default in plain text.
+    :raises urllib.error.URLError: If there's a network error.
     """
     cgi = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/ecitmatch.cgi"
     variables = _update_ecitmatch_variables(keywds)

--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -685,35 +685,36 @@ def _construct_params(params):
     if params is None:
         params = {}
 
+    # Tell Entrez that we are using Biopython (or whatever the user has
+    # specified explicitly in the parameters or by changing the default)
+    params.setdefault("tool", tool)
+
+    # Tell Entrez who we are
+    params.setdefault("email", email)
+    params.setdefault("api_key", api_key)
+
     # Remove None values from the parameters
     for key, value in list(params.items()):
         if value is None:
             del params[key]
-    # Tell Entrez that we are using Biopython (or whatever the user has
-    # specified explicitly in the parameters or by changing the default)
-    if "tool" not in params:
-        params["tool"] = tool
-    # Tell Entrez who we are
-    if "email" not in params:
-        if email is not None:
-            params["email"] = email
-        else:
-            warnings.warn(
-                """
-Email address is not specified.
 
-To make use of NCBI's E-utilities, NCBI requires you to specify your
-email address with each request.  As an example, if your email address
-is A.N.Other@example.com, you can specify it as follows:
-   from Bio import Entrez
-   Entrez.email = 'A.N.Other@example.com'
-In case of excessive usage of the E-utilities, NCBI will attempt to contact
-a user at the email address provided before blocking access to the
-E-utilities.""",
-                UserWarning,
-            )
-    if api_key and "api_key" not in params:
-        params["api_key"] = api_key
+    # Warn if email not set
+    if "email" not in params:
+        warnings.warn(
+            """
+            Email address is not specified.
+
+            To make use of NCBI's E-utilities, NCBI requires you to specify your
+            email address with each request.  As an example, if your email address
+            is A.N.Other@example.com, you can specify it as follows:
+               from Bio import Entrez
+               Entrez.email = 'A.N.Other@example.com'
+            In case of excessive usage of the E-utilities, NCBI will attempt to contact
+            a user at the email address provided before blocking access to the
+            E-utilities.""",
+            UserWarning,
+        )
+
     return params
 
 

--- a/Tests/test_Entrez.py
+++ b/Tests/test_Entrez.py
@@ -341,6 +341,31 @@ class TestURLConstruction(unittest.TestCase):
 
                     self.assertDictEqual(query, expected)
 
+    def test_has_api_key(self):
+        """Test checking whether a Request object specifies an API key.
+
+        The _has_api_key() private function is used to set the delay in _open().
+        """
+        variables = {
+            "db": "protein",
+            "id": "15718680",
+        }
+
+        for etool in [Entrez.efetch, Entrez.epost]:  # Make both GET and POST requests
+
+            with patch_urlopen() as patched:
+                etool(**variables)
+            assert Entrez._has_api_key(get_patched_request(patched, self))
+
+            with patch_urlopen() as patched:
+                etool(**variables, api_key=None)
+            assert not Entrez._has_api_key(get_patched_request(patched, self))
+
+            with patch_urlopen() as patched:
+                with mock.patch("Bio.Entrez.api_key", None):
+                    etool(**variables)
+            assert not Entrez._has_api_key(get_patched_request(patched, self))
+
 
 class CustomDirectoryTest(unittest.TestCase):
     """Offline unit test for custom directory feature.


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This is part of my effort to finally get #3432 merged but thought it should be submitted as its own PR first.

* Moved URL-building functionality from the `_open()` function to a new function `_build_request()`. This improves separation of concerns and makes things easier to test.
  * New function returns a `urllib.request.Request` object which encapsulates target URL, HTTP method, and query string or POST data.
  * `_open()` takes the `Request` object and handles rate limiting and retries.
  * Still supports previous signature of `_open()` for backwards compatibility, with deprecation warning. Not sure if this is actually necessary as it is a private function.
  * Improvements to docstrings of these functions.
* Added `:returns:` and `:raises:` attributes to public function docstrings.
* Calling eutil functions with the `email`, `api_key`, or `tool` parameter explicitly set to `None` will remove that parameter from the request, even if the module's global variable is set to a non-`None` value. Previous behavior was to use the global variable if the parameter was not passed OR was set to `None`, but I'm not sure if it was intentional.
  * More complete tests for setting these parameters using both methods