### PR TITLE
Add SeqFeature __sub__

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -926,6 +926,23 @@ class FeatureLocation:
         else:
             return NotImplemented
 
+    def __sub__(self, other):
+        """Subtracting an integer will shift back its start and end offset by that amount.
+
+        >>> from Bio.SeqFeature import FeatureLocation
+        >>> f1 = FeatureLocation(105, 150)
+        >>> print(f1)
+        [105:150]
+        >>> print(f1 - 100)
+        [5:50]
+
+        This can be useful when editing annotation.
+        """
+        if isinstance(other, int):
+            return self._shift(-other)
+        else:
+            return NotImplemented
+
     def __nonzero__(self):
         """Return True regardless of the length of the feature.
 

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -927,7 +927,7 @@ class FeatureLocation:
             return NotImplemented
 
     def __sub__(self, other):
-        """Subtracting an integer will shift back its start and end offset by that amount.
+        """Subtracting an integer will shift the start and end by that amount.
 
         >>> from Bio.SeqFeature import FeatureLocation
         >>> f1 = FeatureLocation(105, 150)
@@ -936,7 +936,8 @@ class FeatureLocation:
         >>> print(f1 - 100)
         [5:50]
 
-        This can be useful when editing annotation.
+        This can be useful when editing annotation. You can also add an integer
+        to a feature location (which shifts in the opposite direction).
         """
         if isinstance(other, int):
             return self._shift(-other)

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -296,6 +296,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Veronika Berman <https://github.com/NikiB>
 - Victor Lin <https://github.com/victorlin>
 - Vini Salazar <https://github.com/vinisalazar>
+- Vishesh Soni <https://github.com/vishesh2802>
 - Walter Gillett <https://github.com/wgillett>
 - Wayne Decatur <https://github.com/fomightez>
 - Wibowo Arindrarto <https://github.com/bow>

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -57,6 +57,19 @@ class TestReference(unittest.TestCase):
 class TestFeatureLocation(unittest.TestCase):
     """Tests for the SeqFeature.FeatureLocation class."""
 
+    def test_offsets(self):
+        """Test adding and subtracting integer offsets."""
+        loc1 = FeatureLocation(23, 42, -1)
+        loc2 = FeatureLocation(123, 142, -1)
+        self.assertEqual(loc1 + 100, loc2)
+        self.assertEqual(loc1, loc2 + (-100))
+        self.assertEqual(loc1, loc2 - 100)
+        self.assertEqual(loc1 + 50, loc2 - 50)
+        with self.assertRaises(TypeError):
+            loc1 + "Hello"
+        with self.assertRaises(TypeError):
+            loc1 - "Hello"
+
     def test_eq_identical(self):
         """Test two identical locations are equal."""
         loc1 = FeatureLocation(23, 42, 1)


### PR DESCRIPTION
As discussed on #3831, addition is straight-forward, but subtraction is roundabout: `loc + (-5)` instead of `loc - 5`. In this PR, I added the` __sub__` feature to workaround `feature + (-5)` instead of `feature - 5`.

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3831 
