### PR TITLE
Add experimental warnings to new alignment parsers

### DIFF
--- a/Bio/Align/bed.py
+++ b/Bio/Align/bed.py
@@ -32,6 +32,15 @@ from Bio.Align import Alignment
 from Bio.Align import interfaces
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+from Bio import BiopythonExperimentalWarning
+
+import warnings
+
+warnings.warn(
+    "Bio.Align.bed is an experimental module which may undergo "
+    "significant changes prior to its future official release.",
+    BiopythonExperimentalWarning,
+)
 
 
 class AlignmentWriter(interfaces.AlignmentWriter):

--- a/Bio/Align/clustal.py
+++ b/Bio/Align/clustal.py
@@ -14,6 +14,16 @@ from Bio.Align import Alignment
 from Bio.Align import interfaces
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+from Bio import BiopythonExperimentalWarning
+
+
+import warnings
+
+warnings.warn(
+    "Bio.Align.clustal is an experimental module which may undergo "
+    "significant changes prior to its future official release.",
+    BiopythonExperimentalWarning,
+)
 
 
 class AlignmentWriter(interfaces.AlignmentWriter):

--- a/Bio/Align/emboss.py
+++ b/Bio/Align/emboss.py
@@ -13,6 +13,16 @@ from Bio.Align import Alignment
 from Bio.Align import interfaces
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+from Bio import BiopythonExperimentalWarning
+
+
+import warnings
+
+warnings.warn(
+    "Bio.Align.emboss is an experimental module which may undergo "
+    "significant changes prior to its future official release.",
+    BiopythonExperimentalWarning,
+)
 
 
 class AlignmentIterator(interfaces.AlignmentIterator):

--- a/Bio/Align/fasta_m8.py
+++ b/Bio/Align/fasta_m8.py
@@ -16,6 +16,16 @@ from Bio.Align import Alignment
 from Bio.Align import interfaces
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+from Bio import BiopythonExperimentalWarning
+
+
+import warnings
+
+warnings.warn(
+    "Bio.Align.fasta_m8 is an experimental module which may undergo "
+    "significant changes prior to its future official release.",
+    BiopythonExperimentalWarning,
+)
 
 
 class State(enum.Enum):

--- a/Bio/Align/maf.py
+++ b/Bio/Align/maf.py
@@ -37,6 +37,16 @@ from Bio.Align import Alignment
 from Bio.Align import interfaces
 from Bio.Seq import Seq, reverse_complement
 from Bio.SeqRecord import SeqRecord
+from Bio import BiopythonExperimentalWarning
+
+
+import warnings
+
+warnings.warn(
+    "Bio.Align.maf is an experimental module which may undergo "
+    "significant changes prior to its future official release.",
+    BiopythonExperimentalWarning,
+)
 
 
 class AlignmentWriter(interfaces.AlignmentWriter):

--- a/Bio/Align/mauve.py
+++ b/Bio/Align/mauve.py
@@ -12,6 +12,16 @@ You are expected to use this module via the Bio.Align functions.
 from Bio.Align import interfaces, Alignment
 from Bio.Seq import Seq, reverse_complement
 from Bio.SeqRecord import SeqRecord
+from Bio import BiopythonExperimentalWarning
+
+
+import warnings
+
+warnings.warn(
+    "Bio.Align.mauve is an experimental module which may undergo "
+    "significant changes prior to its future official release.",
+    BiopythonExperimentalWarning,
+)
 
 
 class AlignmentWriter(interfaces.AlignmentWriter):

--- a/Bio/Align/msf.py
+++ b/Bio/Align/msf.py
@@ -20,6 +20,15 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
 from Bio import BiopythonParserWarning
+from Bio import BiopythonExperimentalWarning
+
+import warnings
+
+warnings.warn(
+    "Bio.Align.bed is an experimental module which may undergo "
+    "significant changes prior to its future official release.",
+    BiopythonExperimentalWarning,
+)
 
 
 class AlignmentIterator(interfaces.AlignmentIterator):

