### PR TITLE
add sphinx directives to .flake8 file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -16,6 +16,15 @@
 
 [flake8]
 doctests = True
+rst-roles =
+    class,
+    func,
+    meth,
+    mod,
+    data,
+rst-directives =
+    seealso,
+    todo,
 # Exclude some file types and folders that shouldn't be checked:
 exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.github,build
 ignore =


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This adds some Sphinx directives to the distribution .flake8 file, so that API documentation can use hyperlinks and other niceties.

Closes #3802 
