### PR TITLE
possible fix for #3746

### DIFF
--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -269,7 +269,7 @@ def _pos(pos_str, offset=0):
         return SeqFeature.ExactPosition(int(pos_str) + offset)
 
 
-def _loc(loc_str, expected_seq_length, strand, seq_type=None):
+def _loc(loc_str, expected_seq_length, strand, seq_is_circular=False):
     """Make FeatureLocation from non-compound non-complement location (PRIVATE).
 
     This is also invoked to 'automatically' fix ambiguous formatting of features
@@ -348,7 +348,7 @@ def _loc(loc_str, expected_seq_length, strand, seq_type=None):
     s_pos = _pos(s, -1)
     e_pos = _pos(e)
     if int(s_pos) > int(e_pos):
-        if seq_type is None or "circular" not in seq_type.lower():
+        if not seq_is_circular:
             warnings.warn(
                 "It appears that %r is a feature that spans "
                 "the origin, but the sequence topology is "
@@ -1099,6 +1099,12 @@ class _FeatureConsumer(_BaseGenBankConsumer):
 
         cur_feature = self._cur_feature
 
+        # Check if the sequence is circular for features that span the origin
+        seq_is_circular = (
+            "topology" in self.data.annotations
+            and self.data.annotations["topology"] == "circular"
+        )
+
         # Handle top level complement here for speed
         if location_line.startswith("complement("):
             assert location_line.endswith(")")
@@ -1125,7 +1131,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                     location_line,
                     self._expected_size,
                     strand,
-                    seq_type=self._seq_type.lower(),
+                    seq_is_circular=seq_is_circular,
                 )
             return
 
@@ -1196,7 +1202,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                 location_line,
                 self._expected_size,
                 strand,
-                seq_type=self._seq_type.lower(),
+                seq_is_circular=seq_is_circular,
             )
             return
 
@@ -1222,7 +1228,7 @@ class _FeatureConsumer(_BaseGenBankConsumer):
                         part,
                         self._expected_size,
                         part_strand,
-                        seq_type=self._seq_type.lower(),
+                        seq_is_circular=seq_is_circular,
                     ).parts
 
                 except ValueError:

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -197,6 +197,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Lewis A. Marshall <https://github.com/lewisamarshall>
 - Lucas Sinclair <https://github.com/xapple>
 - Lukasz Walejko <https://github.com/lwalejko>
+- Manuel Lera Ramirez <https://github.com/manulera>
 - Manuel Nuno Melo <https://github.com/mnmelo>
 - Marc Colosimo <mcolosimo at domain mitre.org>
 - Marcin Magnus <https://github.com/mmagnus>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -46,6 +46,7 @@ possible, especially the following contributors:
 - Damien Goutte-Gattat
 - Erik  Whiting
 - Fabian Egli
+- Manuel Lera Ramirez
 - Markus Piotrowski
 - Michiel de Hoon
 - Neil P. (first contribution)

--- a/Tests/GenBank/addgene-plasmid-11664-sequence-180430.gbk
+++ b/Tests/GenBank/addgene-plasmid-11664-sequence-180430.gbk
@@ -1,0 +1,322 @@
+LOCUS       Exported                8596 bp ds-DNA     linear   SYN 18-MAY-2021
+DEFINITION  3rd generation lentiviral transfer vector. pPRIME cloning plasmid 
+            with a CMV promoter controlling expression of dsRed and miR30-based 
+            shRNA targeting firefly luciferase.
+ACCESSION   .
+VERSION     .
+KEYWORDS    pPRIME-CMV-dsRed-FF3
+SOURCE      synthetic DNA construct
+  ORGANISM  synthetic DNA construct
+REFERENCE   1  (bases 1 to 8596)
+  AUTHORS   Stegmeier F, Hu G, Rickles RJ, Hannon GJ, Elledge SJ
+  TITLE     A lentiviral microRNA-based system for single-copy polymerase 
+            II-regulated RNA interference in mammalian cells.
+  JOURNAL   Proc Natl Acad Sci U S A. 2005 Sep 13. 102(37):13212-7.
+  PUBMED    16141338
+REFERENCE   2  (bases 1 to 8596)
+  AUTHORS   .
+  TITLE     Direct Submission
+  JOURNAL   Exported May 18, 2021 from SnapGene Server 1.1.58
+            http://www.snapgene.com
+FEATURES             Location/Qualifiers
+     source          1..8596
+                     /organism="synthetic DNA construct"
+                     /mol_type="other DNA"
+     promoter        277..480
+                     /label=CMV promoter
+                     /note="human cytomegalovirus (CMV) immediate early 
+                     promoter"
+     CDS             526..1203
+                     /codon_start=1
+                     /product="rapidly maturing tetrameric variant of DsRed 
+                     fluorescent protein (Bevis and Glick, 2002)"
+                     /label=DsRed-Express
+                     /note="mammalian codon-optimized"
+                     /translation="MDSSEDVIKEFMRFKVRMEGSVNGHEFEIEGEGEGRPYEGTQTAK
+                     LKVTKGGPLPFAWDILSPQFQYGSKVYVKHPADIPDYKKLSFPEGFKWERVMNFEDGGV
+                     VTVTQDSSLQDGSFIYKVKFIGVNFPSDGPVMQKKTMGWEASTERLYPRDGVLKGEIHK
+                     ALKLKDGGHYLVEFKSIYMAKKPVQLPGYYYVDSKLDITSHNEDYTIVEQYERAEGRHH
+                     LFL"
+     primer_bind     complement(656..674)
+                     /label=mCherry-R
+                     /note="mCherry, reverse primer"
+     primer_bind     complement(706..726)
+                     /label=DsRed1-N
+                     /note="DsRed1, reverse primer"
+     primer_bind     924..943
+                     /label=mCherry-F
+                     /note="mCherry, forward primer"
+     primer_bind     1118..1141
+                     /label=DsRed1-C
+                     /note="DsRed1, forward primer"
+     ncRNA           1253..1374
+                     /label=5' miR-30a
+                     /note="sequence upstream of the 71-nt precursor of the 
+                     human miR-30a microRNA (Zeng et al., 2002)"
+                     /ncRNA_class="miRNA"
+     ncRNA           1401..1415
+                     /label=miR-30a loop
+                     /note="loop from the the 71-nt precursor of the human 
+                     miR-30a microRNA (Zeng et al., 2002)"
+                     /ncRNA_class="miRNA"
+     ncRNA           1443..1569
+                     /label=3' miR-30a
+                     /note="sequence downstream of the 71-nt precursor of the 
+                     human miR-30a microRNA (Zeng et al., 2002)"
+                     /ncRNA_class="miRNA"
+     promoter        1723..1825
+                     /label=cat promoter
+                     /note="promoter of the E. coli cat gene encoding 
+                     chloramphenicol acetyltransferase"
+     CDS             1826..2485
+                     /codon_start=1
+                     /gene="cat"
+                     /product="chloramphenicol acetyltransferase"
+                     /label=CmR
+                     /note="confers resistance to chloramphenicol"
+                     /translation="MEKKITGYTTVDISQWHRKEHFEAFQSVAQCTYNQTVQLDITAFL
+                     KTVKKNKHKFYPAFIHILARLMNAHPELRMAMKDGELVIWDSVHPCYTVFHEQTETFSS
+                     LWSEYHDDFRQFLHIYSQDVACYGENLAYFPKGFIENMFFVSANPWVSFTSFDLNVANM
+                     DNFFAPVFTMGKYYTQGDKVLMPLAIQVHHAVCDGFHVGRMLNELQQYCDEWQGGA"
+     primer_bind     complement(1892..1911)
+                     /label=CAT-R
+                     /note="Chloramphenicol resistance gene, reverse primer"
+     CDS             2615..2644
+                     /codon_start=1
+                     /product="Myc (human c-Myc proto-oncogene) epitope tag"
+                     /label=Myc
+                     /translation="EQKLISEEDL"
+     primer_bind     2669..2685
+                     /label=KS primer
+                     /note="common sequencing primer, one of multiple similar 
+                     variants"
+     misc_feature    2760..3348
+                     /label=WPRE
+                     /note="woodchuck hepatitis virus posttranscriptional 
+                     regulatory element"
+     primer_bind     complement(2813..2833)
+                     /label=WPRE-R
+                     /note="WPRE, reverse primer"
+     CDS             complement(3231..3242)
+                     /codon_start=1
+                     /product="Factor Xa recognition and cleavage site"
+                     /label=Factor Xa site
+                     /translation="IEGR"
+     primer_bind     complement(3351..3367)
+                     /label=KS primer
+                     /note="common sequencing primer, one of multiple similar 
+                     variants"
+     LTR             3877..4057
+                     /label=5' LTR (truncated)
+                     /note="truncated 5' long terminal repeat (LTR) from HIV-1"
+     rep_origin      complement(4119..4707)
+                     /direction=LEFT
+                     /label=ori
+                     /note="high-copy-number ColE1/pMB1/pBR322/pUC origin of 
+                     replication"
+     primer_bind     complement(4199..4218)
+                     /label=pBR322ori-F
+                     /note="pBR322 origin, forward primer"
+     CDS             complement(4878..5738)
+                     /codon_start=1
+                     /gene="bla"
+                     /product="beta-lactamase"
+                     /label=AmpR
+                     /note="confers resistance to ampicillin, carbenicillin, and
+                     related antibiotics"
+                     /translation="MSIQHFRVALIPFFAAFCLPVFAHPETLVKVKDAEDQLGARVGYI
+                     ELDLNSGKILESFRPEERFPMMSTFKVLLCGAVLSRIDAGQEQLGRRIHYSQNDLVEYS
+                     PVTEKHLTDGMTVRELCSAAITMSDNTAANLLLTTIGGPKELTAFLHNMGDHVTRLDRW
+                     EPELNEAIPNDERDTTMPVAMATTLRKLLTGELLTLASRQQLIDWMEADKVAGPLLRSA
+                     LPAGWFIADKSGAGERGSRGIIAALGPDGKPSRIVVIYTTGSQATMDERNRQIAEIGAS
+                     LIKHW"
+     primer_bind     5501..5520
+                     /label=Amp-R
+                     /note="Ampicillin resistance gene, reverse primer"
+     promoter        complement(5739..5843)
+                     /gene="bla"
+                     /label=AmpR promoter
+     primer_bind     complement(5918..5937)
+                     /label=pRS-marker
+                     /note="pRS vectors, use to sequence yeast selectable 
+                     marker"
+     enhancer        6109..6488
+                     /label=CMV enhancer
+                     /note="human cytomegalovirus immediate early enhancer"
+     promoter        6490..6688
+                     /label=CMV promoter
+                     /note="human cytomegalovirus (CMV) immediate early 
+                     promoter"
+     LTR             6706..6886
+                     /label=5' LTR (truncated)
+                     /note="truncated 5' long terminal repeat (LTR) from HIV-1"
+     misc_feature    6933..7058
+                     /label=HIV-1 Psi
+                     /note="packaging signal of human immunodeficiency virus 
+                     type 1"
+     misc_feature    7555..7788
+                     /label=RRE
+                     /note="The Rev response element (RRE) of HIV-1 allows for 
+                     Rev-dependent mRNA export from the nucleus to the 
+                     cytoplasm."
+     CDS             7973..8017
+                     /codon_start=1
+                     /product="antigenic peptide corresponding to amino acids 
+                     655 to 669 of the HIV envelope protein gp41 (Lutje Hulsik 
+                     et al., 2013)"
+                     /label=gp41 peptide
+                     /note="recognized by the 2H10 single-chain llama nanobody"
+                     /translation="KNEQELLELDKWASL"
+     misc_feature    8315..8432
+                     /label=cPPT/CTS
+                     /note="central polypurine tract and central termination 
+                     sequence of HIV-1"
+     enhancer        8569..276
+                     /label=CMV enhancer
+                     /note="human cytomegalovirus immediate early enhancer"
+ORIGIN
+        1 cctggctgac cgcccaacga cccccgccca ttgacgtcaa taatgacgta tgttcccata
+       61 gtaacgccaa tagggacttt ccattgacgt caatgggtgg agtatttacg gtaaactacc
+      121 cacttggcag tacatcaagt gtatcatatg ccaagtacgc cccctattga cgtcaatgac
+      181 ggtaaatggc ccgcctggca ttatgcccag tacatgacct tatgggactt tcctacttgg
+      241 cagtacatct acgtattagt catcgctatt accatggtga tgcggttttg gcagtacatc
+      301 aatgggcgtg gatagcggtt tgactcacgg ggatttccaa gtctccaccc cattgacgtc
+      361 aatgggagtt tgttttggca ccaaaatcaa cgggactttc caaaatgtcg taacaactcc
+      421 gccccattga cgcaaatggg cggtaggcgt gtacggtggg aggtctatat aagcagagct
+      481 ggtttagtga accgtcagat ccgctagcgc taccgggcct gcaggatgga ctcctccgag
+      541 gacgtcatca aggagttcat gcgcttcaag gtgcgcatgg agggctccgt gaacggccac
+      601 gagttcgaga tcgagggcga gggcgagggc cgcccctacg agggcaccca gaccgccaag
+      661 ctgaaggtga ccaagggcgg ccccctgccc ttcgcctggg acatcctgtc cccccagttc
+      721 cagtacggct ccaaggtgta cgtgaagcac cccgccgaca tccccgacta caagaagctg
+      781 tccttccccg agggcttcaa gtgggagcgc gtgatgaact tcgaggacgg cggcgtggtg
+      841 accgtgaccc aggactcctc cctgcaggac ggctccttca tctacaaggt gaagttcatc
+      901 ggcgtgaact tcccctccga cggccccgta atgcagaaga agactatggg ctgggaggcc
+      961 tccaccgagc gcctgtaccc ccgcgacggc gtgctgaagg gcgagatcca caaggccctg
+     1021 aagctgaagg acggcggcca ctacctggtg gagttcaagt ccatctacat ggccaagaag
+     1081 cccgtgcagc tgcccggcta ctactacgtg gactccaagc tggacatcac ctcccacaac
+     1141 gaggactaca ccatcgtgga gcagtacgag cgcgccgagg gccgccacca cctgttcctg
+     1201 taggcggccg caagccttgt taagtgctcg cttcggcagc acatatacta tgttgaatga
+     1261 ggcttcagta ctttacagaa tcgttgcctg cacatcttgg aaacacttgc tgggattact
+     1321 tcttcaggtt aacccaacag aaggctcgag aaggtatatt gctgttgaca gtgagcgagc
+     1381 tcccgtgaat tggaatccta gtgaagccac agatgtagga ttccaattca gcgggagcct
+     1441 gcctactgcc tcggaattca aggggctact ttaggagcaa ttatcttgtt tactaaaact
+     1501 gaataccttg ctatctcttt gatacatttt tacaaagctg aattaaaatg gtataaatta
+     1561 aatcactttt ttcaattgga agactaatgc gtttaaacac gcggcgacgc gttcgaccga
+     1621 ataaatacct gtgacggaag atcacttcgc agaataaata aatcctggtg tccctgttga
+     1681 taccgggaag ccctgggcca acttttggcg aaaatgagac gttgatcggc acgtaagagg
+     1741 ttccaacttt caccataatg aaataagatc actaccgggc gtattttttg agttgtcgag
+     1801 attttcagga gctaaggaag ctaaaatgga gaaaaaaatc actggatata ccaccgttga
+     1861 tatatcccaa tggcatcgta aagaacattt tgaggcattt cagtcagttg ctcaatgtac
+     1921 ctataaccag accgttcagc tggatattac ggccttttta aagaccgtaa agaaaaataa
+     1981 gcacaagttt tatccggcct ttattcacat tcttgcccgc ctgatgaatg ctcatccgga
+     2041 attacgtatg gcaatgaaag acggtgagct ggtgatatgg gatagtgttc acccttgtta
+     2101 caccgttttc catgagcaaa ctgaaacgtt ttcatcgctc tggagtgaat accacgacga
+     2161 tttccggcag tttctacaca tatattcgca agatgtggcg tgttacggtg aaaacctggc
+     2221 ctatttccct aaagggttta ttgagaatat gtttttcgtc tcagccaatc cctgggtgag
+     2281 tttcaccagt tttgatttaa acgtggccaa tatggacaac ttcttcgccc ccgttttcac
+     2341 catgggcaaa tattatacgc aaggcgacaa ggtgctgatg ccgctggcga ttcaggttca
+     2401 tcatgccgtt tgtgatggct tccatgtcgg cagaatgctt aatgaattac aacagtactg
+     2461 cgatgagtgg cagggcgggg cgtaattttt ttaaggcagt tattggtgcc cttaaacgcc
+     2521 tggttgctac gcctgaataa gtgataataa gcggatgaat ggcagaaatt cggatctcgc
+     2581 gcgtttgggc ggtggctccc tgccacgcgg ctccgaacag aagctgatct ccgaagagga
+     2641 tctgacatgt gtttaaactt aattaagtcg aggtcgacgg tatcgataag ctcgcttcac
+     2701 gagatcatgt ttaagggttc cggttccact aggtacaatt cgatatcaag cttatcgata
+     2761 atcaacctct ggattacaaa atttgtgaaa gattgactgg tattcttaac tatgttgctc
+     2821 cttttacgct atgtggatac gctgctttaa tgcctttgta tcatgctatt gcttcccgta
+     2881 tggctttcat tttctcctcc ttgtataaat cctggttgct gtctctttat gaggagttgt
+     2941 ggcccgttgt caggcaacgt ggcgtggtgt gcactgtgtt tgctgacgca acccccactg
+     3001 gttggggcat tgccaccacc tgtcagctcc tttccgggac tttcgctttc cccctcccta
+     3061 ttgccacggc ggaactcatc gccgcctgcc ttgcccgctg ctggacaggg gctcggctgt
+     3121 tgggcactga caattccgtg gtgttgtcgg ggaaatcatc gtcctttcct tggctgctcg
+     3181 cctgtgttgc cacctggatt ctgcgcggga cgtccttctg ctacgtccct tcggccctca
+     3241 atccagcgga ccttccttcc cgcggcctgc tgccggctct gcggcctctt ccgcgtcttc
+     3301 gccttcgccc tcagacgagt cggatctccc tttgggccgc ctccccgcat cgataccgtc
+     3361 gacctcgatc gagacctaga aaaacatgga gcaatcacaa gtagcaatac agcagctacc
+     3421 aatgctgatt gtgcctggct agaagcacaa gaggaggagg aggtgggttt tccagtcaca
+     3481 cctcaggtac ctttaagacc aatgacttac aaggcagctg tagatcttag ccacttttta
+     3541 aaagaaaagg ggggactgga agggctaatt cactcccaac gaagacaaga tatccttgat
+     3601 ctgtggatct accacacaca aggctacttc cctgattggc agaactacac accagggcca
+     3661 gggatcagat atccactgac ctttggatgg tgctacaagc tagtaccagt tgagcaagag
+     3721 aaggtagaag aagccaatga aggagagaac acccgcttgt tacaccctgt gagcctgcat
+     3781 gggatggatg acccggagag agaagtatta gagtggaggt ttgacagccg cctagcattt
+     3841 catcacatgg cccgagagct gcatccggac tgtactgggt ctctctggtt agaccagatc
+     3901 tgagcctggg agctctctgg ctaactaggg aacccactgc ttaagcctca ataaagcttg
+     3961 ccttgagtgc ttcaagtagt gtgtgcccgt ctgttgtgtg actctggtaa ctagagatcc
+     4021 ctcagaccct tttagtcagt gtggaaaatc tctagcagca tgtgagcaaa aggccagcaa
+     4081 aaggccagga accgtaaaaa ggccgcgttg ctggcgtttt tccataggct ccgcccccct
+     4141 gacgagcatc acaaaaatcg acgctcaagt cagaggtggc gaaacccgac aggactataa
+     4201 agataccagg cgtttccccc tggaagctcc ctcgtgcgct ctcctgttcc gaccctgccg
+     4261 cttaccggat acctgtccgc ctttctccct tcgggaagcg tggcgctttc tcatagctca
+     4321 cgctgtaggt atctcagttc ggtgtaggtc gttcgctcca agctgggctg tgtgcacgaa
+     4381 ccccccgttc agcccgaccg ctgcgcctta tccggtaact atcgtcttga gtccaacccg
+     4441 gtaagacacg acttatcgcc actggcagca gccactggta acaggattag cagagcgagg
+     4501 tatgtaggcg gtgctacaga gttcttgaag tggtggccta actacggcta cactagaaga
+     4561 acagtatttg gtatctgcgc tctgctgaag ccagttacct tcggaaaaag agttggtagc
+     4621 tcttgatccg gcaaacaaac caccgctggt agcggtggtt tttttgtttg caagcagcag
+     4681 attacgcgca gaaaaaaagg atctcaagaa gatcctttga tcttttctac ggggtctgac
+     4741 gctcagtgga acgaaaactc acgttaaggg attttggtca tgagattatc aaaaaggatc
+     4801 ttcacctaga tccttttaaa ttaaaaatga agttttaaat caatctaaag tatatatgag
+     4861 taaacttggt ctgacagtta ccaatgctta atcagtgagg cacctatctc agcgatctgt
+     4921 ctatttcgtt catccatagt tgcctgactc cccgtcgtgt agataactac gatacgggag
+     4981 ggcttaccat ctggccccag tgctgcaatg ataccgcgag acccacgctc accggctcca
+     5041 gatttatcag caataaacca gccagccgga agggccgagc gcagaagtgg tcctgcaact
+     5101 ttatccgcct ccatccagtc tattaattgt tgccgggaag ctagagtaag tagttcgcca
+     5161 gttaatagtt tgcgcaacgt tgttgccatt gctacaggca tcgtggtgtc acgctcgtcg
+     5221 tttggtatgg cttcattcag ctccggttcc caacgatcaa ggcgagttac atgatccccc
+     5281 atgttgtgca aaaaagcggt tagctccttc ggtcctccga tcgttgtcag aagtaagttg
+     5341 gccgcagtgt tatcactcat ggttatggca gcactgcata attctcttac tgtcatgcca
+     5401 tccgtaagat gcttttctgt gactggtgag tactcaacca agtcattctg agaatagtgt
+     5461 atgcggcgac cgagttgctc ttgcccggcg tcaatacggg ataataccgc gccacatagc
+     5521 agaactttaa aagtgctcat cattggaaaa cgttcttcgg ggcgaaaact ctcaaggatc
+     5581 ttaccgctgt tgagatccag ttcgatgtaa cccactcgtg cacccaactg atcttcagca
+     5641 tcttttactt tcaccagcgt ttctgggtga gcaaaaacag gaaggcaaaa tgccgcaaaa
+     5701 aagggaataa gggcgacacg gaaatgttga atactcatac tcttcctttt tcaatattat
+     5761 tgaagcattt atcagggtta ttgtctcatg agcggataca tatttgaatg tatttagaaa
+     5821 aataaacaaa taggggttcc gcgcacattt ccccgaaaag tgccacctga cgtcgacgga
+     5881 tcgggagatc tcccgatccc ctatggtgca ctctcagtac aatctgctct gatgccgcat
+     5941 agttaagcca gtatctgctc cctgcttgtg tgttggaggt cgctgagtag tgcgcgagca
+     6001 aaatttaagc tacaacaagg caaggcttga ccgacaattg catgaagaat ctgcttaggg
+     6061 ttaggcgttt tgcgctgctt cgcgatgtac gggccagata tacgcgttga cattgattat
+     6121 tgactagtta ttaatagtaa tcaattacgg ggtcattagt tcatagccca tatatggagt
+     6181 tccgcgttac ataacttacg gtaaatggcc cgcctggctg accgcccaac gacccccgcc
+     6241 cattgacgtc aataatgacg tatgttccca tagtaacgcc aatagggact ttccattgac
+     6301 gtcaatgggt ggagtattta cggtaaactg cccacttggc agtacatcaa gtgtatcata
+     6361 tgccaagtac gccccctatt gacgtcaatg acggtaaatg gcccgcctgg cattatgccc
+     6421 agtacatgac cttatgggac tttcctactt ggcagtacat ctacgtatta gtcatcgcta
+     6481 ttaccatggt gatgcggttt tggcagtaca tcaatgggcg tggatagcgg tttgactcac
+     6541 ggggatttcc aagtctccac cccattgacg tcaatgggag tttgttttgg caccaaaatc
+     6601 aacgggactt tccaaaatgt cgtaacaact ccgccccatt gacgcaaatg ggcggtaggc
+     6661 gtgtacggtg ggaggtctat ataagcagcg cgttttgcct gtactgggtc tctctggtta
+     6721 gaccagatct gagcctggga gctctctggc taactaggga acccactgct taagcctcaa
+     6781 taaagcttgc cttgagtgct tcaagtagtg tgtgcccgtc tgttgtgtga ctctggtaac
+     6841 tagagatccc tcagaccctt ttagtcagtg tggaaaatct ctagcagtgg cgcccgaaca
+     6901 gggacttgaa agcgaaaggg aaaccagagg agctctctcg acgcaggact cggcttgctg
+     6961 aagcgcgcac ggcaagaggc gaggggcggc gactggtgag tacgccaaaa attttgacta
+     7021 gcggaggcta gaaggagaga gatgggtgcg agagcgtcag tattaagcgg gggagaatta
+     7081 gatcgcgatg ggaaaaaatt cggttaaggc cagggggaaa gaaaaaatat aaattaaaac
+     7141 atatagtatg ggcaagcagg gagctagaac gattcgcagt taatcctggc ctgttagaaa
+     7201 catcagaagg ctgtagacaa atactgggac agctacaacc atcccttcag acaggatcag
+     7261 aagaacttag atcattatat aatacagtag caaccctcta ttgtgtgcat caaaggatag
+     7321 agataaaaga caccaaggaa gctttagaca agatagagga agagcaaaac aaaagtaaga
+     7381 ccaccgcaca gcaagcggcc ggccgctgat cttcagacct ggaggaggag atatgaggga
+     7441 caattggaga agtgaattat ataaatataa agtagtaaaa attgaaccat taggagtagc
+     7501 acccaccaag gcaaagagaa gagtggtgca gagagaaaaa agagcagtgg gaataggagc
+     7561 tttgttcctt gggttcttgg gagcagcagg aagcactatg ggcgcagcgt caatgacgct
+     7621 gacggtacag gccagacaat tattgtctgg tatagtgcag cagcagaaca atttgctgag
+     7681 ggctattgag gcgcaacagc atctgttgca actcacagtc tggggcatca agcagctcca
+     7741 ggcaagaatc ctggctgtgg aaagatacct aaaggatcaa cagctcctgg ggatttgggg
+     7801 ttgctctgga aaactcattt gcaccactgc tgtgccttgg aatgctagtt ggagtaataa
+     7861 atctctggaa cagatttgga atcacacgac ctggatggag tgggacagag aaattaacaa
+     7921 ttacacaagc ttaatacact ccttaattga agaatcgcaa aaccagcaag aaaagaatga
+     7981 acaagaatta ttggaattag ataaatgggc aagtttgtgg aattggttta acataacaaa
+     8041 ttggctgtgg tatataaaat tattcataat gatagtagga ggcttggtag gtttaagaat
+     8101 agtttttgct gtactttcta tagtgaatag agttaggcag ggatattcac cattatcgtt
+     8161 tcagacccac ctcccaaccc cgaggggacc cgacaggccc gaaggaatag aagaagaagg
+     8221 tggagagaga gacagagaca gatccattcg attagtgaac ggatcggcac tgcgtgcgcc
+     8281 aattctgcag acaaatggca gtattcatcc acaattttaa aagaaaaggg gggattgggg
+     8341 ggtacagtgc aggggaaaga atagtagaca taatagcaac agacatacaa actaaagaat
+     8401 tacaaaaaca aattacaaaa attcaaaatt ttcgggttta ttacagggac agcagagatc
+     8461 cagtttggtt agtaccgggc ccgctctaga cgtattaccg ccatgcatta gttattaata
+     8521 gtaatcaatt acggggtcat tagttcatag cccatatatg gagttccgcg ttacataact
+     8581 tacggtaaat ggcccg
+//

--- a/Tests/GenBank/addgene-plasmid-39296-sequence-49545.gbk
+++ b/Tests/GenBank/addgene-plasmid-39296-sequence-49545.gbk
@@ -1,0 +1,168 @@
+LOCUS       pFA6a-kanMX6                3938 bp ds-DNA     circular SYN 12-MAY-2021
+DEFINITION  synthetic circular DNA
+ACCESSION   .
+VERSION     .
+KEYWORDS    pFA6a-kanMX6
+SOURCE      synthetic DNA construct
+  ORGANISM  synthetic DNA construct
+REFERENCE   1  (bases 1 to 3938)
+  AUTHORS   Bahler J, Wu JQ, Longtine MS, Shah NG, McKenzie A 3rd, Steever AB, 
+            Wach A, Philippsen P, Pringle JR
+  TITLE     Heterologous modules for efficient and versatile PCR-based gene 
+            targeting in Schizosaccharomyces pombe.
+  JOURNAL   Yeast. 1998 Jul;14(10):943-51.
+  PUBMED    9717240
+REFERENCE   2  (bases 1 to 3938)
+  AUTHORS   .
+  TITLE     Direct Submission
+  JOURNAL   Exported May 12, 2021 from SnapGene Server 1.1.58
+            http://www.snapgene.com
+FEATURES             Location/Qualifiers
+     source          1..3938
+                     /organism="synthetic DNA construct"
+                     /mol_type="other DNA"
+     gene            115..1471
+                     /label=kanMX
+                     /note="yeast selectable marker conferring kanamycin 
+                     resistance (Wach et al., 1994)"
+     promoter        115..458
+                     /label=TEF promoter
+                     /note="Ashbya gossypii TEF promoter"
+     CDS             459..1268
+                     /codon_start=1
+                     /gene="aph(3')-Ia"
+                     /product="aminoglycoside phosphotransferase"
+                     /label=KanR
+                     /note="confers resistance to kanamycin"
+                     /translation="MGKEKTHVSRPRLNSNMDADLYGYKWARDNVGQSGATIYRLYGKP
+                     DAPELFLKHGKGSVANDVTDEMVRLNWLTEFMPLPTIKHFIRTPDDAWLLTTAIPGKTA
+                     FQVLEEYPDSGENIVDALAVFLRRLHSIPVCNCPFNSDRVFRLAQAQSRMNNGLVDASD
+                     FDDERNGWPVEQVWKEMHKLLPFSPDSVVTHGDFSLDNLIFDEGKLIGCIDVGRVGIAD
+                     RYQDLAILWNCLGEFSPSLQKRLFQKYGIDNPDMNKLQFHLMLDEFF"
+     primer_bind     complement(526..545)
+                     /label=Kan-R
+                     /note="Kanamycin resistance gene, reverse primer"
+     terminator      1274..1471
+                     /label=TEF terminator
+                     /note="Ashbya gossypii TEF terminator"
+     primer_bind     complement(1575..1594)
+                     /label=T7
+                     /note="T7 promoter, forward primer"
+     promoter        complement(1576..1594)
+                     /label=T7 promoter
+                     /note="promoter for bacteriophage T7 RNA polymerase"
+     primer_bind     complement(1681..1698)
+                     /label=L4440
+                     /note="L4440 vector, forward primer"
+     rep_origin      complement(1852..2440)
+                     /direction=LEFT
+                     /label=ori
+                     /note="high-copy-number ColE1/pMB1/pBR322/pUC origin of 
+                     replication"
+     primer_bind     complement(1932..1951)
+                     /label=pBR322ori-F
+                     /note="pBR322 origin, forward primer"
+     CDS             complement(2611..3471)
+                     /codon_start=1
+                     /gene="bla"
+                     /product="beta-lactamase"
+                     /label=AmpR
+                     /note="confers resistance to ampicillin, carbenicillin, and
+                     related antibiotics"
+                     /translation="MSIQHFRVALIPFFAAFCLPVFAHPETLVKVKDAEDQLGARVGYI
+                     ELDLNSGKILESFRPEERFPMMSTFKVLLCGAVLSRIDAGQEQLGRRIHYSQNDLVEYS
+                     PVTEKHLTDGMTVRELCSAAITMSDNTAANLLLTTIGGPKELTAFLHNMGDHVTRLDRW
+                     EPELNEAIPNDERDTTMPVAMATTLRKLLTGELLTLASRQQLIDWMEADKVAGPLLRSA
+                     LPAGWFIADKSGAGERGSRGIIAALGPDGKPSRIVVIYTTGSQATMDERNRQIAEIGAS
+                     LIKHW"
+     primer_bind     3234..3253
+                     /label=Amp-R
+                     /note="Ampicillin resistance gene, reverse primer"
+     promoter        complement(3472..3576)
+                     /gene="bla"
+                     /label=AmpR promoter
+     primer_bind     3644..3662
+                     /label=pBRforEco
+                     /note="pBR322 vectors, upsteam of EcoRI site, forward 
+                     primer"
+     primer_bind     complement(3700..3722)
+                     /label=pGEX 3'
+                     /note="pGEX vectors, reverse primer"
+     primer_bind     3822..3841
+                     /label=pRS-marker
+                     /note="pRS vectors, use to sequence yeast selectable 
+                     marker"
+     promoter        3922..2
+                     /label=SP6 promoter
+                     /note="promoter for bacteriophage SP6 RNA polymerase"
+     primer_bind     3922..1
+                     /label=SP6
+                     /note="SP6 promoter, forward primer"
+ORIGIN
+        1 gaacgcggcc gccagctgaa gcttcgtacg ctgcaggtcg acggatcccc gggttaatta
+       61 aggcgcgcca gatctgttta gcttgcctcg tccccgccgg gtcacccggc cagcgacatg
+      121 gaggcccaga ataccctcct tgacagtctt gacgtgcgca gctcaggggc atgatgtgac
+      181 tgtcgcccgt acatttagcc catacatccc catgtataat catttgcatc catacatttt
+      241 gatggccgca cggcgcgaag caaaaattac ggctcctcgc tgcagacctg cgagcaggga
+      301 aacgctcccc tcacagacgc gttgaattgt ccccacgccg cgcccctgta gagaaatata
+      361 aaaggttagg atttgccact gaggttcttc tttcatatac ttccttttaa aatcttgcta
+      421 ggatacagtt ctcacatcac atccgaacat aaacaaccat gggtaaggaa aagactcacg
+      481 tttcgaggcc gcgattaaat tccaacatgg atgctgattt atatgggtat aaatgggctc
+      541 gcgataatgt cgggcaatca ggtgcgacaa tctatcgatt gtatgggaag cccgatgcgc
+      601 cagagttgtt tctgaaacat ggcaaaggta gcgttgccaa tgatgttaca gatgagatgg
+      661 tcagactaaa ctggctgacg gaatttatgc ctcttccgac catcaagcat tttatccgta
+      721 ctcctgatga tgcatggtta ctcaccactg cgatccccgg caaaacagca ttccaggtat
+      781 tagaagaata tcctgattca ggtgaaaata ttgttgatgc gctggcagtg ttcctgcgcc
+      841 ggttgcattc gattcctgtt tgtaattgtc cttttaacag cgatcgcgta tttcgtctcg
+      901 ctcaggcgca atcacgaatg aataacggtt tggttgatgc gagtgatttt gatgacgagc
+      961 gtaatggctg gcctgttgaa caagtctgga aagaaatgca taagcttttg ccattctcac
+     1021 cggattcagt cgtcactcat ggtgatttct cacttgataa ccttattttt gacgagggga
+     1081 aattaatagg ttgtattgat gttggacgag tcggaatcgc agaccgatac caggatcttg
+     1141 ccatcctatg gaactgcctc ggtgagtttt ctccttcatt acagaaacgg ctttttcaaa
+     1201 aatatggtat tgataatcct gatatgaata aattgcagtt tcatttgatg ctcgatgagt
+     1261 ttttctaatc agtactgaca ataaaaagat tcttgttttc aagaacttgt catttgtata
+     1321 gtttttttat attgtagttg ttctatttta atcaaatgtt agcgtgattt atattttttt
+     1381 tcgcctcgac atcatctgcc cagatgcgaa gttaagtgcg cagaaagtaa tatcatgcgt
+     1441 caatcgtatg tgaatgctgg tcgctatact gctgtcgatt cgatactaac gccgccatcc
+     1501 agtttaaacg agctcgaatt catcgatgat atcagatcca ctagtggcct atgcggccgc
+     1561 ggatctgccg gtctccctat agtgagtcgt attaatttcg ataagccagg ttaacctgca
+     1621 ttaatgaatc ggccaacgcg cggggagagg cggtttgcgt attgggcgct cttccgcttc
+     1681 ctcgctcact gactcgctgc gctcggtcgt tcggctgcgg cgagcggtat cagctcactc
+     1741 aaaggcggta atacggttat ccacagaatc aggggataac gcaggaaaga acatgtgagc
+     1801 aaaaggccag caaaaggcca ggaaccgtaa aaaggccgcg ttgctggcgt ttttccatag
+     1861 gctccgcccc cctgacgagc atcacaaaaa tcgacgctca agtcagaggt ggcgaaaccc
+     1921 gacaggacta taaagatacc aggcgtttcc ccctggaagc tccctcgtgc gctctcctgt
+     1981 tccgaccctg ccgcttaccg gatacctgtc cgcctttctc ccttcgggaa gcgtggcgct
+     2041 ttctcaatgc tcacgctgta ggtatctcag ttcggtgtag gtcgttcgct ccaagctggg
+     2101 ctgtgtgcac gaaccccccg ttcagcccga ccgctgcgcc ttatccggta actatcgtct
+     2161 tgagtccaac ccggtaagac acgacttatc gccactggca gcagccactg gtaacaggat
+     2221 tagcagagcg aggtatgtag gcggtgctac agagttcttg aagtggtggc ctaactacgg
+     2281 ctacactaga aggacagtat ttggtatctg cgctctgctg aagccagtta ccttcggaaa
+     2341 aagagttggt agctcttgat ccggcaaaca aaccaccgct ggtagcggtg gtttttttgt
+     2401 ttgcaagcag cagattacgc gcagaaaaaa aggatctcaa gaagatcctt tgatcttttc
+     2461 tacggggtct gacgctcagt ggaacgaaaa ctcacgttaa gggattttgg tcatgagatt
+     2521 atcaaaaagg atcttcacct agatcctttt aaattaaaaa tgaagtttta aatcaatcta
+     2581 aagtatatat gagtaaactt ggtctgacag ttaccaatgc ttaatcagtg aggcacctat
+     2641 ctcagcgatc tgtctatttc gttcatccat agttgcctga ctccccgtcg tgtagataac
+     2701 tacgatacgg gagggcttac catctggccc cagtgctgca atgataccgc gagacccacg
+     2761 ctcaccggct ccagatttat cagcaataaa ccagccagcc ggaagggccg agcgcagaag
+     2821 tggtcctgca actttatccg cctccatcca gtctattaat tgttgccggg aagctagagt
+     2881 aagtagttcg ccagttaata gtttgcgcaa cgttgttgcc attgctacag gcatcgtggt
+     2941 gtcacgctcg tcgtttggta tggcttcatt cagctccggt tcccaacgat caaggcgagt
+     3001 tacatgatcc cccatgttgt gcaaaaaagc ggttagctcc ttcggtcctc cgatcgttgt
+     3061 cagaagtaag ttggccgcag tgttatcact catggttatg gcagcactgc ataattctct
+     3121 tactgtcatg ccatccgtaa gatgcttttc tgtgactggt gagtactcaa ccaagtcatt
+     3181 ctgagaatag tgtatgcggc gaccgagttg ctcttgcccg gcgtcaatac gggataatac
+     3241 cgcgccacat agcagaactt taaaagtgct catcattgga aaacgttctt cggggcgaaa
+     3301 actctcaagg atcttaccgc tgttgagatc cagttcgatg taacccactc gtgcacccaa
+     3361 ctgatcttca gcatctttta ctttcaccag cgtttctggg tgagcaaaaa caggaaggca
+     3421 aaatgccgca aaaaagggaa taagggcgac acggaaatgt tgaatactca tactcttcct
+     3481 ttttcaatat tattgaagca tttatcaggg ttattgtctc atgagcggat acatatttga
+     3541 atgtatttag aaaaataaac aaataggggt tccgcgcaca tttccccgaa aagtgccacc
+     3601 tgacgtctaa gaaaccatta ttatcatgac attaacctat aaaaataggc gtatcacgag
+     3661 gccctttcgt ctcgcgcgtt tcggtgatga cggtgaaaac ctctgacaca tgcagctccc
+     3721 ggagacggtc acagcttgtc tgtaagcgga tgccgggagc agacaagccc gtcagggcgc
+     3781 gtcagcgggt gttggcgggt gtcggggctg gcttaactat gcggcatcag agcagattgt
+     3841 actgagagtg caccatatgg acatattgtc gttagaacgc ggctacaatt aatacataac
+     3901 cttatgtatc atacacatac gatttaggtg acactata
+//


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3746

I encountered the same problem described by @jakebeal. Instead of passing the `seq_type` to the function `_loc`, one could pass a boolean indicating whether the sequence is circular. This can accessed from `self.data.annotations["topology"]`. This is correctly set for the two examples that I provided for the test:

* One was mentioned in #3746 by @starling13 and should return an error: trying to set an origin-spanning feature in a linear molecule.
* The other one is AddGene plasmid [39296](https://www.addgene.org/39296/) , a plasmid commonly used in many labs that gave the problem described by @jakebeal.

This is one of my first times contributing to Open Source, so please let me know if I should do something else.
