### PR TITLE
pairwise2: Convert substitution_matrices_Array to dict in dictionary_match

### DIFF
--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -273,6 +273,7 @@ from collections import namedtuple
 
 from Bio import BiopythonWarning
 from Bio import BiopythonDeprecationWarning
+from Bio.Align import substitution_matrices
 
 warnings.warn(
     "Bio.pairwise2 has been deprecated, and we intend to remove it in a "
@@ -1282,6 +1283,8 @@ class dictionary_match:
 
     def __init__(self, score_dict, symmetric=1):
         """Initialize the class."""
+        if isinstance(score_dict, substitution_matrices.Array):
+            score_dict = dict(score_dict)  # Access to dict is much faster
         self.score_dict = score_dict
         self.symmetric = symmetric
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

The access to substitution matrices via `Bio.Align.substitution_matrices` is (much) slower than access via the now removed `Bio.SubsMat`. `pairwise2` suffers much from this change: Alignments using substitution matrices have become much slower now. This has already been reported twice: #3807, #3862

Although we are deprecating `pairwise2` with this release, the fix to this is simple (just convert a possible `Bio.Align.substitution_matrices.Array` to a regular `dict`) and should be included, since  `pairwise2` still seems to be quite popular.

Closes #3807, #3862 (both are already closed).
