### PR TITLE
SeqFeature: Implement equality object method (closes #3874)

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -285,6 +285,15 @@ class SeqFeature:
         doc="Location operator for compound locations (e.g. join).",
     )
 
+    def __eq__(self, other):
+        """Check if two SeqFeature objects should be considered equal."""
+        return (
+            self.id == other.id
+            and self.type == other.type
+            and self.location == other.location
+            and self.qualifiers == other.qualifiers
+        )
+
     def __repr__(self):
         """Represent the feature as a string for debugging."""
         answer = f"{self.__class__.__name__}({self.location!r}"

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -7,6 +7,7 @@
 """Tests Bio.SeqFeature."""
 import unittest
 
+from copy import deepcopy
 from os import path
 
 from Bio import Seq
@@ -171,6 +172,17 @@ class TestCompoundLocation(unittest.TestCase):
 
 class TestSeqFeature(unittest.TestCase):
     """Tests for the SeqFeature.SeqFeature class."""
+
+    def test_eq_identical(self):
+        f1 = SeqFeature(
+            type="CDS",
+            location=FeatureLocation(0, 182, 1),
+            qualifiers={
+                "product": ["interferon beta, fibroblast"],
+            },
+        )
+        f2 = deepcopy(f1)
+        self.assertEqual(f1, f2)
 
     def test_translation_checks_cds(self):
         """Test that a CDS feature is subject to respective checks."""


### PR DESCRIPTION


<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3874
Without `__eq__`, testing equality falls back to `is` identity,
so `==` will report `False` for deepcopies. Since the underlying objects
have `__eq__`  implemented, we can easily add it for SeqFeature as
a whole now.