### PR TITLE
Bio.SeqUtils.MeltingTemp: Correction of salt-correction methods for Tm_GC

### DIFF
--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -766,7 +766,7 @@ def Tm_GC(
        concentration is calculated and used for salt correction (von Ahsen et
        al., 2001).
      - saltcorr: Type of salt correction (see method salt_correction).
-       Default=5. 0 or None means no salt correction.
+       Default=0. 0 or None means no salt correction.
      - mismatch: If 'True' (default) every 'X' in the sequence is counted as
        mismatch.
 
@@ -800,19 +800,19 @@ def Tm_GC(
             saltcorr = 0
         if valueset == 3:
             A, B, C, D = (81.5, 0.41, 675, 1)
-            saltcorr = 2
+            saltcorr = 1
         if valueset == 4:
             A, B, C, D = (81.5, 0.41, 500, 1)
-            saltcorr = 3
+            saltcorr = 2
         if valueset == 5:
             A, B, C, D = (78.0, 0.7, 500, 1)
-            saltcorr = 3
+            saltcorr = 2
         if valueset == 6:
             A, B, C, D = (67.0, 0.8, 500, 1)
-            saltcorr = 3
+            saltcorr = 2
         if valueset == 7:
             A, B, C, D = (81.5, 0.41, 600, 1)
-            saltcorr = 2
+            saltcorr = 1
         if valueset == 8:
             A, B, C, D = (77.1, 0.41, 528, 1)
             saltcorr = 4

--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -62,7 +62,7 @@ For example:
     >>> print('%0.2f' % mt.Tm_Wallace(myseq))
     84.00
     >>> print('%0.2f' % mt.Tm_GC(myseq))
-    58.73
+    58.97
     >>> print('%0.2f' % mt.Tm_NN(myseq))
     60.32
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -43,13 +43,14 @@ possible, especially the following contributors:
 - Aziz Khan
 - Chenghao Zhu
 - Damien Goutte-Gattat
+- Erik  Whiting
 - Fabian Egli
+- Markus Piotrowski
+- Michiel de Hoon
+- Neil P. (first contribution)
+- Peter Cock
 - Sebastian Bassi
 - Tim Burke
-- Michiel de Hoon
-- Peter Cock
-- Erik  Whiting
-- Neil P. (first contribution)
 
 3 June 2021: Biopython 1.79
 ===========================


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3842
There were some wrong assignments of salt-correction methods to some `valuesets` in `Tm_GC` which have been corrected now.