### PR TITLE
Add support for ignoring file extensions in codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,8 @@ repos:
         files: \.(rst|md|tex)$
         args: [
             --ignore-regex,
-            '(^|\W)([A-Z]{2,3})(\W|$)',
+            '(^|\W)([A-Z]{2,3})(\W|$)|(.aks)',
+            # last grouping above is for filenames. Add more with a pipe, e.g., (.aks|.txt|.asm)
             -L,
             'ser,hsa,hist,fpr'
         ]


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3888 . I added a second regex flag for ignoring file extensions in codespell. Also left a comment to guide future devs if they need to ignore more file extensions.
