### PR TITLE
Unfold should keep order

### DIFF
--- a/Bio/PDB/Selection.py
+++ b/Bio/PDB/Selection.py
@@ -74,7 +74,7 @@ def unfold_entities(entity_list, target_level):
     else:  # we're going up, e.g. A->S
         for i in range(level_index, target_index):
             # find unique parents
-            entity_list = {entity.get_parent() for entity in entity_list}
+            entity_list = dict.fromkeys([entity.get_parent() for entity in entity_list])
     return list(entity_list)
 
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -258,6 +258,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Ryan Stecher <https://github.com/rystecher>
 - Sacha Laurent <https://github.com/Cashalow>
 - Saket Choudhary <https://github.com/saketkc>
+- Sean Aubin <https://github.com/seanny123>
 - Sean Davis <https://github.com/seandavi>
 - Sebastian Bassi <https://about.me/bassi>
 - Sergei Lebedev <https://github.com/superbobry>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -50,6 +50,7 @@ possible, especially the following contributors:
 - Neil P. (first contribution)
 - Peter Cock
 - Sebastian Bassi
+- Sean Aubin
 - Tim Burke
 
 3 June 2021: Biopython 1.79


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

When unfolding Entities, duplicate parents have to be removed. Previously, this was accomplished by using a `set` comprehension, but this would destroy insertion order. Using `dict.from_keys()` preserves insertion order. 

Can add tests to replicate this specific error if desired.