### PR TITLE
Use black v22.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,10 @@ repos:
         files: \.py$
     -   id: mixed-line-ending
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
     -   id: black
-        args: [--check]
+        args: [--check,--target-version,py37]
 -   repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
@@ -33,10 +33,10 @@ repos:
             'pydocstyle>=6.0.0',
         ]
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.0
+    rev: v1.12.1
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==21.12b0]
+        additional_dependencies: [black==22.1.0]
         exclude: ^.github/
 -   repo: https://github.com/myint/rstcheck
     rev: 3f92957478422df87bd730abde66f089cc1ee19b

--- a/Bio/Affy/CelFile.py
+++ b/Bio/Affy/CelFile.py
@@ -226,7 +226,7 @@ def _read_v4(f):
     # the record.AlgorithmParameters repeated in the data section, until an
     # EOF, i.e. b"\x04".
     char = b"\x00"
-    safetyValve = 10 ** 4
+    safetyValve = 10**4
     for i in range(safetyValve):
         char = f.read(1)
         # For debugging

--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -901,14 +901,10 @@ class DataHandler(metaclass=DataHandlerMeta):
             self.constructors[name] = (DictionaryElement, args)
             return
         # List-type elements
-        if (
-            model[0]
-            in (
-                expat.model.XML_CTYPE_CHOICE,
-                expat.model.XML_CTYPE_SEQ,
-            )
-            and model[1] in (expat.model.XML_CQUANT_PLUS, expat.model.XML_CQUANT_REP)
-        ):
+        if model[0] in (
+            expat.model.XML_CTYPE_CHOICE,
+            expat.model.XML_CTYPE_SEQ,
+        ) and model[1] in (expat.model.XML_CQUANT_PLUS, expat.model.XML_CQUANT_REP):
             children = model[3]
             allowed_tags = frozenset(child[2] for child in children)
             if model[0] == expat.model.XML_CTYPE_SEQ:

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1738,7 +1738,7 @@ class GenBankScanner(InsdcScanner):
                         print("Found comment")
                     comment_list = []
                     structured_comment_dict = defaultdict(dict)
-                    regex = fr"([^#]+){self.STRUCTURED_COMMENT_START}$"
+                    regex = rf"([^#]+){self.STRUCTURED_COMMENT_START}$"
                     structured_comment_key = re.search(regex, data)
                     if structured_comment_key is not None:
                         structured_comment_key = structured_comment_key.group(1)

--- a/Bio/PDB/SASA.py
+++ b/Bio/PDB/SASA.py
@@ -123,7 +123,7 @@ class ShrakeRupley:
         """
         n = self.n_points
 
-        dl = np.pi * (3 - 5 ** 0.5)
+        dl = np.pi * (3 - 5**0.5)
         dz = 2.0 / n
 
         longitude = 0

--- a/Bio/PDB/vectors.py
+++ b/Bio/PDB/vectors.py
@@ -236,9 +236,9 @@ def calc_dihedral(v1, v2, v3, v4):
     ab = v1 - v2
     cb = v3 - v2
     db = v4 - v3
-    u = ab ** cb
-    v = db ** cb
-    w = u ** v
+    u = ab**cb
+    v = db**cb
+    w = u**v
     angle = u.angle(v)
     # Determine sign of angle
     try:

--- a/Bio/Phylo/NeXML.py
+++ b/Bio/Phylo/NeXML.py
@@ -34,7 +34,7 @@ class Clade(BaseTree.Clade):
         clades=None,
         confidence=None,
         comment=None,
-        **kwargs
+        **kwargs,
     ):
         """Initialize parameters for NeXML Clade object."""
         BaseTree.Clade.__init__(

--- a/Bio/SearchIO/BlastIO/blast_xml.py
+++ b/Bio/SearchIO/BlastIO/blast_xml.py
@@ -574,7 +574,7 @@ class BlastXmlIndexer(SearchIndexer):
         handle.seek(0)
         re_desc = re.compile(
             b"<Iteration_query-ID>(.*?)"
-            br"</Iteration_query-ID>\s+?"
+            rb"</Iteration_query-ID>\s+?"
             b"<Iteration_query-def>"
             b"(.*?)</Iteration_query-def>"
         )

--- a/Bio/SearchIO/HmmerIO/hmmer2_text.py
+++ b/Bio/SearchIO/HmmerIO/hmmer2_text.py
@@ -338,7 +338,7 @@ class Hmmer2TextIndexer(_BaseHmmerTextIndexer):
         handle = self._handle
         handle.seek(0)
         start_offset = handle.tell()
-        regex_id = re.compile(br"Query\s*(?:sequence|HMM)?:\s*(.*)")
+        regex_id = re.compile(rb"Query\s*(?:sequence|HMM)?:\s*(.*)")
 
         # determine flag for hmmsearch
         is_hmmsearch = False

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -783,7 +783,7 @@ def _sff_read_seq_record(
     return record
 
 
-_powers_of_36 = [36 ** i for i in range(6)]
+_powers_of_36 = [36**i for i in range(6)]
 
 
 def _string_as_base_36(string):

--- a/Bio/motifs/jaspar/db.py
+++ b/Bio/motifs/jaspar/db.py
@@ -101,7 +101,7 @@ class JASPAR5:
 
     def __str__(self):
         """Return a string represention of the JASPAR5 DB connection."""
-        return fr"{self.user}\@{self.host}:{self.name}"
+        return rf"{self.user}\@{self.host}:{self.name}"
 
     def fetch_motif_by_id(self, id):
         """Fetch a single JASPAR motif from the DB by its JASPAR matrix ID.

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -380,7 +380,7 @@ class PositionSpecificScoringMatrix(GenericPositionMatrix):
         else:
             return scores
 
