### PR TITLE
update black to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     rev: v1.12.1
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==22.1.0]
+        additional_dependencies: [black==22.3.0]
         exclude: ^.github/
 -   repo: https://github.com/myint/rstcheck
     rev: 3f92957478422df87bd730abde66f089cc1ee19b


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This tiny PR changes the black dependency to 22.3.0 in .pre-commit-config.yaml and closes #3893, however
I think black now triggers on 

    Bio/SwissProt/__init__.py:699:9: B020 Found for loop that reassigns the iterable it is iterating with each iterable value.
    Bio/Affy/CelFile.py:177:9: B020 Found for loop that reassigns the iterable it is iterating with each iterable value.
    Bio/SCOP/__init__.py:333:13: B020 Found for loop that reassigns the iterable it is iterating with each iterable value.
    Bio/SCOP/__init__.py:339:13: B020 Found for loop that reassigns the iterable it is iterating with each iterable value.
    Bio/SCOP/__init__.py:346:13: B020 Found for loop that reassigns the iterable it is iterating with each iterable value.

but I did not attempt to address these as not familiar with the code - but happy to dive in if no one else is available.

