### PR TITLE
HSExposure: Allow skipping residues with missing HSE-relevant atoms

### DIFF
--- a/Bio/PDB/HSExposure.py
+++ b/Bio/PDB/HSExposure.py
@@ -132,6 +132,7 @@ class _AbstractHSExposure(AbstractPropertyMap):
             c_v = residue["C"].get_vector()
             ca_v = residue["CA"].get_vector()
         except KeyError:
+            warnings.warn(f"pCB vector not calculated for {residue} (no CA, N, or C atoms)")
             return None
         # center at origin
         n_v = n_v - ca_v
@@ -193,12 +194,14 @@ class HSExposureCA(_AbstractHSExposure):
         :type r1, r2, r3: L{Residue}
         """
         if r1 is None or r3 is None:
+            warnings.warn(f"Approx. CA-CB vector not calculated for {r2} (missing neighbors).")
             return None
         try:
             ca1 = r1["CA"].get_vector()
             ca2 = r2["CA"].get_vector()
             ca3 = r3["CA"].get_vector()
         except KeyError:
+            warnings.warn(f"Approx. CA-CB vector not calculated for {r2} (missing CA atoms).")
             return None
         # center
         d1 = ca2 - ca1
@@ -294,7 +297,9 @@ class HSExposureCB(_AbstractHSExposure):
                 vcb = r2["CB"].get_vector()
                 vca = r2["CA"].get_vector()
                 return (vcb - vca), 0.0
-        return None
+            else:
+                warnings.warn(f"CA-CB vector not calculated for {r2} (missing CA or CB atoms).")
+                return None
 
 
 class ExposureCN(AbstractPropertyMap):

--- a/Bio/PDB/HSExposure.py
+++ b/Bio/PDB/HSExposure.py
@@ -262,7 +262,11 @@ class HSExposureCB(_AbstractHSExposure):
         :type r1, r2, r3: L{Residue}
         """
         if r2.get_resname() == "GLY":
-            return self._get_gly_cb_vector(r2), 0.0
+            vcb_gly = self._get_gly_cb_vector(r2)
+            if vcb_gly is None:
+                return None
+            else:
+                return vcb_gly, 0.0
         else:
             if r2.has_id("CB") and r2.has_id("CA"):
                 vcb = r2["CB"].get_vector()

--- a/Bio/PDB/HSExposure.py
+++ b/Bio/PDB/HSExposure.py
@@ -131,7 +131,7 @@ class _AbstractHSExposure(AbstractPropertyMap):
             n_v = residue["N"].get_vector()
             c_v = residue["C"].get_vector()
             ca_v = residue["CA"].get_vector()
-        except Exception:
+        except KeyError:
             return None
         # center at origin
         n_v = n_v - ca_v
@@ -198,7 +198,7 @@ class HSExposureCA(_AbstractHSExposure):
             ca1 = r1["CA"].get_vector()
             ca2 = r2["CA"].get_vector()
             ca3 = r3["CA"].get_vector()
-        except Exception:
+        except KeyError:
             return None
         # center
         d1 = ca2 - ca1

--- a/Bio/PDB/HSExposure.py
+++ b/Bio/PDB/HSExposure.py
@@ -25,7 +25,14 @@ class _AbstractHSExposure(AbstractPropertyMap):
     """
 
     def __init__(
-        self, model, radius, offset, hse_up_key, hse_down_key, skip_residues=False, angle_key=None
+        self,
+        model,
+        radius,
+        offset,
+        hse_up_key,
+        hse_down_key,
+        skip_residues=False,
+        angle_key=None,
     ):
         """Initialize class.
 
@@ -132,7 +139,9 @@ class _AbstractHSExposure(AbstractPropertyMap):
             c_v = residue["C"].get_vector()
             ca_v = residue["CA"].get_vector()
         except KeyError:
-            warnings.warn(f"pCB vector not calculated for {residue} (no CA, N, or C atoms)")
+            warnings.warn(
+                f"pCB vector not calculated for {residue} (no CA, N, or C atoms)"
+            )
             return None
         # center at origin
         n_v = n_v - ca_v
@@ -194,14 +203,18 @@ class HSExposureCA(_AbstractHSExposure):
         :type r1, r2, r3: L{Residue}
         """
         if r1 is None or r3 is None:
-            warnings.warn(f"Approx. CA-CB vector not calculated for {r2} (missing neighbors).")
+            warnings.warn(
+                f"Approx. CA-CB vector not calculated for {r2} (missing neighbors)."
+            )
             return None
         try:
             ca1 = r1["CA"].get_vector()
             ca2 = r2["CA"].get_vector()
             ca3 = r3["CA"].get_vector()
         except KeyError:
-            warnings.warn(f"Approx. CA-CB vector not calculated for {r2} (missing CA atoms).")
+            warnings.warn(
+                f"Approx. CA-CB vector not calculated for {r2} (missing CA atoms)."
+            )
             return None
         # center
         d1 = ca2 - ca1
@@ -298,7 +311,9 @@ class HSExposureCB(_AbstractHSExposure):
                 vca = r2["CA"].get_vector()
                 return (vcb - vca), 0.0
             else:
-                warnings.warn(f"CA-CB vector not calculated for {r2} (missing CA or CB atoms).")
+                warnings.warn(
+                    f"CA-CB vector not calculated for {r2} (missing CA or CB atoms)."
+                )
                 return None
 
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -100,6 +100,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Devang Thakkar <https://github.com/devangthakkar>
 - Diana Jaunzeikare
 - Diego Brouard <diego at domain conysis.com>
+- Dominique Sydow <https://github.com/dominiquesydow>
 - Edward Liaw <https://github.com/edliaw>
 - Emmanuel Noutahi <https://github.com/maclandrol>
 - Eric Rasche <https://github.com/erasche>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -43,6 +43,7 @@ possible, especially the following contributors:
 - Aziz Khan
 - Chenghao Zhu
 - Damien Goutte-Gattat
+- Dominique Sydow (first contribution)
 - Fabian Egli
 - Sebastian Bassi
 - Tim Burke


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3469

### Background
In 4 cases the CA-CB vector generation can fail:
1. (HSExposureCA/B) GLY residue without CA, N, and/or C (`_AbstractHSExposure._get_gly_cb_vector`)
2. (HSExposureCB) Non-GLY residue with missing CA and/or CB atom (`HSExposureCB._get_cb`)
3. (HSExposureCA) Non-GLY residue whose two neighbors are missing (`HSExposureCA._get_cb`)
4. (HSExposureCA) Non-GLY residue without CA atom or neighbors without CA atoms (`HSExposureCA._get_cb`)

### Issue
Usually, residues are skipped if the `_get_cb` return value is None (no vector) but in case 1 the return value is `(None, 0.0)`, which makes the whole protein's HSE calculation fail as described in #3469.

In the issue discussion, the following was suggested:
- @noamkremen: add a flag that allows choosing between skipping residues or not 
- @JoaoRodrigues: add warning when residues are skipped

### Proposed solution
This PR suggests the following behavior:
- Fix `HSExposureCB._get_cb`: Return either `(vector, angle)` or `None`; not `(None, 0.0)`
- Add `skip_residue` flag to decide if residue skipping is allowed (default: False); _this check is applied to all 4 cases (not only case 1)_
- Add warnings to all 4 cases (always shown regardless of `skip_residues`)
- Minor: Changed generic `Exception` to `KeyError`

### Notes
- I ran `pre-commit run --all-files` successfully, however, the tests run with [`python setup.py test`](https://github.com/biopython/biopython/blob/master/CONTRIBUTING.rst#local-testing) stall for me after `test_NCBI_BLAST_tools`