-    def search(self, sequence, threshold=0.0, both=True, chunksize=10 ** 6):
+    def search(self, sequence, threshold=0.0, both=True, chunksize=10**6):
         """Find hits with PWM score above given threshold.
 
         A generator function, returning found hits in the given sequence
@@ -537,7 +537,7 @@ class PositionSpecificScoringMatrix(GenericPositionMatrix):
         denominator = math.sqrt((sxx - sx * sx) * (syy - sy * sy))
         return numerator / denominator
 
-    def distribution(self, background=None, precision=10 ** 3):
+    def distribution(self, background=None, precision=10**3):
         """Calculate the distribution of the scores at the given precision."""
         from .thresholds import ScoreDistribution
 

--- a/Bio/motifs/thresholds.py
+++ b/Bio/motifs/thresholds.py
@@ -14,7 +14,7 @@ class ScoreDistribution:
     thresholds for motif occurrences.
     """
 
-    def __init__(self, motif=None, precision=10 ** 3, pssm=None, background=None):
+    def __init__(self, motif=None, precision=10**3, pssm=None, background=None):
         """Initialize the class."""
         if pssm is None:
             self.min_score = min(0.0, motif.min_score())
@@ -106,4 +106,4 @@ class ScoreDistribution:
         note: the actual patser software uses natural logarithms instead of log_2, so the numbers
         are not directly comparable.
         """
-        return self.threshold_fpr(fpr=2 ** -self.ic)
+        return self.threshold_fpr(fpr=2**-self.ic)

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -1209,7 +1209,7 @@ approximation with a given precision to keep computation cost manageable:
 
 %cont-doctest
 \begin{minted}{pycon}
->>> distribution = pssm.distribution(background=background, precision=10 ** 4)
+>>> distribution = pssm.distribution(background=background, precision=10**4)
 \end{minted}
 The \verb+distribution+ object can be used to determine a number of different thresholds.
 We can specify the requested false-positive rate (probability of ``finding'' a motif instance in background generated sequence):

--- a/Tests/test_Affy.py
+++ b/Tests/test_Affy.py
@@ -317,7 +317,7 @@ class AffyTest(unittest.TestCase):
         preHeadersOrder = ["magic", "version", "columns", "rows", "cellNo", "headerLen"]
         headersEncoded = struct.pack(
             "<" + "i" * len(preHeadersOrder),
-            *(preHeaders[header] for header in preHeadersOrder)
+            *(preHeaders[header] for header in preHeadersOrder),
         )
 
         def packData(intensity, sdev, pixel):

--- a/Tests/test_PDB_vectors.py
+++ b/Tests/test_PDB_vectors.py
@@ -78,10 +78,10 @@ class VectorTests(unittest.TestCase):
         self.assertTrue(numpy.array_equal(v1.get_array() / 2, numpy.array([0, 0, 0.5])))
         self.assertEqual(v1 * v2, 0.0)
         self.assertTrue(
-            numpy.array_equal((v1 ** v2).get_array(), numpy.array([0.0, -0.0, 0.0]))
+            numpy.array_equal((v1**v2).get_array(), numpy.array([0.0, -0.0, 0.0]))
         )
         self.assertTrue(
-            numpy.array_equal((v1 ** 2).get_array(), numpy.array([0.0, 0.0, 2.0]))
+            numpy.array_equal((v1**2).get_array(), numpy.array([0.0, 0.0, 2.0]))
         )
         self.assertTrue(
             numpy.array_equal(


### PR DESCRIPTION
Black is finally out of beta, and aims to make no non-bug fixing releases during each year of releases.

Main change is to simple power expressions, e.g.

```
>>> pssm.distribution(background=background, precision=10 ** 4)
```

becomes:

```
>>> pssm.distribution(background=background, precision=10**4)
```

Also standardises string prefixes (e.g raw bytes), and there are some tweaks to multi-line expressions.

I have used the "black --target-version py37 ..." form, but it does not seem to make any difference over the default.

Note also had to update to blacken-docs v1.12.1

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3851.

