### PR TITLE
Avoid Sphinx 4.4.0 which is breaking CI

### DIFF
--- a/.circleci/requirements-sphinx.txt
+++ b/.circleci/requirements-sphinx.txt
@@ -4,7 +4,7 @@ numpy
 rdflib
 reportlab
 scipy
-sphinx>=4.2.0
+sphinx==4.3
 numpydoc==1.0.0
 pygments
 sphinx_rtd_theme

--- a/ci-dependencies.txt
+++ b/ci-dependencies.txt
@@ -28,6 +28,5 @@ scipy
 ## Documentation
 numpydoc==1.0.0
 pygments
-sphinx>=4.2.0
+sphinx==4.3
 sphinx_rtd_theme
-


### PR DESCRIPTION
Looks like Sphinx 4.4.0 is issuing new warning, and we're using strict mode so that errors:

``.../Bio/PDB/internal_coords.py:docstring of Bio.PDB.internal_coords.IC_Chain:: WARNING: more than one target found for cross-reference 'Chain': Bio.Nexus.Nodes.Chain, Bio.PDB.Chain.Chain``

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

