### PR TITLE
Fix broken link

### DIFF
--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -8,7 +8,7 @@
 r"""Use the DSSP program to calculate secondary structure and accessibility.
 
 You need to have a working version of DSSP (and a license, free for academic
-use) in order to use this. For DSSP, see http://swift.cmbi.ru.nl/gv/dssp/.
+use) in order to use this. For DSSP, see https://swift.cmbi.umcn.nl/gv/dssp/.
 
 The following Accessible surface area (ASA) values can be used, defaulting
 to the Sander and Rost values:


### PR DESCRIPTION
The link to the dssp website is broken. The correct one is https://swift.cmbi.umcn.nl/gv/dssp/


- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally,
and understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.
