### PR TITLE
PDBList switch findall attributes on multiple PDB Entries Download case

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -572,7 +572,7 @@ if __name__ == "__main__":
 
         elif sys.argv[1][0] == "(":
             # get a set of PDB entries
-            pdb_ids = re.findall(sys.argv[1], "[0-9A-Za-z]{4}")
+            pdb_ids = re.findall("[0-9A-Za-z]{4}", sys.argv[1])
             for pdb_id in pdb_ids:
                 pl.retrieve_pdb_file(
                     pdb_id, pdir=pdb_path, file_format=file_format, overwrite=overwrite

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -246,6 +246,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Philip Bergstrom <https://github.com/phber>
 - Philip Capel <https://github.com/pcapel>
 - Phillip Garland <pgarland at gmail>
+- Pol Estecha <https://github.com/poleshe>
 - Ralf Stephan <https://github.com/rwst>
 - Rasmus Fonseca <https://github.com/RasmusFonseca>
 - rht <https://github.com/rht>


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #... Not an opened issue, but discovered that multiple PDB Entries download by using the CMD did not get the PDB list correctly, turns out the re.findall syntax is switches. 

Switching back the attributes gives the expected output, a download of multiple PDB Entries to the desired folder.

This is my first contribution, please, any errors or feedback will be greatly appreciated! Thanks!