--- a/Bio/Align/msf.py
+++ b/Bio/Align/msf.py
@@ -13,7 +13,6 @@ output format.
 
 You are expected to use this module via the Bio.Align functions.
 """
-import warnings
 from Bio.Align import Alignment
 from Bio.Align import interfaces
 from Bio.Seq import Seq

--- a/Bio/Align/nexus.py
+++ b/Bio/Align/nexus.py
@@ -21,6 +21,15 @@ from Bio.Align import interfaces
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Nexus import Nexus
+from Bio import BiopythonExperimentalWarning
+
+import warnings
+
+warnings.warn(
+    "Bio.Align.nexus is an experimental module which may undergo "
+    "significant changes prior to its future official release.",
+    BiopythonExperimentalWarning,
+)
 
 
 class AlignmentWriter(interfaces.AlignmentWriter):

--- a/Bio/Align/phylip.py
+++ b/Bio/Align/phylip.py
@@ -12,6 +12,15 @@ from Bio.Align import Alignment
 from Bio.Align import interfaces
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+from Bio import BiopythonExperimentalWarning
+
+import warnings
+
+warnings.warn(
+    "Bio.Align.phylip is an experimental module which may undergo "
+    "significant changes prior to its future official release.",
+    BiopythonExperimentalWarning,
+)
 
 
 _PHYLIP_ID_WIDTH = 10

--- a/Bio/Align/psl.py
+++ b/Bio/Align/psl.py
@@ -33,6 +33,15 @@ from Bio.Align import Alignment
 from Bio.Align import interfaces
 from Bio.Seq import Seq, reverse_complement, UndefinedSequenceError
 from Bio.SeqRecord import SeqRecord
+from Bio import BiopythonExperimentalWarning
+
+import warnings
+
+warnings.warn(
+    "Bio.Align.psl is an experimental module which may undergo "
+    "significant changes prior to its future official release.",
+    BiopythonExperimentalWarning,
+)
 
 
 class AlignmentWriter(interfaces.AlignmentWriter):

--- a/Bio/Align/stockholm.py
+++ b/Bio/Align/stockholm.py
@@ -94,6 +94,15 @@ from Bio.Align import Alignment
 from Bio.Align import interfaces
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+from Bio import BiopythonExperimentalWarning
+
+import warnings
+
+warnings.warn(
+    "Bio.Align.stockholm is an experimental module which may undergo "
+    "significant changes prior to its future official release.",
+    BiopythonExperimentalWarning,
+)
 
 
 class AlignmentIterator(interfaces.AlignmentIterator):

--- a/Tests/test_Align_Alignment.py
+++ b/Tests/test_Align_Alignment.py
@@ -634,7 +634,12 @@ T  12.0  16.5   7.0 145.0
 
 class TestMultipleAlignment(unittest.TestCase):
     def setUp(self):
-        from Bio.Align import clustal
+        import warnings
+        from Bio import BiopythonExperimentalWarning
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", BiopythonExperimentalWarning)
+            from Bio.Align import clustal
 
         path = "Clustalw/opuntia.aln"
         with open(path) as stream:

--- a/Tests/test_Align_bed.py
+++ b/Tests/test_Align_bed.py
@@ -5,13 +5,19 @@
 """Tests for Align.bed module."""
 import unittest
 import os
+import warnings
 from io import StringIO
 
 
-from Bio.Align import Alignment, bed
+from Bio.Align import Alignment
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio import SeqIO
+from Bio import BiopythonExperimentalWarning
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonExperimentalWarning)
+    from Bio.Align import bed
 
 
 try:

--- a/Tests/test_Align_clustal.py
+++ b/Tests/test_Align_clustal.py
@@ -4,11 +4,16 @@
 # as part of this package.
 """Tests for Bio.Align.clustal module."""
 import unittest
+import warnings
 
 from io import StringIO
 
-from Bio.Align.clustal import AlignmentIterator
-from Bio.Align.clustal import AlignmentWriter
+from Bio import BiopythonExperimentalWarning
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonExperimentalWarning)
+    from Bio.Align.clustal import AlignmentIterator
+    from Bio.Align.clustal import AlignmentWriter
 
 
 class TestClustalReadingWriting(unittest.TestCase):

--- a/Tests/test_Align_emboss.py
+++ b/Tests/test_Align_emboss.py
@@ -5,10 +5,16 @@
 # as part of this package.
 """Tests for Bio.Align.emboss module."""
 import unittest
+import warnings
 
 from io import StringIO
 
-from Bio.Align.emboss import AlignmentIterator
+from Bio import BiopythonExperimentalWarning
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonExperimentalWarning)
+    from Bio.Align.emboss import AlignmentIterator
+
 
 try:
     import numpy

--- a/Tests/test_Align_fasta.py
+++ b/Tests/test_Align_fasta.py
@@ -5,11 +5,17 @@
 # as part of this package.
 """Tests for Bio.Align.fasta module."""
 import unittest
+import warnings
 import os
 
 from Bio.Seq import Seq
 from Bio import SeqIO
-from Bio.Align.fasta_m8 import AlignmentIterator
+from Bio import BiopythonExperimentalWarning
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonExperimentalWarning)
+    from Bio.Align.fasta_m8 import AlignmentIterator
+
 
 try:
     import numpy

--- a/Tests/test_Align_maf.py
+++ b/Tests/test_Align_maf.py
@@ -4,10 +4,15 @@
 # as part of this package.
 """Tests for Align.maf module."""
 import unittest
+import warnings
 from io import StringIO
 
 
-from Bio.Align import maf
+from Bio import BiopythonExperimentalWarning
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonExperimentalWarning)
+    from Bio.Align import maf
 
 
 try:

--- a/Tests/test_Align_mauve.py
+++ b/Tests/test_Align_mauve.py
@@ -6,12 +6,17 @@
 """Tests for Bio.Align.mauve module."""
 import os
 import unittest
+import warnings
 
 from io import StringIO
 
 from Bio.Seq import Seq, MutableSeq
 from Bio import SeqIO
-from Bio.Align.mauve import AlignmentIterator, AlignmentWriter
+from Bio import BiopythonExperimentalWarning
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonExperimentalWarning)
+    from Bio.Align.mauve import AlignmentIterator, AlignmentWriter
 
 
 try:

--- a/Tests/test_Align_msf.py
+++ b/Tests/test_Align_msf.py
@@ -9,7 +9,12 @@ import warnings
 
 
 from Bio import BiopythonParserWarning
-from Bio.Align.msf import AlignmentIterator
+from Bio import BiopythonExperimentalWarning
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonExperimentalWarning)
+    from Bio.Align.msf import AlignmentIterator
+
 
 try:
     import numpy

--- a/Tests/test_Align_nexus.py
+++ b/Tests/test_Align_nexus.py
@@ -5,9 +5,14 @@
 # as part of this package.
 """Tests for Bio.Align.nexus module."""
 import unittest
+import warnings
 from io import StringIO
 
-from Bio.Align.nexus import AlignmentIterator, AlignmentWriter
+from Bio import BiopythonExperimentalWarning
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonExperimentalWarning)
+    from Bio.Align.nexus import AlignmentIterator, AlignmentWriter
 
 try:
     import numpy

--- a/Tests/test_Align_phylip.py
+++ b/Tests/test_Align_phylip.py
@@ -5,11 +5,16 @@
 # as part of this package.
 """Tests for Bio.Align.phylip module."""
 import unittest
+import warnings
 
 from io import StringIO
 
-from Bio.Align.phylip import AlignmentIterator
-from Bio.Align.phylip import AlignmentWriter
+from Bio import BiopythonExperimentalWarning
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonExperimentalWarning)
+    from Bio.Align.phylip import AlignmentIterator
+    from Bio.Align.phylip import AlignmentWriter
 
 
 try:

--- a/Tests/test_Align_psl.py
+++ b/Tests/test_Align_psl.py
@@ -4,13 +4,19 @@
 # as part of this package.
 """Tests for Align.psl module."""
 import unittest
+import warnings
 from io import StringIO
 
 
-from Bio.Align import Alignment, psl
+from Bio.Align import Alignment
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio import SeqIO
+from Bio import BiopythonExperimentalWarning
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonExperimentalWarning)
+    from Bio.Align import psl
 
 
 try:

--- a/Tests/test_Align_stockholm.py
+++ b/Tests/test_Align_stockholm.py
@@ -4,10 +4,14 @@
 # as part of this package.
 """Tests for Align.stockholm module."""
 import unittest
+import warnings
 from io import StringIO
 
+from Bio import BiopythonExperimentalWarning
 
-from Bio.Align import stockholm
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonExperimentalWarning)
+    from Bio.Align import stockholm
 
 
 try:


### PR DESCRIPTION
Add a  BiopythonExperimentalWarning` to the new alignment parsers under `Bio.Align`, so we can proceed with a Biopython release without having to wait until all parsers have been implemented.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
