### PR TITLE
Added SeqFeature __sub__

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -939,7 +939,7 @@ class FeatureLocation:
         >>> f2 = FeatureLocation(end, start)
         >>> combined = f1 + f2
         >>> print(combined)
-        join{[5:10], [-30:-0]}
+        join{[5:10], [-30:-20]}
         
         This is thus equivalent to:
             

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -925,6 +925,60 @@ class FeatureLocation:
             return self._shift(other)
         else:
             return NotImplemented
+    
+    def __sub__(self,other):
+        """Combine location with another FeatureLocation object, or shift it.
+        
+        You can subtract two feature locations to make a join CompoundLocation:
+            
+        >>> from Bio.SeqFeature import FeatureLocation
+        >>> f1 = FeatureLocation(5, 10)
+        >>> f2 = FeatureLocation(20, 30)
+        >>> start = -f2.start
+        >>> end = -f2.end
+        >>> f2 = FeatureLocation(end, start)
+        >>> combined = f1 + f2
+        >>> print(combined)
+        join{[5:10], [-30:-0]}
+        
+        This is thus equivalent to:
+            
+        >>> from Bio.SeqFeature import CompoundLocation
+        >>> join = CompoundLocation([f1, f2])
+        >>> print(join)
+        join{[5:10], [-30:-20]}
+        
+        You can also use sum(...) in this way:
+            
+        >>> join = sum([f1, f2])
+        >>> print(join)
+        join{[5:10], [-30:-20]}
+        
+        Furthermore, you can combine a FeatureLocation with a CompoundLocation
+        in this way.
+        
+        Separately, subtracting an integer will give a new FeatureLocation with
+        its start and end offset by that amount. For example:
+            
+        >>> print(f1)
+        [5:10]
+        >>> print(f1 + (-100))
+        [-95:-90]
+        >>> print((-200) + f1)
+        [-195:-190]
+        
+        This can be useful when editing annotation.
+        """
+        
+        if isinstance(other, FeatureLocation):
+            start = -other.start
+            end = -other.end
+            other = FeatureLocation(end, start)
+            return CompoundLocation([self, other])
+        elif isinstance(other, int):
+            return self._shift(-other)
+        else:
+            return NotImplemented
 
     def __nonzero__(self):
         """Return True regardless of the length of the feature.

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -295,7 +295,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Veronika Berman <https://github.com/NikiB>
 - Victor Lin <https://github.com/victorlin>
 - Vini Salazar <https://github.com/vinisalazar>
--Vishesh Soni <https://github.com/vishesh2802>
+- Vishesh Soni <https://github.com/vishesh2802>
 - Walter Gillett <https://github.com/wgillett>
 - Wayne Decatur <https://github.com/fomightez>
 - Wibowo Arindrarto <https://github.com/bow>

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -295,6 +295,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Veronika Berman <https://github.com/NikiB>
 - Victor Lin <https://github.com/victorlin>
 - Vini Salazar <https://github.com/vinisalazar>
+-Vishesh Soni <https://github.com/vishesh2802>
 - Walter Gillett <https://github.com/wgillett>
 - Wayne Decatur <https://github.com/fomightez>
 - Wibowo Arindrarto <https://github.com/bow>


### PR DESCRIPTION
As discussed on #3831, addition is straight-forward, but subtraction is roundabout: `loc + (-5)` instead of `loc - 5`. In this PR, I added the `__sub__` feature to workaround `feature + (-5)` instead of `feature - 5`.

- [ ] I hereby agree to dual-license this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ ] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributor's listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already or do not wish to be listed. (*This acknowledgment is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3831
