### PR TITLE
Fix broken reference in selected_child when copying a DisorderedAtom

### DIFF
--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -564,3 +564,21 @@ class DisorderedAtom(DisorderedEntityWrapper):
         """
         for child in self:
             child.coord = np.dot(child.coord, rot) + tran
+
+    def copy(self):
+        """Copy disorderd atom recursively.
+
+        Loses parent relationship, and sets selected_child to own of it's own
+        children.
+        """
+        shallow = copy(self)
+        shallow.child_dict = {}
+        shallow.detach_parent()
+
+        shallow.selected_child = None
+        shallow.last_occupancy = 0
+
+        for child in self.disordered_get_list():
+            shallow.disordered_add(child.copy())
+
+        return shallow

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -44,6 +44,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Aziz Khan <https://github.com/asntech>
 - Barbara Mühlemann <https://github.com/bamueh>
 - Bart de Koning <bratdaking gmail>
+- Bart Grosman <https://github.com/Bartvelp>
 - Bartek Wilczynski <bartek at domain rezolwenta.eu.org>
 - Bartosz Telenczuk <bartosz.telenczuk at domain gmail.com>
 - Ben Fulton <https://github.com/benfulton>

--- a/Tests/test_PDB_Disordered.py
+++ b/Tests/test_PDB_Disordered.py
@@ -46,6 +46,23 @@ class TestDisordered(unittest.TestCase):
         for ai, aj in zip(resi27_atoms, resi27_copy_atoms):
             self.assertEqual(ai.name, aj.name)
 
+    def test_copy_selected_child(self):
+        """Checks if the DisorderedAtom.selected_child reference is it's own child."""
+        resi27 = self.structure[0]["A"][27]
+        disordered_nh1 = resi27.child_dict["NH1"]
+        self.assertTrue(
+            disordered_nh1.is_disordered()
+        )  # Check if actually DisorderedAtom
+
+        disordered_copy_nh1 = disordered_nh1.copy()
+
+        atom_possibilities = disordered_copy_nh1.disordered_get_list()
+        # Re-calculate the proper selected child from the Atom children
+        best_atom_of_copy = max(
+            atom_possibilities, key=lambda pos_atom: pos_atom.occupancy
+        )
+        self.assertEqual(best_atom_of_copy, disordered_copy_nh1.selected_child)
+
     def test_copy_entire_chain(self):
         """Copy propagates throughout SMCRA object."""
         s = self.structure

--- a/Tests/test_PDB_Disordered.py
+++ b/Tests/test_PDB_Disordered.py
@@ -40,7 +40,7 @@ class TestDisordered(unittest.TestCase):
         self.assertNotEqual(id(resi27), id(resi27_copy))  # did we really copy
 
         resi27_atoms = resi27.get_unpacked_list()
-        resi27_copy_atoms = resi27.get_unpacked_list()
+        resi27_copy_atoms = resi27_copy.get_unpacked_list()
         self.assertEqual(len(resi27_atoms), len(resi27_copy_atoms))
 
         for ai, aj in zip(resi27_atoms, resi27_copy_atoms):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3896

Due to the agnostic nature of `DisorderedEntityWrapper.copy()`, it does not reset the `selected_child` and `last_occupancy` on a DisorderedAtom. This results in a broken reference in DisorderedEntityWrapper in the `selected_child`, because it never get's overwritten with one of the copied children Atoms.
This fix implement a new `copy()` method, specifically for `DisorderedAtom`s, which _does_ reset the relevant properties.