### PR TITLE
Fix for Bio.Align.PairwiseAligner memory leak

### DIFF
--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -5031,6 +5031,9 @@ exit: \
     if (M_row[nB] < score - epsilon) M[nA][nB].trace = 0; \
     if (Ix_row[nB] < score - epsilon) gaps[nA][nB].Ix = 0; \
     if (Iy_row[nB] < score - epsilon) gaps[nA][nB].Iy = 0; \
+    PyMem_Free(M_row); \
+    PyMem_Free(Ix_row); \
+    PyMem_Free(Iy_row); \
     return Py_BuildValue("fN", score, paths); \
 exit: \
     Py_DECREF(paths); \


### PR DESCRIPTION
This fixed Bio.Align.PairwiseAligner memory leak #2758, second issue.

Missing PyMem_Free statements were added.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #2758
