### PR TITLE
Pdb dbref1 dbref2

### DIFF
--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -216,6 +216,16 @@ class PdbSeqresIterator(SequenceIterator):
                         "db_id_code": db_id_code,
                     }
                 )
+            elif rec_name == "DBREF1":
+                # ID code of this entry (PDB ID)
+                pdb_id = line[7:11]
+                # Chain identifier.
+                chn_id = line[12]
+                metadata[chn_id].append(
+                    {
+                        "pdb_id": pdb_id,
+                    }
+                )
             # ENH: 'SEQADV' 'MODRES'
 
         if rec_name is None:

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -232,6 +232,15 @@ class PdbSeqresIterator(SequenceIterator):
                         "db_id_code": db_id_code,
                     }
                 )
+            elif rec_name == "DBREF2":
+                # ID code of this entry (PDB ID)
+                pdb_id = line[7:11]
+                # Chain identifier.
+                chn_id = line[12]
+                # Sequence database accession code.
+                db_acc = line[18:40].strip()
+                if chn_id in metadata:
+                    metadata[chn_id][0]["db_acc"] = db_acc
             # ENH: 'SEQADV' 'MODRES'
 
         if rec_name is None:

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -221,9 +221,15 @@ class PdbSeqresIterator(SequenceIterator):
                 pdb_id = line[7:11]
                 # Chain identifier.
                 chn_id = line[12]
+                # Sequence database name.
+                database = line[26:32].strip()
+                # Sequence database identification code.
+                db_id_code = line[47:67].strip()
                 metadata[chn_id].append(
                     {
                         "pdb_id": pdb_id,
+                        "database": database,
+                        "db_id_code": db_id_code,
                     }
                 )
             # ENH: 'SEQADV' 'MODRES'

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -122,7 +122,7 @@ class PdbSeqresIterator(SequenceIterator):
         The sequences are derived from the SEQRES lines in the
         PDB file header, not the atoms of the 3D structure.
 
-        Specifically, these PDB records are handled: DBREF, SEQADV, SEQRES, MODRES
+        Specifically, these PDB records are handled: DBREF, DBREF1, DBREF2, SEQADV, SEQRES, MODRES
 
         See: http://www.wwpdb.org/documentation/format23/sect3.html
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -34,6 +34,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Andrew Guy <https://github.com/andrewguy>
 - Andrew Sczesnak <https://github.com/polyatail>
 - Andrey Raspopov <https://github.com/Andrey-Raspopov>
+- Andrius Merkys <https://github.com/merkys>
 - Anne Pajon <ap one two at sanger ac uk>
 - Anthony Bradley <https://github.com/abradle>
 - Antony Lee <https://github.com/anntzer>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -34,12 +34,15 @@ Biopython 1.67).
 Sequences now have a ``defined`` attribute that returns a boolean indicating
 if the underlying data is defined or not.
 
+PDB ``DBREF1`` and ``DBREF2`` records are now read alongside ``DBREF``.
+
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite.
 
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
+- Andrius Merkys
 - Aziz Khan
 - Alex Morehead
 - Chenghao Zhu

--- a/Tests/PDB/7DDO.pdb
+++ b/Tests/PDB/7DDO.pdb
@@ -1,0 +1,6904 @@
+HEADER    HYDROLASE/VIRAL PROTEIN                 29-OCT-20   7DDO              
+TITLE     CRYO-EM STRUCTURE OF HUMAN ACE2 AND GD/1/2019 RBD                     
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: ANGIOTENSIN-CONVERTING ENZYME 2;                           
+COMPND   3 CHAIN: A;                                                            
+COMPND   4 SYNONYM: ANGIOTENSIN-CONVERTING ENZYME HOMOLOG,ACEH,ANGIOTENSIN-     
+COMPND   5 CONVERTING ENZYME-RELATED CARBOXYPEPTIDASE,ACE-RELATED               
+COMPND   6 CARBOXYPEPTIDASE,METALLOPROTEASE MPROT15;                            
+COMPND   7 EC: 3.4.17.23,3.4.17.-;                                              
+COMPND   8 ENGINEERED: YES;                                                     
+COMPND   9 MOL_ID: 2;                                                           
+COMPND  10 MOLECULE: SPIKE PROTEIN S1;                                          
+COMPND  11 CHAIN: C;                                                            
+COMPND  12 ENGINEERED: YES                                                      
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE   3 ORGANISM_COMMON: HUMAN;                                              
+SOURCE   4 ORGANISM_TAXID: 9606;                                                
+SOURCE   5 GENE: ACE2, UNQ868/PRO1885;                                          
+SOURCE   6 EXPRESSION_SYSTEM: UNIDENTIFIED BACULOVIRUS;                         
+SOURCE   7 EXPRESSION_SYSTEM_TAXID: 10469;                                      
+SOURCE   8 MOL_ID: 2;                                                           
+SOURCE   9 ORGANISM_SCIENTIFIC: PANGOLIN CORONAVIRUS;                           
+SOURCE  10 ORGANISM_TAXID: 2708335;                                             
+SOURCE  11 EXPRESSION_SYSTEM: UNIDENTIFIED BACULOVIRUS;                         
+SOURCE  12 EXPRESSION_SYSTEM_TAXID: 10469                                       
+KEYWDS    PANGOLIN, RBD, ACE2, PROTEIN BINDING, HYDROLASE-VIRAL PROTEIN COMPLEX 
+EXPDTA    ELECTRON MICROSCOPY                                                   
+AUTHOR    S.NIU,J.WANG,H.W.WANG,J.X.QI,Q.H.WANG,G.F.GAO                         
+REVDAT   2   16-FEB-22 7DDO    1       JRNL                                     
+REVDAT   1   19-MAY-21 7DDO    0                                                
+JRNL        AUTH   S.NIU,J.WANG,B.BAI,L.WU,A.ZHENG,Q.CHEN,P.DU,P.HAN,Y.ZHANG,   
+JRNL        AUTH 2 Y.JIA,C.QIAO,J.QI,W.X.TIAN,H.W.WANG,Q.WANG,G.F.GAO           
+JRNL        TITL   MOLECULAR BASIS OF CROSS-SPECIES ACE2 INTERACTIONS WITH      
+JRNL        TITL 2 SARS-COV-2-LIKE VIRUSES OF PANGOLIN ORIGIN.                  
+JRNL        REF    EMBO J.                       V.  40 07786 2021              
+JRNL        REFN                   ESSN 1460-2075                               
+JRNL        PMID   34018203                                                     
+JRNL        DOI    10.15252/EMBJ.2021107786                                     
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    3.40 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   SOFTWARE PACKAGES      : NULL                                      
+REMARK   3   RECONSTRUCTION SCHEMA  : NULL                                      
+REMARK   3                                                                      
+REMARK   3 EM MAP-MODEL FITTING AND REFINEMENT                                  
+REMARK   3   PDB ENTRY                    : NULL                                
+REMARK   3   REFINEMENT SPACE             : NULL                                
+REMARK   3   REFINEMENT PROTOCOL          : NULL                                
+REMARK   3   REFINEMENT TARGET            : NULL                                
+REMARK   3   OVERALL ANISOTROPIC B VALUE  : NULL                                
+REMARK   3                                                                      
+REMARK   3 FITTING PROCEDURE : NULL                                             
+REMARK   3                                                                      
+REMARK   3 EM IMAGE RECONSTRUCTION STATISTICS                                   
+REMARK   3   NOMINAL PIXEL SIZE (ANGSTROMS)    : NULL                           
+REMARK   3   ACTUAL PIXEL SIZE  (ANGSTROMS)    : NULL                           
+REMARK   3   EFFECTIVE RESOLUTION (ANGSTROMS)  : 3.400                          
+REMARK   3   NUMBER OF PARTICLES               : 126986                         
+REMARK   3   CTF CORRECTION METHOD             : NONE                           
+REMARK   3                                                                      
+REMARK   3 EM RECONSTRUCTION MAGNIFICATION CALIBRATION: NULL                    
+REMARK   3                                                                      
+REMARK   3 OTHER DETAILS: NULL                                                  
+REMARK   4                                                                      
+REMARK   4 7DDO COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY PDBJ ON 30-OCT-20.                  
+REMARK 100 THE DEPOSITION ID IS D_1300019194.                                   
+REMARK 245                                                                      
+REMARK 245 EXPERIMENTAL DETAILS                                                 
+REMARK 245   RECONSTRUCTION METHOD          : SINGLE PARTICLE                   
+REMARK 245   SPECIMEN TYPE                  : NULL                              
+REMARK 245                                                                      
+REMARK 245 ELECTRON MICROSCOPE SAMPLE                                           
+REMARK 245   SAMPLE TYPE                    : PARTICLE                          
+REMARK 245   PARTICLE TYPE                  : POINT                             
+REMARK 245   NAME OF SAMPLE                 : CRYO-EM STRUCTURE OF HUMAN ACE2   
+REMARK 245                                    AND GD/1/2019 RBD; HUMAN ACE2;    
+REMARK 245                                    GD/1/2019 RBD                     
+REMARK 245   SAMPLE CONCENTRATION (MG ML-1) : 0.20                              
+REMARK 245   SAMPLE SUPPORT DETAILS         : NULL                              
+REMARK 245   SAMPLE VITRIFICATION DETAILS   : NULL                              
+REMARK 245   SAMPLE BUFFER                  : NULL                              
+REMARK 245   PH                             : 8.00                              
+REMARK 245   SAMPLE DETAILS                 : NULL                              
+REMARK 245                                                                      
+REMARK 245 DATA ACQUISITION                                                     
+REMARK 245   DATE OF EXPERIMENT                : NULL                           
+REMARK 245   NUMBER OF MICROGRAPHS-IMAGES      : NULL                           
+REMARK 245   TEMPERATURE (KELVIN)              : NULL                           
+REMARK 245   MICROSCOPE MODEL                  : FEI TITAN KRIOS                
+REMARK 245   DETECTOR TYPE                     : GATAN K3 BIOQUANTUM (6K X      
+REMARK 245                                       4K)                            
+REMARK 245   MINIMUM DEFOCUS (NM)              : NULL                           
+REMARK 245   MAXIMUM DEFOCUS (NM)              : NULL                           
+REMARK 245   MINIMUM TILT ANGLE (DEGREES)      : NULL                           
+REMARK 245   MAXIMUM TILT ANGLE (DEGREES)      : NULL                           
+REMARK 245   NOMINAL CS                        : NULL                           
+REMARK 245   IMAGING MODE                      : BRIGHT FIELD                   
+REMARK 245   ELECTRON DOSE (ELECTRONS NM**-2)  : 5000.00                        
+REMARK 245   ILLUMINATION MODE                 : FLOOD BEAM                     
+REMARK 245   NOMINAL MAGNIFICATION             : NULL                           
+REMARK 245   CALIBRATED MAGNIFICATION          : NULL                           
+REMARK 245   SOURCE                            : FIELD EMISSION GUN             
+REMARK 245   ACCELERATION VOLTAGE (KV)         : 300                            
+REMARK 245   IMAGING DETAILS                   : NULL                           
+REMARK 247                                                                      
+REMARK 247 ELECTRON MICROSCOPY                                                  
+REMARK 247  THE COORDINATES IN THIS ENTRY WERE GENERATED FROM ELECTRON          
+REMARK 247  MICROSCOPY DATA. PROTEIN DATA BANK CONVENTIONS REQUIRE              
+REMARK 247  THAT CRYST1 AND SCALE RECORDS BE INCLUDED, BUT THE VALUES           
+REMARK 247  ON THESE RECORDS ARE MEANINGLESS EXCEPT FOR THE CALCULATION         
+REMARK 247  OF THE STRUCTURE FACTORS.                                           
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: DIMERIC                           
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A, C                                  
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 465                                                                      
+REMARK 465 MISSING RESIDUES                                                     
+REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
+REMARK 465 EXPERIMENT. (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 465 IDENTIFIER; SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                
+REMARK 465                                                                      
+REMARK 465   M RES C SSSEQI                                                     
+REMARK 465     ARG C   319                                                      
+REMARK 465     VAL C   320                                                      
+REMARK 465     GLN C   321                                                      
+REMARK 465     PRO C   322                                                      
+REMARK 465     THR C   323                                                      
+REMARK 465     GLU C   324                                                      
+REMARK 465     SER C   325                                                      
+REMARK 465     ILE C   326                                                      
+REMARK 465     VAL C   327                                                      
+REMARK 465     ARG C   328                                                      
+REMARK 465     PHE C   329                                                      
+REMARK 465     PRO C   330                                                      
+REMARK 465     ASN C   331                                                      
+REMARK 465     ILE C   332                                                      
+REMARK 465     PRO C   527                                                      
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS IN SAME ASYMMETRIC UNIT                     
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS ARE IN CLOSE CONTACT.                            
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI           DISTANCE          
+REMARK 500   OH   TYR A   237     O    VAL A   485              2.17            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    PRO A 138        3.01    -67.66                                   
+REMARK 500    CYS A 344       38.07    -99.51                                   
+REMARK 500    ILE A 446      -60.13   -108.89                                   
+REMARK 500    THR C 372       10.50     57.79                                   
+REMARK 500    PHE C 392     -164.61   -126.34                                   
+REMARK 500    ASN C 487       14.58     58.93                                   
+REMARK 500    PRO C 491       47.00    -85.63                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 620                                                                      
+REMARK 620 METAL COORDINATION                                                   
+REMARK 620 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 620 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                             
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              ZN A 901  ZN                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 HIS A 374   NE2                                                    
+REMARK 620 2 HIS A 378   NE2  88.9                                              
+REMARK 620 3 GLU A 402   OE1  83.2  72.6                                        
+REMARK 620 N                    1     2                                         
+REMARK 900                                                                      
+REMARK 900 RELATED ENTRIES                                                      
+REMARK 900 RELATED ID: EMD-30655   RELATED DB: EMDB                             
+REMARK 900 CRYO-EM STRUCTURE OF HUMAN ACE2 AND GD/1/2019 RBD                    
+DBREF  7DDO A   19   615  UNP    Q9BYF1   ACE2_HUMAN      19    615             
+DBREF1 7DDO C  319   527  UNP                  A0A6M3G9R1_9BETC                 
+DBREF2 7DDO C     A0A6M3G9R1                        315         523             
+SEQADV 7DDO ASN C  519  UNP  A0A6M3G9R LYS   515 CONFLICT                       
+SEQRES   1 A  597  SER THR ILE GLU GLU GLN ALA LYS THR PHE LEU ASP LYS          
+SEQRES   2 A  597  PHE ASN HIS GLU ALA GLU ASP LEU PHE TYR GLN SER SER          
+SEQRES   3 A  597  LEU ALA SER TRP ASN TYR ASN THR ASN ILE THR GLU GLU          
+SEQRES   4 A  597  ASN VAL GLN ASN MET ASN ASN ALA GLY ASP LYS TRP SER          
+SEQRES   5 A  597  ALA PHE LEU LYS GLU GLN SER THR LEU ALA GLN MET TYR          
+SEQRES   6 A  597  PRO LEU GLN GLU ILE GLN ASN LEU THR VAL LYS LEU GLN          
+SEQRES   7 A  597  LEU GLN ALA LEU GLN GLN ASN GLY SER SER VAL LEU SER          
+SEQRES   8 A  597  GLU ASP LYS SER LYS ARG LEU ASN THR ILE LEU ASN THR          
+SEQRES   9 A  597  MET SER THR ILE TYR SER THR GLY LYS VAL CYS ASN PRO          
+SEQRES  10 A  597  ASP ASN PRO GLN GLU CYS LEU LEU LEU GLU PRO GLY LEU          
+SEQRES  11 A  597  ASN GLU ILE MET ALA ASN SER LEU ASP TYR ASN GLU ARG          
+SEQRES  12 A  597  LEU TRP ALA TRP GLU SER TRP ARG SER GLU VAL GLY LYS          
+SEQRES  13 A  597  GLN LEU ARG PRO LEU TYR GLU GLU TYR VAL VAL LEU LYS          
+SEQRES  14 A  597  ASN GLU MET ALA ARG ALA ASN HIS TYR GLU ASP TYR GLY          
+SEQRES  15 A  597  ASP TYR TRP ARG GLY ASP TYR GLU VAL ASN GLY VAL ASP          
+SEQRES  16 A  597  GLY TYR ASP TYR SER ARG GLY GLN LEU ILE GLU ASP VAL          
+SEQRES  17 A  597  GLU HIS THR PHE GLU GLU ILE LYS PRO LEU TYR GLU HIS          
+SEQRES  18 A  597  LEU HIS ALA TYR VAL ARG ALA LYS LEU MET ASN ALA TYR          
+SEQRES  19 A  597  PRO SER TYR ILE SER PRO ILE GLY CYS LEU PRO ALA HIS          
+SEQRES  20 A  597  LEU LEU GLY ASP MET TRP GLY ARG PHE TRP THR ASN LEU          
+SEQRES  21 A  597  TYR SER LEU THR VAL PRO PHE GLY GLN LYS PRO ASN ILE          
+SEQRES  22 A  597  ASP VAL THR ASP ALA MET VAL ASP GLN ALA TRP ASP ALA          
+SEQRES  23 A  597  GLN ARG ILE PHE LYS GLU ALA GLU LYS PHE PHE VAL SER          
+SEQRES  24 A  597  VAL GLY LEU PRO ASN MET THR GLN GLY PHE TRP GLU ASN          
+SEQRES  25 A  597  SER MET LEU THR ASP PRO GLY ASN VAL GLN LYS ALA VAL          
+SEQRES  26 A  597  CYS HIS PRO THR ALA TRP ASP LEU GLY LYS GLY ASP PHE          
+SEQRES  27 A  597  ARG ILE LEU MET CYS THR LYS VAL THR MET ASP ASP PHE          
+SEQRES  28 A  597  LEU THR ALA HIS HIS GLU MET GLY HIS ILE GLN TYR ASP          
+SEQRES  29 A  597  MET ALA TYR ALA ALA GLN PRO PHE LEU LEU ARG ASN GLY          
+SEQRES  30 A  597  ALA ASN GLU GLY PHE HIS GLU ALA VAL GLY GLU ILE MET          
+SEQRES  31 A  597  SER LEU SER ALA ALA THR PRO LYS HIS LEU LYS SER ILE          
+SEQRES  32 A  597  GLY LEU LEU SER PRO ASP PHE GLN GLU ASP ASN GLU THR          
+SEQRES  33 A  597  GLU ILE ASN PHE LEU LEU LYS GLN ALA LEU THR ILE VAL          
+SEQRES  34 A  597  GLY THR LEU PRO PHE THR TYR MET LEU GLU LYS TRP ARG          
+SEQRES  35 A  597  TRP MET VAL PHE LYS GLY GLU ILE PRO LYS ASP GLN TRP          
+SEQRES  36 A  597  MET LYS LYS TRP TRP GLU MET LYS ARG GLU ILE VAL GLY          
+SEQRES  37 A  597  VAL VAL GLU PRO VAL PRO HIS ASP GLU THR TYR CYS ASP          
+SEQRES  38 A  597  PRO ALA SER LEU PHE HIS VAL SER ASN ASP TYR SER PHE          
+SEQRES  39 A  597  ILE ARG TYR TYR THR ARG THR LEU TYR GLN PHE GLN PHE          
+SEQRES  40 A  597  GLN GLU ALA LEU CYS GLN ALA ALA LYS HIS GLU GLY PRO          
+SEQRES  41 A  597  LEU HIS LYS CYS ASP ILE SER ASN SER THR GLU ALA GLY          
+SEQRES  42 A  597  GLN LYS LEU PHE ASN MET LEU ARG LEU GLY LYS SER GLU          
+SEQRES  43 A  597  PRO TRP THR LEU ALA LEU GLU ASN VAL VAL GLY ALA LYS          
+SEQRES  44 A  597  ASN MET ASN VAL ARG PRO LEU LEU ASN TYR PHE GLU PRO          
+SEQRES  45 A  597  LEU PHE THR TRP LEU LYS ASP GLN ASN LYS ASN SER PHE          
+SEQRES  46 A  597  VAL GLY TRP SER THR ASP TRP SER PRO TYR ALA ASP              
+SEQRES   1 C  209  ARG VAL GLN PRO THR GLU SER ILE VAL ARG PHE PRO ASN          
+SEQRES   2 C  209  ILE THR ASN LEU CYS PRO PHE GLY GLU VAL PHE ASN ALA          
+SEQRES   3 C  209  THR THR PHE ALA SER VAL TYR ALA TRP ASN ARG LYS ARG          
+SEQRES   4 C  209  ILE SER ASN CYS VAL ALA ASP TYR SER VAL LEU TYR ASN          
+SEQRES   5 C  209  SER THR SER PHE SER THR PHE LYS CYS TYR GLY VAL SER          
+SEQRES   6 C  209  PRO THR LYS LEU ASN ASP LEU CYS PHE THR ASN VAL TYR          
+SEQRES   7 C  209  ALA ASP SER PHE VAL VAL ARG GLY ASP GLU VAL ARG GLN          
+SEQRES   8 C  209  ILE ALA PRO GLY GLN THR GLY ARG ILE ALA ASP TYR ASN          
+SEQRES   9 C  209  TYR LYS LEU PRO ASP ASP PHE THR GLY CYS VAL ILE ALA          
+SEQRES  10 C  209  TRP ASN SER ASN ASN LEU ASP SER LYS VAL GLY GLY ASN          
+SEQRES  11 C  209  TYR ASN TYR LEU TYR ARG LEU PHE ARG LYS SER ASN LEU          
+SEQRES  12 C  209  LYS PRO PHE GLU ARG ASP ILE SER THR GLU ILE TYR GLN          
+SEQRES  13 C  209  ALA GLY SER THR PRO CYS ASN GLY VAL GLU GLY PHE ASN          
+SEQRES  14 C  209  CYS TYR PHE PRO LEU GLN SER TYR GLY PHE HIS PRO THR          
+SEQRES  15 C  209  ASN GLY VAL GLY TYR GLN PRO TYR ARG VAL VAL VAL LEU          
+SEQRES  16 C  209  SER PHE GLU LEU LEU ASN ALA PRO ALA THR VAL CYS GLY          
+SEQRES  17 C  209  PRO                                                          
+HET     ZN  A 901       1                                                       
+HET    NAG  A 902      14                                                       
+HET    NAG  A 903      14                                                       
+HET    NAG  A 904      14                                                       
+HET    NAG  C 601      14                                                       
+HETNAM      ZN ZINC ION                                                         
+HETNAM     NAG 2-ACETAMIDO-2-DEOXY-BETA-D-GLUCOPYRANOSE                         
+HETSYN     NAG N-ACETYL-BETA-D-GLUCOSAMINE; 2-ACETAMIDO-2-DEOXY-BETA-           
+HETSYN   2 NAG  D-GLUCOSE; 2-ACETAMIDO-2-DEOXY-D-GLUCOSE; 2-ACETAMIDO-          
+HETSYN   3 NAG  2-DEOXY-GLUCOSE; N-ACETYL-D-GLUCOSAMINE                         
+FORMUL   3   ZN    ZN 2+                                                        
+FORMUL   4  NAG    4(C8 H15 N O6)                                               
+HELIX    1 AA1 THR A   20  ASN A   53  1                                  34    
+HELIX    2 AA2 THR A   55  GLN A   81  1                                  27    
+HELIX    3 AA3 MET A   82  TYR A   83  5                                   2    
+HELIX    4 AA4 PRO A   84  ILE A   88  5                                   5    
+HELIX    5 AA5 ASN A   90  GLN A  101  1                                  12    
+HELIX    6 AA6 ASN A  103  LEU A  108  5                                   6    
+HELIX    7 AA7 SER A  109  THR A  129  1                                  21    
+HELIX    8 AA8 LEU A  143  SER A  155  1                                  13    
+HELIX    9 AA9 ASP A  157  ASN A  194  1                                  38    
+HELIX   10 AB1 ASP A  198  GLY A  205  1                                   8    
+HELIX   11 AB2 GLY A  220  TYR A  252  1                                  33    
+HELIX   12 AB3 HIS A  265  LEU A  267  5                                   3    
+HELIX   13 AB4 TRP A  275  TYR A  279  5                                   5    
+HELIX   14 AB5 VAL A  293  GLN A  300  1                                   8    
+HELIX   15 AB6 ASP A  303  VAL A  318  1                                  16    
+HELIX   16 AB7 THR A  324  SER A  331  1                                   8    
+HELIX   17 AB8 THR A  365  TYR A  385  1                                  21    
+HELIX   18 AB9 PRO A  389  ARG A  393  5                                   5    
+HELIX   19 AC1 GLY A  399  ALA A  413  1                                  15    
+HELIX   20 AC2 THR A  414  ILE A  421  1                                   8    
+HELIX   21 AC3 ASP A  431  ILE A  446  1                                  16    
+HELIX   22 AC4 THR A  449  LYS A  465  1                                  17    
+HELIX   23 AC5 PRO A  469  ASP A  471  5                                   3    
+HELIX   24 AC6 GLN A  472  VAL A  485  1                                  14    
+HELIX   25 AC7 CYS A  498  SER A  502  5                                   5    
+HELIX   26 AC8 LEU A  503  ASN A  508  1                                   6    
+HELIX   27 AC9 ILE A  513  ALA A  533  1                                  21    
+HELIX   28 AD1 SER A  547  ARG A  559  1                                  13    
+HELIX   29 AD2 PRO A  565  GLY A  575  1                                  11    
+HELIX   30 AD3 VAL A  581  ASN A  599  1                                  19    
+HELIX   31 AD4 LYS A  600  SER A  602  5                                   3    
+HELIX   32 AD5 PHE C  338  ASN C  343  1                                   6    
+HELIX   33 AD6 TYR C  365  ASN C  370  1                                   6    
+HELIX   34 AD7 GLY C  416  ASN C  422  1                                   7    
+HELIX   35 AD8 GLY C  502  GLN C  506  5                                   5    
+SHEET    1 AA1 2 LEU A 262  PRO A 263  0                                        
+SHEET    2 AA1 2 VAL A 487  VAL A 488  1  O  VAL A 488   N  LEU A 262           
+SHEET    1 AA2 2 THR A 347  GLY A 352  0                                        
+SHEET    2 AA2 2 ASP A 355  LEU A 359 -1  O  ARG A 357   N  TRP A 349           
+SHEET    1 AA3 5 ASN C 354  ILE C 358  0                                        
+SHEET    2 AA3 5 ASN C 394  VAL C 402 -1  O  ALA C 397   N  LYS C 356           
+SHEET    3 AA3 5 TYR C 508  GLU C 516 -1  O  VAL C 512   N  ASP C 398           
+SHEET    4 AA3 5 VAL C 433  ASN C 437 -1  N  ILE C 434   O  VAL C 511           
+SHEET    5 AA3 5 THR C 376  LYS C 378 -1  N  THR C 376   O  ALA C 435           
+SHEET    1 AA4 2 LEU C 452  TYR C 453  0                                        
+SHEET    2 AA4 2 GLN C 493  SER C 494 -1  O  GLN C 493   N  TYR C 453           
+SHEET    1 AA5 2 TYR C 473  GLN C 474  0                                        
+SHEET    2 AA5 2 CYS C 488  TYR C 489 -1  O  TYR C 489   N  TYR C 473           
+SSBOND   1 CYS A  133    CYS A  141                          1555   1555  2.03  
+SSBOND   2 CYS A  344    CYS A  361                          1555   1555  2.03  
+SSBOND   3 CYS A  530    CYS A  542                          1555   1555  2.03  
+SSBOND   4 CYS C  336    CYS C  361                          1555   1555  2.03  
+SSBOND   5 CYS C  379    CYS C  432                          1555   1555  2.03  
+SSBOND   6 CYS C  391    CYS C  525                          1555   1555  2.03  
+SSBOND   7 CYS C  480    CYS C  488                          1555   1555  2.03  
+LINK         ND2 ASN A  53                 C1  NAG A 904     1555   1555  1.44  
+LINK         ND2 ASN A  90                 C1  NAG A 903     1555   1555  1.44  
+LINK         ND2 ASN A 546                 C1  NAG A 902     1555   1555  1.44  
+LINK         ND2 ASN C 343                 C1  NAG C 601     1555   1555  1.44  
+LINK         NE2 HIS A 374                ZN    ZN A 901     1555   1555  2.20  
+LINK         NE2 HIS A 378                ZN    ZN A 901     1555   1555  2.14  
+LINK         OE1 GLU A 402                ZN    ZN A 901     1555   1555  2.06  
+CRYST1    1.000    1.000    1.000  90.00  90.00  90.00 P 1                      
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      1.000000  0.000000  0.000000        0.00000                         
+SCALE2      0.000000  1.000000  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  1.000000        0.00000                         
+ATOM      1  N   SER A  19     102.780  48.284  75.094  1.00 71.91           N  
+ATOM      2  CA  SER A  19     102.157  47.065  75.597  1.00 71.91           C  
+ATOM      3  C   SER A  19     101.497  47.315  76.948  1.00 71.91           C  
+ATOM      4  O   SER A  19     100.637  46.547  77.381  1.00 71.91           O  
+ATOM      5  CB  SER A  19     103.188  45.941  75.712  1.00 71.91           C  
+ATOM      6  OG  SER A  19     102.558  44.673  75.771  1.00 71.91           O  
+ATOM      7  N   THR A  20     101.904  48.395  77.608  1.00 70.72           N  
+ATOM      8  CA  THR A  20     101.327  48.762  78.891  1.00 70.72           C  
+ATOM      9  C   THR A  20      99.932  49.351  78.691  1.00 70.72           C  
+ATOM     10  O   THR A  20      99.395  49.398  77.581  1.00 70.72           O  
+ATOM     11  CB  THR A  20     102.230  49.754  79.620  1.00 70.72           C  
+ATOM     12  OG1 THR A  20     101.584  50.196  80.820  1.00 70.72           O  
+ATOM     13  CG2 THR A  20     102.517  50.958  78.737  1.00 70.72           C  
+ATOM     14  N   ILE A  21      99.335  49.809  79.790  1.00 73.14           N  
+ATOM     15  CA  ILE A  21      98.020  50.431  79.696  1.00 73.14           C  
+ATOM     16  C   ILE A  21      98.130  51.853  79.156  1.00 73.14           C  
+ATOM     17  O   ILE A  21      97.171  52.375  78.576  1.00 73.14           O  
+ATOM     18  CB  ILE A  21      97.311  50.395  81.061  1.00 73.14           C  
+ATOM     19  CG1 ILE A  21      95.811  50.630  80.889  1.00 73.14           C  
+ATOM     20  CG2 ILE A  21      97.910  51.422  82.011  1.00 73.14           C  
+ATOM     21  CD1 ILE A  21      95.121  49.552  80.086  1.00 73.14           C  
+ATOM     22  N   GLU A  22      99.291  52.491  79.317  1.00 72.94           N  
+ATOM     23  CA  GLU A  22      99.458  53.866  78.854  1.00 72.94           C  
+ATOM     24  C   GLU A  22      99.367  53.951  77.337  1.00 72.94           C  
+ATOM     25  O   GLU A  22      98.650  54.797  76.794  1.00 72.94           O  
+ATOM     26  CB  GLU A  22     100.791  54.425  79.348  1.00 72.94           C  
+ATOM     27  CG  GLU A  22     100.712  55.094  80.707  1.00 72.94           C  
+ATOM     28  CD  GLU A  22      99.991  56.427  80.656  1.00 72.94           C  
+ATOM     29  OE1 GLU A  22     100.501  57.355  79.995  1.00 72.94           O  
+ATOM     30  OE2 GLU A  22      98.912  56.543  81.271  1.00 72.94           O  
+ATOM     31  N   GLU A  23     100.093  53.079  76.633  1.00 72.17           N  
+ATOM     32  CA  GLU A  23     100.071  53.107  75.174  1.00 72.17           C  
+ATOM     33  C   GLU A  23      98.691  52.752  74.634  1.00 72.17           C  
+ATOM     34  O   GLU A  23      98.221  53.362  73.666  1.00 72.17           O  
+ATOM     35  CB  GLU A  23     101.128  52.154  74.618  1.00 72.17           C  
+ATOM     36  CG  GLU A  23     102.545  52.480  75.058  1.00 72.17           C  
+ATOM     37  CD  GLU A  23     103.126  53.669  74.319  1.00 72.17           C  
+ATOM     38  OE1 GLU A  23     103.418  53.534  73.112  1.00 72.17           O  
+ATOM     39  OE2 GLU A  23     103.289  54.738  74.944  1.00 72.17           O  
+ATOM     40  N   GLN A  24      98.027  51.770  75.246  1.00 70.29           N  
+ATOM     41  CA  GLN A  24      96.693  51.390  74.795  1.00 70.29           C  
+ATOM     42  C   GLN A  24      95.694  52.519  75.012  1.00 70.29           C  
+ATOM     43  O   GLN A  24      94.858  52.791  74.142  1.00 70.29           O  
+ATOM     44  CB  GLN A  24      96.242  50.119  75.513  1.00 70.29           C  
+ATOM     45  CG  GLN A  24      97.169  48.936  75.294  1.00 70.29           C  
+ATOM     46  CD  GLN A  24      96.866  47.779  76.221  1.00 70.29           C  
+ATOM     47  OE1 GLN A  24      95.759  47.662  76.746  1.00 70.29           O  
+ATOM     48  NE2 GLN A  24      97.854  46.916  76.433  1.00 70.29           N  
+ATOM     49  N   ALA A  25      95.772  53.195  76.161  1.00 63.77           N  
+ATOM     50  CA  ALA A  25      94.897  54.335  76.402  1.00 63.77           C  
+ATOM     51  C   ALA A  25      95.193  55.471  75.429  1.00 63.77           C  
+ATOM     52  O   ALA A  25      94.272  56.142  74.948  1.00 63.77           O  
+ATOM     53  CB  ALA A  25      95.044  54.811  77.846  1.00 63.77           C  
+ATOM     54  N   LYS A  26      96.474  55.698  75.124  1.00 61.55           N  
+ATOM     55  CA  LYS A  26      96.833  56.732  74.160  1.00 61.55           C  
+ATOM     56  C   LYS A  26      96.248  56.430  72.788  1.00 61.55           C  
+ATOM     57  O   LYS A  26      95.696  57.322  72.133  1.00 61.55           O  
+ATOM     58  CB  LYS A  26      98.353  56.865  74.072  1.00 61.55           C  
+ATOM     59  CG  LYS A  26      98.982  57.638  75.220  1.00 61.55           C  
+ATOM     60  CD  LYS A  26     100.484  57.770  75.030  1.00 61.55           C  
+ATOM     61  CE  LYS A  26     101.131  58.479  76.208  1.00 61.55           C  
+ATOM     62  NZ  LYS A  26     102.600  58.632  76.023  1.00 61.55           N  
+ATOM     63  N   THR A  27      96.355  55.178  72.338  1.00 61.66           N  
+ATOM     64  CA  THR A  27      95.795  54.820  71.038  1.00 61.66           C  
+ATOM     65  C   THR A  27      94.275  54.934  71.039  1.00 61.66           C  
+ATOM     66  O   THR A  27      93.680  55.420  70.066  1.00 61.66           O  
+ATOM     67  CB  THR A  27      96.226  53.410  70.643  1.00 61.66           C  
+ATOM     68  OG1 THR A  27      95.756  52.473  71.620  1.00 61.66           O  
+ATOM     69  CG2 THR A  27      97.739  53.321  70.536  1.00 61.66           C  
+ATOM     70  N   PHE A  28      93.627  54.496  72.121  1.00 55.31           N  
+ATOM     71  CA  PHE A  28      92.176  54.613  72.197  1.00 55.31           C  
+ATOM     72  C   PHE A  28      91.738  56.069  72.129  1.00 55.31           C  
+ATOM     73  O   PHE A  28      90.780  56.404  71.424  1.00 55.31           O  
+ATOM     74  CB  PHE A  28      91.656  53.964  73.477  1.00 55.31           C  
+ATOM     75  CG  PHE A  28      90.260  54.374  73.832  1.00 55.31           C  
+ATOM     76  CD1 PHE A  28      89.179  53.876  73.128  1.00 55.31           C  
+ATOM     77  CD2 PHE A  28      90.028  55.268  74.863  1.00 55.31           C  
+ATOM     78  CE1 PHE A  28      87.892  54.255  73.449  1.00 55.31           C  
+ATOM     79  CE2 PHE A  28      88.745  55.651  75.186  1.00 55.31           C  
+ATOM     80  CZ  PHE A  28      87.675  55.144  74.479  1.00 55.31           C  
+ATOM     81  N   LEU A  29      92.434  56.951  72.850  1.00 53.06           N  
+ATOM     82  CA  LEU A  29      92.082  58.366  72.821  1.00 53.06           C  
+ATOM     83  C   LEU A  29      92.367  58.980  71.457  1.00 53.06           C  
+ATOM     84  O   LEU A  29      91.613  59.840  70.993  1.00 53.06           O  
+ATOM     85  CB  LEU A  29      92.836  59.117  73.915  1.00 53.06           C  
+ATOM     86  CG  LEU A  29      92.349  58.853  75.336  1.00 53.06           C  
+ATOM     87  CD1 LEU A  29      93.234  59.573  76.328  1.00 53.06           C  
+ATOM     88  CD2 LEU A  29      90.904  59.291  75.485  1.00 53.06           C  
+ATOM     89  N   ASP A  30      93.443  58.549  70.797  1.00 53.33           N  
+ATOM     90  CA  ASP A  30      93.758  59.082  69.477  1.00 53.33           C  
+ATOM     91  C   ASP A  30      92.687  58.690  68.465  1.00 53.33           C  
+ATOM     92  O   ASP A  30      92.323  59.488  67.593  1.00 53.33           O  
+ATOM     93  CB  ASP A  30      95.144  58.596  69.044  1.00 53.33           C  
+ATOM     94  CG  ASP A  30      95.617  59.220  67.740  1.00 53.33           C  
+ATOM     95  OD1 ASP A  30      96.728  59.791  67.732  1.00 53.33           O  
+ATOM     96  OD2 ASP A  30      94.909  59.122  66.717  1.00 53.33           O  
+ATOM     97  N   LYS A  31      92.163  57.469  68.571  1.00 51.35           N  
+ATOM     98  CA  LYS A  31      91.063  57.061  67.699  1.00 51.35           C  
+ATOM     99  C   LYS A  31      89.777  57.811  68.040  1.00 51.35           C  
+ATOM    100  O   LYS A  31      89.056  58.276  67.140  1.00 51.35           O  
+ATOM    101  CB  LYS A  31      90.853  55.551  67.806  1.00 51.35           C  
+ATOM    102  CG  LYS A  31      89.487  55.067  67.352  1.00 51.35           C  
+ATOM    103  CD  LYS A  31      89.420  54.923  65.844  1.00 51.35           C  
+ATOM    104  CE  LYS A  31      88.145  54.218  65.420  1.00 51.35           C  
+ATOM    105  NZ  LYS A  31      88.050  54.094  63.941  1.00 51.35           N  
+ATOM    106  N   PHE A  32      89.478  57.938  69.336  1.00 47.16           N  
+ATOM    107  CA  PHE A  32      88.256  58.611  69.755  1.00 47.16           C  
+ATOM    108  C   PHE A  32      88.252  60.069  69.325  1.00 47.16           C  
+ATOM    109  O   PHE A  32      87.206  60.608  68.959  1.00 47.16           O  
+ATOM    110  CB  PHE A  32      88.086  58.508  71.269  1.00 47.16           C  
+ATOM    111  CG  PHE A  32      87.104  59.492  71.831  1.00 47.16           C  
+ATOM    112  CD1 PHE A  32      85.744  59.277  71.708  1.00 47.16           C  
+ATOM    113  CD2 PHE A  32      87.539  60.635  72.475  1.00 47.16           C  
+ATOM    114  CE1 PHE A  32      84.837  60.181  72.220  1.00 47.16           C  
+ATOM    115  CE2 PHE A  32      86.636  61.541  72.986  1.00 47.16           C  
+ATOM    116  CZ  PHE A  32      85.284  61.315  72.860  1.00 47.16           C  
+ATOM    117  N   ASN A  33      89.411  60.728  69.373  1.00 48.48           N  
+ATOM    118  CA  ASN A  33      89.482  62.126  68.960  1.00 48.48           C  
+ATOM    119  C   ASN A  33      89.101  62.279  67.495  1.00 48.48           C  
+ATOM    120  O   ASN A  33      88.235  63.090  67.147  1.00 48.48           O  
+ATOM    121  CB  ASN A  33      90.887  62.672  69.211  1.00 48.48           C  
+ATOM    122  CG  ASN A  33      91.201  62.814  70.684  1.00 48.48           C  
+ATOM    123  OD1 ASN A  33      90.319  63.090  71.496  1.00 48.48           O  
+ATOM    124  ND2 ASN A  33      92.465  62.621  71.040  1.00 48.48           N  
+ATOM    125  N   HIS A  34      89.729  61.494  66.621  1.00 50.00           N  
+ATOM    126  CA  HIS A  34      89.502  61.617  65.189  1.00 50.00           C  
+ATOM    127  C   HIS A  34      88.140  61.100  64.750  1.00 50.00           C  
+ATOM    128  O   HIS A  34      87.711  61.416  63.635  1.00 50.00           O  
+ATOM    129  CB  HIS A  34      90.610  60.893  64.424  1.00 50.00           C  
+ATOM    130  CG  HIS A  34      91.969  61.483  64.638  1.00 50.00           C  
+ATOM    131  ND1 HIS A  34      92.803  61.080  65.658  1.00 50.00           N  
+ATOM    132  CD2 HIS A  34      92.634  62.456  63.972  1.00 50.00           C  
+ATOM    133  CE1 HIS A  34      93.926  61.774  65.607  1.00 50.00           C  
+ATOM    134  NE2 HIS A  34      93.849  62.615  64.593  1.00 50.00           N  
+ATOM    135  N   GLU A  35      87.450  60.316  65.579  1.00 48.67           N  
+ATOM    136  CA  GLU A  35      86.060  60.008  65.249  1.00 48.67           C  
+ATOM    137  C   GLU A  35      85.084  61.052  65.793  1.00 48.67           C  
+ATOM    138  O   GLU A  35      84.205  61.538  65.058  1.00 48.67           O  
+ATOM    139  CB  GLU A  35      85.688  58.621  65.776  1.00 48.67           C  
+ATOM    140  CG  GLU A  35      86.347  57.475  65.030  1.00 48.67           C  
+ATOM    141  CD  GLU A  35      85.388  56.766  64.094  1.00 48.67           C  
+ATOM    142  OE1 GLU A  35      85.565  55.551  63.865  1.00 48.67           O  
+ATOM    143  OE2 GLU A  35      84.455  57.424  63.588  1.00 48.67           O  
+ATOM    144  N   ALA A  36      85.226  61.402  67.074  1.00 46.31           N  
+ATOM    145  CA  ALA A  36      84.317  62.343  67.712  1.00 46.31           C  
+ATOM    146  C   ALA A  36      84.406  63.725  67.095  1.00 46.31           C  
+ATOM    147  O   ALA A  36      83.408  64.447  67.078  1.00 46.31           O  
+ATOM    148  CB  ALA A  36      84.605  62.418  69.210  1.00 46.31           C  
+ATOM    149  N   GLU A  37      85.574  64.120  66.582  1.00 45.22           N  
+ATOM    150  CA  GLU A  37      85.682  65.425  65.945  1.00 45.22           C  
+ATOM    151  C   GLU A  37      84.738  65.523  64.755  1.00 45.22           C  
+ATOM    152  O   GLU A  37      83.928  66.452  64.662  1.00 45.22           O  
+ATOM    153  CB  GLU A  37      87.127  65.678  65.515  1.00 45.22           C  
+ATOM    154  CG  GLU A  37      87.415  67.115  65.135  1.00 45.22           C  
+ATOM    155  CD  GLU A  37      88.890  67.370  64.923  1.00 45.22           C  
+ATOM    156  OE1 GLU A  37      89.669  66.394  64.931  1.00 45.22           O  
+ATOM    157  OE2 GLU A  37      89.274  68.546  64.763  1.00 45.22           O  
+ATOM    158  N   ASP A  38      84.808  64.544  63.851  1.00 47.98           N  
+ATOM    159  CA  ASP A  38      83.942  64.547  62.678  1.00 47.98           C  
+ATOM    160  C   ASP A  38      82.476  64.433  63.082  1.00 47.98           C  
+ATOM    161  O   ASP A  38      81.619  65.145  62.541  1.00 47.98           O  
+ATOM    162  CB  ASP A  38      84.347  63.404  61.744  1.00 47.98           C  
+ATOM    163  CG  ASP A  38      83.625  63.437  60.401  1.00 47.98           C  
+ATOM    164  OD1 ASP A  38      84.155  62.829  59.449  1.00 47.98           O  
+ATOM    165  OD2 ASP A  38      82.552  64.062  60.274  1.00 47.98           O  
+ATOM    166  N   LEU A  39      82.165  63.552  64.037  1.00 47.40           N  
+ATOM    167  CA  LEU A  39      80.758  63.365  64.390  1.00 47.40           C  
+ATOM    168  C   LEU A  39      80.171  64.611  65.050  1.00 47.40           C  
+ATOM    169  O   LEU A  39      79.055  65.032  64.715  1.00 47.40           O  
+ATOM    170  CB  LEU A  39      80.600  62.139  65.287  1.00 47.40           C  
+ATOM    171  CG  LEU A  39      80.454  60.848  64.479  1.00 47.40           C  
+ATOM    172  CD1 LEU A  39      80.471  59.631  65.378  1.00 47.40           C  
+ATOM    173  CD2 LEU A  39      79.181  60.885  63.649  1.00 47.40           C  
+ATOM    174  N   PHE A  40      80.908  65.222  65.980  1.00 43.92           N  
+ATOM    175  CA  PHE A  40      80.443  66.450  66.612  1.00 43.92           C  
+ATOM    176  C   PHE A  40      80.354  67.586  65.605  1.00 43.92           C  
+ATOM    177  O   PHE A  40      79.461  68.434  65.697  1.00 43.92           O  
+ATOM    178  CB  PHE A  40      81.372  66.825  67.766  1.00 43.92           C  
+ATOM    179  CG  PHE A  40      81.056  68.151  68.396  1.00 43.92           C  
+ATOM    180  CD1 PHE A  40      79.999  68.279  69.281  1.00 43.92           C  
+ATOM    181  CD2 PHE A  40      81.820  69.268  68.109  1.00 43.92           C  
+ATOM    182  CE1 PHE A  40      79.708  69.496  69.862  1.00 43.92           C  
+ATOM    183  CE2 PHE A  40      81.532  70.489  68.687  1.00 43.92           C  
+ATOM    184  CZ  PHE A  40      80.475  70.600  69.565  1.00 43.92           C  
+ATOM    185  N   TYR A  41      81.265  67.617  64.628  1.00 41.60           N  
+ATOM    186  CA  TYR A  41      81.189  68.645  63.600  1.00 41.60           C  
+ATOM    187  C   TYR A  41      79.926  68.493  62.766  1.00 41.60           C  
+ATOM    188  O   TYR A  41      79.260  69.483  62.451  1.00 41.60           O  
+ATOM    189  CB  TYR A  41      82.428  68.594  62.710  1.00 41.60           C  
+ATOM    190  CG  TYR A  41      82.413  69.627  61.613  1.00 41.60           C  
+ATOM    191  CD1 TYR A  41      82.511  70.978  61.907  1.00 41.60           C  
+ATOM    192  CD2 TYR A  41      82.298  69.255  60.284  1.00 41.60           C  
+ATOM    193  CE1 TYR A  41      82.496  71.928  60.911  1.00 41.60           C  
+ATOM    194  CE2 TYR A  41      82.284  70.198  59.281  1.00 41.60           C  
+ATOM    195  CZ  TYR A  41      82.383  71.532  59.601  1.00 41.60           C  
+ATOM    196  OH  TYR A  41      82.371  72.475  58.605  1.00 41.60           O  
+ATOM    197  N   GLN A  42      79.578  67.257  62.403  1.00 44.56           N  
+ATOM    198  CA  GLN A  42      78.345  67.038  61.652  1.00 44.56           C  
+ATOM    199  C   GLN A  42      77.121  67.413  62.478  1.00 44.56           C  
+ATOM    200  O   GLN A  42      76.176  68.026  61.961  1.00 44.56           O  
+ATOM    201  CB  GLN A  42      78.258  65.584  61.192  1.00 44.56           C  
+ATOM    202  CG  GLN A  42      79.260  65.218  60.115  1.00 44.56           C  
+ATOM    203  CD  GLN A  42      79.025  63.835  59.550  1.00 44.56           C  
+ATOM    204  OE1 GLN A  42      77.938  63.273  59.681  1.00 44.56           O  
+ATOM    205  NE2 GLN A  42      80.047  63.273  58.916  1.00 44.56           N  
+ATOM    206  N   SER A  43      77.121  67.056  63.765  1.00 43.76           N  
+ATOM    207  CA  SER A  43      76.006  67.425  64.634  1.00 43.76           C  
+ATOM    208  C   SER A  43      75.850  68.939  64.716  1.00 43.76           C  
+ATOM    209  O   SER A  43      74.737  69.469  64.603  1.00 43.76           O  
+ATOM    210  CB  SER A  43      76.210  66.831  66.027  1.00 43.76           C  
+ATOM    211  OG  SER A  43      75.460  67.544  66.994  1.00 43.76           O  
+ATOM    212  N   SER A  44      76.961  69.651  64.911  1.00 39.99           N  
+ATOM    213  CA  SER A  44      76.906  71.103  65.018  1.00 39.99           C  
+ATOM    214  C   SER A  44      76.498  71.740  63.696  1.00 39.99           C  
+ATOM    215  O   SER A  44      75.782  72.746  63.683  1.00 39.99           O  
+ATOM    216  CB  SER A  44      78.256  71.645  65.482  1.00 39.99           C  
+ATOM    217  OG  SER A  44      79.292  71.243  64.603  1.00 39.99           O  
+ATOM    218  N   LEU A  45      76.933  71.165  62.574  1.00 43.81           N  
+ATOM    219  CA  LEU A  45      76.539  71.692  61.273  1.00 43.81           C  
+ATOM    220  C   LEU A  45      75.041  71.538  61.052  1.00 43.81           C  
+ATOM    221  O   LEU A  45      74.379  72.462  60.561  1.00 43.81           O  
+ATOM    222  CB  LEU A  45      77.325  70.986  60.170  1.00 43.81           C  
+ATOM    223  CG  LEU A  45      77.620  71.785  58.903  1.00 43.81           C  
+ATOM    224  CD1 LEU A  45      78.313  73.090  59.249  1.00 43.81           C  
+ATOM    225  CD2 LEU A  45      78.471  70.964  57.952  1.00 43.81           C  
+ATOM    226  N   ALA A  46      74.484  70.382  61.422  1.00 48.24           N  
+ATOM    227  CA  ALA A  46      73.042  70.193  61.306  1.00 48.24           C  
+ATOM    228  C   ALA A  46      72.284  71.145  62.224  1.00 48.24           C  
+ATOM    229  O   ALA A  46      71.279  71.746  61.819  1.00 48.24           O  
+ATOM    230  CB  ALA A  46      72.676  68.742  61.615  1.00 48.24           C  
+ATOM    231  N   SER A  47      72.756  71.309  63.463  1.00 46.78           N  
+ATOM    232  CA  SER A  47      72.080  72.210  64.391  1.00 46.78           C  
+ATOM    233  C   SER A  47      72.144  73.654  63.907  1.00 46.78           C  
+ATOM    234  O   SER A  47      71.186  74.416  64.076  1.00 46.78           O  
+ATOM    235  CB  SER A  47      72.687  72.083  65.786  1.00 46.78           C  
+ATOM    236  OG  SER A  47      72.399  73.226  66.568  1.00 46.78           O  
+ATOM    237  N   TRP A  48      73.264  74.049  63.298  1.00 47.68           N  
+ATOM    238  CA  TRP A  48      73.377  75.397  62.754  1.00 47.68           C  
+ATOM    239  C   TRP A  48      72.439  75.588  61.572  1.00 47.68           C  
+ATOM    240  O   TRP A  48      71.745  76.606  61.477  1.00 47.68           O  
+ATOM    241  CB  TRP A  48      74.820  75.681  62.344  1.00 47.68           C  
+ATOM    242  CG  TRP A  48      74.979  76.946  61.553  1.00 47.68           C  
+ATOM    243  CD1 TRP A  48      74.824  77.096  60.205  1.00 47.68           C  
+ATOM    244  CD2 TRP A  48      75.323  78.237  62.063  1.00 47.68           C  
+ATOM    245  NE1 TRP A  48      75.053  78.400  59.846  1.00 47.68           N  
+ATOM    246  CE2 TRP A  48      75.361  79.121  60.968  1.00 47.68           C  
+ATOM    247  CE3 TRP A  48      75.602  78.733  63.339  1.00 47.68           C  
+ATOM    248  CZ2 TRP A  48      75.666  80.471  61.111  1.00 47.68           C  
+ATOM    249  CZ3 TRP A  48      75.907  80.071  63.478  1.00 47.68           C  
+ATOM    250  CH2 TRP A  48      75.935  80.925  62.372  1.00 47.68           C  
+ATOM    251  N   ASN A  49      72.419  74.624  60.647  1.00 53.16           N  
+ATOM    252  CA  ASN A  49      71.470  74.684  59.542  1.00 53.16           C  
+ATOM    253  C   ASN A  49      70.041  74.791  60.049  1.00 53.16           C  
+ATOM    254  O   ASN A  49      69.200  75.431  59.408  1.00 53.16           O  
+ATOM    255  CB  ASN A  49      71.629  73.460  58.642  1.00 53.16           C  
+ATOM    256  CG  ASN A  49      72.942  73.460  57.884  1.00 53.16           C  
+ATOM    257  OD1 ASN A  49      73.424  74.508  57.454  1.00 53.16           O  
+ATOM    258  ND2 ASN A  49      73.530  72.282  57.718  1.00 53.16           N  
+ATOM    259  N   TYR A  50      69.749  74.181  61.199  1.00 56.90           N  
+ATOM    260  CA  TYR A  50      68.431  74.352  61.800  1.00 56.90           C  
+ATOM    261  C   TYR A  50      68.252  75.761  62.358  1.00 56.90           C  
+ATOM    262  O   TYR A  50      67.166  76.341  62.253  1.00 56.90           O  
+ATOM    263  CB  TYR A  50      68.210  73.316  62.901  1.00 56.90           C  
+ATOM    264  CG  TYR A  50      67.192  73.745  63.935  1.00 56.90           C  
+ATOM    265  CD1 TYR A  50      65.845  73.841  63.614  1.00 56.90           C  
+ATOM    266  CD2 TYR A  50      67.577  74.059  65.230  1.00 56.90           C  
+ATOM    267  CE1 TYR A  50      64.914  74.236  64.552  1.00 56.90           C  
+ATOM    268  CE2 TYR A  50      66.651  74.452  66.175  1.00 56.90           C  
+ATOM    269  CZ  TYR A  50      65.321  74.538  65.830  1.00 56.90           C  
+ATOM    270  OH  TYR A  50      64.392  74.931  66.766  1.00 56.90           O  
+ATOM    271  N   ASN A  51      69.303  76.326  62.954  1.00 54.28           N  
+ATOM    272  CA  ASN A  51      69.176  77.611  63.634  1.00 54.28           C  
+ATOM    273  C   ASN A  51      69.062  78.788  62.675  1.00 54.28           C  
+ATOM    274  O   ASN A  51      68.437  79.794  63.028  1.00 54.28           O  
+ATOM    275  CB  ASN A  51      70.361  77.826  64.577  1.00 54.28           C  
+ATOM    276  CG  ASN A  51      70.238  77.022  65.855  1.00 54.28           C  
+ATOM    277  OD1 ASN A  51      69.571  77.438  66.801  1.00 54.28           O  
+ATOM    278  ND2 ASN A  51      70.885  75.864  65.891  1.00 54.28           N  
+ATOM    279  N   THR A  52      69.650  78.698  61.484  1.00 60.17           N  
+ATOM    280  CA  THR A  52      69.498  79.739  60.475  1.00 60.17           C  
+ATOM    281  C   THR A  52      68.288  79.516  59.578  1.00 60.17           C  
+ATOM    282  O   THR A  52      67.878  80.445  58.873  1.00 60.17           O  
+ATOM    283  CB  THR A  52      70.753  79.828  59.601  1.00 60.17           C  
+ATOM    284  OG1 THR A  52      70.731  78.782  58.622  1.00 60.17           O  
+ATOM    285  CG2 THR A  52      72.001  79.689  60.446  1.00 60.17           C  
+ATOM    286  N   ASN A  53      67.716  78.312  59.586  1.00 71.47           N  
+ATOM    287  CA  ASN A  53      66.578  77.993  58.729  1.00 71.47           C  
+ATOM    288  C   ASN A  53      65.739  76.968  59.488  1.00 71.47           C  
+ATOM    289  O   ASN A  53      65.997  75.766  59.390  1.00 71.47           O  
+ATOM    290  CB  ASN A  53      67.052  77.459  57.387  1.00 71.47           C  
+ATOM    291  CG  ASN A  53      65.930  77.285  56.386  1.00 71.47           C  
+ATOM    292  OD1 ASN A  53      64.783  77.651  56.638  1.00 71.47           O  
+ATOM    293  ND2 ASN A  53      66.266  76.715  55.234  1.00 71.47           N  
+ATOM    294  N   ILE A  54      64.749  77.447  60.234  1.00 72.24           N  
+ATOM    295  CA  ILE A  54      63.974  76.594  61.128  1.00 72.24           C  
+ATOM    296  C   ILE A  54      62.760  76.047  60.384  1.00 72.24           C  
+ATOM    297  O   ILE A  54      61.868  76.800  59.978  1.00 72.24           O  
+ATOM    298  CB  ILE A  54      63.563  77.347  62.404  1.00 72.24           C  
+ATOM    299  CG1 ILE A  54      62.601  76.501  63.241  1.00 72.24           C  
+ATOM    300  CG2 ILE A  54      62.979  78.711  62.083  1.00 72.24           C  
+ATOM    301  CD1 ILE A  54      62.394  77.026  64.644  1.00 72.24           C  
+ATOM    302  N   THR A  55      62.739  74.730  60.194  1.00 77.71           N  
+ATOM    303  CA  THR A  55      61.617  74.011  59.609  1.00 77.71           C  
+ATOM    304  C   THR A  55      61.382  72.766  60.451  1.00 77.71           C  
+ATOM    305  O   THR A  55      61.888  72.650  61.569  1.00 77.71           O  
+ATOM    306  CB  THR A  55      61.874  73.642  58.141  1.00 77.71           C  
+ATOM    307  OG1 THR A  55      63.024  72.794  58.054  1.00 77.71           O  
+ATOM    308  CG2 THR A  55      62.104  74.888  57.298  1.00 77.71           C  
+ATOM    309  N   GLU A  56      60.592  71.832  59.923  1.00 83.78           N  
+ATOM    310  CA  GLU A  56      60.417  70.555  60.606  1.00 83.78           C  
+ATOM    311  C   GLU A  56      61.464  69.537  60.171  1.00 83.78           C  
+ATOM    312  O   GLU A  56      61.987  68.788  61.009  1.00 83.78           O  
+ATOM    313  CB  GLU A  56      59.010  70.002  60.358  1.00 83.78           C  
+ATOM    314  CG  GLU A  56      57.874  70.996  60.601  1.00 83.78           C  
+ATOM    315  CD  GLU A  56      57.698  71.993  59.469  1.00 83.78           C  
+ATOM    316  OE1 GLU A  56      57.623  71.561  58.300  1.00 83.78           O  
+ATOM    317  OE2 GLU A  56      57.643  73.209  59.749  1.00 83.78           O  
+ATOM    318  N   GLU A  57      61.789  69.505  58.877  1.00 81.27           N  
+ATOM    319  CA  GLU A  57      62.831  68.605  58.397  1.00 81.27           C  
+ATOM    320  C   GLU A  57      64.187  68.980  58.976  1.00 81.27           C  
+ATOM    321  O   GLU A  57      65.039  68.112  59.195  1.00 81.27           O  
+ATOM    322  CB  GLU A  57      62.871  68.618  56.869  1.00 81.27           C  
+ATOM    323  CG  GLU A  57      63.020  70.004  56.266  1.00 81.27           C  
+ATOM    324  CD  GLU A  57      61.684  70.627  55.914  1.00 81.27           C  
+ATOM    325  OE1 GLU A  57      61.468  70.945  54.725  1.00 81.27           O  
+ATOM    326  OE2 GLU A  57      60.850  70.800  56.828  1.00 81.27           O  
+ATOM    327  N   ASN A  58      64.403  70.270  59.241  1.00 74.66           N  
+ATOM    328  CA  ASN A  58      65.643  70.685  59.884  1.00 74.66           C  
+ATOM    329  C   ASN A  58      65.741  70.144  61.304  1.00 74.66           C  
+ATOM    330  O   ASN A  58      66.813  69.687  61.716  1.00 74.66           O  
+ATOM    331  CB  ASN A  58      65.757  72.208  59.877  1.00 74.66           C  
+ATOM    332  CG  ASN A  58      66.042  72.761  58.495  1.00 74.66           C  
+ATOM    333  OD1 ASN A  58      66.799  72.175  57.723  1.00 74.66           O  
+ATOM    334  ND2 ASN A  58      65.429  73.894  58.173  1.00 74.66           N  
+ATOM    335  N   VAL A  59      64.640  70.170  62.060  1.00 75.01           N  
+ATOM    336  CA  VAL A  59      64.651  69.569  63.392  1.00 75.01           C  
+ATOM    337  C   VAL A  59      64.867  68.066  63.296  1.00 75.01           C  
+ATOM    338  O   VAL A  59      65.564  67.474  64.127  1.00 75.01           O  
+ATOM    339  CB  VAL A  59      63.358  69.901  64.159  1.00 75.01           C  
+ATOM    340  CG1 VAL A  59      63.506  69.517  65.620  1.00 75.01           C  
+ATOM    341  CG2 VAL A  59      63.050  71.370  64.054  1.00 75.01           C  
+ATOM    342  N   GLN A  60      64.272  67.422  62.289  1.00 77.14           N  
+ATOM    343  CA  GLN A  60      64.476  65.984  62.124  1.00 77.14           C  
+ATOM    344  C   GLN A  60      65.946  65.665  61.870  1.00 77.14           C  
+ATOM    345  O   GLN A  60      66.519  64.764  62.497  1.00 77.14           O  
+ATOM    346  CB  GLN A  60      63.601  65.453  60.988  1.00 77.14           C  
+ATOM    347  CG  GLN A  60      62.140  65.273  61.367  1.00 77.14           C  
+ATOM    348  CD  GLN A  60      61.195  65.606  60.229  1.00 77.14           C  
+ATOM    349  OE1 GLN A  60      61.582  65.591  59.060  1.00 77.14           O  
+ATOM    350  NE2 GLN A  60      59.948  65.912  60.566  1.00 77.14           N  
+ATOM    351  N   ASN A  61      66.578  66.410  60.960  1.00 70.91           N  
+ATOM    352  CA  ASN A  61      67.991  66.191  60.659  1.00 70.91           C  
+ATOM    353  C   ASN A  61      68.863  66.478  61.876  1.00 70.91           C  
+ATOM    354  O   ASN A  61      69.803  65.728  62.174  1.00 70.91           O  
+ATOM    355  CB  ASN A  61      68.411  67.062  59.476  1.00 70.91           C  
+ATOM    356  CG  ASN A  61      69.884  66.927  59.144  1.00 70.91           C  
+ATOM    357  OD1 ASN A  61      70.500  65.892  59.399  1.00 70.91           O  
+ATOM    358  ND2 ASN A  61      70.458  67.978  58.569  1.00 70.91           N  
+ATOM    359  N   MET A  62      68.569  67.567  62.590  1.00 66.87           N  
+ATOM    360  CA  MET A  62      69.355  67.919  63.767  1.00 66.87           C  
+ATOM    361  C   MET A  62      69.240  66.850  64.844  1.00 66.87           C  
+ATOM    362  O   MET A  62      70.241  66.474  65.464  1.00 66.87           O  
+ATOM    363  CB  MET A  62      68.906  69.278  64.303  1.00 66.87           C  
+ATOM    364  CG  MET A  62      69.128  69.468  65.792  1.00 66.87           C  
+ATOM    365  SD  MET A  62      68.241  70.891  66.449  1.00 66.87           S  
+ATOM    366  CE  MET A  62      68.440  70.627  68.207  1.00 66.87           C  
+ATOM    367  N   ASN A  63      68.027  66.342  65.077  1.00 68.70           N  
+ATOM    368  CA  ASN A  63      67.841  65.306  66.085  1.00 68.70           C  
+ATOM    369  C   ASN A  63      68.514  64.005  65.671  1.00 68.70           C  
+ATOM    370  O   ASN A  63      69.075  63.300  66.515  1.00 68.70           O  
+ATOM    371  CB  ASN A  63      66.351  65.090  66.343  1.00 68.70           C  
+ATOM    372  CG  ASN A  63      65.775  66.108  67.305  1.00 68.70           C  
+ATOM    373  OD1 ASN A  63      66.456  66.569  68.221  1.00 68.70           O  
+ATOM    374  ND2 ASN A  63      64.513  66.468  67.102  1.00 68.70           N  
+ATOM    375  N   ASN A  64      68.486  63.677  64.376  1.00 68.54           N  
+ATOM    376  CA  ASN A  64      69.181  62.481  63.908  1.00 68.54           C  
+ATOM    377  C   ASN A  64      70.684  62.598  64.132  1.00 68.54           C  
+ATOM    378  O   ASN A  64      71.328  61.660  64.622  1.00 68.54           O  
+ATOM    379  CB  ASN A  64      68.872  62.243  62.430  1.00 68.54           C  
+ATOM    380  CG  ASN A  64      67.445  61.797  62.199  1.00 68.54           C  
+ATOM    381  OD1 ASN A  64      66.914  60.972  62.942  1.00 68.54           O  
+ATOM    382  ND2 ASN A  64      66.813  62.343  61.168  1.00 68.54           N  
+ATOM    383  N   ALA A  65      71.261  63.749  63.782  1.00 64.12           N  
+ATOM    384  CA  ALA A  65      72.693  63.949  63.981  1.00 64.12           C  
+ATOM    385  C   ALA A  65      73.056  63.918  65.462  1.00 64.12           C  
+ATOM    386  O   ALA A  65      74.063  63.312  65.852  1.00 64.12           O  
+ATOM    387  CB  ALA A  65      73.134  65.264  63.345  1.00 64.12           C  
+ATOM    388  N   GLY A  66      72.245  64.562  66.303  1.00 65.34           N  
+ATOM    389  CA  GLY A  66      72.511  64.543  67.731  1.00 65.34           C  
+ATOM    390  C   GLY A  66      72.392  63.153  68.326  1.00 65.34           C  
+ATOM    391  O   GLY A  66      73.152  62.786  69.224  1.00 65.34           O  
+ATOM    392  N   ASP A  67      71.448  62.354  67.824  1.00 68.90           N  
+ATOM    393  CA  ASP A  67      71.308  60.987  68.308  1.00 68.90           C  
+ATOM    394  C   ASP A  67      72.496  60.134  67.888  1.00 68.90           C  
+ATOM    395  O   ASP A  67      72.985  59.316  68.674  1.00 68.90           O  
+ATOM    396  CB  ASP A  67      70.001  60.382  67.800  1.00 68.90           C  
+ATOM    397  CG  ASP A  67      68.794  60.879  68.569  1.00 68.90           C  
+ATOM    398  OD1 ASP A  67      68.981  61.664  69.521  1.00 68.90           O  
+ATOM    399  OD2 ASP A  67      67.661  60.484  68.224  1.00 68.90           O  
+ATOM    400  N   LYS A  68      72.974  60.309  66.653  1.00 61.35           N  
+ATOM    401  CA  LYS A  68      74.189  59.617  66.234  1.00 61.35           C  
+ATOM    402  C   LYS A  68      75.362  59.988  67.134  1.00 61.35           C  
+ATOM    403  O   LYS A  68      76.111  59.117  67.596  1.00 61.35           O  
+ATOM    404  CB  LYS A  68      74.509  59.946  64.776  1.00 61.35           C  
+ATOM    405  CG  LYS A  68      73.519  59.389  63.770  1.00 61.35           C  
+ATOM    406  CD  LYS A  68      74.112  59.388  62.369  1.00 61.35           C  
+ATOM    407  CE  LYS A  68      73.033  59.288  61.304  1.00 61.35           C  
+ATOM    408  NZ  LYS A  68      72.257  60.553  61.178  1.00 61.35           N  
+ATOM    409  N   TRP A  69      75.526  61.287  67.399  1.00 55.25           N  
+ATOM    410  CA  TRP A  69      76.627  61.752  68.238  1.00 55.25           C  
+ATOM    411  C   TRP A  69      76.527  61.176  69.648  1.00 55.25           C  
+ATOM    412  O   TRP A  69      77.524  60.715  70.216  1.00 55.25           O  
+ATOM    413  CB  TRP A  69      76.638  63.281  68.264  1.00 55.25           C  
+ATOM    414  CG  TRP A  69      77.454  63.889  69.363  1.00 55.25           C  
+ATOM    415  CD1 TRP A  69      76.990  64.611  70.424  1.00 55.25           C  
+ATOM    416  CD2 TRP A  69      78.879  63.849  69.499  1.00 55.25           C  
+ATOM    417  NE1 TRP A  69      78.036  65.013  71.218  1.00 55.25           N  
+ATOM    418  CE2 TRP A  69      79.207  64.558  70.671  1.00 55.25           C  
+ATOM    419  CE3 TRP A  69      79.909  63.279  68.748  1.00 55.25           C  
+ATOM    420  CZ2 TRP A  69      80.518  64.712  71.108  1.00 55.25           C  
+ATOM    421  CZ3 TRP A  69      81.210  63.433  69.184  1.00 55.25           C  
+ATOM    422  CH2 TRP A  69      81.504  64.141  70.352  1.00 55.25           C  
+ATOM    423  N   SER A  70      75.320  61.171  70.219  1.00 61.03           N  
+ATOM    424  CA  SER A  70      75.144  60.672  71.579  1.00 61.03           C  
+ATOM    425  C   SER A  70      75.368  59.166  71.655  1.00 61.03           C  
+ATOM    426  O   SER A  70      75.972  58.674  72.615  1.00 61.03           O  
+ATOM    427  CB  SER A  70      73.752  61.035  72.094  1.00 61.03           C  
+ATOM    428  OG  SER A  70      73.720  62.364  72.583  1.00 61.03           O  
+ATOM    429  N   ALA A  71      74.884  58.416  70.661  1.00 60.34           N  
+ATOM    430  CA  ALA A  71      75.114  56.977  70.649  1.00 60.34           C  
+ATOM    431  C   ALA A  71      76.598  56.659  70.529  1.00 60.34           C  
+ATOM    432  O   ALA A  71      77.108  55.760  71.211  1.00 60.34           O  
+ATOM    433  CB  ALA A  71      74.331  56.328  69.508  1.00 60.34           C  
+ATOM    434  N   PHE A  72      77.309  57.390  69.667  1.00 57.80           N  
+ATOM    435  CA  PHE A  72      78.748  57.186  69.545  1.00 57.80           C  
+ATOM    436  C   PHE A  72      79.456  57.510  70.854  1.00 57.80           C  
+ATOM    437  O   PHE A  72      80.376  56.797  71.270  1.00 57.80           O  
+ATOM    438  CB  PHE A  72      79.303  58.039  68.407  1.00 57.80           C  
+ATOM    439  CG  PHE A  72      80.796  58.186  68.434  1.00 57.80           C  
+ATOM    440  CD1 PHE A  72      81.610  57.212  67.885  1.00 57.80           C  
+ATOM    441  CD2 PHE A  72      81.386  59.303  69.001  1.00 57.80           C  
+ATOM    442  CE1 PHE A  72      82.982  57.346  67.906  1.00 57.80           C  
+ATOM    443  CE2 PHE A  72      82.755  59.438  69.027  1.00 57.80           C  
+ATOM    444  CZ  PHE A  72      83.554  58.462  68.478  1.00 57.80           C  
+ATOM    445  N   LEU A  73      79.041  58.594  71.515  1.00 61.62           N  
+ATOM    446  CA  LEU A  73      79.659  58.968  72.783  1.00 61.62           C  
+ATOM    447  C   LEU A  73      79.416  57.903  73.844  1.00 61.62           C  
+ATOM    448  O   LEU A  73      80.308  57.586  74.638  1.00 61.62           O  
+ATOM    449  CB  LEU A  73      79.123  60.324  73.243  1.00 61.62           C  
+ATOM    450  CG  LEU A  73      80.065  61.175  74.095  1.00 61.62           C  
+ATOM    451  CD1 LEU A  73      81.284  61.588  73.288  1.00 61.62           C  
+ATOM    452  CD2 LEU A  73      79.338  62.394  74.639  1.00 61.62           C  
+ATOM    453  N   LYS A  74      78.210  57.331  73.865  1.00 62.57           N  
+ATOM    454  CA  LYS A  74      77.904  56.273  74.825  1.00 62.57           C  
+ATOM    455  C   LYS A  74      78.751  55.035  74.562  1.00 62.57           C  
+ATOM    456  O   LYS A  74      79.298  54.431  75.493  1.00 62.57           O  
+ATOM    457  CB  LYS A  74      76.416  55.931  74.771  1.00 62.57           C  
+ATOM    458  CG  LYS A  74      75.990  54.869  75.771  1.00 62.57           C  
+ATOM    459  CD  LYS A  74      74.483  54.672  75.764  1.00 62.57           C  
+ATOM    460  CE  LYS A  74      74.014  54.009  74.480  1.00 62.57           C  
+ATOM    461  NZ  LYS A  74      74.557  52.630  74.336  1.00 62.57           N  
+ATOM    462  N   GLU A  75      78.867  54.641  73.292  1.00 63.55           N  
+ATOM    463  CA  GLU A  75      79.701  53.492  72.949  1.00 63.55           C  
+ATOM    464  C   GLU A  75      81.155  53.727  73.343  1.00 63.55           C  
+ATOM    465  O   GLU A  75      81.816  52.832  73.888  1.00 63.55           O  
+ATOM    466  CB  GLU A  75      79.589  53.197  71.454  1.00 63.55           C  
+ATOM    467  CG  GLU A  75      80.707  52.332  70.898  1.00 63.55           C  
+ATOM    468  CD  GLU A  75      80.787  52.389  69.386  1.00 63.55           C  
+ATOM    469  OE1 GLU A  75      79.830  52.886  68.755  1.00 63.55           O  
+ATOM    470  OE2 GLU A  75      81.809  51.938  68.827  1.00 63.55           O  
+ATOM    471  N   GLN A  76      81.668  54.934  73.090  1.00 59.97           N  
+ATOM    472  CA  GLN A  76      83.058  55.228  73.420  1.00 59.97           C  
+ATOM    473  C   GLN A  76      83.278  55.265  74.926  1.00 59.97           C  
+ATOM    474  O   GLN A  76      84.322  54.823  75.413  1.00 59.97           O  
+ATOM    475  CB  GLN A  76      83.479  56.547  72.780  1.00 59.97           C  
+ATOM    476  CG  GLN A  76      83.629  56.464  71.277  1.00 59.97           C  
+ATOM    477  CD  GLN A  76      84.730  55.514  70.853  1.00 59.97           C  
+ATOM    478  OE1 GLN A  76      85.878  55.650  71.272  1.00 59.97           O  
+ATOM    479  NE2 GLN A  76      84.384  54.545  70.015  1.00 59.97           N  
+ATOM    480  N   SER A  77      82.307  55.779  75.684  1.00 60.99           N  
+ATOM    481  CA  SER A  77      82.426  55.761  77.138  1.00 60.99           C  
+ATOM    482  C   SER A  77      82.402  54.334  77.670  1.00 60.99           C  
+ATOM    483  O   SER A  77      83.141  53.996  78.605  1.00 60.99           O  
+ATOM    484  CB  SER A  77      81.308  56.591  77.767  1.00 60.99           C  
+ATOM    485  OG  SER A  77      81.482  56.704  79.168  1.00 60.99           O  
+ATOM    486  N   THR A  78      81.558  53.481  77.085  1.00 65.25           N  
+ATOM    487  CA  THR A  78      81.539  52.075  77.475  1.00 65.25           C  
+ATOM    488  C   THR A  78      82.881  51.410  77.194  1.00 65.25           C  
+ATOM    489  O   THR A  78      83.389  50.644  78.020  1.00 65.25           O  
+ATOM    490  CB  THR A  78      80.412  51.342  76.745  1.00 65.25           C  
+ATOM    491  OG1 THR A  78      79.146  51.836  77.200  1.00 65.25           O  
+ATOM    492  CG2 THR A  78      80.488  49.844  77.003  1.00 65.25           C  
+ATOM    493  N   LEU A  79      83.475  51.701  76.034  1.00 64.31           N  
+ATOM    494  CA  LEU A  79      84.785  51.138  75.720  1.00 64.31           C  
+ATOM    495  C   LEU A  79      85.867  51.697  76.638  1.00 64.31           C  
+ATOM    496  O   LEU A  79      86.837  51.002  76.961  1.00 64.31           O  
+ATOM    497  CB  LEU A  79      85.137  51.404  74.257  1.00 64.31           C  
+ATOM    498  CG  LEU A  79      84.679  50.360  73.238  1.00 64.31           C  
+ATOM    499  CD1 LEU A  79      85.077  50.772  71.830  1.00 64.31           C  
+ATOM    500  CD2 LEU A  79      85.254  48.996  73.582  1.00 64.31           C  
+ATOM    501  N   ALA A  80      85.717  52.951  77.069  1.00 65.92           N  
+ATOM    502  CA  ALA A  80      86.744  53.585  77.888  1.00 65.92           C  
+ATOM    503  C   ALA A  80      86.686  53.106  79.331  1.00 65.92           C  
+ATOM    504  O   ALA A  80      87.710  53.084  80.024  1.00 65.92           O  
+ATOM    505  CB  ALA A  80      86.595  55.103  77.832  1.00 65.92           C  
+ATOM    506  N   GLN A  81      85.497  52.731  79.805  1.00 70.81           N  
+ATOM    507  CA  GLN A  81      85.329  52.299  81.188  1.00 70.81           C  
+ATOM    508  C   GLN A  81      86.196  51.087  81.515  1.00 70.81           C  
+ATOM    509  O   GLN A  81      86.484  50.823  82.686  1.00 70.81           O  
+ATOM    510  CB  GLN A  81      83.859  51.986  81.473  1.00 70.81           C  
+ATOM    511  CG  GLN A  81      83.481  52.064  82.943  1.00 70.81           C  
+ATOM    512  CD  GLN A  81      83.166  53.478  83.391  1.00 70.81           C  
+ATOM    513  OE1 GLN A  81      82.649  54.284  82.618  1.00 70.81           O  
+ATOM    514  NE2 GLN A  81      83.476  53.785  84.645  1.00 70.81           N  
+ATOM    515  N   MET A  82      86.623  50.351  80.492  1.00 77.54           N  
+ATOM    516  CA  MET A  82      87.448  49.165  80.672  1.00 77.54           C  
+ATOM    517  C   MET A  82      88.939  49.479  80.718  1.00 77.54           C  
+ATOM    518  O   MET A  82      89.755  48.594  80.444  1.00 77.54           O  
+ATOM    519  CB  MET A  82      87.161  48.151  79.561  1.00 77.54           C  
+ATOM    520  CG  MET A  82      85.679  47.885  79.344  1.00 77.54           C  
+ATOM    521  SD  MET A  82      85.265  47.512  77.629  1.00 77.54           S  
+ATOM    522  CE  MET A  82      85.735  45.786  77.535  1.00 77.54           C  
+ATOM    523  N   TYR A  83      89.312  50.712  81.052  1.00 75.52           N  
+ATOM    524  CA  TYR A  83      90.712  51.078  81.234  1.00 75.52           C  
+ATOM    525  C   TYR A  83      90.932  51.516  82.674  1.00 75.52           C  
+ATOM    526  O   TYR A  83      90.330  52.509  83.112  1.00 75.52           O  
+ATOM    527  CB  TYR A  83      91.115  52.194  80.268  1.00 75.52           C  
+ATOM    528  CG  TYR A  83      91.263  51.736  78.837  1.00 75.52           C  
+ATOM    529  CD1 TYR A  83      90.212  51.849  77.939  1.00 75.52           C  
+ATOM    530  CD2 TYR A  83      92.454  51.186  78.385  1.00 75.52           C  
+ATOM    531  CE1 TYR A  83      90.343  51.428  76.630  1.00 75.52           C  
+ATOM    532  CE2 TYR A  83      92.595  50.762  77.079  1.00 75.52           C  
+ATOM    533  CZ  TYR A  83      91.536  50.885  76.206  1.00 75.52           C  
+ATOM    534  OH  TYR A  83      91.673  50.464  74.903  1.00 75.52           O  
+ATOM    535  N   PRO A  84      91.765  50.819  83.447  1.00 81.52           N  
+ATOM    536  CA  PRO A  84      91.963  51.203  84.851  1.00 81.52           C  
+ATOM    537  C   PRO A  84      92.753  52.500  84.960  1.00 81.52           C  
+ATOM    538  O   PRO A  84      93.880  52.602  84.469  1.00 81.52           O  
+ATOM    539  CB  PRO A  84      92.735  50.017  85.438  1.00 81.52           C  
+ATOM    540  CG  PRO A  84      93.434  49.410  84.269  1.00 81.52           C  
+ATOM    541  CD  PRO A  84      92.538  49.620  83.081  1.00 81.52           C  
+ATOM    542  N   LEU A  85      92.150  53.495  85.614  1.00 80.37           N  
+ATOM    543  CA  LEU A  85      92.794  54.792  85.777  1.00 80.37           C  
+ATOM    544  C   LEU A  85      93.891  54.781  86.832  1.00 80.37           C  
+ATOM    545  O   LEU A  85      94.680  55.730  86.887  1.00 80.37           O  
+ATOM    546  CB  LEU A  85      91.756  55.855  86.135  1.00 80.37           C  
+ATOM    547  CG  LEU A  85      91.247  56.730  84.988  1.00 80.37           C  
+ATOM    548  CD1 LEU A  85      90.121  57.633  85.466  1.00 80.37           C  
+ATOM    549  CD2 LEU A  85      92.379  57.547  84.388  1.00 80.37           C  
+ATOM    550  N   GLN A  86      93.959  53.742  87.668  1.00 90.15           N  
+ATOM    551  CA  GLN A  86      94.976  53.691  88.711  1.00 90.15           C  
+ATOM    552  C   GLN A  86      96.378  53.499  88.150  1.00 90.15           C  
+ATOM    553  O   GLN A  86      97.353  53.850  88.821  1.00 90.15           O  
+ATOM    554  CB  GLN A  86      94.654  52.571  89.701  1.00 90.15           C  
+ATOM    555  CG  GLN A  86      94.658  51.183  89.085  1.00 90.15           C  
+ATOM    556  CD  GLN A  86      93.626  50.267  89.709  1.00 90.15           C  
+ATOM    557  OE1 GLN A  86      92.424  50.449  89.522  1.00 90.15           O  
+ATOM    558  NE2 GLN A  86      94.092  49.275  90.458  1.00 90.15           N  
+ATOM    559  N   GLU A  87      96.503  52.952  86.941  1.00 89.33           N  
+ATOM    560  CA  GLU A  87      97.798  52.739  86.309  1.00 89.33           C  
+ATOM    561  C   GLU A  87      98.098  53.788  85.244  1.00 89.33           C  
+ATOM    562  O   GLU A  87      98.957  53.567  84.384  1.00 89.33           O  
+ATOM    563  CB  GLU A  87      97.870  51.335  85.709  1.00 89.33           C  
+ATOM    564  CG  GLU A  87      98.130  50.234  86.728  1.00 89.33           C  
+ATOM    565  CD  GLU A  87      99.056  50.677  87.846  1.00 89.33           C  
+ATOM    566  OE1 GLU A  87      98.576  50.840  88.987  1.00 89.33           O  
+ATOM    567  OE2 GLU A  87     100.263  50.858  87.584  1.00 89.33           O  
+ATOM    568  N   ILE A  88      97.409  54.925  85.284  1.00 75.91           N  
+ATOM    569  CA  ILE A  88      97.600  56.004  84.323  1.00 75.91           C  
+ATOM    570  C   ILE A  88      98.506  57.050  84.957  1.00 75.91           C  
+ATOM    571  O   ILE A  88      98.236  57.526  86.066  1.00 75.91           O  
+ATOM    572  CB  ILE A  88      96.259  56.618  83.895  1.00 75.91           C  
+ATOM    573  CG1 ILE A  88      95.390  55.567  83.202  1.00 75.91           C  
+ATOM    574  CG2 ILE A  88      96.490  57.798  82.973  1.00 75.91           C  
+ATOM    575  CD1 ILE A  88      95.984  55.037  81.918  1.00 75.91           C  
+ATOM    576  N   GLN A  89      99.578  57.412  84.254  1.00 70.78           N  
+ATOM    577  CA  GLN A  89     100.574  58.344  84.768  1.00 70.78           C  
+ATOM    578  C   GLN A  89     100.482  59.727  84.138  1.00 70.78           C  
+ATOM    579  O   GLN A  89     100.551  60.732  84.854  1.00 70.78           O  
+ATOM    580  CB  GLN A  89     101.982  57.782  84.548  1.00 70.78           C  
+ATOM    581  CG  GLN A  89     102.276  56.519  85.338  1.00 70.78           C  
+ATOM    582  CD  GLN A  89     102.769  56.811  86.741  1.00 70.78           C  
+ATOM    583  OE1 GLN A  89     103.001  57.964  87.102  1.00 70.78           O  
+ATOM    584  NE2 GLN A  89     102.931  55.763  87.540  1.00 70.78           N  
+ATOM    585  N   ASN A  90     100.337  59.802  82.817  1.00 65.85           N  
+ATOM    586  CA  ASN A  90     100.284  61.089  82.134  1.00 65.85           C  
+ATOM    587  C   ASN A  90      99.062  61.880  82.580  1.00 65.85           C  
+ATOM    588  O   ASN A  90      97.950  61.348  82.641  1.00 65.85           O  
+ATOM    589  CB  ASN A  90     100.258  60.873  80.621  1.00 65.85           C  
+ATOM    590  CG  ASN A  90     100.664  62.108  79.844  1.00 65.85           C  
+ATOM    591  OD1 ASN A  90     100.446  63.237  80.284  1.00 65.85           O  
+ATOM    592  ND2 ASN A  90     101.261  61.899  78.676  1.00 65.85           N  
+ATOM    593  N   LEU A  91      99.273  63.160  82.892  1.00 64.71           N  
+ATOM    594  CA  LEU A  91      98.182  63.987  83.398  1.00 64.71           C  
+ATOM    595  C   LEU A  91      97.143  64.260  82.318  1.00 64.71           C  
+ATOM    596  O   LEU A  91      95.937  64.236  82.588  1.00 64.71           O  
+ATOM    597  CB  LEU A  91      98.728  65.300  83.960  1.00 64.71           C  
+ATOM    598  CG  LEU A  91      99.223  65.318  85.411  1.00 64.71           C  
+ATOM    599  CD1 LEU A  91      98.077  65.022  86.367  1.00 64.71           C  
+ATOM    600  CD2 LEU A  91     100.383  64.357  85.642  1.00 64.71           C  
+ATOM    601  N   THR A  92      97.588  64.523  81.087  1.00 60.18           N  
+ATOM    602  CA  THR A  92      96.643  64.815  80.014  1.00 60.18           C  
+ATOM    603  C   THR A  92      95.835  63.580  79.635  1.00 60.18           C  
+ATOM    604  O   THR A  92      94.612  63.659  79.462  1.00 60.18           O  
+ATOM    605  CB  THR A  92      97.385  65.365  78.796  1.00 60.18           C  
+ATOM    606  OG1 THR A  92      97.964  64.282  78.060  1.00 60.18           O  
+ATOM    607  CG2 THR A  92      98.488  66.314  79.235  1.00 60.18           C  
+ATOM    608  N   VAL A  93      96.502  62.432  79.498  1.00 56.98           N  
+ATOM    609  CA  VAL A  93      95.795  61.191  79.198  1.00 56.98           C  
+ATOM    610  C   VAL A  93      94.833  60.842  80.324  1.00 56.98           C  
+ATOM    611  O   VAL A  93      93.711  60.383  80.080  1.00 56.98           O  
+ATOM    612  CB  VAL A  93      96.801  60.055  78.935  1.00 56.98           C  
+ATOM    613  CG1 VAL A  93      96.095  58.848  78.353  1.00 56.98           C  
+ATOM    614  CG2 VAL A  93      97.890  60.529  77.988  1.00 56.98           C  
+ATOM    615  N   LYS A  94      95.249  61.066  81.572  1.00 59.34           N  
+ATOM    616  CA  LYS A  94      94.367  60.794  82.702  1.00 59.34           C  
+ATOM    617  C   LYS A  94      93.144  61.699  82.674  1.00 59.34           C  
+ATOM    618  O   LYS A  94      92.021  61.242  82.912  1.00 59.34           O  
+ATOM    619  CB  LYS A  94      95.128  60.959  84.017  1.00 59.34           C  
+ATOM    620  CG  LYS A  94      94.356  60.498  85.241  1.00 59.34           C  
+ATOM    621  CD  LYS A  94      95.252  59.742  86.210  1.00 59.34           C  
+ATOM    622  CE  LYS A  94      96.440  60.584  86.640  1.00 59.34           C  
+ATOM    623  NZ  LYS A  94      97.386  59.814  87.493  1.00 59.34           N  
+ATOM    624  N   LEU A  95      93.340  62.984  82.375  1.00 54.35           N  
+ATOM    625  CA  LEU A  95      92.214  63.910  82.319  1.00 54.35           C  
+ATOM    626  C   LEU A  95      91.251  63.544  81.197  1.00 54.35           C  
+ATOM    627  O   LEU A  95      90.029  63.599  81.378  1.00 54.35           O  
+ATOM    628  CB  LEU A  95      92.719  65.342  82.149  1.00 54.35           C  
+ATOM    629  CG  LEU A  95      93.077  66.082  83.437  1.00 54.35           C  
+ATOM    630  CD1 LEU A  95      93.651  67.454  83.124  1.00 54.35           C  
+ATOM    631  CD2 LEU A  95      91.856  66.199  84.333  1.00 54.35           C  
+ATOM    632  N   GLN A  96      91.780  63.159  80.034  1.00 51.16           N  
+ATOM    633  CA  GLN A  96      90.905  62.773  78.930  1.00 51.16           C  
+ATOM    634  C   GLN A  96      90.137  61.497  79.250  1.00 51.16           C  
+ATOM    635  O   GLN A  96      88.927  61.416  79.003  1.00 51.16           O  
+ATOM    636  CB  GLN A  96      91.717  62.611  77.647  1.00 51.16           C  
+ATOM    637  CG  GLN A  96      92.360  63.898  77.168  1.00 51.16           C  
+ATOM    638  CD  GLN A  96      93.058  63.736  75.838  1.00 51.16           C  
+ATOM    639  OE1 GLN A  96      92.415  63.600  74.799  1.00 51.16           O  
+ATOM    640  NE2 GLN A  96      94.385  63.751  75.862  1.00 51.16           N  
+ATOM    641  N   LEU A  97      90.817  60.493  79.810  1.00 54.55           N  
+ATOM    642  CA  LEU A  97      90.134  59.258  80.180  1.00 54.55           C  
+ATOM    643  C   LEU A  97      89.082  59.509  81.251  1.00 54.55           C  
+ATOM    644  O   LEU A  97      88.019  58.880  81.242  1.00 54.55           O  
+ATOM    645  CB  LEU A  97      91.146  58.220  80.658  1.00 54.55           C  
+ATOM    646  CG  LEU A  97      92.042  57.599  79.587  1.00 54.55           C  
+ATOM    647  CD1 LEU A  97      93.029  56.642  80.225  1.00 54.55           C  
+ATOM    648  CD2 LEU A  97      91.206  56.889  78.538  1.00 54.55           C  
+ATOM    649  N   GLN A  98      89.355  60.425  82.181  1.00 55.63           N  
+ATOM    650  CA  GLN A  98      88.381  60.727  83.224  1.00 55.63           C  
+ATOM    651  C   GLN A  98      87.179  61.470  82.657  1.00 55.63           C  
+ATOM    652  O   GLN A  98      86.039  61.224  83.068  1.00 55.63           O  
+ATOM    653  CB  GLN A  98      89.040  61.538  84.338  1.00 55.63           C  
+ATOM    654  CG  GLN A  98      88.113  61.873  85.494  1.00 55.63           C  
+ATOM    655  CD  GLN A  98      88.641  63.003  86.352  1.00 55.63           C  
+ATOM    656  OE1 GLN A  98      88.712  64.150  85.912  1.00 55.63           O  
+ATOM    657  NE2 GLN A  98      89.016  62.685  87.585  1.00 55.63           N  
+ATOM    658  N   ALA A  99      87.413  62.384  81.714  1.00 52.25           N  
+ATOM    659  CA  ALA A  99      86.303  63.090  81.085  1.00 52.25           C  
+ATOM    660  C   ALA A  99      85.462  62.147  80.237  1.00 52.25           C  
+ATOM    661  O   ALA A  99      84.250  62.343  80.089  1.00 52.25           O  
+ATOM    662  CB  ALA A  99      86.829  64.247  80.238  1.00 52.25           C  
+ATOM    663  N   LEU A 100      86.087  61.111  79.675  1.00 53.29           N  
+ATOM    664  CA  LEU A 100      85.353  60.186  78.820  1.00 53.29           C  
+ATOM    665  C   LEU A 100      84.651  59.088  79.612  1.00 53.29           C  
+ATOM    666  O   LEU A 100      83.617  58.579  79.167  1.00 53.29           O  
+ATOM    667  CB  LEU A 100      86.300  59.565  77.793  1.00 53.29           C  
+ATOM    668  CG  LEU A 100      85.646  58.892  76.588  1.00 53.29           C  
+ATOM    669  CD1 LEU A 100      84.511  59.747  76.054  1.00 53.29           C  
+ATOM    670  CD2 LEU A 100      86.680  58.633  75.508  1.00 53.29           C  
+ATOM    671  N   GLN A 101      85.182  58.715  80.776  1.00 61.84           N  
+ATOM    672  CA  GLN A 101      84.639  57.601  81.543  1.00 61.84           C  
+ATOM    673  C   GLN A 101      83.428  57.977  82.385  1.00 61.84           C  
+ATOM    674  O   GLN A 101      82.978  57.154  83.189  1.00 61.84           O  
+ATOM    675  CB  GLN A 101      85.719  57.012  82.453  1.00 61.84           C  
+ATOM    676  CG  GLN A 101      86.633  56.014  81.765  1.00 61.84           C  
+ATOM    677  CD  GLN A 101      87.777  55.572  82.650  1.00 61.84           C  
+ATOM    678  OE1 GLN A 101      87.852  55.945  83.820  1.00 61.84           O  
+ATOM    679  NE2 GLN A 101      88.680  54.772  82.095  1.00 61.84           N  
+ATOM    680  N   GLN A 102      82.892  59.186  82.232  1.00 66.94           N  
+ATOM    681  CA  GLN A 102      81.717  59.579  82.998  1.00 66.94           C  
+ATOM    682  C   GLN A 102      80.475  58.885  82.455  1.00 66.94           C  
+ATOM    683  O   GLN A 102      79.857  59.360  81.496  1.00 66.94           O  
+ATOM    684  CB  GLN A 102      81.541  61.100  82.976  1.00 66.94           C  
+ATOM    685  CG  GLN A 102      82.813  61.892  83.269  1.00 66.94           C  
+ATOM    686  CD  GLN A 102      83.270  61.805  84.719  1.00 66.94           C  
+ATOM    687  OE1 GLN A 102      82.836  60.940  85.479  1.00 66.94           O  
+ATOM    688  NE2 GLN A 102      84.160  62.713  85.107  1.00 66.94           N  
+ATOM    689  N   ASN A 103      80.108  57.754  83.063  1.00 76.71           N  
+ATOM    690  CA  ASN A 103      78.930  57.019  82.612  1.00 76.71           C  
+ATOM    691  C   ASN A 103      77.651  57.806  82.871  1.00 76.71           C  
+ATOM    692  O   ASN A 103      76.746  57.830  82.029  1.00 76.71           O  
+ATOM    693  CB  ASN A 103      78.883  55.648  83.290  1.00 76.71           C  
+ATOM    694  CG  ASN A 103      78.887  55.741  84.806  1.00 76.71           C  
+ATOM    695  OD1 ASN A 103      78.833  56.829  85.378  1.00 76.71           O  
+ATOM    696  ND2 ASN A 103      78.955  54.590  85.464  1.00 76.71           N  
+ATOM    697  N   GLY A 104      77.556  58.454  84.029  1.00 83.02           N  
+ATOM    698  CA  GLY A 104      76.435  59.325  84.321  1.00 83.02           C  
+ATOM    699  C   GLY A 104      75.139  58.606  84.634  1.00 83.02           C  
+ATOM    700  O   GLY A 104      75.018  57.952  85.673  1.00 83.02           O  
+ATOM    701  N   SER A 105      74.158  58.724  83.736  1.00 86.56           N  
+ATOM    702  CA  SER A 105      72.837  58.166  84.006  1.00 86.56           C  
+ATOM    703  C   SER A 105      72.786  56.666  83.745  1.00 86.56           C  
+ATOM    704  O   SER A 105      71.801  56.010  84.100  1.00 86.56           O  
+ATOM    705  CB  SER A 105      71.785  58.886  83.162  1.00 86.56           C  
+ATOM    706  OG  SER A 105      72.234  59.061  81.830  1.00 86.56           O  
+ATOM    707  N   SER A 106      73.826  56.106  83.125  1.00 84.19           N  
+ATOM    708  CA  SER A 106      73.816  54.678  82.829  1.00 84.19           C  
+ATOM    709  C   SER A 106      74.171  53.845  84.053  1.00 84.19           C  
+ATOM    710  O   SER A 106      73.963  52.626  84.050  1.00 84.19           O  
+ATOM    711  CB  SER A 106      74.778  54.371  81.682  1.00 84.19           C  
+ATOM    712  OG  SER A 106      76.119  54.613  82.063  1.00 84.19           O  
+ATOM    713  N   VAL A 107      74.700  54.476  85.104  1.00 78.90           N  
+ATOM    714  CA  VAL A 107      75.135  53.731  86.278  1.00 78.90           C  
+ATOM    715  C   VAL A 107      73.957  53.136  87.037  1.00 78.90           C  
+ATOM    716  O   VAL A 107      74.130  52.169  87.787  1.00 78.90           O  
+ATOM    717  CB  VAL A 107      75.991  54.635  87.193  1.00 78.90           C  
+ATOM    718  CG1 VAL A 107      75.113  55.593  87.983  1.00 78.90           C  
+ATOM    719  CG2 VAL A 107      76.856  53.794  88.120  1.00 78.90           C  
+ATOM    720  N   LEU A 108      72.756  53.681  86.860  1.00 81.63           N  
+ATOM    721  CA  LEU A 108      71.580  53.134  87.514  1.00 81.63           C  
+ATOM    722  C   LEU A 108      70.997  51.998  86.680  1.00 81.63           C  
+ATOM    723  O   LEU A 108      71.576  51.555  85.684  1.00 81.63           O  
+ATOM    724  CB  LEU A 108      70.529  54.218  87.741  1.00 81.63           C  
+ATOM    725  CG  LEU A 108      70.957  55.555  88.342  1.00 81.63           C  
+ATOM    726  CD1 LEU A 108      71.230  56.556  87.236  1.00 81.63           C  
+ATOM    727  CD2 LEU A 108      69.894  56.076  89.295  1.00 81.63           C  
+ATOM    728  N   SER A 109      69.826  51.522  87.093  1.00 84.12           N  
+ATOM    729  CA  SER A 109      69.104  50.535  86.310  1.00 84.12           C  
+ATOM    730  C   SER A 109      68.474  51.197  85.085  1.00 84.12           C  
+ATOM    731  O   SER A 109      68.658  52.387  84.816  1.00 84.12           O  
+ATOM    732  CB  SER A 109      68.037  49.854  87.164  1.00 84.12           C  
+ATOM    733  OG  SER A 109      67.334  50.800  87.951  1.00 84.12           O  
+ATOM    734  N   GLU A 110      67.718  50.398  84.330  1.00 85.29           N  
+ATOM    735  CA  GLU A 110      67.072  50.922  83.131  1.00 85.29           C  
+ATOM    736  C   GLU A 110      65.777  51.645  83.481  1.00 85.29           C  
+ATOM    737  O   GLU A 110      65.520  52.751  82.983  1.00 85.29           O  
+ATOM    738  CB  GLU A 110      66.831  49.778  82.142  1.00 85.29           C  
+ATOM    739  CG  GLU A 110      66.714  50.183  80.673  1.00 85.29           C  
+ATOM    740  CD  GLU A 110      65.447  50.944  80.345  1.00 85.29           C  
+ATOM    741  OE1 GLU A 110      64.452  50.803  81.085  1.00 85.29           O  
+ATOM    742  OE2 GLU A 110      65.447  51.687  79.341  1.00 85.29           O  
+ATOM    743  N   ASP A 111      64.954  51.044  84.344  1.00 83.72           N  
+ATOM    744  CA  ASP A 111      63.690  51.668  84.724  1.00 83.72           C  
+ATOM    745  C   ASP A 111      63.923  52.958  85.501  1.00 83.72           C  
+ATOM    746  O   ASP A 111      63.207  53.947  85.309  1.00 83.72           O  
+ATOM    747  CB  ASP A 111      62.848  50.688  85.542  1.00 83.72           C  
+ATOM    748  CG  ASP A 111      63.605  50.112  86.721  1.00 83.72           C  
+ATOM    749  OD1 ASP A 111      62.953  49.651  87.682  1.00 83.72           O  
+ATOM    750  OD2 ASP A 111      64.852  50.120  86.686  1.00 83.72           O  
+ATOM    751  N   LYS A 112      64.929  52.971  86.379  1.00 76.16           N  
+ATOM    752  CA  LYS A 112      65.229  54.187  87.128  1.00 76.16           C  
+ATOM    753  C   LYS A 112      65.759  55.284  86.212  1.00 76.16           C  
+ATOM    754  O   LYS A 112      65.443  56.464  86.402  1.00 76.16           O  
+ATOM    755  CB  LYS A 112      66.226  53.886  88.246  1.00 76.16           C  
+ATOM    756  CG  LYS A 112      65.610  53.168  89.433  1.00 76.16           C  
+ATOM    757  CD  LYS A 112      66.490  53.269  90.666  1.00 76.16           C  
+ATOM    758  CE  LYS A 112      65.799  52.661  91.876  1.00 76.16           C  
+ATOM    759  NZ  LYS A 112      66.553  52.907  93.134  1.00 76.16           N  
+ATOM    760  N   SER A 113      66.554  54.915  85.205  1.00 75.02           N  
+ATOM    761  CA  SER A 113      67.030  55.906  84.246  1.00 75.02           C  
+ATOM    762  C   SER A 113      65.876  56.485  83.438  1.00 75.02           C  
+ATOM    763  O   SER A 113      65.819  57.701  83.205  1.00 75.02           O  
+ATOM    764  CB  SER A 113      68.074  55.282  83.321  1.00 75.02           C  
+ATOM    765  OG  SER A 113      68.598  56.247  82.424  1.00 75.02           O  
+ATOM    766  N   LYS A 114      64.948  55.630  82.996  1.00 75.02           N  
+ATOM    767  CA  LYS A 114      63.779  56.133  82.281  1.00 75.02           C  
+ATOM    768  C   LYS A 114      62.937  57.039  83.170  1.00 75.02           C  
+ATOM    769  O   LYS A 114      62.430  58.069  82.711  1.00 75.02           O  
+ATOM    770  CB  LYS A 114      62.936  54.974  81.751  1.00 75.02           C  
+ATOM    771  CG  LYS A 114      63.533  54.260  80.551  1.00 75.02           C  
+ATOM    772  CD  LYS A 114      62.619  53.142  80.074  1.00 75.02           C  
+ATOM    773  CE  LYS A 114      62.581  53.067  78.556  1.00 75.02           C  
+ATOM    774  NZ  LYS A 114      61.200  52.846  78.045  1.00 75.02           N  
+ATOM    775  N   ARG A 115      62.784  56.677  84.446  1.00 70.10           N  
+ATOM    776  CA  ARG A 115      62.039  57.523  85.370  1.00 70.10           C  
+ATOM    777  C   ARG A 115      62.714  58.878  85.542  1.00 70.10           C  
+ATOM    778  O   ARG A 115      62.043  59.915  85.567  1.00 70.10           O  
+ATOM    779  CB  ARG A 115      61.893  56.825  86.721  1.00 70.10           C  
+ATOM    780  CG  ARG A 115      61.001  57.562  87.704  1.00 70.10           C  
+ATOM    781  CD  ARG A 115      59.545  57.497  87.281  1.00 70.10           C  
+ATOM    782  NE  ARG A 115      58.699  58.353  88.107  1.00 70.10           N  
+ATOM    783  CZ  ARG A 115      58.235  59.538  87.722  1.00 70.10           C  
+ATOM    784  NH1 ARG A 115      57.472  60.250  88.539  1.00 70.10           N  
+ATOM    785  NH2 ARG A 115      58.530  60.008  86.518  1.00 70.10           N  
+ATOM    786  N   LEU A 116      64.044  58.887  85.657  1.00 64.20           N  
+ATOM    787  CA  LEU A 116      64.767  60.145  85.811  1.00 64.20           C  
+ATOM    788  C   LEU A 116      64.614  61.020  84.574  1.00 64.20           C  
+ATOM    789  O   LEU A 116      64.400  62.234  84.680  1.00 64.20           O  
+ATOM    790  CB  LEU A 116      66.242  59.871  86.096  1.00 64.20           C  
+ATOM    791  CG  LEU A 116      67.115  61.108  86.312  1.00 64.20           C  
+ATOM    792  CD1 LEU A 116      66.639  61.886  87.527  1.00 64.20           C  
+ATOM    793  CD2 LEU A 116      68.576  60.715  86.457  1.00 64.20           C  
+ATOM    794  N   ASN A 117      64.731  60.421  83.386  1.00 64.59           N  
+ATOM    795  CA  ASN A 117      64.549  61.189  82.158  1.00 64.59           C  
+ATOM    796  C   ASN A 117      63.131  61.738  82.060  1.00 64.59           C  
+ATOM    797  O   ASN A 117      62.924  62.876  81.621  1.00 64.59           O  
+ATOM    798  CB  ASN A 117      64.877  60.326  80.941  1.00 64.59           C  
+ATOM    799  CG  ASN A 117      66.342  59.955  80.870  1.00 64.59           C  
+ATOM    800  OD1 ASN A 117      67.196  60.637  81.435  1.00 64.59           O  
+ATOM    801  ND2 ASN A 117      66.644  58.867  80.169  1.00 64.59           N  
+ATOM    802  N   THR A 118      62.140  60.942  82.470  1.00 65.02           N  
+ATOM    803  CA  THR A 118      60.760  61.413  82.468  1.00 65.02           C  
+ATOM    804  C   THR A 118      60.581  62.590  83.417  1.00 65.02           C  
+ATOM    805  O   THR A 118      59.901  63.565  83.083  1.00 65.02           O  
+ATOM    806  CB  THR A 118      59.812  60.276  82.846  1.00 65.02           C  
+ATOM    807  OG1 THR A 118      60.198  59.081  82.157  1.00 65.02           O  
+ATOM    808  CG2 THR A 118      58.382  60.629  82.473  1.00 65.02           C  
+ATOM    809  N   ILE A 119      61.187  62.517  84.604  1.00 59.96           N  
+ATOM    810  CA  ILE A 119      61.089  63.615  85.563  1.00 59.96           C  
+ATOM    811  C   ILE A 119      61.736  64.874  85.000  1.00 59.96           C  
+ATOM    812  O   ILE A 119      61.195  65.980  85.118  1.00 59.96           O  
+ATOM    813  CB  ILE A 119      61.723  63.213  86.906  1.00 59.96           C  
+ATOM    814  CG1 ILE A 119      60.964  62.041  87.523  1.00 59.96           C  
+ATOM    815  CG2 ILE A 119      61.750  64.394  87.862  1.00 59.96           C  
+ATOM    816  CD1 ILE A 119      61.408  61.709  88.916  1.00 59.96           C  
+ATOM    817  N   LEU A 120      62.911  64.724  84.385  1.00 57.55           N  
+ATOM    818  CA  LEU A 120      63.596  65.880  83.815  1.00 57.55           C  
+ATOM    819  C   LEU A 120      62.760  66.529  82.720  1.00 57.55           C  
+ATOM    820  O   LEU A 120      62.588  67.757  82.703  1.00 57.55           O  
+ATOM    821  CB  LEU A 120      64.963  65.466  83.272  1.00 57.55           C  
+ATOM    822  CG  LEU A 120      66.008  65.032  84.302  1.00 57.55           C  
+ATOM    823  CD1 LEU A 120      67.293  64.603  83.611  1.00 57.55           C  
+ATOM    824  CD2 LEU A 120      66.276  66.142  85.303  1.00 57.55           C  
+ATOM    825  N   ASN A 121      62.224  65.721  81.801  1.00 58.22           N  
+ATOM    826  CA  ASN A 121      61.410  66.273  80.723  1.00 58.22           C  
+ATOM    827  C   ASN A 121      60.130  66.901  81.261  1.00 58.22           C  
+ATOM    828  O   ASN A 121      59.690  67.945  80.764  1.00 58.22           O  
+ATOM    829  CB  ASN A 121      61.090  65.188  79.697  1.00 58.22           C  
+ATOM    830  CG  ASN A 121      62.292  64.813  78.852  1.00 58.22           C  
+ATOM    831  OD1 ASN A 121      62.575  65.450  77.838  1.00 58.22           O  
+ATOM    832  ND2 ASN A 121      63.006  63.775  79.267  1.00 58.22           N  
+ATOM    833  N   THR A 122      59.529  66.294  82.286  1.00 55.83           N  
+ATOM    834  CA  THR A 122      58.310  66.849  82.861  1.00 55.83           C  
+ATOM    835  C   THR A 122      58.576  68.197  83.516  1.00 55.83           C  
+ATOM    836  O   THR A 122      57.790  69.136  83.356  1.00 55.83           O  
+ATOM    837  CB  THR A 122      57.712  65.868  83.872  1.00 55.83           C  
+ATOM    838  OG1 THR A 122      57.443  64.619  83.227  1.00 55.83           O  
+ATOM    839  CG2 THR A 122      56.419  66.421  84.449  1.00 55.83           C  
+ATOM    840  N   MET A 123      59.684  68.314  84.252  1.00 52.36           N  
+ATOM    841  CA  MET A 123      60.023  69.593  84.867  1.00 52.36           C  
+ATOM    842  C   MET A 123      60.312  70.651  83.809  1.00 52.36           C  
+ATOM    843  O   MET A 123      59.848  71.796  83.918  1.00 52.36           O  
+ATOM    844  CB  MET A 123      61.222  69.429  85.801  1.00 52.36           C  
+ATOM    845  CG  MET A 123      60.942  68.587  87.034  1.00 52.36           C  
+ATOM    846  SD  MET A 123      62.168  68.827  88.333  1.00 52.36           S  
+ATOM    847  CE  MET A 123      63.680  68.479  87.441  1.00 52.36           C  
+ATOM    848  N   SER A 124      61.070  70.282  82.773  1.00 52.41           N  
+ATOM    849  CA  SER A 124      61.368  71.225  81.700  1.00 52.41           C  
+ATOM    850  C   SER A 124      60.090  71.713  81.029  1.00 52.41           C  
+ATOM    851  O   SER A 124      59.936  72.909  80.757  1.00 52.41           O  
+ATOM    852  CB  SER A 124      62.302  70.576  80.678  1.00 52.41           C  
+ATOM    853  OG  SER A 124      62.605  71.471  79.624  1.00 52.41           O  
+ATOM    854  N   THR A 125      59.152  70.800  80.766  1.00 53.31           N  
+ATOM    855  CA  THR A 125      57.909  71.186  80.108  1.00 53.31           C  
+ATOM    856  C   THR A 125      57.036  72.037  81.023  1.00 53.31           C  
+ATOM    857  O   THR A 125      56.442  73.024  80.576  1.00 53.31           O  
+ATOM    858  CB  THR A 125      57.152  69.942  79.642  1.00 53.31           C  
+ATOM    859  OG1 THR A 125      57.950  69.224  78.694  1.00 53.31           O  
+ATOM    860  CG2 THR A 125      55.836  70.331  78.989  1.00 53.31           C  
+ATOM    861  N   ILE A 126      56.951  71.678  82.306  1.00 54.06           N  
+ATOM    862  CA  ILE A 126      56.154  72.461  83.246  1.00 54.06           C  
+ATOM    863  C   ILE A 126      56.688  73.883  83.339  1.00 54.06           C  
+ATOM    864  O   ILE A 126      55.917  74.847  83.415  1.00 54.06           O  
+ATOM    865  CB  ILE A 126      56.123  71.773  84.625  1.00 54.06           C  
+ATOM    866  CG1 ILE A 126      55.224  70.538  84.587  1.00 54.06           C  
+ATOM    867  CG2 ILE A 126      55.641  72.736  85.700  1.00 54.06           C  
+ATOM    868  CD1 ILE A 126      55.103  69.833  85.920  1.00 54.06           C  
+ATOM    869  N   TYR A 127      58.013  74.041  83.316  1.00 51.87           N  
+ATOM    870  CA  TYR A 127      58.578  75.386  83.370  1.00 51.87           C  
+ATOM    871  C   TYR A 127      58.343  76.139  82.065  1.00 51.87           C  
+ATOM    872  O   TYR A 127      57.882  77.288  82.076  1.00 51.87           O  
+ATOM    873  CB  TYR A 127      60.070  75.330  83.689  1.00 51.87           C  
+ATOM    874  CG  TYR A 127      60.746  76.677  83.576  1.00 51.87           C  
+ATOM    875  CD1 TYR A 127      61.572  76.975  82.500  1.00 51.87           C  
+ATOM    876  CD2 TYR A 127      60.547  77.657  84.539  1.00 51.87           C  
+ATOM    877  CE1 TYR A 127      62.184  78.207  82.391  1.00 51.87           C  
+ATOM    878  CE2 TYR A 127      61.156  78.891  84.438  1.00 51.87           C  
+ATOM    879  CZ  TYR A 127      61.974  79.160  83.363  1.00 51.87           C  
+ATOM    880  OH  TYR A 127      62.584  80.388  83.258  1.00 51.87           O  
+ATOM    881  N   SER A 128      58.649  75.510  80.926  1.00 54.98           N  
+ATOM    882  CA  SER A 128      58.631  76.230  79.658  1.00 54.98           C  
+ATOM    883  C   SER A 128      57.215  76.541  79.190  1.00 54.98           C  
+ATOM    884  O   SER A 128      57.013  77.505  78.444  1.00 54.98           O  
+ATOM    885  CB  SER A 128      59.372  75.428  78.590  1.00 54.98           C  
+ATOM    886  OG  SER A 128      58.500  74.529  77.930  1.00 54.98           O  
+ATOM    887  N   THR A 129      56.228  75.749  79.605  1.00 57.35           N  
+ATOM    888  CA  THR A 129      54.842  75.966  79.211  1.00 57.35           C  
+ATOM    889  C   THR A 129      53.980  76.469  80.360  1.00 57.35           C  
+ATOM    890  O   THR A 129      52.759  76.283  80.333  1.00 57.35           O  
+ATOM    891  CB  THR A 129      54.243  74.682  78.636  1.00 57.35           C  
+ATOM    892  OG1 THR A 129      53.881  73.800  79.705  1.00 57.35           O  
+ATOM    893  CG2 THR A 129      55.240  73.987  77.721  1.00 57.35           C  
+ATOM    894  N   GLY A 130      54.581  77.093  81.368  1.00 63.47           N  
+ATOM    895  CA  GLY A 130      53.804  77.603  82.478  1.00 63.47           C  
+ATOM    896  C   GLY A 130      53.060  78.874  82.116  1.00 63.47           C  
+ATOM    897  O   GLY A 130      53.553  79.731  81.383  1.00 63.47           O  
+ATOM    898  N   LYS A 131      51.845  78.992  82.645  1.00 71.98           N  
+ATOM    899  CA  LYS A 131      51.008  80.158  82.408  1.00 71.98           C  
+ATOM    900  C   LYS A 131      50.034  80.300  83.565  1.00 71.98           C  
+ATOM    901  O   LYS A 131      49.389  79.328  83.965  1.00 71.98           O  
+ATOM    902  CB  LYS A 131      50.249  80.046  81.081  1.00 71.98           C  
+ATOM    903  CG  LYS A 131      49.639  78.677  80.825  1.00 71.98           C  
+ATOM    904  CD  LYS A 131      49.380  78.457  79.345  1.00 71.98           C  
+ATOM    905  CE  LYS A 131      48.461  79.529  78.783  1.00 71.98           C  
+ATOM    906  NZ  LYS A 131      48.145  79.293  77.348  1.00 71.98           N  
+ATOM    907  N   VAL A 132      49.938  81.513  84.102  1.00 78.56           N  
+ATOM    908  CA  VAL A 132      49.085  81.785  85.249  1.00 78.56           C  
+ATOM    909  C   VAL A 132      48.512  83.189  85.111  1.00 78.56           C  
+ATOM    910  O   VAL A 132      49.175  84.107  84.619  1.00 78.56           O  
+ATOM    911  CB  VAL A 132      49.854  81.625  86.581  1.00 78.56           C  
+ATOM    912  CG1 VAL A 132      51.073  82.537  86.615  1.00 78.56           C  
+ATOM    913  CG2 VAL A 132      48.939  81.873  87.770  1.00 78.56           C  
+ATOM    914  N   CYS A 133      47.264  83.346  85.545  1.00 96.42           N  
+ATOM    915  CA  CYS A 133      46.573  84.624  85.458  1.00 96.42           C  
+ATOM    916  C   CYS A 133      45.385  84.624  86.405  1.00 96.42           C  
+ATOM    917  O   CYS A 133      44.832  83.574  86.743  1.00 96.42           O  
+ATOM    918  CB  CYS A 133      46.138  84.923  84.021  1.00 96.42           C  
+ATOM    919  SG  CYS A 133      45.239  83.594  83.186  1.00 96.42           S  
+ATOM    920  N   ASN A 134      45.005  85.827  86.829  1.00103.35           N  
+ATOM    921  CA  ASN A 134      43.959  85.996  87.820  1.00103.35           C  
+ATOM    922  C   ASN A 134      42.603  85.577  87.257  1.00103.35           C  
+ATOM    923  O   ASN A 134      42.395  85.576  86.042  1.00103.35           O  
+ATOM    924  CB  ASN A 134      43.918  87.450  88.291  1.00103.35           C  
+ATOM    925  CG  ASN A 134      43.860  88.436  87.140  1.00103.35           C  
+ATOM    926  OD1 ASN A 134      43.798  88.048  85.974  1.00103.35           O  
+ATOM    927  ND2 ASN A 134      43.882  89.722  87.464  1.00103.35           N  
+ATOM    928  N   PRO A 135      41.658  85.208  88.130  1.00111.68           N  
+ATOM    929  CA  PRO A 135      40.334  84.786  87.646  1.00111.68           C  
+ATOM    930  C   PRO A 135      39.482  85.921  87.102  1.00111.68           C  
+ATOM    931  O   PRO A 135      38.305  85.685  86.796  1.00111.68           O  
+ATOM    932  CB  PRO A 135      39.689  84.160  88.889  1.00111.68           C  
+ATOM    933  CG  PRO A 135      40.375  84.821  90.035  1.00111.68           C  
+ATOM    934  CD  PRO A 135      41.793  85.028  89.586  1.00111.68           C  
+ATOM    935  N   ASP A 136      40.022  87.138  86.985  1.00112.31           N  
+ATOM    936  CA  ASP A 136      39.270  88.222  86.364  1.00112.31           C  
+ATOM    937  C   ASP A 136      38.844  87.861  84.949  1.00112.31           C  
+ATOM    938  O   ASP A 136      37.714  88.155  84.544  1.00112.31           O  
+ATOM    939  CB  ASP A 136      40.102  89.505  86.356  1.00112.31           C  
+ATOM    940  CG  ASP A 136      40.590  89.894  87.737  1.00112.31           C  
+ATOM    941  OD1 ASP A 136      41.276  90.930  87.855  1.00112.31           O  
+ATOM    942  OD2 ASP A 136      40.293  89.160  88.702  1.00112.31           O  
+ATOM    943  N   ASN A 137      39.730  87.224  84.189  1.00114.17           N  
+ATOM    944  CA  ASN A 137      39.400  86.693  82.875  1.00114.17           C  
+ATOM    945  C   ASN A 137      40.350  85.536  82.594  1.00114.17           C  
+ATOM    946  O   ASN A 137      41.460  85.749  82.089  1.00114.17           O  
+ATOM    947  CB  ASN A 137      39.498  87.785  81.804  1.00114.17           C  
+ATOM    948  CG  ASN A 137      39.205  87.270  80.399  1.00114.17           C  
+ATOM    949  OD1 ASN A 137      39.817  86.316  79.922  1.00114.17           O  
+ATOM    950  ND2 ASN A 137      38.255  87.913  79.730  1.00114.17           N  
+ATOM    951  N   PRO A 138      39.960  84.300  82.922  1.00112.33           N  
+ATOM    952  CA  PRO A 138      40.854  83.151  82.707  1.00112.33           C  
+ATOM    953  C   PRO A 138      41.119  82.822  81.246  1.00112.33           C  
+ATOM    954  O   PRO A 138      41.813  81.836  80.972  1.00112.33           O  
+ATOM    955  CB  PRO A 138      40.112  81.997  83.401  1.00112.33           C  
+ATOM    956  CG  PRO A 138      39.155  82.657  84.342  1.00112.33           C  
+ATOM    957  CD  PRO A 138      38.746  83.924  83.663  1.00112.33           C  
+ATOM    958  N   GLN A 139      40.598  83.600  80.298  1.00114.11           N  
+ATOM    959  CA  GLN A 139      40.807  83.312  78.886  1.00114.11           C  
+ATOM    960  C   GLN A 139      42.001  84.044  78.293  1.00114.11           C  
+ATOM    961  O   GLN A 139      42.654  83.504  77.393  1.00114.11           O  
+ATOM    962  CB  GLN A 139      39.556  83.653  78.059  1.00114.11           C  
+ATOM    963  CG  GLN A 139      38.264  82.891  78.404  1.00114.11           C  
+ATOM    964  CD  GLN A 139      37.826  83.029  79.851  1.00114.11           C  
+ATOM    965  OE1 GLN A 139      38.073  84.048  80.492  1.00114.11           O  
+ATOM    966  NE2 GLN A 139      37.175  81.995  80.372  1.00114.11           N  
+ATOM    967  N   GLU A 140      42.309  85.251  78.767  1.00110.61           N  
+ATOM    968  CA  GLU A 140      43.421  86.037  78.233  1.00110.61           C  
+ATOM    969  C   GLU A 140      44.470  86.215  79.327  1.00110.61           C  
+ATOM    970  O   GLU A 140      44.177  86.714  80.416  1.00110.61           O  
+ATOM    971  CB  GLU A 140      42.927  87.368  77.666  1.00110.61           C  
+ATOM    972  CG  GLU A 140      42.020  88.213  78.564  1.00110.61           C  
+ATOM    973  CD  GLU A 140      42.773  89.034  79.595  1.00110.61           C  
+ATOM    974  OE1 GLU A 140      42.154  89.438  80.601  1.00110.61           O  
+ATOM    975  OE2 GLU A 140      43.980  89.286  79.393  1.00110.61           O  
+ATOM    976  N   CYS A 141      45.687  85.751  79.040  1.00 97.97           N  
+ATOM    977  CA  CYS A 141      46.859  85.952  79.880  1.00 97.97           C  
+ATOM    978  C   CYS A 141      48.079  85.382  79.172  1.00 97.97           C  
+ATOM    979  O   CYS A 141      47.968  84.480  78.338  1.00 97.97           O  
+ATOM    980  CB  CYS A 141      46.700  85.325  81.271  1.00 97.97           C  
+ATOM    981  SG  CYS A 141      46.064  83.641  81.332  1.00 97.97           S  
+ATOM    982  N   LEU A 142      49.247  85.919  79.516  1.00 82.40           N  
+ATOM    983  CA  LEU A 142      50.485  85.641  78.801  1.00 82.40           C  
+ATOM    984  C   LEU A 142      51.351  84.674  79.596  1.00 82.40           C  
+ATOM    985  O   LEU A 142      51.130  84.474  80.795  1.00 82.40           O  
+ATOM    986  CB  LEU A 142      51.259  86.933  78.531  1.00 82.40           C  
+ATOM    987  CG  LEU A 142      51.096  87.534  77.133  1.00 82.40           C  
+ATOM    988  CD1 LEU A 142      51.784  88.888  77.046  1.00 82.40           C  
+ATOM    989  CD2 LEU A 142      51.633  86.583  76.076  1.00 82.40           C  
+ATOM    990  N   LEU A 143      52.335  84.084  78.922  1.00 72.10           N  
+ATOM    991  CA  LEU A 143      53.275  83.181  79.562  1.00 72.10           C  
+ATOM    992  C   LEU A 143      54.288  83.971  80.390  1.00 72.10           C  
+ATOM    993  O   LEU A 143      54.178  85.185  80.573  1.00 72.10           O  
+ATOM    994  CB  LEU A 143      53.999  82.335  78.516  1.00 72.10           C  
+ATOM    995  CG  LEU A 143      53.145  81.504  77.560  1.00 72.10           C  
+ATOM    996  CD1 LEU A 143      53.981  81.023  76.387  1.00 72.10           C  
+ATOM    997  CD2 LEU A 143      52.524  80.326  78.288  1.00 72.10           C  
+ATOM    998  N   LEU A 144      55.289  83.255  80.900  1.00 65.32           N  
+ATOM    999  CA  LEU A 144      56.357  83.886  81.665  1.00 65.32           C  
+ATOM   1000  C   LEU A 144      57.160  84.855  80.806  1.00 65.32           C  
+ATOM   1001  O   LEU A 144      57.147  86.065  81.055  1.00 65.32           O  
+ATOM   1002  CB  LEU A 144      57.286  82.830  82.266  1.00 65.32           C  
+ATOM   1003  CG  LEU A 144      58.564  83.363  82.921  1.00 65.32           C  
+ATOM   1004  CD1 LEU A 144      58.243  84.129  84.194  1.00 65.32           C  
+ATOM   1005  CD2 LEU A 144      59.544  82.237  83.202  1.00 65.32           C  
+ATOM   1006  N   GLU A 145      57.830  84.331  79.777  1.00 72.73           N  
+ATOM   1007  CA  GLU A 145      58.815  85.061  78.984  1.00 72.73           C  
+ATOM   1008  C   GLU A 145      58.283  86.388  78.442  1.00 72.73           C  
+ATOM   1009  O   GLU A 145      58.929  87.422  78.654  1.00 72.73           O  
+ATOM   1010  CB  GLU A 145      59.342  84.165  77.851  1.00 72.73           C  
+ATOM   1011  CG  GLU A 145      60.472  84.761  76.998  1.00 72.73           C  
+ATOM   1012  CD  GLU A 145      60.003  85.722  75.918  1.00 72.73           C  
+ATOM   1013  OE1 GLU A 145      60.856  86.441  75.354  1.00 72.73           O  
+ATOM   1014  OE2 GLU A 145      58.798  85.730  75.596  1.00 72.73           O  
+ATOM   1015  N   PRO A 146      57.147  86.433  77.741  1.00 68.99           N  
+ATOM   1016  CA  PRO A 146      56.718  87.702  77.140  1.00 68.99           C  
+ATOM   1017  C   PRO A 146      55.908  88.618  78.044  1.00 68.99           C  
+ATOM   1018  O   PRO A 146      55.986  89.840  77.866  1.00 68.99           O  
+ATOM   1019  CB  PRO A 146      55.865  87.227  75.955  1.00 68.99           C  
+ATOM   1020  CG  PRO A 146      55.267  85.948  76.415  1.00 68.99           C  
+ATOM   1021  CD  PRO A 146      56.169  85.359  77.473  1.00 68.99           C  
+ATOM   1022  N   GLY A 147      55.143  88.092  78.997  1.00 66.04           N  
+ATOM   1023  CA  GLY A 147      54.314  88.949  79.822  1.00 66.04           C  
+ATOM   1024  C   GLY A 147      54.786  89.126  81.249  1.00 66.04           C  
+ATOM   1025  O   GLY A 147      54.813  90.249  81.767  1.00 66.04           O  
+ATOM   1026  N   LEU A 148      55.188  88.029  81.893  1.00 64.06           N  
+ATOM   1027  CA  LEU A 148      55.562  88.112  83.299  1.00 64.06           C  
+ATOM   1028  C   LEU A 148      56.901  88.809  83.481  1.00 64.06           C  
+ATOM   1029  O   LEU A 148      57.066  89.584  84.427  1.00 64.06           O  
+ATOM   1030  CB  LEU A 148      55.594  86.717  83.919  1.00 64.06           C  
+ATOM   1031  CG  LEU A 148      54.230  86.064  84.143  1.00 64.06           C  
+ATOM   1032  CD1 LEU A 148      54.392  84.680  84.739  1.00 64.06           C  
+ATOM   1033  CD2 LEU A 148      53.367  86.934  85.038  1.00 64.06           C  
+ATOM   1034  N   ASN A 149      57.864  88.552  82.592  1.00 64.53           N  
+ATOM   1035  CA  ASN A 149      59.134  89.266  82.664  1.00 64.53           C  
+ATOM   1036  C   ASN A 149      58.933  90.760  82.449  1.00 64.53           C  
+ATOM   1037  O   ASN A 149      59.554  91.583  83.132  1.00 64.53           O  
+ATOM   1038  CB  ASN A 149      60.116  88.701  81.638  1.00 64.53           C  
+ATOM   1039  CG  ASN A 149      60.568  87.296  81.979  1.00 64.53           C  
+ATOM   1040  OD1 ASN A 149      60.376  86.827  83.101  1.00 64.53           O  
+ATOM   1041  ND2 ASN A 149      61.179  86.618  81.013  1.00 64.53           N  
+ATOM   1042  N   GLU A 150      58.056  91.129  81.513  1.00 65.26           N  
+ATOM   1043  CA  GLU A 150      57.766  92.540  81.286  1.00 65.26           C  
+ATOM   1044  C   GLU A 150      57.105  93.172  82.505  1.00 65.26           C  
+ATOM   1045  O   GLU A 150      57.439  94.302  82.883  1.00 65.26           O  
+ATOM   1046  CB  GLU A 150      56.883  92.700  80.049  1.00 65.26           C  
+ATOM   1047  CG  GLU A 150      56.799  94.123  79.521  1.00 65.26           C  
+ATOM   1048  CD  GLU A 150      55.638  94.897  80.111  1.00 65.26           C  
+ATOM   1049  OE1 GLU A 150      55.651  96.144  80.035  1.00 65.26           O  
+ATOM   1050  OE2 GLU A 150      54.711  94.258  80.650  1.00 65.26           O  
+ATOM   1051  N   ILE A 151      56.164  92.462  83.132  1.00 66.41           N  
+ATOM   1052  CA  ILE A 151      55.522  92.985  84.335  1.00 66.41           C  
+ATOM   1053  C   ILE A 151      56.543  93.157  85.452  1.00 66.41           C  
+ATOM   1054  O   ILE A 151      56.546  94.168  86.162  1.00 66.41           O  
+ATOM   1055  CB  ILE A 151      54.361  92.068  84.764  1.00 66.41           C  
+ATOM   1056  CG1 ILE A 151      53.183  92.213  83.801  1.00 66.41           C  
+ATOM   1057  CG2 ILE A 151      53.924  92.383  86.187  1.00 66.41           C  
+ATOM   1058  CD1 ILE A 151      51.946  91.457  84.234  1.00 66.41           C  
+ATOM   1059  N   MET A 152      57.434  92.178  85.619  1.00 63.15           N  
+ATOM   1060  CA  MET A 152      58.425  92.252  86.687  1.00 63.15           C  
+ATOM   1061  C   MET A 152      59.431  93.368  86.438  1.00 63.15           C  
+ATOM   1062  O   MET A 152      59.930  93.985  87.387  1.00 63.15           O  
+ATOM   1063  CB  MET A 152      59.142  90.912  86.827  1.00 63.15           C  
+ATOM   1064  CG  MET A 152      58.273  89.791  87.366  1.00 63.15           C  
+ATOM   1065  SD  MET A 152      58.111  89.829  89.158  1.00 63.15           S  
+ATOM   1066  CE  MET A 152      56.520  90.621  89.323  1.00 63.15           C  
+ATOM   1067  N   ALA A 153      59.739  93.647  85.171  1.00 61.67           N  
+ATOM   1068  CA  ALA A 153      60.770  94.633  84.870  1.00 61.67           C  
+ATOM   1069  C   ALA A 153      60.220  96.053  84.897  1.00 61.67           C  
+ATOM   1070  O   ALA A 153      60.817  96.942  85.514  1.00 61.67           O  
+ATOM   1071  CB  ALA A 153      61.402  94.329  83.513  1.00 61.67           C  
+ATOM   1072  N   ASN A 154      59.083  96.290  84.239  1.00 65.21           N  
+ATOM   1073  CA  ASN A 154      58.628  97.650  83.982  1.00 65.21           C  
+ATOM   1074  C   ASN A 154      57.548  98.150  84.930  1.00 65.21           C  
+ATOM   1075  O   ASN A 154      57.440  99.365  85.118  1.00 65.21           O  
+ATOM   1076  CB  ASN A 154      58.112  97.769  82.540  1.00 65.21           C  
+ATOM   1077  CG  ASN A 154      59.215  97.606  81.513  1.00 65.21           C  
+ATOM   1078  OD1 ASN A 154      59.527  96.493  81.089  1.00 65.21           O  
+ATOM   1079  ND2 ASN A 154      59.814  98.719  81.109  1.00 65.21           N  
+ATOM   1080  N   SER A 155      56.754  97.266  85.526  1.00 65.77           N  
+ATOM   1081  CA  SER A 155      55.668  97.722  86.380  1.00 65.77           C  
+ATOM   1082  C   SER A 155      56.202  98.270  87.697  1.00 65.77           C  
+ATOM   1083  O   SER A 155      57.191  97.781  88.248  1.00 65.77           O  
+ATOM   1084  CB  SER A 155      54.683  96.586  86.654  1.00 65.77           C  
+ATOM   1085  OG  SER A 155      53.600  97.034  87.450  1.00 65.77           O  
+ATOM   1086  N   LEU A 156      55.531  99.306  88.198  1.00 64.87           N  
+ATOM   1087  CA  LEU A 156      55.870  99.916  89.477  1.00 64.87           C  
+ATOM   1088  C   LEU A 156      54.736  99.806  90.488  1.00 64.87           C  
+ATOM   1089  O   LEU A 156      54.772 100.483  91.522  1.00 64.87           O  
+ATOM   1090  CB  LEU A 156      56.256 101.385  89.283  1.00 64.87           C  
+ATOM   1091  CG  LEU A 156      57.371 101.663  88.273  1.00 64.87           C  
+ATOM   1092  CD1 LEU A 156      57.710 103.144  88.239  1.00 64.87           C  
+ATOM   1093  CD2 LEU A 156      58.605 100.835  88.593  1.00 64.87           C  
+ATOM   1094  N   ASP A 157      53.731  98.977  90.217  1.00 72.85           N  
+ATOM   1095  CA  ASP A 157      52.598  98.787  91.112  1.00 72.85           C  
+ATOM   1096  C   ASP A 157      52.889  97.617  92.041  1.00 72.85           C  
+ATOM   1097  O   ASP A 157      53.160  96.505  91.576  1.00 72.85           O  
+ATOM   1098  CB  ASP A 157      51.313  98.541  90.324  1.00 72.85           C  
+ATOM   1099  CG  ASP A 157      50.116  98.299  91.223  1.00 72.85           C  
+ATOM   1100  OD1 ASP A 157      49.669  99.255  91.890  1.00 72.85           O  
+ATOM   1101  OD2 ASP A 157      49.623  97.153  91.264  1.00 72.85           O  
+ATOM   1102  N   TYR A 158      52.827  97.871  93.350  1.00 72.64           N  
+ATOM   1103  CA  TYR A 158      53.121  96.832  94.332  1.00 72.64           C  
+ATOM   1104  C   TYR A 158      52.181  95.641  94.176  1.00 72.64           C  
+ATOM   1105  O   TYR A 158      52.615  94.484  94.194  1.00 72.64           O  
+ATOM   1106  CB  TYR A 158      53.025  97.417  95.741  1.00 72.64           C  
+ATOM   1107  CG  TYR A 158      53.567  96.526  96.835  1.00 72.64           C  
+ATOM   1108  CD1 TYR A 158      54.875  96.659  97.280  1.00 72.64           C  
+ATOM   1109  CD2 TYR A 158      52.768  95.561  97.432  1.00 72.64           C  
+ATOM   1110  CE1 TYR A 158      55.373  95.852  98.283  1.00 72.64           C  
+ATOM   1111  CE2 TYR A 158      53.258  94.749  98.434  1.00 72.64           C  
+ATOM   1112  CZ  TYR A 158      54.561  94.898  98.856  1.00 72.64           C  
+ATOM   1113  OH  TYR A 158      55.054  94.093  99.854  1.00 72.64           O  
+ATOM   1114  N   ASN A 159      50.883  95.912  94.016  1.00 73.84           N  
+ATOM   1115  CA  ASN A 159      49.902  94.835  93.957  1.00 73.84           C  
+ATOM   1116  C   ASN A 159      50.097  93.966  92.721  1.00 73.84           C  
+ATOM   1117  O   ASN A 159      50.008  92.737  92.799  1.00 73.84           O  
+ATOM   1118  CB  ASN A 159      48.488  95.412  93.989  1.00 73.84           C  
+ATOM   1119  CG  ASN A 159      48.136  96.014  95.333  1.00 73.84           C  
+ATOM   1120  OD1 ASN A 159      48.567  95.524  96.377  1.00 73.84           O  
+ATOM   1121  ND2 ASN A 159      47.352  97.085  95.316  1.00 73.84           N  
+ATOM   1122  N   GLU A 160      50.372  94.585  91.571  1.00 72.94           N  
+ATOM   1123  CA  GLU A 160      50.542  93.820  90.339  1.00 72.94           C  
+ATOM   1124  C   GLU A 160      51.770  92.920  90.413  1.00 72.94           C  
+ATOM   1125  O   GLU A 160      51.714  91.740  90.040  1.00 72.94           O  
+ATOM   1126  CB  GLU A 160      50.638  94.766  89.144  1.00 72.94           C  
+ATOM   1127  CG  GLU A 160      50.899  94.069  87.820  1.00 72.94           C  
+ATOM   1128  CD  GLU A 160      51.039  95.043  86.667  1.00 72.94           C  
+ATOM   1129  OE1 GLU A 160      50.873  96.260  86.892  1.00 72.94           O  
+ATOM   1130  OE2 GLU A 160      51.316  94.591  85.537  1.00 72.94           O  
+ATOM   1131  N   ARG A 161      52.892  93.462  90.892  1.00 64.82           N  
+ATOM   1132  CA  ARG A 161      54.105  92.660  91.006  1.00 64.82           C  
+ATOM   1133  C   ARG A 161      53.932  91.541  92.022  1.00 64.82           C  
+ATOM   1134  O   ARG A 161      54.371  90.408  91.789  1.00 64.82           O  
+ATOM   1135  CB  ARG A 161      55.288  93.552  91.381  1.00 64.82           C  
+ATOM   1136  CG  ARG A 161      55.470  94.743  90.463  1.00 64.82           C  
+ATOM   1137  CD  ARG A 161      56.747  95.498  90.774  1.00 64.82           C  
+ATOM   1138  NE  ARG A 161      57.920  94.826  90.227  1.00 64.82           N  
+ATOM   1139  CZ  ARG A 161      59.110  95.400  90.091  1.00 64.82           C  
+ATOM   1140  NH1 ARG A 161      59.287  96.659  90.462  1.00 64.82           N  
+ATOM   1141  NH2 ARG A 161      60.122  94.714  89.581  1.00 64.82           N  
+ATOM   1142  N   LEU A 162      53.291  91.838  93.156  1.00 69.56           N  
+ATOM   1143  CA  LEU A 162      53.035  90.803  94.151  1.00 69.56           C  
+ATOM   1144  C   LEU A 162      52.153  89.699  93.582  1.00 69.56           C  
+ATOM   1145  O   LEU A 162      52.409  88.508  93.808  1.00 69.56           O  
+ATOM   1146  CB  LEU A 162      52.390  91.421  95.390  1.00 69.56           C  
+ATOM   1147  CG  LEU A 162      51.889  90.453  96.460  1.00 69.56           C  
+ATOM   1148  CD1 LEU A 162      53.019  89.559  96.930  1.00 69.56           C  
+ATOM   1149  CD2 LEU A 162      51.291  91.219  97.624  1.00 69.56           C  
+ATOM   1150  N   TRP A 163      51.108  90.076  92.840  1.00 74.16           N  
+ATOM   1151  CA  TRP A 163      50.233  89.084  92.230  1.00 74.16           C  
+ATOM   1152  C   TRP A 163      51.000  88.210  91.250  1.00 74.16           C  
+ATOM   1153  O   TRP A 163      50.883  86.981  91.280  1.00 74.16           O  
+ATOM   1154  CB  TRP A 163      49.062  89.769  91.526  1.00 74.16           C  
+ATOM   1155  CG  TRP A 163      48.427  88.901  90.484  1.00 74.16           C  
+ATOM   1156  CD1 TRP A 163      47.489  87.932  90.688  1.00 74.16           C  
+ATOM   1157  CD2 TRP A 163      48.693  88.912  89.076  1.00 74.16           C  
+ATOM   1158  NE1 TRP A 163      47.150  87.343  89.494  1.00 74.16           N  
+ATOM   1159  CE2 TRP A 163      47.876  87.927  88.489  1.00 74.16           C  
+ATOM   1160  CE3 TRP A 163      49.539  89.662  88.255  1.00 74.16           C  
+ATOM   1161  CZ2 TRP A 163      47.881  87.672  87.121  1.00 74.16           C  
+ATOM   1162  CZ3 TRP A 163      49.543  89.406  86.897  1.00 74.16           C  
+ATOM   1163  CH2 TRP A 163      48.719  88.420  86.344  1.00 74.16           C  
+ATOM   1164  N   ALA A 164      51.784  88.830  90.364  1.00 68.86           N  
+ATOM   1165  CA  ALA A 164      52.551  88.056  89.391  1.00 68.86           C  
+ATOM   1166  C   ALA A 164      53.503  87.092  90.083  1.00 68.86           C  
+ATOM   1167  O   ALA A 164      53.571  85.908  89.728  1.00 68.86           O  
+ATOM   1168  CB  ALA A 164      53.318  88.995  88.460  1.00 68.86           C  
+ATOM   1169  N   TRP A 165      54.232  87.580  91.088  1.00 64.59           N  
+ATOM   1170  CA  TRP A 165      55.180  86.746  91.818  1.00 64.59           C  
+ATOM   1171  C   TRP A 165      54.483  85.550  92.459  1.00 64.59           C  
+ATOM   1172  O   TRP A 165      54.843  84.392  92.207  1.00 64.59           O  
+ATOM   1173  CB  TRP A 165      55.892  87.599  92.870  1.00 64.59           C  
+ATOM   1174  CG  TRP A 165      57.011  86.913  93.584  1.00 64.59           C  
+ATOM   1175  CD1 TRP A 165      58.306  86.813  93.170  1.00 64.59           C  
+ATOM   1176  CD2 TRP A 165      56.941  86.252  94.851  1.00 64.59           C  
+ATOM   1177  NE1 TRP A 165      59.046  86.121  94.097  1.00 64.59           N  
+ATOM   1178  CE2 TRP A 165      58.230  85.766  95.139  1.00 64.59           C  
+ATOM   1179  CE3 TRP A 165      55.913  86.020  95.767  1.00 64.59           C  
+ATOM   1180  CZ2 TRP A 165      58.517  85.061  96.304  1.00 64.59           C  
+ATOM   1181  CZ3 TRP A 165      56.200  85.319  96.921  1.00 64.59           C  
+ATOM   1182  CH2 TRP A 165      57.491  84.847  97.180  1.00 64.59           C  
+ATOM   1183  N   GLU A 166      53.472  85.819  93.292  1.00 69.68           N  
+ATOM   1184  CA  GLU A 166      52.810  84.742  94.019  1.00 69.68           C  
+ATOM   1185  C   GLU A 166      52.123  83.774  93.067  1.00 69.68           C  
+ATOM   1186  O   GLU A 166      52.109  82.563  93.308  1.00 69.68           O  
+ATOM   1187  CB  GLU A 166      51.815  85.325  95.026  1.00 69.68           C  
+ATOM   1188  CG  GLU A 166      51.279  84.333  96.060  1.00 69.68           C  
+ATOM   1189  CD  GLU A 166      50.174  83.430  95.535  1.00 69.68           C  
+ATOM   1190  OE1 GLU A 166      49.844  82.440  96.220  1.00 69.68           O  
+ATOM   1191  OE2 GLU A 166      49.610  83.725  94.460  1.00 69.68           O  
+ATOM   1192  N   SER A 167      51.553  84.285  91.972  1.00 68.20           N  
+ATOM   1193  CA  SER A 167      50.839  83.420  91.042  1.00 68.20           C  
+ATOM   1194  C   SER A 167      51.797  82.499  90.302  1.00 68.20           C  
+ATOM   1195  O   SER A 167      51.526  81.301  90.158  1.00 68.20           O  
+ATOM   1196  CB  SER A 167      50.032  84.269  90.062  1.00 68.20           C  
+ATOM   1197  OG  SER A 167      50.799  85.352  89.573  1.00 68.20           O  
+ATOM   1198  N   TRP A 168      52.929  83.031  89.830  1.00 59.45           N  
+ATOM   1199  CA  TRP A 168      53.911  82.169  89.183  1.00 59.45           C  
+ATOM   1200  C   TRP A 168      54.446  81.126  90.153  1.00 59.45           C  
+ATOM   1201  O   TRP A 168      54.630  79.958  89.783  1.00 59.45           O  
+ATOM   1202  CB  TRP A 168      55.055  83.001  88.609  1.00 59.45           C  
+ATOM   1203  CG  TRP A 168      56.191  82.172  88.096  1.00 59.45           C  
+ATOM   1204  CD1 TRP A 168      57.361  81.899  88.738  1.00 59.45           C  
+ATOM   1205  CD2 TRP A 168      56.262  81.504  86.831  1.00 59.45           C  
+ATOM   1206  NE1 TRP A 168      58.159  81.106  87.952  1.00 59.45           N  
+ATOM   1207  CE2 TRP A 168      57.507  80.849  86.776  1.00 59.45           C  
+ATOM   1208  CE3 TRP A 168      55.396  81.397  85.741  1.00 59.45           C  
+ATOM   1209  CZ2 TRP A 168      57.908  80.100  85.673  1.00 59.45           C  
+ATOM   1210  CZ3 TRP A 168      55.794  80.651  84.648  1.00 59.45           C  
+ATOM   1211  CH2 TRP A 168      57.038  80.012  84.622  1.00 59.45           C  
+ATOM   1212  N   ARG A 169      54.694  81.524  91.405  1.00 62.19           N  
+ATOM   1213  CA  ARG A 169      55.160  80.558  92.396  1.00 62.19           C  
+ATOM   1214  C   ARG A 169      54.136  79.448  92.599  1.00 62.19           C  
+ATOM   1215  O   ARG A 169      54.460  78.261  92.487  1.00 62.19           O  
+ATOM   1216  CB  ARG A 169      55.467  81.260  93.720  1.00 62.19           C  
+ATOM   1217  CG  ARG A 169      56.623  82.242  93.650  1.00 62.19           C  
+ATOM   1218  CD  ARG A 169      57.859  81.609  93.035  1.00 62.19           C  
+ATOM   1219  NE  ARG A 169      58.679  82.595  92.338  1.00 62.19           N  
+ATOM   1220  CZ  ARG A 169      59.646  83.303  92.911  1.00 62.19           C  
+ATOM   1221  NH1 ARG A 169      60.340  84.180  92.199  1.00 62.19           N  
+ATOM   1222  NH2 ARG A 169      59.921  83.135  94.196  1.00 62.19           N  
+ATOM   1223  N   SER A 170      52.882  79.817  92.873  1.00 64.99           N  
+ATOM   1224  CA  SER A 170      51.839  78.826  93.106  1.00 64.99           C  
+ATOM   1225  C   SER A 170      51.546  77.981  91.873  1.00 64.99           C  
+ATOM   1226  O   SER A 170      51.007  76.879  92.010  1.00 64.99           O  
+ATOM   1227  CB  SER A 170      50.557  79.514  93.575  1.00 64.99           C  
+ATOM   1228  OG  SER A 170      50.836  80.493  94.560  1.00 64.99           O  
+ATOM   1229  N   GLU A 171      51.885  78.466  90.678  1.00 66.43           N  
+ATOM   1230  CA  GLU A 171      51.625  77.681  89.477  1.00 66.43           C  
+ATOM   1231  C   GLU A 171      52.763  76.718  89.162  1.00 66.43           C  
+ATOM   1232  O   GLU A 171      52.521  75.626  88.637  1.00 66.43           O  
+ATOM   1233  CB  GLU A 171      51.370  78.607  88.288  1.00 66.43           C  
+ATOM   1234  CG  GLU A 171      50.867  77.892  87.042  1.00 66.43           C  
+ATOM   1235  CD  GLU A 171      49.354  77.885  86.936  1.00 66.43           C  
+ATOM   1236  OE1 GLU A 171      48.704  78.714  87.604  1.00 66.43           O  
+ATOM   1237  OE2 GLU A 171      48.815  77.047  86.183  1.00 66.43           O  
+ATOM   1238  N   VAL A 172      54.004  77.089  89.469  1.00 61.03           N  
+ATOM   1239  CA  VAL A 172      55.162  76.301  89.078  1.00 61.03           C  
+ATOM   1240  C   VAL A 172      55.700  75.457  90.228  1.00 61.03           C  
+ATOM   1241  O   VAL A 172      55.887  74.247  90.072  1.00 61.03           O  
+ATOM   1242  CB  VAL A 172      56.266  77.204  88.491  1.00 61.03           C  
+ATOM   1243  CG1 VAL A 172      57.478  76.377  88.120  1.00 61.03           C  
+ATOM   1244  CG2 VAL A 172      55.734  77.937  87.277  1.00 61.03           C  
+ATOM   1245  N   GLY A 173      55.978  76.069  91.381  1.00 63.71           N  
+ATOM   1246  CA  GLY A 173      56.564  75.314  92.476  1.00 63.71           C  
+ATOM   1247  C   GLY A 173      55.630  74.252  93.026  1.00 63.71           C  
+ATOM   1248  O   GLY A 173      56.068  73.171  93.421  1.00 63.71           O  
+ATOM   1249  N   LYS A 174      54.328  74.544  93.054  1.00 64.04           N  
+ATOM   1250  CA  LYS A 174      53.371  73.573  93.571  1.00 64.04           C  
+ATOM   1251  C   LYS A 174      53.309  72.335  92.687  1.00 64.04           C  
+ATOM   1252  O   LYS A 174      53.045  71.230  93.175  1.00 64.04           O  
+ATOM   1253  CB  LYS A 174      51.991  74.215  93.704  1.00 64.04           C  
+ATOM   1254  CG  LYS A 174      51.891  75.222  94.836  1.00 64.04           C  
+ATOM   1255  CD  LYS A 174      50.455  75.657  95.064  1.00 64.04           C  
+ATOM   1256  CE  LYS A 174      50.343  76.579  96.266  1.00 64.04           C  
+ATOM   1257  NZ  LYS A 174      48.946  77.047  96.477  1.00 64.04           N  
+ATOM   1258  N   GLN A 175      53.553  72.495  91.385  1.00 59.39           N  
+ATOM   1259  CA  GLN A 175      53.558  71.340  90.495  1.00 59.39           C  
+ATOM   1260  C   GLN A 175      54.930  70.682  90.436  1.00 59.39           C  
+ATOM   1261  O   GLN A 175      55.033  69.502  90.077  1.00 59.39           O  
+ATOM   1262  CB  GLN A 175      53.109  71.751  89.093  1.00 59.39           C  
+ATOM   1263  CG  GLN A 175      51.686  72.274  89.026  1.00 59.39           C  
+ATOM   1264  CD  GLN A 175      51.215  72.493  87.602  1.00 59.39           C  
+ATOM   1265  OE1 GLN A 175      51.682  71.835  86.674  1.00 59.39           O  
+ATOM   1266  NE2 GLN A 175      50.284  73.422  87.424  1.00 59.39           N  
+ATOM   1267  N   LEU A 176      55.987  71.416  90.776  1.00 57.81           N  
+ATOM   1268  CA  LEU A 176      57.334  70.869  90.691  1.00 57.81           C  
+ATOM   1269  C   LEU A 176      57.827  70.243  91.990  1.00 57.81           C  
+ATOM   1270  O   LEU A 176      58.828  69.522  91.963  1.00 57.81           O  
+ATOM   1271  CB  LEU A 176      58.319  71.960  90.258  1.00 57.81           C  
+ATOM   1272  CG  LEU A 176      58.307  72.319  88.772  1.00 57.81           C  
+ATOM   1273  CD1 LEU A 176      59.402  73.318  88.454  1.00 57.81           C  
+ATOM   1274  CD2 LEU A 176      58.459  71.071  87.923  1.00 57.81           C  
+ATOM   1275  N   ARG A 177      57.157  70.500  93.119  1.00 61.73           N  
+ATOM   1276  CA  ARG A 177      57.671  70.034  94.408  1.00 61.73           C  
+ATOM   1277  C   ARG A 177      57.875  68.523  94.465  1.00 61.73           C  
+ATOM   1278  O   ARG A 177      59.008  68.083  94.734  1.00 61.73           O  
+ATOM   1279  CB  ARG A 177      56.759  70.541  95.529  1.00 61.73           C  
+ATOM   1280  CG  ARG A 177      57.199  70.123  96.920  1.00 61.73           C  
+ATOM   1281  CD  ARG A 177      58.626  70.556  97.200  1.00 61.73           C  
+ATOM   1282  NE  ARG A 177      59.081  70.111  98.513  1.00 61.73           N  
+ATOM   1283  CZ  ARG A 177      58.995  70.843  99.618  1.00 61.73           C  
+ATOM   1284  NH1 ARG A 177      59.433  70.358 100.772  1.00 61.73           N  
+ATOM   1285  NH2 ARG A 177      58.471  72.058  99.571  1.00 61.73           N  
+ATOM   1286  N   PRO A 178      56.861  67.677  94.233  1.00 60.41           N  
+ATOM   1287  CA  PRO A 178      57.126  66.229  94.305  1.00 60.41           C  
+ATOM   1288  C   PRO A 178      58.037  65.744  93.192  1.00 60.41           C  
+ATOM   1289  O   PRO A 178      58.880  64.859  93.414  1.00 60.41           O  
+ATOM   1290  CB  PRO A 178      55.723  65.613  94.215  1.00 60.41           C  
+ATOM   1291  CG  PRO A 178      54.935  66.602  93.450  1.00 60.41           C  
+ATOM   1292  CD  PRO A 178      55.465  67.952  93.840  1.00 60.41           C  
+ATOM   1293  N   LEU A 179      57.883  66.306  91.991  1.00 55.50           N  
+ATOM   1294  CA  LEU A 179      58.809  66.007  90.907  1.00 55.50           C  
+ATOM   1295  C   LEU A 179      60.238  66.341  91.305  1.00 55.50           C  
+ATOM   1296  O   LEU A 179      61.159  65.558  91.050  1.00 55.50           O  
+ATOM   1297  CB  LEU A 179      58.413  66.773  89.645  1.00 55.50           C  
+ATOM   1298  CG  LEU A 179      57.459  66.103  88.652  1.00 55.50           C  
+ATOM   1299  CD1 LEU A 179      58.093  64.856  88.063  1.00 55.50           C  
+ATOM   1300  CD2 LEU A 179      56.120  65.778  89.298  1.00 55.50           C  
+ATOM   1301  N   TYR A 180      60.442  67.490  91.954  1.00 53.72           N  
+ATOM   1302  CA  TYR A 180      61.796  67.874  92.336  1.00 53.72           C  
+ATOM   1303  C   TYR A 180      62.328  66.996  93.461  1.00 53.72           C  
+ATOM   1304  O   TYR A 180      63.527  66.716  93.512  1.00 53.72           O  
+ATOM   1305  CB  TYR A 180      61.851  69.346  92.739  1.00 53.72           C  
+ATOM   1306  CG  TYR A 180      63.236  69.937  92.605  1.00 53.72           C  
+ATOM   1307  CD1 TYR A 180      63.638  70.551  91.429  1.00 53.72           C  
+ATOM   1308  CD2 TYR A 180      64.147  69.863  93.649  1.00 53.72           C  
+ATOM   1309  CE1 TYR A 180      64.905  71.084  91.300  1.00 53.72           C  
+ATOM   1310  CE2 TYR A 180      65.415  70.392  93.528  1.00 53.72           C  
+ATOM   1311  CZ  TYR A 180      65.789  71.001  92.352  1.00 53.72           C  
+ATOM   1312  OH  TYR A 180      67.052  71.529  92.228  1.00 53.72           O  
+ATOM   1313  N   GLU A 181      61.460  66.545  94.368  1.00 58.67           N  
+ATOM   1314  CA  GLU A 181      61.922  65.650  95.427  1.00 58.67           C  
+ATOM   1315  C   GLU A 181      62.367  64.308  94.857  1.00 58.67           C  
+ATOM   1316  O   GLU A 181      63.422  63.773  95.238  1.00 58.67           O  
+ATOM   1317  CB  GLU A 181      60.822  65.455  96.469  1.00 58.67           C  
+ATOM   1318  CG  GLU A 181      60.505  66.706  97.268  1.00 58.67           C  
+ATOM   1319  CD  GLU A 181      59.326  66.520  98.199  1.00 58.67           C  
+ATOM   1320  OE1 GLU A 181      58.666  65.464  98.121  1.00 58.67           O  
+ATOM   1321  OE2 GLU A 181      59.058  67.433  99.008  1.00 58.67           O  
+ATOM   1322  N   GLU A 182      61.577  63.746  93.939  1.00 59.85           N  
+ATOM   1323  CA  GLU A 182      61.976  62.499  93.299  1.00 59.85           C  
+ATOM   1324  C   GLU A 182      63.240  62.693  92.467  1.00 59.85           C  
+ATOM   1325  O   GLU A 182      64.118  61.822  92.439  1.00 59.85           O  
+ATOM   1326  CB  GLU A 182      60.833  61.958  92.442  1.00 59.85           C  
+ATOM   1327  CG  GLU A 182      60.890  60.455  92.219  1.00 59.85           C  
+ATOM   1328  CD  GLU A 182      59.581  59.892  91.701  1.00 59.85           C  
+ATOM   1329  OE1 GLU A 182      59.533  59.482  90.523  1.00 59.85           O  
+ATOM   1330  OE2 GLU A 182      58.600  59.862  92.472  1.00 59.85           O  
+ATOM   1331  N   TYR A 183      63.354  63.842  91.795  1.00 54.29           N  
+ATOM   1332  CA  TYR A 183      64.578  64.181  91.078  1.00 54.29           C  
+ATOM   1333  C   TYR A 183      65.775  64.225  92.018  1.00 54.29           C  
+ATOM   1334  O   TYR A 183      66.856  63.727  91.683  1.00 54.29           O  
+ATOM   1335  CB  TYR A 183      64.390  65.523  90.371  1.00 54.29           C  
+ATOM   1336  CG  TYR A 183      65.666  66.269  90.060  1.00 54.29           C  
+ATOM   1337  CD1 TYR A 183      66.463  65.905  88.988  1.00 54.29           C  
+ATOM   1338  CD2 TYR A 183      66.064  67.350  90.835  1.00 54.29           C  
+ATOM   1339  CE1 TYR A 183      67.622  66.592  88.699  1.00 54.29           C  
+ATOM   1340  CE2 TYR A 183      67.224  68.040  90.555  1.00 54.29           C  
+ATOM   1341  CZ  TYR A 183      67.999  67.656  89.488  1.00 54.29           C  
+ATOM   1342  OH  TYR A 183      69.156  68.344  89.205  1.00 54.29           O  
+ATOM   1343  N   VAL A 184      65.595  64.808  93.203  1.00 55.60           N  
+ATOM   1344  CA  VAL A 184      66.687  64.928  94.163  1.00 55.60           C  
+ATOM   1345  C   VAL A 184      67.149  63.552  94.615  1.00 55.60           C  
+ATOM   1346  O   VAL A 184      68.351  63.258  94.636  1.00 55.60           O  
+ATOM   1347  CB  VAL A 184      66.258  65.799  95.358  1.00 55.60           C  
+ATOM   1348  CG1 VAL A 184      67.127  65.509  96.570  1.00 55.60           C  
+ATOM   1349  CG2 VAL A 184      66.330  67.269  94.994  1.00 55.60           C  
+ATOM   1350  N   VAL A 185      66.204  62.681  94.980  1.00 57.17           N  
+ATOM   1351  CA  VAL A 185      66.608  61.371  95.488  1.00 57.17           C  
+ATOM   1352  C   VAL A 185      67.230  60.532  94.375  1.00 57.17           C  
+ATOM   1353  O   VAL A 185      68.201  59.797  94.604  1.00 57.17           O  
+ATOM   1354  CB  VAL A 185      65.429  60.645  96.165  1.00 57.17           C  
+ATOM   1355  CG1 VAL A 185      65.081  61.319  97.486  1.00 57.17           C  
+ATOM   1356  CG2 VAL A 185      64.226  60.578  95.258  1.00 57.17           C  
+ATOM   1357  N   LEU A 186      66.716  60.651  93.146  1.00 57.69           N  
+ATOM   1358  CA  LEU A 186      67.292  59.886  92.044  1.00 57.69           C  
+ATOM   1359  C   LEU A 186      68.693  60.377  91.698  1.00 57.69           C  
+ATOM   1360  O   LEU A 186      69.585  59.569  91.413  1.00 57.69           O  
+ATOM   1361  CB  LEU A 186      66.378  59.955  90.822  1.00 57.69           C  
+ATOM   1362  CG  LEU A 186      65.518  58.714  90.573  1.00 57.69           C  
+ATOM   1363  CD1 LEU A 186      64.582  58.461  91.744  1.00 57.69           C  
+ATOM   1364  CD2 LEU A 186      64.731  58.856  89.283  1.00 57.69           C  
+ATOM   1365  N   LYS A 187      68.915  61.693  91.731  1.00 56.03           N  
+ATOM   1366  CA  LYS A 187      70.250  62.214  91.461  1.00 56.03           C  
+ATOM   1367  C   LYS A 187      71.218  61.849  92.577  1.00 56.03           C  
+ATOM   1368  O   LYS A 187      72.397  61.578  92.320  1.00 56.03           O  
+ATOM   1369  CB  LYS A 187      70.195  63.728  91.272  1.00 56.03           C  
+ATOM   1370  CG  LYS A 187      69.670  64.156  89.918  1.00 56.03           C  
+ATOM   1371  CD  LYS A 187      70.594  63.719  88.799  1.00 56.03           C  
+ATOM   1372  CE  LYS A 187      70.104  64.231  87.457  1.00 56.03           C  
+ATOM   1373  NZ  LYS A 187      71.022  63.853  86.350  1.00 56.03           N  
+ATOM   1374  N   ASN A 188      70.739  61.832  93.823  1.00 57.36           N  
+ATOM   1375  CA  ASN A 188      71.583  61.387  94.925  1.00 57.36           C  
+ATOM   1376  C   ASN A 188      71.986  59.930  94.748  1.00 57.36           C  
+ATOM   1377  O   ASN A 188      73.144  59.567  94.982  1.00 57.36           O  
+ATOM   1378  CB  ASN A 188      70.858  61.588  96.255  1.00 57.36           C  
+ATOM   1379  CG  ASN A 188      71.198  62.909  96.906  1.00 57.36           C  
+ATOM   1380  OD1 ASN A 188      72.350  63.341  96.893  1.00 57.36           O  
+ATOM   1381  ND2 ASN A 188      70.196  63.562  97.479  1.00 57.36           N  
+ATOM   1382  N   GLU A 189      71.043  59.080  94.332  1.00 65.50           N  
+ATOM   1383  CA  GLU A 189      71.380  57.685  94.065  1.00 65.50           C  
+ATOM   1384  C   GLU A 189      72.384  57.569  92.925  1.00 65.50           C  
+ATOM   1385  O   GLU A 189      73.343  56.791  93.008  1.00 65.50           O  
+ATOM   1386  CB  GLU A 189      70.116  56.889  93.750  1.00 65.50           C  
+ATOM   1387  CG  GLU A 189      70.383  55.449  93.351  1.00 65.50           C  
+ATOM   1388  CD  GLU A 189      69.212  54.538  93.648  1.00 65.50           C  
+ATOM   1389  OE1 GLU A 189      68.351  54.923  94.466  1.00 65.50           O  
+ATOM   1390  OE2 GLU A 189      69.152  53.434  93.064  1.00 65.50           O  
+ATOM   1391  N   MET A 190      72.180  58.336  91.851  1.00 65.77           N  
+ATOM   1392  CA  MET A 190      73.112  58.312  90.728  1.00 65.77           C  
+ATOM   1393  C   MET A 190      74.514  58.717  91.162  1.00 65.77           C  
+ATOM   1394  O   MET A 190      75.504  58.110  90.738  1.00 65.77           O  
+ATOM   1395  CB  MET A 190      72.614  59.232  89.612  1.00 65.77           C  
+ATOM   1396  CG  MET A 190      73.403  59.132  88.314  1.00 65.77           C  
+ATOM   1397  SD  MET A 190      74.811  60.254  88.229  1.00 65.77           S  
+ATOM   1398  CE  MET A 190      73.982  61.835  88.340  1.00 65.77           C  
+ATOM   1399  N   ALA A 191      74.619  59.744  92.005  1.00 59.87           N  
+ATOM   1400  CA  ALA A 191      75.932  60.223  92.420  1.00 59.87           C  
+ATOM   1401  C   ALA A 191      76.597  59.254  93.388  1.00 59.87           C  
+ATOM   1402  O   ALA A 191      77.803  59.002  93.290  1.00 59.87           O  
+ATOM   1403  CB  ALA A 191      75.811  61.609  93.044  1.00 59.87           C  
+ATOM   1404  N   ARG A 192      75.831  58.699  94.331  1.00 59.81           N  
+ATOM   1405  CA  ARG A 192      76.392  57.724  95.256  1.00 59.81           C  
+ATOM   1406  C   ARG A 192      76.754  56.420  94.562  1.00 59.81           C  
+ATOM   1407  O   ARG A 192      77.576  55.661  95.085  1.00 59.81           O  
+ATOM   1408  CB  ARG A 192      75.413  57.460  96.401  1.00 59.81           C  
+ATOM   1409  CG  ARG A 192      75.175  58.668  97.292  1.00 59.81           C  
+ATOM   1410  CD  ARG A 192      74.537  58.272  98.610  1.00 59.81           C  
+ATOM   1411  NE  ARG A 192      74.190  59.438  99.417  1.00 59.81           N  
+ATOM   1412  CZ  ARG A 192      72.954  59.903  99.563  1.00 59.81           C  
+ATOM   1413  NH1 ARG A 192      72.728  60.969 100.317  1.00 59.81           N  
+ATOM   1414  NH2 ARG A 192      71.941  59.297  98.958  1.00 59.81           N  
+ATOM   1415  N   ALA A 193      76.159  56.142  93.399  1.00 62.18           N  
+ATOM   1416  CA  ALA A 193      76.602  55.001  92.607  1.00 62.18           C  
+ATOM   1417  C   ALA A 193      77.926  55.288  91.913  1.00 62.18           C  
+ATOM   1418  O   ALA A 193      78.670  54.357  91.588  1.00 62.18           O  
+ATOM   1419  CB  ALA A 193      75.534  54.623  91.582  1.00 62.18           C  
+ATOM   1420  N   ASN A 194      78.234  56.563  91.677  1.00 61.49           N  
+ATOM   1421  CA  ASN A 194      79.495  56.973  91.077  1.00 61.49           C  
+ATOM   1422  C   ASN A 194      80.560  57.294  92.116  1.00 61.49           C  
+ATOM   1423  O   ASN A 194      81.514  58.015  91.803  1.00 61.49           O  
+ATOM   1424  CB  ASN A 194      79.277  58.184  90.167  1.00 61.49           C  
+ATOM   1425  CG  ASN A 194      78.619  57.815  88.854  1.00 61.49           C  
+ATOM   1426  OD1 ASN A 194      77.463  58.157  88.608  1.00 61.49           O  
+ATOM   1427  ND2 ASN A 194      79.356  57.115  88.000  1.00 61.49           N  
+ATOM   1428  N   HIS A 195      80.409  56.787  93.341  1.00 62.02           N  
+ATOM   1429  CA  HIS A 195      81.364  56.991  94.428  1.00 62.02           C  
+ATOM   1430  C   HIS A 195      81.497  58.461  94.813  1.00 62.02           C  
+ATOM   1431  O   HIS A 195      82.550  58.892  95.287  1.00 62.02           O  
+ATOM   1432  CB  HIS A 195      82.735  56.400  94.086  1.00 62.02           C  
+ATOM   1433  CG  HIS A 195      82.668  55.017  93.519  1.00 62.02           C  
+ATOM   1434  ND1 HIS A 195      82.789  54.758  92.171  1.00 62.02           N  
+ATOM   1435  CD2 HIS A 195      82.481  53.816  94.117  1.00 62.02           C  
+ATOM   1436  CE1 HIS A 195      82.686  53.457  91.963  1.00 62.02           C  
+ATOM   1437  NE2 HIS A 195      82.499  52.864  93.128  1.00 62.02           N  
+ATOM   1438  N   TYR A 196      80.439  59.238  94.614  1.00 54.45           N  
+ATOM   1439  CA  TYR A 196      80.365  60.607  95.098  1.00 54.45           C  
+ATOM   1440  C   TYR A 196      79.514  60.664  96.360  1.00 54.45           C  
+ATOM   1441  O   TYR A 196      78.685  59.788  96.620  1.00 54.45           O  
+ATOM   1442  CB  TYR A 196      79.781  61.537  94.031  1.00 54.45           C  
+ATOM   1443  CG  TYR A 196      80.736  61.870  92.908  1.00 54.45           C  
+ATOM   1444  CD1 TYR A 196      80.742  61.132  91.734  1.00 54.45           C  
+ATOM   1445  CD2 TYR A 196      81.626  62.927  93.020  1.00 54.45           C  
+ATOM   1446  CE1 TYR A 196      81.611  61.434  90.705  1.00 54.45           C  
+ATOM   1447  CE2 TYR A 196      82.499  63.237  91.997  1.00 54.45           C  
+ATOM   1448  CZ  TYR A 196      82.487  62.487  90.842  1.00 54.45           C  
+ATOM   1449  OH  TYR A 196      83.355  62.791  89.820  1.00 54.45           O  
+ATOM   1450  N   GLU A 197      79.730  61.714  97.153  1.00 54.39           N  
+ATOM   1451  CA  GLU A 197      78.946  61.876  98.372  1.00 54.39           C  
+ATOM   1452  C   GLU A 197      77.502  62.248  98.065  1.00 54.39           C  
+ATOM   1453  O   GLU A 197      76.585  61.788  98.755  1.00 54.39           O  
+ATOM   1454  CB  GLU A 197      79.588  62.928  99.275  1.00 54.39           C  
+ATOM   1455  CG  GLU A 197      80.881  62.478  99.932  1.00 54.39           C  
+ATOM   1456  CD  GLU A 197      80.654  61.444 101.019  1.00 54.39           C  
+ATOM   1457  OE1 GLU A 197      81.598  60.688 101.331  1.00 54.39           O  
+ATOM   1458  OE2 GLU A 197      79.531  61.387 101.563  1.00 54.39           O  
+ATOM   1459  N   ASP A 198      77.281  63.066  97.042  1.00 49.83           N  
+ATOM   1460  CA  ASP A 198      75.946  63.495  96.638  1.00 49.83           C  
+ATOM   1461  C   ASP A 198      76.064  64.112  95.251  1.00 49.83           C  
+ATOM   1462  O   ASP A 198      77.148  64.156  94.662  1.00 49.83           O  
+ATOM   1463  CB  ASP A 198      75.347  64.478  97.644  1.00 49.83           C  
+ATOM   1464  CG  ASP A 198      76.351  65.510  98.112  1.00 49.83           C  
+ATOM   1465  OD1 ASP A 198      77.373  65.702  97.427  1.00 49.83           O  
+ATOM   1466  OD2 ASP A 198      76.125  66.127  99.169  1.00 49.83           O  
+ATOM   1467  N   TYR A 199      74.934  64.590  94.726  1.00 45.46           N  
+ATOM   1468  CA  TYR A 199      74.955  65.233  93.417  1.00 45.46           C  
+ATOM   1469  C   TYR A 199      75.658  66.582  93.460  1.00 45.46           C  
+ATOM   1470  O   TYR A 199      76.295  66.975  92.475  1.00 45.46           O  
+ATOM   1471  CB  TYR A 199      73.533  65.398  92.881  1.00 45.46           C  
+ATOM   1472  CG  TYR A 199      73.480  65.690  91.399  1.00 45.46           C  
+ATOM   1473  CD1 TYR A 199      74.320  65.031  90.515  1.00 45.46           C  
+ATOM   1474  CD2 TYR A 199      72.583  66.614  90.884  1.00 45.46           C  
+ATOM   1475  CE1 TYR A 199      74.275  65.290  89.161  1.00 45.46           C  
+ATOM   1476  CE2 TYR A 199      72.530  66.879  89.531  1.00 45.46           C  
+ATOM   1477  CZ  TYR A 199      73.378  66.213  88.674  1.00 45.46           C  
+ATOM   1478  OH  TYR A 199      73.332  66.471  87.323  1.00 45.46           O  
+ATOM   1479  N   GLY A 200      75.553  67.301  94.580  1.00 39.47           N  
+ATOM   1480  CA  GLY A 200      76.322  68.520  94.736  1.00 39.47           C  
+ATOM   1481  C   GLY A 200      77.813  68.283  94.637  1.00 39.47           C  
+ATOM   1482  O   GLY A 200      78.547  69.121  94.112  1.00 39.47           O  
+ATOM   1483  N   ASP A 201      78.281  67.133  95.125  1.00 43.40           N  
+ATOM   1484  CA  ASP A 201      79.687  66.782  94.972  1.00 43.40           C  
+ATOM   1485  C   ASP A 201      80.031  66.504  93.515  1.00 43.40           C  
+ATOM   1486  O   ASP A 201      81.107  66.894  93.046  1.00 43.40           O  
+ATOM   1487  CB  ASP A 201      80.015  65.573  95.845  1.00 43.40           C  
+ATOM   1488  CG  ASP A 201      81.476  65.493  96.207  1.00 43.40           C  
+ATOM   1489  OD1 ASP A 201      81.939  66.332  97.007  1.00 43.40           O  
+ATOM   1490  OD2 ASP A 201      82.160  64.579  95.706  1.00 43.40           O  
+ATOM   1491  N   TYR A 202      79.129  65.846  92.784  1.00 44.23           N  
+ATOM   1492  CA  TYR A 202      79.338  65.634  91.356  1.00 44.23           C  
+ATOM   1493  C   TYR A 202      79.441  66.964  90.621  1.00 44.23           C  
+ATOM   1494  O   TYR A 202      80.242  67.114  89.691  1.00 44.23           O  
+ATOM   1495  CB  TYR A 202      78.202  64.783  90.786  1.00 44.23           C  
+ATOM   1496  CG  TYR A 202      78.301  64.522  89.300  1.00 44.23           C  
+ATOM   1497  CD1 TYR A 202      77.607  65.307  88.389  1.00 44.23           C  
+ATOM   1498  CD2 TYR A 202      79.083  63.487  88.809  1.00 44.23           C  
+ATOM   1499  CE1 TYR A 202      77.693  65.070  87.031  1.00 44.23           C  
+ATOM   1500  CE2 TYR A 202      79.176  63.242  87.452  1.00 44.23           C  
+ATOM   1501  CZ  TYR A 202      78.479  64.037  86.569  1.00 44.23           C  
+ATOM   1502  OH  TYR A 202      78.568  63.796  85.217  1.00 44.23           O  
+ATOM   1503  N   TRP A 203      78.632  67.944  91.027  1.00 40.70           N  
+ATOM   1504  CA  TRP A 203      78.728  69.277  90.441  1.00 40.70           C  
+ATOM   1505  C   TRP A 203      80.056  69.936  90.788  1.00 40.70           C  
+ATOM   1506  O   TRP A 203      80.777  70.411  89.904  1.00 40.70           O  
+ATOM   1507  CB  TRP A 203      77.562  70.144  90.912  1.00 40.70           C  
+ATOM   1508  CG  TRP A 203      76.345  70.032  90.059  1.00 40.70           C  
+ATOM   1509  CD1 TRP A 203      76.266  69.498  88.808  1.00 40.70           C  
+ATOM   1510  CD2 TRP A 203      75.026  70.475  90.391  1.00 40.70           C  
+ATOM   1511  NE1 TRP A 203      74.977  69.578  88.341  1.00 40.70           N  
+ATOM   1512  CE2 TRP A 203      74.197  70.174  89.295  1.00 40.70           C  
+ATOM   1513  CE3 TRP A 203      74.466  71.094  91.510  1.00 40.70           C  
+ATOM   1514  CZ2 TRP A 203      72.838  70.472  89.286  1.00 40.70           C  
+ATOM   1515  CZ3 TRP A 203      73.121  71.389  91.499  1.00 40.70           C  
+ATOM   1516  CH2 TRP A 203      72.320  71.078  90.396  1.00 40.70           C  
+ATOM   1517  N   ARG A 204      80.396  69.976  92.078  1.00 37.74           N  
+ATOM   1518  CA  ARG A 204      81.638  70.595  92.523  1.00 37.74           C  
+ATOM   1519  C   ARG A 204      82.873  69.919  91.949  1.00 37.74           C  
+ATOM   1520  O   ARG A 204      83.952  70.521  91.976  1.00 37.74           O  
+ATOM   1521  CB  ARG A 204      81.713  70.581  94.049  1.00 37.74           C  
+ATOM   1522  CG  ARG A 204      80.692  71.469  94.725  1.00 37.74           C  
+ATOM   1523  CD  ARG A 204      81.101  71.772  96.150  1.00 37.74           C  
+ATOM   1524  NE  ARG A 204      81.366  70.558  96.914  1.00 37.74           N  
+ATOM   1525  CZ  ARG A 204      80.482  69.972  97.716  1.00 37.74           C  
+ATOM   1526  NH1 ARG A 204      79.271  70.492  97.861  1.00 37.74           N  
+ATOM   1527  NH2 ARG A 204      80.809  68.870  98.374  1.00 37.74           N  
+ATOM   1528  N   GLY A 205      82.747  68.695  91.440  1.00 37.54           N  
+ATOM   1529  CA  GLY A 205      83.866  68.031  90.792  1.00 37.54           C  
+ATOM   1530  C   GLY A 205      84.446  68.782  89.609  1.00 37.54           C  
+ATOM   1531  O   GLY A 205      85.527  68.412  89.138  1.00 37.54           O  
+ATOM   1532  N   ASP A 206      83.761  69.817  89.116  1.00 35.92           N  
+ATOM   1533  CA  ASP A 206      84.307  70.605  88.016  1.00 35.92           C  
+ATOM   1534  C   ASP A 206      85.545  71.383  88.442  1.00 35.92           C  
+ATOM   1535  O   ASP A 206      86.446  71.611  87.627  1.00 35.92           O  
+ATOM   1536  CB  ASP A 206      83.246  71.562  87.472  1.00 35.92           C  
+ATOM   1537  CG  ASP A 206      81.921  70.876  87.212  1.00 35.92           C  
+ATOM   1538  OD1 ASP A 206      80.874  71.552  87.291  1.00 35.92           O  
+ATOM   1539  OD2 ASP A 206      81.925  69.660  86.933  1.00 35.92           O  
+ATOM   1540  N   TYR A 207      85.609  71.794  89.706  1.00 38.13           N  
+ATOM   1541  CA  TYR A 207      86.741  72.546  90.227  1.00 38.13           C  
+ATOM   1542  C   TYR A 207      87.754  71.669  90.947  1.00 38.13           C  
+ATOM   1543  O   TYR A 207      88.770  72.184  91.425  1.00 38.13           O  
+ATOM   1544  CB  TYR A 207      86.253  73.648  91.173  1.00 38.13           C  
+ATOM   1545  CG  TYR A 207      85.221  74.563  90.562  1.00 38.13           C  
+ATOM   1546  CD1 TYR A 207      83.866  74.284  90.673  1.00 38.13           C  
+ATOM   1547  CD2 TYR A 207      85.600  75.704  89.871  1.00 38.13           C  
+ATOM   1548  CE1 TYR A 207      82.918  75.117  90.117  1.00 38.13           C  
+ATOM   1549  CE2 TYR A 207      84.658  76.543  89.310  1.00 38.13           C  
+ATOM   1550  CZ  TYR A 207      83.320  76.244  89.437  1.00 38.13           C  
+ATOM   1551  OH  TYR A 207      82.378  77.074  88.881  1.00 38.13           O  
+ATOM   1552  N   GLU A 208      87.511  70.367  91.038  1.00 44.00           N  
+ATOM   1553  CA  GLU A 208      88.411  69.489  91.771  1.00 44.00           C  
+ATOM   1554  C   GLU A 208      89.635  69.151  90.929  1.00 44.00           C  
+ATOM   1555  O   GLU A 208      89.514  68.746  89.770  1.00 44.00           O  
+ATOM   1556  CB  GLU A 208      87.683  68.210  92.178  1.00 44.00           C  
+ATOM   1557  CG  GLU A 208      88.541  67.236  92.959  1.00 44.00           C  
+ATOM   1558  CD  GLU A 208      87.851  65.910  93.186  1.00 44.00           C  
+ATOM   1559  OE1 GLU A 208      86.803  65.669  92.551  1.00 44.00           O  
+ATOM   1560  OE2 GLU A 208      88.354  65.108  94.000  1.00 44.00           O  
+ATOM   1561  N   VAL A 209      90.815  69.320  91.519  1.00 46.65           N  
+ATOM   1562  CA  VAL A 209      92.082  68.963  90.894  1.00 46.65           C  
+ATOM   1563  C   VAL A 209      92.804  67.992  91.815  1.00 46.65           C  
+ATOM   1564  O   VAL A 209      92.934  68.252  93.017  1.00 46.65           O  
+ATOM   1565  CB  VAL A 209      92.953  70.202  90.616  1.00 46.65           C  
+ATOM   1566  CG1 VAL A 209      94.277  69.787  90.004  1.00 46.65           C  
+ATOM   1567  CG2 VAL A 209      92.222  71.172  89.708  1.00 46.65           C  
+ATOM   1568  N   ASN A 210      93.266  66.876  91.256  1.00 54.90           N  
+ATOM   1569  CA  ASN A 210      93.961  65.852  92.020  1.00 54.90           C  
+ATOM   1570  C   ASN A 210      95.240  65.452  91.301  1.00 54.90           C  
+ATOM   1571  O   ASN A 210      95.374  65.634  90.088  1.00 54.90           O  
+ATOM   1572  CB  ASN A 210      93.085  64.611  92.233  1.00 54.90           C  
+ATOM   1573  CG  ASN A 210      91.715  64.951  92.783  1.00 54.90           C  
+ATOM   1574  OD1 ASN A 210      91.574  65.321  93.948  1.00 54.90           O  
+ATOM   1575  ND2 ASN A 210      90.693  64.818  91.945  1.00 54.90           N  
+ATOM   1576  N   GLY A 211      96.180  64.903  92.065  1.00 65.48           N  
+ATOM   1577  CA  GLY A 211      97.405  64.380  91.485  1.00 65.48           C  
+ATOM   1578  C   GLY A 211      98.386  65.434  91.027  1.00 65.48           C  
+ATOM   1579  O   GLY A 211      99.388  65.102  90.385  1.00 65.48           O  
+ATOM   1580  N   VAL A 212      98.129  66.703  91.337  1.00 62.74           N  
+ATOM   1581  CA  VAL A 212      99.030  67.797  90.992  1.00 62.74           C  
+ATOM   1582  C   VAL A 212      99.377  68.537  92.275  1.00 62.74           C  
+ATOM   1583  O   VAL A 212      98.494  69.116  92.919  1.00 62.74           O  
+ATOM   1584  CB  VAL A 212      98.414  68.758  89.961  1.00 62.74           C  
+ATOM   1585  CG1 VAL A 212      99.483  69.680  89.399  1.00 62.74           C  
+ATOM   1586  CG2 VAL A 212      97.739  67.980  88.843  1.00 62.74           C  
+ATOM   1587  N   ASP A 213     100.655  68.518  92.644  1.00 63.72           N  
+ATOM   1588  CA  ASP A 213     101.085  69.145  93.885  1.00 63.72           C  
+ATOM   1589  C   ASP A 213     101.112  70.660  93.742  1.00 63.72           C  
+ATOM   1590  O   ASP A 213     101.484  71.198  92.695  1.00 63.72           O  
+ATOM   1591  CB  ASP A 213     102.467  68.631  94.285  1.00 63.72           C  
+ATOM   1592  CG  ASP A 213     103.525  68.940  93.246  1.00 63.72           C  
+ATOM   1593  OD1 ASP A 213     104.688  69.178  93.633  1.00 63.72           O  
+ATOM   1594  OD2 ASP A 213     103.192  68.946  92.042  1.00 63.72           O  
+ATOM   1595  N   GLY A 214     100.709  71.352  94.805  1.00 56.44           N  
+ATOM   1596  CA  GLY A 214     100.714  72.801  94.814  1.00 56.44           C  
+ATOM   1597  C   GLY A 214      99.491  73.409  94.163  1.00 56.44           C  
+ATOM   1598  O   GLY A 214      98.983  74.438  94.617  1.00 56.44           O  
+ATOM   1599  N   TYR A 215      99.006  72.776  93.097  1.00 48.73           N  
+ATOM   1600  CA  TYR A 215      97.833  73.244  92.374  1.00 48.73           C  
+ATOM   1601  C   TYR A 215      96.610  72.370  92.605  1.00 48.73           C  
+ATOM   1602  O   TYR A 215      95.632  72.492  91.862  1.00 48.73           O  
+ATOM   1603  CB  TYR A 215      98.132  73.320  90.873  1.00 48.73           C  
+ATOM   1604  CG  TYR A 215      99.268  74.249  90.514  1.00 48.73           C  
+ATOM   1605  CD1 TYR A 215      99.086  75.624  90.494  1.00 48.73           C  
+ATOM   1606  CD2 TYR A 215     100.520  73.750  90.185  1.00 48.73           C  
+ATOM   1607  CE1 TYR A 215     100.120  76.476  90.163  1.00 48.73           C  
+ATOM   1608  CE2 TYR A 215     101.560  74.594  89.852  1.00 48.73           C  
+ATOM   1609  CZ  TYR A 215     101.355  75.956  89.843  1.00 48.73           C  
+ATOM   1610  OH  TYR A 215     102.388  76.802  89.511  1.00 48.73           O  
+ATOM   1611  N   ASP A 216      96.639  71.493  93.604  1.00 51.26           N  
+ATOM   1612  CA  ASP A 216      95.513  70.615  93.870  1.00 51.26           C  
+ATOM   1613  C   ASP A 216      94.326  71.413  94.406  1.00 51.26           C  
+ATOM   1614  O   ASP A 216      94.451  72.562  94.836  1.00 51.26           O  
+ATOM   1615  CB  ASP A 216      95.910  69.521  94.860  1.00 51.26           C  
+ATOM   1616  CG  ASP A 216      96.545  70.078  96.119  1.00 51.26           C  
+ATOM   1617  OD1 ASP A 216      96.371  69.467  97.195  1.00 51.26           O  
+ATOM   1618  OD2 ASP A 216      97.218  71.126  96.034  1.00 51.26           O  
+ATOM   1619  N   TYR A 217      93.156  70.779  94.377  1.00 45.48           N  
+ATOM   1620  CA  TYR A 217      91.929  71.419  94.831  1.00 45.48           C  
+ATOM   1621  C   TYR A 217      90.912  70.339  95.159  1.00 45.48           C  
+ATOM   1622  O   TYR A 217      90.622  69.484  94.317  1.00 45.48           O  
+ATOM   1623  CB  TYR A 217      91.376  72.371  93.765  1.00 45.48           C  
+ATOM   1624  CG  TYR A 217      90.559  73.513  94.322  1.00 45.48           C  
+ATOM   1625  CD1 TYR A 217      89.178  73.430  94.403  1.00 45.48           C  
+ATOM   1626  CD2 TYR A 217      91.171  74.675  94.764  1.00 45.48           C  
+ATOM   1627  CE1 TYR A 217      88.429  74.472  94.909  1.00 45.48           C  
+ATOM   1628  CE2 TYR A 217      90.432  75.721  95.272  1.00 45.48           C  
+ATOM   1629  CZ  TYR A 217      89.062  75.615  95.342  1.00 45.48           C  
+ATOM   1630  OH  TYR A 217      88.323  76.658  95.848  1.00 45.48           O  
+ATOM   1631  N   SER A 218      90.382  70.376  96.377  1.00 47.09           N  
+ATOM   1632  CA  SER A 218      89.372  69.425  96.803  1.00 47.09           C  
+ATOM   1633  C   SER A 218      87.983  69.948  96.445  1.00 47.09           C  
+ATOM   1634  O   SER A 218      87.827  70.918  95.699  1.00 47.09           O  
+ATOM   1635  CB  SER A 218      89.493  69.154  98.302  1.00 47.09           C  
+ATOM   1636  OG  SER A 218      88.322  68.536  98.804  1.00 47.09           O  
+ATOM   1637  N   ARG A 219      86.955  69.296  96.981  1.00 46.19           N  
+ATOM   1638  CA  ARG A 219      85.582  69.709  96.734  1.00 46.19           C  
+ATOM   1639  C   ARG A 219      84.950  70.418  97.925  1.00 46.19           C  
+ATOM   1640  O   ARG A 219      83.804  70.867  97.821  1.00 46.19           O  
+ATOM   1641  CB  ARG A 219      84.735  68.498  96.332  1.00 46.19           C  
+ATOM   1642  CG  ARG A 219      85.107  67.936  94.969  1.00 46.19           C  
+ATOM   1643  CD  ARG A 219      84.215  66.773  94.577  1.00 46.19           C  
+ATOM   1644  NE  ARG A 219      84.515  65.570  95.345  1.00 46.19           N  
+ATOM   1645  CZ  ARG A 219      84.965  64.438  94.814  1.00 46.19           C  
+ATOM   1646  NH1 ARG A 219      85.162  64.349  93.506  1.00 46.19           N  
+ATOM   1647  NH2 ARG A 219      85.210  63.391  95.590  1.00 46.19           N  
+ATOM   1648  N   GLY A 220      85.661  70.526  99.044  1.00 47.46           N  
+ATOM   1649  CA  GLY A 220      85.226  71.353 100.151  1.00 47.46           C  
+ATOM   1650  C   GLY A 220      86.038  72.630 100.189  1.00 47.46           C  
+ATOM   1651  O   GLY A 220      85.636  73.636 100.787  1.00 47.46           O  
+ATOM   1652  N   GLN A 221      87.207  72.583  99.545  1.00 48.70           N  
+ATOM   1653  CA  GLN A 221      87.997  73.791  99.359  1.00 48.70           C  
+ATOM   1654  C   GLN A 221      87.216  74.842  98.584  1.00 48.70           C  
+ATOM   1655  O   GLN A 221      87.342  76.038  98.861  1.00 48.70           O  
+ATOM   1656  CB  GLN A 221      89.305  73.458  98.643  1.00 48.70           C  
+ATOM   1657  CG  GLN A 221      90.331  74.577  98.664  1.00 48.70           C  
+ATOM   1658  CD  GLN A 221      90.824  74.886 100.062  1.00 48.70           C  
+ATOM   1659  OE1 GLN A 221      90.998  73.989 100.885  1.00 48.70           O  
+ATOM   1660  NE2 GLN A 221      91.049  76.166 100.339  1.00 48.70           N  
+ATOM   1661  N   LEU A 222      86.393  74.413  97.624  1.00 43.96           N  
+ATOM   1662  CA  LEU A 222      85.542  75.352  96.901  1.00 43.96           C  
+ATOM   1663  C   LEU A 222      84.504  75.979  97.823  1.00 43.96           C  
+ATOM   1664  O   LEU A 222      84.254  77.188  97.750  1.00 43.96           O  
+ATOM   1665  CB  LEU A 222      84.864  74.648  95.728  1.00 43.96           C  
+ATOM   1666  CG  LEU A 222      83.815  75.465  94.974  1.00 43.96           C  
+ATOM   1667  CD1 LEU A 222      84.469  76.590  94.194  1.00 43.96           C  
+ATOM   1668  CD2 LEU A 222      83.006  74.572  94.056  1.00 43.96           C  
+ATOM   1669  N   ILE A 223      83.885  75.172  98.688  1.00 43.48           N  
+ATOM   1670  CA  ILE A 223      82.947  75.705  99.675  1.00 43.48           C  
+ATOM   1671  C   ILE A 223      83.623  76.775 100.520  1.00 43.48           C  
+ATOM   1672  O   ILE A 223      83.089  77.876 100.715  1.00 43.48           O  
+ATOM   1673  CB  ILE A 223      82.398  74.571 100.559  1.00 43.48           C  
+ATOM   1674  CG1 ILE A 223      81.804  73.452  99.706  1.00 43.48           C  
+ATOM   1675  CG2 ILE A 223      81.359  75.111 101.525  1.00 43.48           C  
+ATOM   1676  CD1 ILE A 223      80.516  73.823  99.041  1.00 43.48           C  
+ATOM   1677  N   GLU A 224      84.813  76.460 101.036  1.00 47.65           N  
+ATOM   1678  CA  GLU A 224      85.511  77.392 101.915  1.00 47.65           C  
+ATOM   1679  C   GLU A 224      85.907  78.665 101.176  1.00 47.65           C  
+ATOM   1680  O   GLU A 224      85.764  79.770 101.713  1.00 47.65           O  
+ATOM   1681  CB  GLU A 224      86.737  76.717 102.526  1.00 47.65           C  
+ATOM   1682  CG  GLU A 224      86.398  75.626 103.530  1.00 47.65           C  
+ATOM   1683  CD  GLU A 224      87.373  75.572 104.688  1.00 47.65           C  
+ATOM   1684  OE1 GLU A 224      88.087  76.571 104.914  1.00 47.65           O  
+ATOM   1685  OE2 GLU A 224      87.425  74.528 105.374  1.00 47.65           O  
+ATOM   1686  N   ASP A 225      86.392  78.533  99.939  1.00 44.83           N  
+ATOM   1687  CA  ASP A 225      86.777  79.708  99.164  1.00 44.83           C  
+ATOM   1688  C   ASP A 225      85.575  80.594  98.870  1.00 44.83           C  
+ATOM   1689  O   ASP A 225      85.662  81.823  98.970  1.00 44.83           O  
+ATOM   1690  CB  ASP A 225      87.454  79.279  97.863  1.00 44.83           C  
+ATOM   1691  CG  ASP A 225      88.903  78.890  98.061  1.00 44.83           C  
+ATOM   1692  OD1 ASP A 225      89.559  79.467  98.953  1.00 44.83           O  
+ATOM   1693  OD2 ASP A 225      89.389  78.007  97.323  1.00 44.83           O  
+ATOM   1694  N   VAL A 226      84.443  79.989  98.507  1.00 40.28           N  
+ATOM   1695  CA  VAL A 226      83.247  80.770  98.204  1.00 40.28           C  
+ATOM   1696  C   VAL A 226      82.757  81.493  99.452  1.00 40.28           C  
+ATOM   1697  O   VAL A 226      82.408  82.681  99.407  1.00 40.28           O  
+ATOM   1698  CB  VAL A 226      82.157  79.864  97.604  1.00 40.28           C  
+ATOM   1699  CG1 VAL A 226      80.819  80.572  97.598  1.00 40.28           C  
+ATOM   1700  CG2 VAL A 226      82.541  79.445  96.195  1.00 40.28           C  
+ATOM   1701  N   GLU A 227      82.746  80.797 100.592  1.00 42.32           N  
+ATOM   1702  CA  GLU A 227      82.300  81.428 101.830  1.00 42.32           C  
+ATOM   1703  C   GLU A 227      83.226  82.568 102.235  1.00 42.32           C  
+ATOM   1704  O   GLU A 227      82.765  83.622 102.689  1.00 42.32           O  
+ATOM   1705  CB  GLU A 227      82.201  80.389 102.945  1.00 42.32           C  
+ATOM   1706  CG  GLU A 227      81.032  79.430 102.790  1.00 42.32           C  
+ATOM   1707  CD  GLU A 227      80.964  78.410 103.907  1.00 42.32           C  
+ATOM   1708  OE1 GLU A 227      81.881  78.392 104.754  1.00 42.32           O  
+ATOM   1709  OE2 GLU A 227      79.994  77.624 103.938  1.00 42.32           O  
+ATOM   1710  N   HIS A 228      84.536  82.387 102.054  1.00 41.38           N  
+ATOM   1711  CA AHIS A 228      85.484  83.437 102.414  0.50 41.38           C  
+ATOM   1712  CA BHIS A 228      85.491  83.431 102.409  0.50 41.38           C  
+ATOM   1713  C   HIS A 228      85.327  84.653 101.511  1.00 41.38           C  
+ATOM   1714  O   HIS A 228      85.302  85.798 101.987  1.00 41.38           O  
+ATOM   1715  CB AHIS A 228      86.912  82.896 102.351  0.50 41.38           C  
+ATOM   1716  CB BHIS A 228      86.912  82.874 102.322  0.50 41.38           C  
+ATOM   1717  CG AHIS A 228      87.226  81.895 103.419  0.50 41.38           C  
+ATOM   1718  CG BHIS A 228      87.984  83.905 102.488  0.50 41.38           C  
+ATOM   1719  ND1AHIS A 228      88.403  81.179 103.445  0.50 41.38           N  
+ATOM   1720  ND1BHIS A 228      88.394  84.359 103.722  0.50 41.38           N  
+ATOM   1721  CD2AHIS A 228      86.515  81.490 104.497  0.50 41.38           C  
+ATOM   1722  CD2BHIS A 228      88.741  84.558 101.575  0.50 41.38           C  
+ATOM   1723  CE1AHIS A 228      88.404  80.377 104.495  0.50 41.38           C  
+ATOM   1724  CE1BHIS A 228      89.352  85.256 103.562  0.50 41.38           C  
+ATOM   1725  NE2AHIS A 228      87.270  80.546 105.149  0.50 41.38           N  
+ATOM   1726  NE2BHIS A 228      89.581  85.395 102.269  0.50 41.38           N  
+ATOM   1727  N   THR A 229      85.214  84.428 100.200  1.00 38.94           N  
+ATOM   1728  CA  THR A 229      85.038  85.543  99.278  1.00 38.94           C  
+ATOM   1729  C   THR A 229      83.736  86.283  99.551  1.00 38.94           C  
+ATOM   1730  O   THR A 229      83.688  87.514  99.466  1.00 38.94           O  
+ATOM   1731  CB  THR A 229      85.083  85.046  97.835  1.00 38.94           C  
+ATOM   1732  OG1 THR A 229      84.154  83.968  97.670  1.00 38.94           O  
+ATOM   1733  CG2 THR A 229      86.482  84.561  97.485  1.00 38.94           C  
+ATOM   1734  N   PHE A 230      82.673  85.560  99.909  1.00 40.18           N  
+ATOM   1735  CA  PHE A 230      81.423  86.244 100.222  1.00 40.18           C  
+ATOM   1736  C   PHE A 230      81.511  87.008 101.537  1.00 40.18           C  
+ATOM   1737  O   PHE A 230      80.919  88.087 101.665  1.00 40.18           O  
+ATOM   1738  CB  PHE A 230      80.263  85.255 100.266  1.00 40.18           C  
+ATOM   1739  CG  PHE A 230      78.931  85.914 100.429  1.00 40.18           C  
+ATOM   1740  CD1 PHE A 230      78.396  86.674  99.406  1.00 40.18           C  
+ATOM   1741  CD2 PHE A 230      78.224  85.794 101.611  1.00 40.18           C  
+ATOM   1742  CE1 PHE A 230      77.175  87.295  99.552  1.00 40.18           C  
+ATOM   1743  CE2 PHE A 230      77.001  86.413 101.763  1.00 40.18           C  
+ATOM   1744  CZ  PHE A 230      76.477  87.165 100.732  1.00 40.18           C  
+ATOM   1745  N   GLU A 231      82.231  86.468 102.525  1.00 43.07           N  
+ATOM   1746  CA  GLU A 231      82.459  87.214 103.757  1.00 43.07           C  
+ATOM   1747  C   GLU A 231      83.205  88.510 103.474  1.00 43.07           C  
+ATOM   1748  O   GLU A 231      82.948  89.537 104.112  1.00 43.07           O  
+ATOM   1749  CB  GLU A 231      83.233  86.357 104.757  1.00 43.07           C  
+ATOM   1750  CG  GLU A 231      82.380  85.349 105.505  1.00 43.07           C  
+ATOM   1751  CD  GLU A 231      81.339  86.008 106.387  1.00 43.07           C  
+ATOM   1752  OE1 GLU A 231      80.148  85.650 106.272  1.00 43.07           O  
+ATOM   1753  OE2 GLU A 231      81.710  86.885 107.194  1.00 43.07           O  
+ATOM   1754  N   GLU A 232      84.134  88.478 102.519  1.00 39.62           N  
+ATOM   1755  CA  GLU A 232      84.822  89.709 102.139  1.00 39.62           C  
+ATOM   1756  C   GLU A 232      83.904  90.662 101.378  1.00 39.62           C  
+ATOM   1757  O   GLU A 232      84.018  91.883 101.532  1.00 39.62           O  
+ATOM   1758  CB  GLU A 232      86.058  89.386 101.301  1.00 39.62           C  
+ATOM   1759  CG  GLU A 232      87.093  88.541 102.018  1.00 39.62           C  
+ATOM   1760  CD  GLU A 232      88.471  88.665 101.402  1.00 39.62           C  
+ATOM   1761  OE1 GLU A 232      88.829  89.776 100.963  1.00 39.62           O  
+ATOM   1762  OE2 GLU A 232      89.195  87.649 101.353  1.00 39.62           O  
+ATOM   1763  N   ILE A 233      82.999  90.128 100.554  1.00 40.02           N  
+ATOM   1764  CA  ILE A 233      82.093  90.969  99.774  1.00 40.02           C  
+ATOM   1765  C   ILE A 233      81.036  91.640 100.645  1.00 40.02           C  
+ATOM   1766  O   ILE A 233      80.598  92.752 100.331  1.00 40.02           O  
+ATOM   1767  CB  ILE A 233      81.429  90.135  98.660  1.00 40.02           C  
+ATOM   1768  CG1 ILE A 233      82.463  89.727  97.617  1.00 40.02           C  
+ATOM   1769  CG2 ILE A 233      80.306  90.901  97.981  1.00 40.02           C  
+ATOM   1770  CD1 ILE A 233      81.896  88.943  96.462  1.00 40.02           C  
+ATOM   1771  N   LYS A 234      80.646  91.001 101.746  1.00 42.43           N  
+ATOM   1772  CA  LYS A 234      79.493  91.444 102.532  1.00 42.43           C  
+ATOM   1773  C   LYS A 234      79.402  92.947 102.807  1.00 42.43           C  
+ATOM   1774  O   LYS A 234      78.280  93.477 102.756  1.00 42.43           O  
+ATOM   1775  CB  LYS A 234      79.462  90.665 103.855  1.00 42.43           C  
+ATOM   1776  CG  LYS A 234      78.640  89.388 103.792  1.00 42.43           C  
+ATOM   1777  CD  LYS A 234      78.640  88.660 105.124  1.00 42.43           C  
+ATOM   1778  CE  LYS A 234      77.698  87.469 105.100  1.00 42.43           C  
+ATOM   1779  NZ  LYS A 234      77.748  86.697 106.371  1.00 42.43           N  
+ATOM   1780  N   PRO A 235      80.481  93.683 103.111  1.00 42.78           N  
+ATOM   1781  CA  PRO A 235      80.299  95.126 103.365  1.00 42.78           C  
+ATOM   1782  C   PRO A 235      79.859  95.921 102.144  1.00 42.78           C  
+ATOM   1783  O   PRO A 235      78.984  96.791 102.262  1.00 42.78           O  
+ATOM   1784  CB  PRO A 235      81.683  95.569 103.863  1.00 42.78           C  
+ATOM   1785  CG  PRO A 235      82.305  94.335 104.393  1.00 42.78           C  
+ATOM   1786  CD  PRO A 235      81.834  93.240 103.490  1.00 42.78           C  
+ATOM   1787  N   LEU A 236      80.452  95.662 100.976  1.00 42.35           N  
+ATOM   1788  CA  LEU A 236      80.068  96.397  99.773  1.00 42.35           C  
+ATOM   1789  C   LEU A 236      78.619  96.115  99.399  1.00 42.35           C  
+ATOM   1790  O   LEU A 236      77.848  97.037  99.096  1.00 42.35           O  
+ATOM   1791  CB  LEU A 236      81.001  96.038  98.617  1.00 42.35           C  
+ATOM   1792  CG  LEU A 236      80.565  96.499  97.226  1.00 42.35           C  
+ATOM   1793  CD1 LEU A 236      80.389  98.007  97.187  1.00 42.35           C  
+ATOM   1794  CD2 LEU A 236      81.566  96.053  96.177  1.00 42.35           C  
+ATOM   1795  N   TYR A 237      78.232  94.838  99.403  1.00 42.44           N  
+ATOM   1796  CA  TYR A 237      76.842  94.502  99.133  1.00 42.44           C  
+ATOM   1797  C   TYR A 237      75.919  95.079 100.190  1.00 42.44           C  
+ATOM   1798  O   TYR A 237      74.782  95.439  99.883  1.00 42.44           O  
+ATOM   1799  CB  TYR A 237      76.652  92.989  99.053  1.00 42.44           C  
+ATOM   1800  CG  TYR A 237      75.195  92.595  98.984  1.00 42.44           C  
+ATOM   1801  CD1 TYR A 237      74.444  92.854  97.846  1.00 42.44           C  
+ATOM   1802  CD2 TYR A 237      74.564  91.989 100.061  1.00 42.44           C  
+ATOM   1803  CE1 TYR A 237      73.113  92.507  97.776  1.00 42.44           C  
+ATOM   1804  CE2 TYR A 237      73.231  91.638  99.999  1.00 42.44           C  
+ATOM   1805  CZ  TYR A 237      72.512  91.901  98.854  1.00 42.44           C  
+ATOM   1806  OH  TYR A 237      71.184  91.556  98.781  1.00 42.44           O  
+ATOM   1807  N   GLU A 238      76.389  95.195 101.433  1.00 47.77           N  
+ATOM   1808  CA  GLU A 238      75.560  95.776 102.481  1.00 47.77           C  
+ATOM   1809  C   GLU A 238      75.292  97.251 102.212  1.00 47.77           C  
+ATOM   1810  O   GLU A 238      74.154  97.718 102.344  1.00 47.77           O  
+ATOM   1811  CB  GLU A 238      76.231  95.585 103.840  1.00 47.77           C  
+ATOM   1812  CG  GLU A 238      75.310  95.758 105.038  1.00 47.77           C  
+ATOM   1813  CD  GLU A 238      74.008  94.993 104.902  1.00 47.77           C  
+ATOM   1814  OE1 GLU A 238      73.933  93.858 105.416  1.00 47.77           O  
+ATOM   1815  OE2 GLU A 238      73.053  95.535 104.306  1.00 47.77           O  
+ATOM   1816  N   HIS A 239      76.329  97.996 101.827  1.00 49.82           N  
+ATOM   1817  CA  HIS A 239      76.137  99.403 101.484  1.00 49.82           C  
+ATOM   1818  C   HIS A 239      75.220  99.558 100.276  1.00 49.82           C  
+ATOM   1819  O   HIS A 239      74.320 100.411 100.271  1.00 49.82           O  
+ATOM   1820  CB  HIS A 239      77.486 100.070 101.222  1.00 49.82           C  
+ATOM   1821  CG  HIS A 239      78.157 100.581 102.457  1.00 49.82           C  
+ATOM   1822  ND1 HIS A 239      79.072  99.837 103.170  1.00 49.82           N  
+ATOM   1823  CD2 HIS A 239      78.046 101.763 103.108  1.00 49.82           C  
+ATOM   1824  CE1 HIS A 239      79.496 100.538 104.206  1.00 49.82           C  
+ATOM   1825  NE2 HIS A 239      78.889 101.710 104.191  1.00 49.82           N  
+ATOM   1826  N   LEU A 240      75.436  98.743  99.238  1.00 43.98           N  
+ATOM   1827  CA  LEU A 240      74.581  98.808  98.056  1.00 43.98           C  
+ATOM   1828  C   LEU A 240      73.132  98.484  98.404  1.00 43.98           C  
+ATOM   1829  O   LEU A 240      72.205  99.141  97.913  1.00 43.98           O  
+ATOM   1830  CB  LEU A 240      75.102  97.852  96.984  1.00 43.98           C  
+ATOM   1831  CG  LEU A 240      74.308  97.773  95.681  1.00 43.98           C  
+ATOM   1832  CD1 LEU A 240      74.296  99.121  94.981  1.00 43.98           C  
+ATOM   1833  CD2 LEU A 240      74.883  96.700  94.775  1.00 43.98           C  
+ATOM   1834  N   HIS A 241      72.922  97.484  99.260  1.00 48.74           N  
+ATOM   1835  CA  HIS A 241      71.576  97.109  99.671  1.00 48.74           C  
+ATOM   1836  C   HIS A 241      70.915  98.225 100.462  1.00 48.74           C  
+ATOM   1837  O   HIS A 241      69.727  98.505 100.275  1.00 48.74           O  
+ATOM   1838  CB  HIS A 241      71.634  95.820 100.493  1.00 48.74           C  
+ATOM   1839  CG  HIS A 241      70.307  95.374 101.021  1.00 48.74           C  
+ATOM   1840  ND1 HIS A 241      69.725  95.930 102.140  1.00 48.74           N  
+ATOM   1841  CD2 HIS A 241      69.457  94.410 100.594  1.00 48.74           C  
+ATOM   1842  CE1 HIS A 241      68.569  95.335 102.373  1.00 48.74           C  
+ATOM   1843  NE2 HIS A 241      68.383  94.409 101.450  1.00 48.74           N  
+ATOM   1844  N   ALA A 242      71.669  98.876 101.351  1.00 49.07           N  
+ATOM   1845  CA  ALA A 242      71.109  99.989 102.112  1.00 49.07           C  
+ATOM   1846  C   ALA A 242      70.703 101.135 101.195  1.00 49.07           C  
+ATOM   1847  O   ALA A 242      69.624 101.719 101.356  1.00 49.07           O  
+ATOM   1848  CB  ALA A 242      72.113 100.468 103.160  1.00 49.07           C  
+ATOM   1849  N   TYR A 243      71.550 101.463 100.215  1.00 51.03           N  
+ATOM   1850  CA  TYR A 243      71.213 102.543  99.292  1.00 51.03           C  
+ATOM   1851  C   TYR A 243      69.987 102.197  98.456  1.00 51.03           C  
+ATOM   1852  O   TYR A 243      69.097 103.037  98.261  1.00 51.03           O  
+ATOM   1853  CB  TYR A 243      72.403 102.856  98.387  1.00 51.03           C  
+ATOM   1854  CG  TYR A 243      72.155 104.013  97.449  1.00 51.03           C  
+ATOM   1855  CD1 TYR A 243      72.111 105.317  97.922  1.00 51.03           C  
+ATOM   1856  CD2 TYR A 243      71.964 103.804  96.091  1.00 51.03           C  
+ATOM   1857  CE1 TYR A 243      71.883 106.379  97.069  1.00 51.03           C  
+ATOM   1858  CE2 TYR A 243      71.736 104.859  95.230  1.00 51.03           C  
+ATOM   1859  CZ  TYR A 243      71.697 106.145  95.725  1.00 51.03           C  
+ATOM   1860  OH  TYR A 243      71.471 107.201  94.873  1.00 51.03           O  
+ATOM   1861  N   VAL A 244      69.921 100.960  97.955  1.00 49.12           N  
+ATOM   1862  CA  VAL A 244      68.779 100.549  97.146  1.00 49.12           C  
+ATOM   1863  C   VAL A 244      67.505 100.558  97.980  1.00 49.12           C  
+ATOM   1864  O   VAL A 244      66.439 100.957  97.502  1.00 49.12           O  
+ATOM   1865  CB  VAL A 244      69.041  99.169  96.514  1.00 49.12           C  
+ATOM   1866  CG1 VAL A 244      67.753  98.567  95.983  1.00 49.12           C  
+ATOM   1867  CG2 VAL A 244      70.068  99.290  95.400  1.00 49.12           C  
+ATOM   1868  N   ARG A 245      67.598 100.141  99.246  1.00 57.40           N  
+ATOM   1869  CA  ARG A 245      66.428 100.160 100.117  1.00 57.40           C  
+ATOM   1870  C   ARG A 245      65.964 101.584 100.386  1.00 57.40           C  
+ATOM   1871  O   ARG A 245      64.758 101.856 100.407  1.00 57.40           O  
+ATOM   1872  CB  ARG A 245      66.738  99.439 101.429  1.00 57.40           C  
+ATOM   1873  CG  ARG A 245      65.596  99.466 102.430  1.00 57.40           C  
+ATOM   1874  CD  ARG A 245      65.983  98.784 103.728  1.00 57.40           C  
+ATOM   1875  NE  ARG A 245      67.141  99.418 104.349  1.00 57.40           N  
+ATOM   1876  CZ  ARG A 245      67.829  98.891 105.356  1.00 57.40           C  
+ATOM   1877  NH1 ARG A 245      68.870  99.538 105.859  1.00 57.40           N  
+ATOM   1878  NH2 ARG A 245      67.476  97.719 105.860  1.00 57.40           N  
+ATOM   1879  N   ALA A 246      66.905 102.507 100.597  1.00 54.61           N  
+ATOM   1880  CA  ALA A 246      66.533 103.904 100.796  1.00 54.61           C  
+ATOM   1881  C   ALA A 246      65.829 104.465  99.565  1.00 54.61           C  
+ATOM   1882  O   ALA A 246      64.789 105.126  99.673  1.00 54.61           O  
+ATOM   1883  CB  ALA A 246      67.772 104.734 101.135  1.00 54.61           C  
+ATOM   1884  N   LYS A 247      66.376 104.195  98.379  1.00 53.24           N  
+ATOM   1885  CA  LYS A 247      65.751 104.698  97.159  1.00 53.24           C  
+ATOM   1886  C   LYS A 247      64.378 104.073  96.935  1.00 53.24           C  
+ATOM   1887  O   LYS A 247      63.441 104.751  96.496  1.00 53.24           O  
+ATOM   1888  CB  LYS A 247      66.662 104.448  95.959  1.00 53.24           C  
+ATOM   1889  CG  LYS A 247      67.991 105.177  96.029  1.00 53.24           C  
+ATOM   1890  CD  LYS A 247      67.797 106.681  96.154  1.00 53.24           C  
+ATOM   1891  CE  LYS A 247      67.165 107.261  94.900  1.00 53.24           C  
+ATOM   1892  NZ  LYS A 247      67.012 108.739  94.985  1.00 53.24           N  
+ATOM   1893  N   LEU A 248      64.232 102.781  97.242  1.00 57.18           N  
+ATOM   1894  CA  LEU A 248      62.946 102.123  97.044  1.00 57.18           C  
+ATOM   1895  C   LEU A 248      61.907 102.606  98.045  1.00 57.18           C  
+ATOM   1896  O   LEU A 248      60.724 102.703  97.704  1.00 57.18           O  
+ATOM   1897  CB  LEU A 248      63.105 100.606  97.135  1.00 57.18           C  
+ATOM   1898  CG  LEU A 248      63.809  99.921  95.962  1.00 57.18           C  
+ATOM   1899  CD1 LEU A 248      63.639  98.412  96.043  1.00 57.18           C  
+ATOM   1900  CD2 LEU A 248      63.300 100.451  94.631  1.00 57.18           C  
+ATOM   1901  N   MET A 249      62.319 102.910  99.279  1.00 64.71           N  
+ATOM   1902  CA  MET A 249      61.376 103.487 100.229  1.00 64.71           C  
+ATOM   1903  C   MET A 249      61.019 104.915  99.843  1.00 64.71           C  
+ATOM   1904  O   MET A 249      59.916 105.380 100.149  1.00 64.71           O  
+ATOM   1905  CB  MET A 249      61.944 103.433 101.649  1.00 64.71           C  
+ATOM   1906  CG  MET A 249      62.826 104.608 102.028  1.00 64.71           C  
+ATOM   1907  SD  MET A 249      62.935 104.847 103.807  1.00 64.71           S  
+ATOM   1908  CE  MET A 249      63.595 103.260 104.297  1.00 64.71           C  
+ATOM   1909  N   ASN A 250      61.932 105.621  99.172  1.00 64.75           N  
+ATOM   1910  CA  ASN A 250      61.567 106.900  98.575  1.00 64.75           C  
+ATOM   1911  C   ASN A 250      60.618 106.719  97.399  1.00 64.75           C  
+ATOM   1912  O   ASN A 250      59.860 107.641  97.079  1.00 64.75           O  
+ATOM   1913  CB  ASN A 250      62.820 107.654  98.129  1.00 64.75           C  
+ATOM   1914  CG  ASN A 250      63.542 108.317  99.286  1.00 64.75           C  
+ATOM   1915  OD1 ASN A 250      64.602 108.918  99.108  1.00 64.75           O  
+ATOM   1916  ND2 ASN A 250      62.970 108.213 100.479  1.00 64.75           N  
+ATOM   1917  N   ALA A 251      60.646 105.555  96.750  1.00 63.69           N  
+ATOM   1918  CA  ALA A 251      59.708 105.251  95.676  1.00 63.69           C  
+ATOM   1919  C   ALA A 251      58.460 104.529  96.169  1.00 63.69           C  
+ATOM   1920  O   ALA A 251      57.359 104.811  95.683  1.00 63.69           O  
+ATOM   1921  CB  ALA A 251      60.393 104.406  94.598  1.00 63.69           C  
+ATOM   1922  N   TYR A 252      58.605 103.602  97.119  1.00 64.23           N  
+ATOM   1923  CA  TYR A 252      57.486 102.891  97.736  1.00 64.23           C  
+ATOM   1924  C   TYR A 252      57.400 103.350  99.187  1.00 64.23           C  
+ATOM   1925  O   TYR A 252      58.023 102.751 100.077  1.00 64.23           O  
+ATOM   1926  CB  TYR A 252      57.659 101.376  97.650  1.00 64.23           C  
+ATOM   1927  CG  TYR A 252      57.842 100.844  96.246  1.00 64.23           C  
+ATOM   1928  CD1 TYR A 252      57.225 101.451  95.163  1.00 64.23           C  
+ATOM   1929  CD2 TYR A 252      58.634  99.730  96.007  1.00 64.23           C  
+ATOM   1930  CE1 TYR A 252      57.394 100.963  93.881  1.00 64.23           C  
+ATOM   1931  CE2 TYR A 252      58.807  99.237  94.731  1.00 64.23           C  
+ATOM   1932  CZ  TYR A 252      58.186  99.856  93.672  1.00 64.23           C  
+ATOM   1933  OH  TYR A 252      58.359  99.365  92.400  1.00 64.23           O  
+ATOM   1934  N   PRO A 253      56.636 104.407  99.463  1.00 72.36           N  
+ATOM   1935  CA  PRO A 253      56.664 104.992 100.813  1.00 72.36           C  
+ATOM   1936  C   PRO A 253      56.005 104.126 101.873  1.00 72.36           C  
+ATOM   1937  O   PRO A 253      56.438 104.150 103.032  1.00 72.36           O  
+ATOM   1938  CB  PRO A 253      55.921 106.320 100.627  1.00 72.36           C  
+ATOM   1939  CG  PRO A 253      54.997 106.066  99.483  1.00 72.36           C  
+ATOM   1940  CD  PRO A 253      55.726 105.132  98.560  1.00 72.36           C  
+ATOM   1941  N   SER A 254      54.972 103.365 101.521  1.00 78.19           N  
+ATOM   1942  CA  SER A 254      54.207 102.600 102.495  1.00 78.19           C  
+ATOM   1943  C   SER A 254      54.435 101.097 102.388  1.00 78.19           C  
+ATOM   1944  O   SER A 254      53.574 100.323 102.816  1.00 78.19           O  
+ATOM   1945  CB  SER A 254      52.716 102.907 102.346  1.00 78.19           C  
+ATOM   1946  OG  SER A 254      52.210 102.388 101.129  1.00 78.19           O  
+ATOM   1947  N   TYR A 255      55.568 100.666 101.835  1.00 75.42           N  
+ATOM   1948  CA  TYR A 255      55.816  99.243 101.660  1.00 75.42           C  
+ATOM   1949  C   TYR A 255      57.230  98.802 102.011  1.00 75.42           C  
+ATOM   1950  O   TYR A 255      57.518  97.606 101.917  1.00 75.42           O  
+ATOM   1951  CB  TYR A 255      55.502  98.826 100.214  1.00 75.42           C  
+ATOM   1952  CG  TYR A 255      54.023  98.778  99.904  1.00 75.42           C  
+ATOM   1953  CD1 TYR A 255      53.151  98.050 100.702  1.00 75.42           C  
+ATOM   1954  CD2 TYR A 255      53.499  99.463  98.816  1.00 75.42           C  
+ATOM   1955  CE1 TYR A 255      51.799  98.004 100.425  1.00 75.42           C  
+ATOM   1956  CE2 TYR A 255      52.147  99.421  98.531  1.00 75.42           C  
+ATOM   1957  CZ  TYR A 255      51.303  98.689  99.338  1.00 75.42           C  
+ATOM   1958  OH  TYR A 255      49.956  98.644  99.060  1.00 75.42           O  
+ATOM   1959  N   ILE A 256      58.118  99.713 102.408  1.00 74.42           N  
+ATOM   1960  CA  ILE A 256      59.494  99.371 102.750  1.00 74.42           C  
+ATOM   1961  C   ILE A 256      59.784  99.880 104.154  1.00 74.42           C  
+ATOM   1962  O   ILE A 256      59.434 101.016 104.492  1.00 74.42           O  
+ATOM   1963  CB  ILE A 256      60.502  99.962 101.745  1.00 74.42           C  
+ATOM   1964  CG1 ILE A 256      60.058  99.686 100.309  1.00 74.42           C  
+ATOM   1965  CG2 ILE A 256      61.887  99.385 101.984  1.00 74.42           C  
+ATOM   1966  CD1 ILE A 256      60.047  98.222  99.947  1.00 74.42           C  
+ATOM   1967  N   SER A 257      60.431  99.031 104.977  1.00 83.04           N  
+ATOM   1968  CA  SER A 257      60.820  99.359 106.340  1.00 83.04           C  
+ATOM   1969  C   SER A 257      62.215  99.977 106.366  1.00 83.04           C  
+ATOM   1970  O   SER A 257      63.061  99.651 105.527  1.00 83.04           O  
+ATOM   1971  CB  SER A 257      60.799  98.108 107.213  1.00 83.04           C  
+ATOM   1972  OG  SER A 257      60.712  98.440 108.588  1.00 83.04           O  
+ATOM   1973  N   PRO A 258      62.476 100.879 107.316  1.00 80.69           N  
+ATOM   1974  CA  PRO A 258      63.808 101.501 107.382  1.00 80.69           C  
+ATOM   1975  C   PRO A 258      64.932 100.516 107.641  1.00 80.69           C  
+ATOM   1976  O   PRO A 258      66.049 100.727 107.152  1.00 80.69           O  
+ATOM   1977  CB  PRO A 258      63.666 102.509 108.532  1.00 80.69           C  
+ATOM   1978  CG  PRO A 258      62.204 102.787 108.613  1.00 80.69           C  
+ATOM   1979  CD  PRO A 258      61.527 101.499 108.255  1.00 80.69           C  
+ATOM   1980  N   ILE A 259      64.677  99.448 108.394  1.00 76.65           N  
+ATOM   1981  CA  ILE A 259      65.700  98.465 108.729  1.00 76.65           C  
+ATOM   1982  C   ILE A 259      65.383  97.085 108.183  1.00 76.65           C  
+ATOM   1983  O   ILE A 259      66.204  96.168 108.335  1.00 76.65           O  
+ATOM   1984  CB  ILE A 259      65.928  98.392 110.250  1.00 76.65           C  
+ATOM   1985  CG1 ILE A 259      64.590  98.293 110.983  1.00 76.65           C  
+ATOM   1986  CG2 ILE A 259      66.710  99.605 110.726  1.00 76.65           C  
+ATOM   1987  CD1 ILE A 259      64.682  97.621 112.333  1.00 76.65           C  
+ATOM   1988  N   GLY A 260      64.227  96.903 107.549  1.00 76.92           N  
+ATOM   1989  CA  GLY A 260      63.847  95.599 107.057  1.00 76.92           C  
+ATOM   1990  C   GLY A 260      64.580  95.204 105.789  1.00 76.92           C  
+ATOM   1991  O   GLY A 260      65.349  95.968 105.208  1.00 76.92           O  
+ATOM   1992  N   CYS A 261      64.328  93.969 105.362  1.00 66.64           N  
+ATOM   1993  CA  CYS A 261      64.918  93.459 104.137  1.00 66.64           C  
+ATOM   1994  C   CYS A 261      64.156  93.985 102.921  1.00 66.64           C  
+ATOM   1995  O   CYS A 261      63.169  94.716 103.035  1.00 66.64           O  
+ATOM   1996  CB  CYS A 261      64.924  91.931 104.144  1.00 66.64           C  
+ATOM   1997  SG  CYS A 261      65.581  91.186 105.653  1.00 66.64           S  
+ATOM   1998  N   LEU A 262      64.630  93.600 101.744  1.00 55.44           N  
+ATOM   1999  CA  LEU A 262      63.992  94.031 100.505  1.00 55.44           C  
+ATOM   2000  C   LEU A 262      62.975  92.991 100.051  1.00 55.44           C  
+ATOM   2001  O   LEU A 262      63.290  91.798 100.028  1.00 55.44           O  
+ATOM   2002  CB  LEU A 262      65.033  94.251  99.415  1.00 55.44           C  
+ATOM   2003  CG  LEU A 262      65.854  95.535  99.528  1.00 55.44           C  
+ATOM   2004  CD1 LEU A 262      66.786  95.677  98.336  1.00 55.44           C  
+ATOM   2005  CD2 LEU A 262      64.937  96.740  99.648  1.00 55.44           C  
+ATOM   2006  N   PRO A 263      61.757  93.395  99.697  1.00 56.97           N  
+ATOM   2007  CA  PRO A 263      60.782  92.428  99.181  1.00 56.97           C  
+ATOM   2008  C   PRO A 263      61.276  91.777  97.897  1.00 56.97           C  
+ATOM   2009  O   PRO A 263      61.995  92.388  97.104  1.00 56.97           O  
+ATOM   2010  CB  PRO A 263      59.530  93.278  98.941  1.00 56.97           C  
+ATOM   2011  CG  PRO A 263      59.696  94.454  99.846  1.00 56.97           C  
+ATOM   2012  CD  PRO A 263      61.168  94.733  99.874  1.00 56.97           C  
+ATOM   2013  N   ALA A 264      60.877  90.520  97.697  1.00 55.49           N  
+ATOM   2014  CA  ALA A 264      61.402  89.747  96.577  1.00 55.49           C  
+ATOM   2015  C   ALA A 264      60.810  90.203  95.249  1.00 55.49           C  
+ATOM   2016  O   ALA A 264      61.505  90.217  94.227  1.00 55.49           O  
+ATOM   2017  CB  ALA A 264      61.136  88.258  96.798  1.00 55.49           C  
+ATOM   2018  N   HIS A 265      59.532  90.575  95.241  1.00 60.75           N  
+ATOM   2019  CA  HIS A 265      58.845  90.925  94.004  1.00 60.75           C  
+ATOM   2020  C   HIS A 265      59.178  92.326  93.508  1.00 60.75           C  
+ATOM   2021  O   HIS A 265      58.631  92.745  92.483  1.00 60.75           O  
+ATOM   2022  CB  HIS A 265      57.332  90.788  94.189  1.00 60.75           C  
+ATOM   2023  CG  HIS A 265      56.755  91.740  95.189  1.00 60.75           C  
+ATOM   2024  ND1 HIS A 265      57.020  91.654  96.538  1.00 60.75           N  
+ATOM   2025  CD2 HIS A 265      55.919  92.794  95.036  1.00 60.75           C  
+ATOM   2026  CE1 HIS A 265      56.377  92.618  97.173  1.00 60.75           C  
+ATOM   2027  NE2 HIS A 265      55.701  93.324  96.285  1.00 60.75           N  
+ATOM   2028  N   LEU A 266      60.057  93.053  94.196  1.00 56.58           N  
+ATOM   2029  CA  LEU A 266      60.441  94.401  93.802  1.00 56.58           C  
+ATOM   2030  C   LEU A 266      61.909  94.496  93.404  1.00 56.58           C  
+ATOM   2031  O   LEU A 266      62.550  95.519  93.669  1.00 56.58           O  
+ATOM   2032  CB  LEU A 266      60.140  95.385  94.933  1.00 56.58           C  
+ATOM   2033  CG  LEU A 266      58.730  95.328  95.520  1.00 56.58           C  
+ATOM   2034  CD1 LEU A 266      58.634  96.201  96.759  1.00 56.58           C  
+ATOM   2035  CD2 LEU A 266      57.701  95.748  94.485  1.00 56.58           C  
+ATOM   2036  N   LEU A 267      62.456  93.458  92.774  1.00 49.57           N  
+ATOM   2037  CA  LEU A 267      63.867  93.424  92.418  1.00 49.57           C  
+ATOM   2038  C   LEU A 267      64.097  93.474  90.912  1.00 49.57           C  
+ATOM   2039  O   LEU A 267      65.187  93.124  90.445  1.00 49.57           O  
+ATOM   2040  CB  LEU A 267      64.531  92.184  93.013  1.00 49.57           C  
+ATOM   2041  CG  LEU A 267      64.532  92.100  94.539  1.00 49.57           C  
+ATOM   2042  CD1 LEU A 267      65.419  90.962  94.998  1.00 49.57           C  
+ATOM   2043  CD2 LEU A 267      64.981  93.416  95.153  1.00 49.57           C  
+ATOM   2044  N   GLY A 268      63.100  93.898  90.143  1.00 51.75           N  
+ATOM   2045  CA  GLY A 268      63.276  94.096  88.722  1.00 51.75           C  
+ATOM   2046  C   GLY A 268      63.086  92.870  87.858  1.00 51.75           C  
+ATOM   2047  O   GLY A 268      63.063  93.004  86.628  1.00 51.75           O  
+ATOM   2048  N   ASP A 269      62.954  91.684  88.442  1.00 48.51           N  
+ATOM   2049  CA  ASP A 269      62.727  90.481  87.654  1.00 48.51           C  
+ATOM   2050  C   ASP A 269      61.918  89.496  88.490  1.00 48.51           C  
+ATOM   2051  O   ASP A 269      61.577  89.764  89.645  1.00 48.51           O  
+ATOM   2052  CB  ASP A 269      64.046  89.867  87.175  1.00 48.51           C  
+ATOM   2053  CG  ASP A 269      64.915  89.393  88.314  1.00 48.51           C  
+ATOM   2054  OD1 ASP A 269      65.761  90.178  88.784  1.00 48.51           O  
+ATOM   2055  OD2 ASP A 269      64.756  88.230  88.739  1.00 48.51           O  
+ATOM   2056  N   MET A 270      61.619  88.345  87.886  1.00 55.98           N  
+ATOM   2057  CA  MET A 270      60.728  87.377  88.516  1.00 55.98           C  
+ATOM   2058  C   MET A 270      61.324  86.797  89.791  1.00 55.98           C  
+ATOM   2059  O   MET A 270      60.586  86.470  90.728  1.00 55.98           O  
+ATOM   2060  CB  MET A 270      60.398  86.262  87.522  1.00 55.98           C  
+ATOM   2061  CG  MET A 270      59.457  85.205  88.058  1.00 55.98           C  
+ATOM   2062  SD  MET A 270      57.942  85.916  88.721  1.00 55.98           S  
+ATOM   2063  CE  MET A 270      57.748  84.930  90.199  1.00 55.98           C  
+ATOM   2064  N   TRP A 271      62.649  86.671  89.857  1.00 48.60           N  
+ATOM   2065  CA  TRP A 271      63.306  86.044  90.993  1.00 48.60           C  
+ATOM   2066  C   TRP A 271      64.213  86.975  91.778  1.00 48.60           C  
+ATOM   2067  O   TRP A 271      64.524  86.668  92.934  1.00 48.60           O  
+ATOM   2068  CB  TRP A 271      64.137  84.838  90.530  1.00 48.60           C  
+ATOM   2069  CG  TRP A 271      63.394  83.927  89.614  1.00 48.60           C  
+ATOM   2070  CD1 TRP A 271      62.607  82.872  89.968  1.00 48.60           C  
+ATOM   2071  CD2 TRP A 271      63.357  83.995  88.185  1.00 48.60           C  
+ATOM   2072  NE1 TRP A 271      62.087  82.274  88.846  1.00 48.60           N  
+ATOM   2073  CE2 TRP A 271      62.533  82.946  87.739  1.00 48.60           C  
+ATOM   2074  CE3 TRP A 271      63.944  84.840  87.240  1.00 48.60           C  
+ATOM   2075  CZ2 TRP A 271      62.280  82.719  86.389  1.00 48.60           C  
+ATOM   2076  CZ3 TRP A 271      63.692  84.614  85.901  1.00 48.60           C  
+ATOM   2077  CH2 TRP A 271      62.867  83.562  85.488  1.00 48.60           C  
+ATOM   2078  N   GLY A 272      64.639  88.093  91.200  1.00 41.52           N  
+ATOM   2079  CA  GLY A 272      65.619  88.934  91.849  1.00 41.52           C  
+ATOM   2080  C   GLY A 272      67.049  88.549  91.565  1.00 41.52           C  
+ATOM   2081  O   GLY A 272      67.936  88.867  92.364  1.00 41.52           O  
+ATOM   2082  N   ARG A 273      67.302  87.862  90.449  1.00 36.36           N  
+ATOM   2083  CA  ARG A 273      68.663  87.449  90.128  1.00 36.36           C  
+ATOM   2084  C   ARG A 273      69.556  88.654  89.872  1.00 36.36           C  
+ATOM   2085  O   ARG A 273      70.680  88.721  90.380  1.00 36.36           O  
+ATOM   2086  CB  ARG A 273      68.653  86.514  88.919  1.00 36.36           C  
+ATOM   2087  CG  ARG A 273      70.003  85.903  88.595  1.00 36.36           C  
+ATOM   2088  CD  ARG A 273      69.937  85.054  87.339  1.00 36.36           C  
+ATOM   2089  NE  ARG A 273      71.261  84.635  86.892  1.00 36.36           N  
+ATOM   2090  CZ  ARG A 273      71.503  84.032  85.733  1.00 36.36           C  
+ATOM   2091  NH1 ARG A 273      72.740  83.688  85.408  1.00 36.36           N  
+ATOM   2092  NH2 ARG A 273      70.508  83.774  84.898  1.00 36.36           N  
+ATOM   2093  N   PHE A 274      69.072  89.621  89.096  1.00 35.67           N  
+ATOM   2094  CA  PHE A 274      69.810  90.841  88.814  1.00 35.67           C  
+ATOM   2095  C   PHE A 274      69.013  92.041  89.302  1.00 35.67           C  
+ATOM   2096  O   PHE A 274      67.793  91.980  89.466  1.00 35.67           O  
+ATOM   2097  CB  PHE A 274      70.105  90.999  87.317  1.00 35.67           C  
+ATOM   2098  CG  PHE A 274      70.836  89.837  86.714  1.00 35.67           C  
+ATOM   2099  CD1 PHE A 274      72.166  89.606  87.015  1.00 35.67           C  
+ATOM   2100  CD2 PHE A 274      70.199  88.986  85.831  1.00 35.67           C  
+ATOM   2101  CE1 PHE A 274      72.841  88.543  86.456  1.00 35.67           C  
+ATOM   2102  CE2 PHE A 274      70.871  87.921  85.269  1.00 35.67           C  
+ATOM   2103  CZ  PHE A 274      72.193  87.699  85.582  1.00 35.67           C  
+ATOM   2104  N   TRP A 275      69.724  93.143  89.537  1.00 39.08           N  
+ATOM   2105  CA  TRP A 275      69.104  94.409  89.903  1.00 39.08           C  
+ATOM   2106  C   TRP A 275      69.203  95.434  88.780  1.00 39.08           C  
+ATOM   2107  O   TRP A 275      69.179  96.641  89.042  1.00 39.08           O  
+ATOM   2108  CB  TRP A 275      69.732  94.959  91.184  1.00 39.08           C  
+ATOM   2109  CG  TRP A 275      69.400  94.163  92.410  1.00 39.08           C  
+ATOM   2110  CD1 TRP A 275      68.657  93.022  92.470  1.00 39.08           C  
+ATOM   2111  CD2 TRP A 275      69.798  94.454  93.755  1.00 39.08           C  
+ATOM   2112  NE1 TRP A 275      68.569  92.582  93.768  1.00 39.08           N  
+ATOM   2113  CE2 TRP A 275      69.261  93.444  94.576  1.00 39.08           C  
+ATOM   2114  CE3 TRP A 275      70.556  95.469  94.344  1.00 39.08           C  
+ATOM   2115  CZ2 TRP A 275      69.458  93.421  95.953  1.00 39.08           C  
+ATOM   2116  CZ3 TRP A 275      70.751  95.443  95.710  1.00 39.08           C  
+ATOM   2117  CH2 TRP A 275      70.205  94.425  96.499  1.00 39.08           C  
+ATOM   2118  N   THR A 276      69.315  94.974  87.532  1.00 34.64           N  
+ATOM   2119  CA  THR A 276      69.507  95.885  86.410  1.00 34.64           C  
+ATOM   2120  C   THR A 276      68.315  96.812  86.220  1.00 34.64           C  
+ATOM   2121  O   THR A 276      68.490  97.978  85.847  1.00 34.64           O  
+ATOM   2122  CB  THR A 276      69.753  95.094  85.127  1.00 34.64           C  
+ATOM   2123  OG1 THR A 276      68.725  94.109  84.970  1.00 34.64           O  
+ATOM   2124  CG2 THR A 276      71.095  94.394  85.185  1.00 34.64           C  
+ATOM   2125  N   ASN A 277      67.104  96.320  86.468  1.00 41.00           N  
+ATOM   2126  CA  ASN A 277      65.894  97.093  86.217  1.00 41.00           C  
+ATOM   2127  C   ASN A 277      65.582  98.094  87.320  1.00 41.00           C  
+ATOM   2128  O   ASN A 277      64.606  98.841  87.195  1.00 41.00           O  
+ATOM   2129  CB  ASN A 277      64.706  96.148  86.024  1.00 41.00           C  
+ATOM   2130  CG  ASN A 277      64.902  95.203  84.859  1.00 41.00           C  
+ATOM   2131  OD1 ASN A 277      65.521  95.555  83.856  1.00 41.00           O  
+ATOM   2132  ND2 ASN A 277      64.382  93.990  84.988  1.00 41.00           N  
+ATOM   2133  N   LEU A 278      66.373  98.132  88.388  1.00 42.63           N  
+ATOM   2134  CA  LEU A 278      66.205  99.127  89.436  1.00 42.63           C  
+ATOM   2135  C   LEU A 278      66.994 100.400  89.169  1.00 42.63           C  
+ATOM   2136  O   LEU A 278      67.054 101.267  90.045  1.00 42.63           O  
+ATOM   2137  CB  LEU A 278      66.617  98.547  90.792  1.00 42.63           C  
+ATOM   2138  CG  LEU A 278      65.807  97.365  91.322  1.00 42.63           C  
+ATOM   2139  CD1 LEU A 278      66.348  96.918  92.667  1.00 42.63           C  
+ATOM   2140  CD2 LEU A 278      64.337  97.729  91.429  1.00 42.63           C  
+ATOM   2141  N   TYR A 279      67.600 100.535  87.987  1.00 45.58           N  
+ATOM   2142  CA  TYR A 279      68.409 101.716  87.702  1.00 45.58           C  
+ATOM   2143  C   TYR A 279      67.546 102.963  87.581  1.00 45.58           C  
+ATOM   2144  O   TYR A 279      67.945 104.047  88.022  1.00 45.58           O  
+ATOM   2145  CB  TYR A 279      69.219 101.502  86.426  1.00 45.58           C  
+ATOM   2146  CG  TYR A 279      70.216 102.603  86.151  1.00 45.58           C  
+ATOM   2147  CD1 TYR A 279      70.869 103.252  87.192  1.00 45.58           C  
+ATOM   2148  CD2 TYR A 279      70.503 102.999  84.852  1.00 45.58           C  
+ATOM   2149  CE1 TYR A 279      71.779 104.260  86.945  1.00 45.58           C  
+ATOM   2150  CE2 TYR A 279      71.412 104.004  84.596  1.00 45.58           C  
+ATOM   2151  CZ  TYR A 279      72.046 104.630  85.646  1.00 45.58           C  
+ATOM   2152  OH  TYR A 279      72.951 105.632  85.393  1.00 45.58           O  
+ATOM   2153  N   SER A 280      66.362 102.835  86.980  1.00 47.98           N  
+ATOM   2154  CA  SER A 280      65.489 103.993  86.824  1.00 47.98           C  
+ATOM   2155  C   SER A 280      65.002 104.501  88.174  1.00 47.98           C  
+ATOM   2156  O   SER A 280      64.788 105.706  88.354  1.00 47.98           O  
+ATOM   2157  CB  SER A 280      64.307 103.642  85.922  1.00 47.98           C  
+ATOM   2158  OG  SER A 280      63.590 102.534  86.436  1.00 47.98           O  
+ATOM   2159  N   LEU A 281      64.824 103.596  89.138  1.00 49.06           N  
+ATOM   2160  CA  LEU A 281      64.364 103.990  90.463  1.00 49.06           C  
+ATOM   2161  C   LEU A 281      65.508 104.413  91.373  1.00 49.06           C  
+ATOM   2162  O   LEU A 281      65.282 105.178  92.316  1.00 49.06           O  
+ATOM   2163  CB  LEU A 281      63.589 102.844  91.117  1.00 49.06           C  
+ATOM   2164  CG  LEU A 281      62.211 102.486  90.560  1.00 49.06           C  
+ATOM   2165  CD1 LEU A 281      62.326 101.566  89.354  1.00 49.06           C  
+ATOM   2166  CD2 LEU A 281      61.358 101.841  91.640  1.00 49.06           C  
+ATOM   2167  N   THR A 282      66.727 103.936  91.117  1.00 47.49           N  
+ATOM   2168  CA  THR A 282      67.860 104.175  92.000  1.00 47.49           C  
+ATOM   2169  C   THR A 282      68.958 105.001  91.343  1.00 47.49           C  
+ATOM   2170  O   THR A 282      70.126 104.870  91.726  1.00 47.49           O  
+ATOM   2171  CB  THR A 282      68.449 102.847  92.482  1.00 47.49           C  
+ATOM   2172  OG1 THR A 282      68.701 101.999  91.354  1.00 47.49           O  
+ATOM   2173  CG2 THR A 282      67.479 102.144  93.413  1.00 47.49           C  
+ATOM   2174  N   VAL A 283      68.624 105.839  90.367  1.00 50.55           N  
+ATOM   2175  CA  VAL A 283      69.676 106.585  89.668  1.00 50.55           C  
+ATOM   2176  C   VAL A 283      70.270 107.626  90.612  1.00 50.55           C  
+ATOM   2177  O   VAL A 283      69.522 108.288  91.360  1.00 50.55           O  
+ATOM   2178  CB  VAL A 283      69.122 107.228  88.380  1.00 50.55           C  
+ATOM   2179  CG1 VAL A 283      68.203 108.403  88.685  1.00 50.55           C  
+ATOM   2180  CG2 VAL A 283      70.258 107.656  87.463  1.00 50.55           C  
+ATOM   2181  N   PRO A 284      71.595 107.772  90.673  1.00 53.74           N  
+ATOM   2182  CA  PRO A 284      72.187 108.791  91.549  1.00 53.74           C  
+ATOM   2183  C   PRO A 284      71.909 110.204  91.064  1.00 53.74           C  
+ATOM   2184  O   PRO A 284      71.475 111.064  91.836  1.00 53.74           O  
+ATOM   2185  CB  PRO A 284      73.687 108.469  91.505  1.00 53.74           C  
+ATOM   2186  CG  PRO A 284      73.776 107.069  90.986  1.00 53.74           C  
+ATOM   2187  CD  PRO A 284      72.617 106.909  90.061  1.00 53.74           C  
+ATOM   2188  N   PHE A 285      72.161 110.448  89.782  1.00 61.02           N  
+ATOM   2189  CA  PHE A 285      72.009 111.764  89.166  1.00 61.02           C  
+ATOM   2190  C   PHE A 285      71.128 111.603  87.931  1.00 61.02           C  
+ATOM   2191  O   PHE A 285      71.622 111.343  86.832  1.00 61.02           O  
+ATOM   2192  CB  PHE A 285      73.370 112.356  88.816  1.00 61.02           C  
+ATOM   2193  CG  PHE A 285      74.312 112.434  89.982  1.00 61.02           C  
+ATOM   2194  CD1 PHE A 285      75.521 111.763  89.959  1.00 61.02           C  
+ATOM   2195  CD2 PHE A 285      73.991 113.186  91.099  1.00 61.02           C  
+ATOM   2196  CE1 PHE A 285      76.391 111.835  91.028  1.00 61.02           C  
+ATOM   2197  CE2 PHE A 285      74.858 113.263  92.173  1.00 61.02           C  
+ATOM   2198  CZ  PHE A 285      76.060 112.585  92.136  1.00 61.02           C  
+ATOM   2199  N   GLY A 286      69.815 111.757  88.120  1.00 73.41           N  
+ATOM   2200  CA  GLY A 286      68.881 111.602  87.020  1.00 73.41           C  
+ATOM   2201  C   GLY A 286      68.993 112.669  85.954  1.00 73.41           C  
+ATOM   2202  O   GLY A 286      68.684 112.400  84.788  1.00 73.41           O  
+ATOM   2203  N   GLN A 287      69.430 113.874  86.323  1.00 79.58           N  
+ATOM   2204  CA  GLN A 287      69.571 114.957  85.360  1.00 79.58           C  
+ATOM   2205  C   GLN A 287      70.755 114.769  84.421  1.00 79.58           C  
+ATOM   2206  O   GLN A 287      70.835 115.468  83.406  1.00 79.58           O  
+ATOM   2207  CB  GLN A 287      69.704 116.296  86.090  1.00 79.58           C  
+ATOM   2208  CG  GLN A 287      68.453 116.715  86.845  1.00 79.58           C  
+ATOM   2209  CD  GLN A 287      67.179 116.323  86.124  1.00 79.58           C  
+ATOM   2210  OE1 GLN A 287      66.457 115.425  86.559  1.00 79.58           O  
+ATOM   2211  NE2 GLN A 287      66.894 116.996  85.015  1.00 79.58           N  
+ATOM   2212  N   LYS A 288      71.666 113.850  84.731  1.00 70.92           N  
+ATOM   2213  CA  LYS A 288      72.804 113.582  83.864  1.00 70.92           C  
+ATOM   2214  C   LYS A 288      72.491 112.394  82.967  1.00 70.92           C  
+ATOM   2215  O   LYS A 288      72.331 111.276  83.475  1.00 70.92           O  
+ATOM   2216  CB  LYS A 288      74.048 113.299  84.686  1.00 70.92           C  
+ATOM   2217  CG  LYS A 288      74.841 114.537  85.056  1.00 70.92           C  
+ATOM   2218  CD  LYS A 288      75.687 115.022  83.892  1.00 70.92           C  
+ATOM   2219  CE  LYS A 288      76.628 116.133  84.322  1.00 70.92           C  
+ATOM   2220  NZ  LYS A 288      77.524 116.560  83.213  1.00 70.92           N  
+ATOM   2221  N   PRO A 289      72.393 112.578  81.653  1.00 67.98           N  
+ATOM   2222  CA  PRO A 289      72.103 111.439  80.776  1.00 67.98           C  
+ATOM   2223  C   PRO A 289      73.295 110.501  80.677  1.00 67.98           C  
+ATOM   2224  O   PRO A 289      74.442 110.934  80.547  1.00 67.98           O  
+ATOM   2225  CB  PRO A 289      71.794 112.100  79.429  1.00 67.98           C  
+ATOM   2226  CG  PRO A 289      72.547 113.385  79.469  1.00 67.98           C  
+ATOM   2227  CD  PRO A 289      72.527 113.838  80.904  1.00 67.98           C  
+ATOM   2228  N   ASN A 290      73.011 109.204  80.744  1.00 63.83           N  
+ATOM   2229  CA  ASN A 290      74.057 108.201  80.639  1.00 63.83           C  
+ATOM   2230  C   ASN A 290      74.630 108.178  79.225  1.00 63.83           C  
+ATOM   2231  O   ASN A 290      74.036 108.695  78.275  1.00 63.83           O  
+ATOM   2232  CB  ASN A 290      73.521 106.820  81.014  1.00 63.83           C  
+ATOM   2233  CG  ASN A 290      74.598 105.910  81.571  1.00 63.83           C  
+ATOM   2234  OD1 ASN A 290      75.784 106.088  81.290  1.00 63.83           O  
+ATOM   2235  ND2 ASN A 290      74.191 104.928  82.367  1.00 63.83           N  
+ATOM   2236  N   ILE A 291      75.806 107.569  79.095  1.00 63.56           N  
+ATOM   2237  CA  ILE A 291      76.480 107.520  77.805  1.00 63.56           C  
+ATOM   2238  C   ILE A 291      75.754 106.544  76.890  1.00 63.56           C  
+ATOM   2239  O   ILE A 291      75.487 105.395  77.265  1.00 63.56           O  
+ATOM   2240  CB  ILE A 291      77.955 107.130  77.978  1.00 63.56           C  
+ATOM   2241  CG1 ILE A 291      78.660 108.109  78.919  1.00 63.56           C  
+ATOM   2242  CG2 ILE A 291      78.656 107.100  76.632  1.00 63.56           C  
+ATOM   2243  CD1 ILE A 291      78.880 107.566  80.315  1.00 63.56           C  
+ATOM   2244  N   ASP A 292      75.425 107.004  75.684  1.00 70.02           N  
+ATOM   2245  CA  ASP A 292      74.763 106.165  74.689  1.00 70.02           C  
+ATOM   2246  C   ASP A 292      75.224 106.638  73.318  1.00 70.02           C  
+ATOM   2247  O   ASP A 292      74.910 107.760  72.911  1.00 70.02           O  
+ATOM   2248  CB  ASP A 292      73.245 106.243  74.820  1.00 70.02           C  
+ATOM   2249  CG  ASP A 292      72.540 105.112  74.099  1.00 70.02           C  
+ATOM   2250  OD1 ASP A 292      73.221 104.344  73.387  1.00 70.02           O  
+ATOM   2251  OD2 ASP A 292      71.306 104.992  74.243  1.00 70.02           O  
+ATOM   2252  N   VAL A 293      75.962 105.787  72.612  1.00 65.03           N  
+ATOM   2253  CA  VAL A 293      76.593 106.163  71.355  1.00 65.03           C  
+ATOM   2254  C   VAL A 293      75.842 105.596  70.148  1.00 65.03           C  
+ATOM   2255  O   VAL A 293      76.392 105.546  69.049  1.00 65.03           O  
+ATOM   2256  CB  VAL A 293      78.074 105.757  71.332  1.00 65.03           C  
+ATOM   2257  CG1 VAL A 293      78.771 106.263  72.578  1.00 65.03           C  
+ATOM   2258  CG2 VAL A 293      78.206 104.245  71.240  1.00 65.03           C  
+ATOM   2259  N   THR A 294      74.587 105.180  70.330  1.00 68.93           N  
+ATOM   2260  CA  THR A 294      73.830 104.636  69.206  1.00 68.93           C  
+ATOM   2261  C   THR A 294      73.550 105.708  68.158  1.00 68.93           C  
+ATOM   2262  O   THR A 294      73.512 105.416  66.956  1.00 68.93           O  
+ATOM   2263  CB  THR A 294      72.526 104.007  69.700  1.00 68.93           C  
+ATOM   2264  OG1 THR A 294      71.729 103.609  68.578  1.00 68.93           O  
+ATOM   2265  CG2 THR A 294      71.740 104.989  70.557  1.00 68.93           C  
+ATOM   2266  N   ASP A 295      73.367 106.957  68.593  1.00 72.23           N  
+ATOM   2267  CA  ASP A 295      73.087 108.032  67.648  1.00 72.23           C  
+ATOM   2268  C   ASP A 295      74.303 108.338  66.784  1.00 72.23           C  
+ATOM   2269  O   ASP A 295      74.165 108.614  65.587  1.00 72.23           O  
+ATOM   2270  CB  ASP A 295      72.630 109.281  68.400  1.00 72.23           C  
+ATOM   2271  CG  ASP A 295      71.424 109.019  69.276  1.00 72.23           C  
+ATOM   2272  OD1 ASP A 295      70.586 108.175  68.895  1.00 72.23           O  
+ATOM   2273  OD2 ASP A 295      71.316 109.653  70.347  1.00 72.23           O  
+ATOM   2274  N   ALA A 296      75.501 108.298  67.371  1.00 70.04           N  
+ATOM   2275  CA  ALA A 296      76.712 108.501  66.584  1.00 70.04           C  
+ATOM   2276  C   ALA A 296      76.930 107.365  65.595  1.00 70.04           C  
+ATOM   2277  O   ALA A 296      77.505 107.580  64.523  1.00 70.04           O  
+ATOM   2278  CB  ALA A 296      77.922 108.647  67.505  1.00 70.04           C  
+ATOM   2279  N   MET A 297      76.485 106.154  65.936  1.00 69.38           N  
+ATOM   2280  CA  MET A 297      76.565 105.046  64.990  1.00 69.38           C  
+ATOM   2281  C   MET A 297      75.563 105.225  63.858  1.00 69.38           C  
+ATOM   2282  O   MET A 297      75.866 104.930  62.696  1.00 69.38           O  
+ATOM   2283  CB  MET A 297      76.328 103.721  65.711  1.00 69.38           C  
+ATOM   2284  CG  MET A 297      77.347 103.409  66.792  1.00 69.38           C  
+ATOM   2285  SD  MET A 297      76.697 102.290  68.042  1.00 69.38           S  
+ATOM   2286  CE  MET A 297      76.212 100.906  67.017  1.00 69.38           C  
+ATOM   2287  N   VAL A 298      74.361 105.709  64.178  1.00 71.28           N  
+ATOM   2288  CA  VAL A 298      73.357 105.950  63.144  1.00 71.28           C  
+ATOM   2289  C   VAL A 298      73.825 107.049  62.197  1.00 71.28           C  
+ATOM   2290  O   VAL A 298      73.657 106.954  60.975  1.00 71.28           O  
+ATOM   2291  CB  VAL A 298      72.000 106.291  63.786  1.00 71.28           C  
+ATOM   2292  CG1 VAL A 298      71.019 106.780  62.734  1.00 71.28           C  
+ATOM   2293  CG2 VAL A 298      71.440 105.081  64.512  1.00 71.28           C  
+ATOM   2294  N   ASP A 299      74.435 108.102  62.746  1.00 70.19           N  
+ATOM   2295  CA  ASP A 299      74.865 109.225  61.919  1.00 70.19           C  
+ATOM   2296  C   ASP A 299      76.003 108.826  60.988  1.00 70.19           C  
+ATOM   2297  O   ASP A 299      76.005 109.180  59.804  1.00 70.19           O  
+ATOM   2298  CB  ASP A 299      75.284 110.398  62.805  1.00 70.19           C  
+ATOM   2299  CG  ASP A 299      74.125 110.984  63.582  1.00 70.19           C  
+ATOM   2300  OD1 ASP A 299      73.015 110.414  63.515  1.00 70.19           O  
+ATOM   2301  OD2 ASP A 299      74.323 112.014  64.260  1.00 70.19           O  
+ATOM   2302  N   GLN A 300      76.983 108.087  61.505  1.00 69.34           N  
+ATOM   2303  CA  GLN A 300      78.144 107.686  60.722  1.00 69.34           C  
+ATOM   2304  C   GLN A 300      77.886 106.455  59.859  1.00 69.34           C  
+ATOM   2305  O   GLN A 300      78.849 105.849  59.372  1.00 69.34           O  
+ATOM   2306  CB  GLN A 300      79.341 107.436  61.643  1.00 69.34           C  
+ATOM   2307  CG  GLN A 300      79.770 108.653  62.443  1.00 69.34           C  
+ATOM   2308  CD  GLN A 300      80.921 108.359  63.384  1.00 69.34           C  
+ATOM   2309  OE1 GLN A 300      81.664 107.397  63.193  1.00 69.34           O  
+ATOM   2310  NE2 GLN A 300      81.074 109.189  64.409  1.00 69.34           N  
+ATOM   2311  N   ALA A 301      76.619 106.081  59.667  1.00 69.14           N  
+ATOM   2312  CA  ALA A 301      76.239 104.944  58.828  1.00 69.14           C  
+ATOM   2313  C   ALA A 301      76.914 103.656  59.300  1.00 69.14           C  
+ATOM   2314  O   ALA A 301      77.667 103.014  58.566  1.00 69.14           O  
+ATOM   2315  CB  ALA A 301      76.547 105.219  57.354  1.00 69.14           C  
+ATOM   2316  N   TRP A 302      76.636 103.282  60.546  1.00 64.24           N  
+ATOM   2317  CA  TRP A 302      77.174 102.059  61.124  1.00 64.24           C  
+ATOM   2318  C   TRP A 302      76.144 100.942  61.021  1.00 64.24           C  
+ATOM   2319  O   TRP A 302      74.988 101.117  61.419  1.00 64.24           O  
+ATOM   2320  CB  TRP A 302      77.568 102.278  62.585  1.00 64.24           C  
+ATOM   2321  CG  TRP A 302      78.926 102.874  62.764  1.00 64.24           C  
+ATOM   2322  CD1 TRP A 302      79.507 103.837  61.993  1.00 64.24           C  
+ATOM   2323  CD2 TRP A 302      79.878 102.546  63.781  1.00 64.24           C  
+ATOM   2324  NE1 TRP A 302      80.762 104.130  62.466  1.00 64.24           N  
+ATOM   2325  CE2 TRP A 302      81.014 103.350  63.564  1.00 64.24           C  
+ATOM   2326  CE3 TRP A 302      79.880 101.650  64.854  1.00 64.24           C  
+ATOM   2327  CZ2 TRP A 302      82.140 103.285  64.380  1.00 64.24           C  
+ATOM   2328  CZ3 TRP A 302      80.999 101.587  65.662  1.00 64.24           C  
+ATOM   2329  CH2 TRP A 302      82.113 102.400  65.422  1.00 64.24           C  
+ATOM   2330  N   ASP A 303      76.566  99.803  60.486  1.00 63.15           N  
+ATOM   2331  CA  ASP A 303      75.731  98.618  60.373  1.00 63.15           C  
+ATOM   2332  C   ASP A 303      76.358  97.489  61.191  1.00 63.15           C  
+ATOM   2333  O   ASP A 303      77.339  97.689  61.912  1.00 63.15           O  
+ATOM   2334  CB  ASP A 303      75.549  98.228  58.905  1.00 63.15           C  
+ATOM   2335  CG  ASP A 303      76.850  98.256  58.131  1.00 63.15           C  
+ATOM   2336  OD1 ASP A 303      77.883  98.637  58.718  1.00 63.15           O  
+ATOM   2337  OD2 ASP A 303      76.841  97.898  56.935  1.00 63.15           O  
+ATOM   2338  N   ALA A 304      75.777  96.292  61.077  1.00 56.91           N  
+ATOM   2339  CA  ALA A 304      76.308  95.141  61.801  1.00 56.91           C  
+ATOM   2340  C   ALA A 304      77.740  94.838  61.383  1.00 56.91           C  
+ATOM   2341  O   ALA A 304      78.592  94.523  62.227  1.00 56.91           O  
+ATOM   2342  CB  ALA A 304      75.417  93.922  61.570  1.00 56.91           C  
+ATOM   2343  N   GLN A 305      78.023  94.926  60.082  1.00 52.73           N  
+ATOM   2344  CA  GLN A 305      79.375  94.674  59.599  1.00 52.73           C  
+ATOM   2345  C   GLN A 305      80.365  95.659  60.206  1.00 52.73           C  
+ATOM   2346  O   GLN A 305      81.472  95.273  60.594  1.00 52.73           O  
+ATOM   2347  CB  GLN A 305      79.408  94.748  58.074  1.00 52.73           C  
+ATOM   2348  CG  GLN A 305      80.697  94.243  57.454  1.00 52.73           C  
+ATOM   2349  CD  GLN A 305      80.701  92.740  57.266  1.00 52.73           C  
+ATOM   2350  OE1 GLN A 305      79.748  92.055  57.636  1.00 52.73           O  
+ATOM   2351  NE2 GLN A 305      81.775  92.219  56.683  1.00 52.73           N  
+ATOM   2352  N   ARG A 306      79.977  96.933  60.314  1.00 55.32           N  
+ATOM   2353  CA  ARG A 306      80.866  97.925  60.911  1.00 55.32           C  
+ATOM   2354  C   ARG A 306      81.087  97.651  62.393  1.00 55.32           C  
+ATOM   2355  O   ARG A 306      82.209  97.790  62.894  1.00 55.32           O  
+ATOM   2356  CB  ARG A 306      80.300  99.329  60.705  1.00 55.32           C  
+ATOM   2357  CG  ARG A 306      81.108 100.425  61.374  1.00 55.32           C  
+ATOM   2358  CD  ARG A 306      82.534 100.451  60.857  1.00 55.32           C  
+ATOM   2359  NE  ARG A 306      83.332 101.486  61.506  1.00 55.32           N  
+ATOM   2360  CZ  ARG A 306      83.396 102.746  61.093  1.00 55.32           C  
+ATOM   2361  NH1 ARG A 306      82.706 103.132  60.029  1.00 55.32           N  
+ATOM   2362  NH2 ARG A 306      84.150 103.621  61.743  1.00 55.32           N  
+ATOM   2363  N   ILE A 307      80.029  97.263  63.108  1.00 50.69           N  
+ATOM   2364  CA  ILE A 307      80.160  96.938  64.526  1.00 50.69           C  
+ATOM   2365  C   ILE A 307      81.149  95.796  64.718  1.00 50.69           C  
+ATOM   2366  O   ILE A 307      82.069  95.873  65.543  1.00 50.69           O  
+ATOM   2367  CB  ILE A 307      78.785  96.594  65.125  1.00 50.69           C  
+ATOM   2368  CG1 ILE A 307      77.863  97.811  65.081  1.00 50.69           C  
+ATOM   2369  CG2 ILE A 307      78.936  96.082  66.547  1.00 50.69           C  
+ATOM   2370  CD1 ILE A 307      76.443  97.510  65.494  1.00 50.69           C  
+ATOM   2371  N   PHE A 308      80.979  94.718  63.950  1.00 48.16           N  
+ATOM   2372  CA  PHE A 308      81.856  93.566  64.122  1.00 48.16           C  
+ATOM   2373  C   PHE A 308      83.271  93.854  63.634  1.00 48.16           C  
+ATOM   2374  O   PHE A 308      84.235  93.319  64.194  1.00 48.16           O  
+ATOM   2375  CB  PHE A 308      81.266  92.350  63.413  1.00 48.16           C  
+ATOM   2376  CG  PHE A 308      80.232  91.629  64.225  1.00 48.16           C  
+ATOM   2377  CD1 PHE A 308      78.913  92.046  64.219  1.00 48.16           C  
+ATOM   2378  CD2 PHE A 308      80.580  90.541  65.005  1.00 48.16           C  
+ATOM   2379  CE1 PHE A 308      77.960  91.389  64.970  1.00 48.16           C  
+ATOM   2380  CE2 PHE A 308      79.631  89.879  65.759  1.00 48.16           C  
+ATOM   2381  CZ  PHE A 308      78.319  90.304  65.741  1.00 48.16           C  
+ATOM   2382  N   LYS A 309      83.425  94.712  62.624  1.00 47.18           N  
+ATOM   2383  CA  LYS A 309      84.763  95.093  62.186  1.00 47.18           C  
+ATOM   2384  C   LYS A 309      85.475  95.917  63.250  1.00 47.18           C  
+ATOM   2385  O   LYS A 309      86.676  95.740  63.480  1.00 47.18           O  
+ATOM   2386  CB  LYS A 309      84.684  95.864  60.869  1.00 47.18           C  
+ATOM   2387  CG  LYS A 309      84.588  94.975  59.642  1.00 47.18           C  
+ATOM   2388  CD  LYS A 309      85.825  94.107  59.500  1.00 47.18           C  
+ATOM   2389  CE  LYS A 309      85.717  93.185  58.299  1.00 47.18           C  
+ATOM   2390  NZ  LYS A 309      86.967  92.406  58.092  1.00 47.18           N  
+ATOM   2391  N   GLU A 310      84.749  96.814  63.920  1.00 47.14           N  
+ATOM   2392  CA  GLU A 310      85.353  97.577  65.007  1.00 47.14           C  
+ATOM   2393  C   GLU A 310      85.704  96.675  66.184  1.00 47.14           C  
+ATOM   2394  O   GLU A 310      86.740  96.867  66.833  1.00 47.14           O  
+ATOM   2395  CB  GLU A 310      84.416  98.700  65.448  1.00 47.14           C  
+ATOM   2396  CG  GLU A 310      84.325  99.850  64.459  1.00 47.14           C  
+ATOM   2397  CD  GLU A 310      85.632 100.606  64.316  1.00 47.14           C  
+ATOM   2398  OE1 GLU A 310      86.424 100.624  65.281  1.00 47.14           O  
+ATOM   2399  OE2 GLU A 310      85.867 101.186  63.236  1.00 47.14           O  
+ATOM   2400  N   ALA A 311      84.857  95.683  66.471  1.00 40.98           N  
+ATOM   2401  CA  ALA A 311      85.186  94.725  67.522  1.00 40.98           C  
+ATOM   2402  C   ALA A 311      86.445  93.939  67.174  1.00 40.98           C  
+ATOM   2403  O   ALA A 311      87.317  93.734  68.028  1.00 40.98           O  
+ATOM   2404  CB  ALA A 311      84.009  93.782  67.763  1.00 40.98           C  
+ATOM   2405  N   GLU A 312      86.561  93.497  65.920  1.00 41.74           N  
+ATOM   2406  CA  GLU A 312      87.763  92.789  65.491  1.00 41.74           C  
+ATOM   2407  C   GLU A 312      88.992  93.683  65.580  1.00 41.74           C  
+ATOM   2408  O   GLU A 312      90.077  93.224  65.955  1.00 41.74           O  
+ATOM   2409  CB  GLU A 312      87.582  92.267  64.067  1.00 41.74           C  
+ATOM   2410  CG  GLU A 312      88.713  91.377  63.588  1.00 41.74           C  
+ATOM   2411  CD  GLU A 312      88.891  91.425  62.085  1.00 41.74           C  
+ATOM   2412  OE1 GLU A 312      89.927  91.947  61.623  1.00 41.74           O  
+ATOM   2413  OE2 GLU A 312      87.995  90.941  61.364  1.00 41.74           O  
+ATOM   2414  N   LYS A 313      88.843  94.965  65.232  1.00 38.86           N  
+ATOM   2415  CA  LYS A 313      89.961  95.897  65.340  1.00 38.86           C  
+ATOM   2416  C   LYS A 313      90.399  96.058  66.789  1.00 38.86           C  
+ATOM   2417  O   LYS A 313      91.600  96.055  67.089  1.00 38.86           O  
+ATOM   2418  CB  LYS A 313      89.575  97.248  64.739  1.00 38.86           C  
+ATOM   2419  CG  LYS A 313      90.749  98.181  64.507  1.00 38.86           C  
+ATOM   2420  CD  LYS A 313      90.349  99.364  63.640  1.00 38.86           C  
+ATOM   2421  CE  LYS A 313      89.821  98.904  62.292  1.00 38.86           C  
+ATOM   2422  NZ  LYS A 313      89.426 100.052  61.431  1.00 38.86           N  
+ATOM   2423  N   PHE A 314      89.437  96.188  67.703  1.00 38.25           N  
+ATOM   2424  CA  PHE A 314      89.765  96.251  69.123  1.00 38.25           C  
+ATOM   2425  C   PHE A 314      90.504  94.996  69.569  1.00 38.25           C  
+ATOM   2426  O   PHE A 314      91.499  95.070  70.298  1.00 38.25           O  
+ATOM   2427  CB  PHE A 314      88.496  96.438  69.952  1.00 38.25           C  
+ATOM   2428  CG  PHE A 314      88.589  95.853  71.331  1.00 38.25           C  
+ATOM   2429  CD1 PHE A 314      89.343  96.474  72.310  1.00 38.25           C  
+ATOM   2430  CD2 PHE A 314      87.931  94.680  71.647  1.00 38.25           C  
+ATOM   2431  CE1 PHE A 314      89.434  95.939  73.577  1.00 38.25           C  
+ATOM   2432  CE2 PHE A 314      88.019  94.141  72.913  1.00 38.25           C  
+ATOM   2433  CZ  PHE A 314      88.773  94.772  73.877  1.00 38.25           C  
+ATOM   2434  N   PHE A 315      90.025  93.828  69.139  1.00 34.62           N  
+ATOM   2435  CA  PHE A 315      90.629  92.579  69.593  1.00 34.62           C  
+ATOM   2436  C   PHE A 315      92.027  92.383  69.026  1.00 34.62           C  
+ATOM   2437  O   PHE A 315      92.883  91.797  69.695  1.00 34.62           O  
+ATOM   2438  CB  PHE A 315      89.739  91.394  69.225  1.00 34.62           C  
+ATOM   2439  CG  PHE A 315      88.736  91.047  70.282  1.00 34.62           C  
+ATOM   2440  CD1 PHE A 315      89.070  90.200  71.319  1.00 34.62           C  
+ATOM   2441  CD2 PHE A 315      87.459  91.574  70.240  1.00 34.62           C  
+ATOM   2442  CE1 PHE A 315      88.149  89.883  72.290  1.00 34.62           C  
+ATOM   2443  CE2 PHE A 315      86.536  91.261  71.207  1.00 34.62           C  
+ATOM   2444  CZ  PHE A 315      86.880  90.416  72.232  1.00 34.62           C  
+ATOM   2445  N   VAL A 316      92.283  92.852  67.804  1.00 33.35           N  
+ATOM   2446  CA  VAL A 316      93.623  92.708  67.245  1.00 33.35           C  
+ATOM   2447  C   VAL A 316      94.558  93.790  67.776  1.00 33.35           C  
+ATOM   2448  O   VAL A 316      95.783  93.615  67.741  1.00 33.35           O  
+ATOM   2449  CB  VAL A 316      93.584  92.715  65.705  1.00 33.35           C  
+ATOM   2450  CG1 VAL A 316      93.023  94.019  65.181  1.00 33.35           C  
+ATOM   2451  CG2 VAL A 316      94.957  92.416  65.108  1.00 33.35           C  
+ATOM   2452  N   SER A 317      94.012  94.892  68.297  1.00 32.44           N  
+ATOM   2453  CA  SER A 317      94.857  95.913  68.906  1.00 32.44           C  
+ATOM   2454  C   SER A 317      95.649  95.368  70.089  1.00 32.44           C  
+ATOM   2455  O   SER A 317      96.748  95.858  70.374  1.00 32.44           O  
+ATOM   2456  CB  SER A 317      94.006  97.103  69.348  1.00 32.44           C  
+ATOM   2457  OG  SER A 317      93.443  96.873  70.627  1.00 32.44           O  
+ATOM   2458  N   VAL A 318      95.119  94.362  70.784  1.00 32.53           N  
+ATOM   2459  CA  VAL A 318      95.797  93.798  71.948  1.00 32.53           C  
+ATOM   2460  C   VAL A 318      96.639  92.603  71.523  1.00 32.53           C  
+ATOM   2461  O   VAL A 318      97.152  91.859  72.367  1.00 32.53           O  
+ATOM   2462  CB  VAL A 318      94.796  93.407  73.051  1.00 32.53           C  
+ATOM   2463  CG1 VAL A 318      93.849  94.558  73.339  1.00 32.53           C  
+ATOM   2464  CG2 VAL A 318      94.022  92.163  72.657  1.00 32.53           C  
+ATOM   2465  N   GLY A 319      96.795  92.411  70.216  1.00 27.01           N  
+ATOM   2466  CA  GLY A 319      97.659  91.374  69.696  1.00 27.01           C  
+ATOM   2467  C   GLY A 319      96.995  90.044  69.422  1.00 27.01           C  
+ATOM   2468  O   GLY A 319      97.694  89.087  69.063  1.00 27.01           O  
+ATOM   2469  N   LEU A 320      95.680  89.946  69.580  1.00 33.03           N  
+ATOM   2470  CA  LEU A 320      94.994  88.698  69.272  1.00 33.03           C  
+ATOM   2471  C   LEU A 320      94.737  88.599  67.769  1.00 33.03           C  
+ATOM   2472  O   LEU A 320      94.506  89.617  67.111  1.00 33.03           O  
+ATOM   2473  CB  LEU A 320      93.675  88.609  70.036  1.00 33.03           C  
+ATOM   2474  CG  LEU A 320      93.805  88.444  71.550  1.00 33.03           C  
+ATOM   2475  CD1 LEU A 320      92.445  88.499  72.216  1.00 33.03           C  
+ATOM   2476  CD2 LEU A 320      94.506  87.141  71.880  1.00 33.03           C  
+ATOM   2477  N   PRO A 321      94.785  87.398  67.200  1.00 35.22           N  
+ATOM   2478  CA  PRO A 321      94.590  87.264  65.752  1.00 35.22           C  
+ATOM   2479  C   PRO A 321      93.172  87.623  65.340  1.00 35.22           C  
+ATOM   2480  O   PRO A 321      92.212  87.439  66.092  1.00 35.22           O  
+ATOM   2481  CB  PRO A 321      94.888  85.783  65.488  1.00 35.22           C  
+ATOM   2482  CG  PRO A 321      94.660  85.112  66.796  1.00 35.22           C  
+ATOM   2483  CD  PRO A 321      95.066  86.103  67.843  1.00 35.22           C  
+ATOM   2484  N   ASN A 322      93.053  88.148  64.124  1.00 41.25           N  
+ATOM   2485  CA  ASN A 322      91.753  88.546  63.609  1.00 41.25           C  
+ATOM   2486  C   ASN A 322      90.940  87.324  63.195  1.00 41.25           C  
+ATOM   2487  O   ASN A 322      91.459  86.213  63.060  1.00 41.25           O  
+ATOM   2488  CB  ASN A 322      91.912  89.504  62.427  1.00 41.25           C  
+ATOM   2489  CG  ASN A 322      92.946  89.029  61.428  1.00 41.25           C  
+ATOM   2490  OD1 ASN A 322      93.390  87.883  61.472  1.00 41.25           O  
+ATOM   2491  ND2 ASN A 322      93.336  89.913  60.518  1.00 41.25           N  
+ATOM   2492  N   MET A 323      89.643  87.544  62.995  1.00 40.92           N  
+ATOM   2493  CA  MET A 323      88.748  86.457  62.625  1.00 40.92           C  
+ATOM   2494  C   MET A 323      89.058  85.962  61.219  1.00 40.92           C  
+ATOM   2495  O   MET A 323      89.476  86.730  60.349  1.00 40.92           O  
+ATOM   2496  CB  MET A 323      87.295  86.914  62.716  1.00 40.92           C  
+ATOM   2497  CG  MET A 323      86.863  87.290  64.120  1.00 40.92           C  
+ATOM   2498  SD  MET A 323      87.195  85.969  65.296  1.00 40.92           S  
+ATOM   2499  CE  MET A 323      86.858  86.797  66.845  1.00 40.92           C  
+ATOM   2500  N   THR A 324      88.851  84.666  61.001  1.00 43.48           N  
+ATOM   2501  CA  THR A 324      89.171  84.050  59.724  1.00 43.48           C  
+ATOM   2502  C   THR A 324      88.127  84.419  58.670  1.00 43.48           C  
+ATOM   2503  O   THR A 324      87.090  85.022  58.960  1.00 43.48           O  
+ATOM   2504  CB  THR A 324      89.259  82.532  59.872  1.00 43.48           C  
+ATOM   2505  OG1 THR A 324      88.182  82.070  60.695  1.00 43.48           O  
+ATOM   2506  CG2 THR A 324      90.582  82.138  60.508  1.00 43.48           C  
+ATOM   2507  N   GLN A 325      88.421  84.044  57.422  1.00 46.29           N  
+ATOM   2508  CA  GLN A 325      87.493  84.317  56.329  1.00 46.29           C  
+ATOM   2509  C   GLN A 325      86.193  83.544  56.507  1.00 46.29           C  
+ATOM   2510  O   GLN A 325      85.112  84.047  56.173  1.00 46.29           O  
+ATOM   2511  CB  GLN A 325      88.138  83.966  54.990  1.00 46.29           C  
+ATOM   2512  CG  GLN A 325      89.629  84.240  54.922  1.00 46.29           C  
+ATOM   2513  CD  GLN A 325      90.282  83.603  53.711  1.00 46.29           C  
+ATOM   2514  OE1 GLN A 325      89.692  83.543  52.633  1.00 46.29           O  
+ATOM   2515  NE2 GLN A 325      91.507  83.121  53.884  1.00 46.29           N  
+ATOM   2516  N   GLY A 326      86.280  82.318  57.025  1.00 42.05           N  
+ATOM   2517  CA  GLY A 326      85.080  81.525  57.234  1.00 42.05           C  
+ATOM   2518  C   GLY A 326      84.109  82.178  58.197  1.00 42.05           C  
+ATOM   2519  O   GLY A 326      82.892  82.031  58.061  1.00 42.05           O  
+ATOM   2520  N   PHE A 327      84.632  82.913  59.180  1.00 34.71           N  
+ATOM   2521  CA  PHE A 327      83.767  83.621  60.117  1.00 34.71           C  
+ATOM   2522  C   PHE A 327      82.896  84.639  59.392  1.00 34.71           C  
+ATOM   2523  O   PHE A 327      81.685  84.716  59.625  1.00 34.71           O  
+ATOM   2524  CB  PHE A 327      84.610  84.306  61.194  1.00 34.71           C  
+ATOM   2525  CG  PHE A 327      83.817  85.187  62.117  1.00 34.71           C  
+ATOM   2526  CD1 PHE A 327      83.693  86.543  61.871  1.00 34.71           C  
+ATOM   2527  CD2 PHE A 327      83.200  84.657  63.234  1.00 34.71           C  
+ATOM   2528  CE1 PHE A 327      82.966  87.350  62.717  1.00 34.71           C  
+ATOM   2529  CE2 PHE A 327      82.474  85.463  64.083  1.00 34.71           C  
+ATOM   2530  CZ  PHE A 327      82.356  86.808  63.823  1.00 34.71           C  
+ATOM   2531  N   TRP A 328      83.499  85.431  58.505  1.00 47.29           N  
+ATOM   2532  CA  TRP A 328      82.738  86.458  57.800  1.00 47.29           C  
+ATOM   2533  C   TRP A 328      81.855  85.849  56.720  1.00 47.29           C  
+ATOM   2534  O   TRP A 328      80.799  86.401  56.391  1.00 47.29           O  
+ATOM   2535  CB  TRP A 328      83.688  87.492  57.197  1.00 47.29           C  
+ATOM   2536  CG  TRP A 328      84.482  88.236  58.219  1.00 47.29           C  
+ATOM   2537  CD1 TRP A 328      85.834  88.206  58.387  1.00 47.29           C  
+ATOM   2538  CD2 TRP A 328      83.972  89.121  59.222  1.00 47.29           C  
+ATOM   2539  NE1 TRP A 328      86.199  89.020  59.431  1.00 47.29           N  
+ATOM   2540  CE2 TRP A 328      85.073  89.593  59.960  1.00 47.29           C  
+ATOM   2541  CE3 TRP A 328      82.691  89.562  59.566  1.00 47.29           C  
+ATOM   2542  CZ2 TRP A 328      84.933  90.483  61.021  1.00 47.29           C  
+ATOM   2543  CZ3 TRP A 328      82.555  90.445  60.619  1.00 47.29           C  
+ATOM   2544  CH2 TRP A 328      83.669  90.895  61.333  1.00 47.29           C  
+ATOM   2545  N   GLU A 329      82.266  84.713  56.157  1.00 45.83           N  
+ATOM   2546  CA  GLU A 329      81.501  84.123  55.065  1.00 45.83           C  
+ATOM   2547  C   GLU A 329      80.287  83.356  55.576  1.00 45.83           C  
+ATOM   2548  O   GLU A 329      79.237  83.347  54.924  1.00 45.83           O  
+ATOM   2549  CB  GLU A 329      82.398  83.206  54.233  1.00 45.83           C  
+ATOM   2550  CG  GLU A 329      83.465  83.937  53.438  1.00 45.83           C  
+ATOM   2551  CD  GLU A 329      84.394  82.990  52.707  1.00 45.83           C  
+ATOM   2552  OE1 GLU A 329      84.168  81.763  52.775  1.00 45.83           O  
+ATOM   2553  OE2 GLU A 329      85.351  83.469  52.066  1.00 45.83           O  
+ATOM   2554  N   ASN A 330      80.403  82.715  56.738  1.00 40.29           N  
+ATOM   2555  CA  ASN A 330      79.400  81.755  57.181  1.00 40.29           C  
+ATOM   2556  C   ASN A 330      78.500  82.264  58.297  1.00 40.29           C  
+ATOM   2557  O   ASN A 330      77.364  81.797  58.416  1.00 40.29           O  
+ATOM   2558  CB  ASN A 330      80.082  80.465  57.646  1.00 40.29           C  
+ATOM   2559  CG  ASN A 330      80.914  79.825  56.556  1.00 40.29           C  
+ATOM   2560  OD1 ASN A 330      80.450  79.639  55.432  1.00 40.29           O  
+ATOM   2561  ND2 ASN A 330      82.156  79.487  56.882  1.00 40.29           N  
+ATOM   2562  N   SER A 331      78.966  83.199  59.119  1.00 41.74           N  
+ATOM   2563  CA  SER A 331      78.190  83.627  60.272  1.00 41.74           C  
+ATOM   2564  C   SER A 331      77.024  84.514  59.852  1.00 41.74           C  
+ATOM   2565  O   SER A 331      77.097  85.255  58.869  1.00 41.74           O  
+ATOM   2566  CB  SER A 331      79.074  84.377  61.267  1.00 41.74           C  
+ATOM   2567  OG  SER A 331      79.782  85.421  60.623  1.00 41.74           O  
+ATOM   2568  N   MET A 332      75.940  84.428  60.619  1.00 51.07           N  
+ATOM   2569  CA  MET A 332      74.739  85.228  60.394  1.00 51.07           C  
+ATOM   2570  C   MET A 332      74.794  86.426  61.335  1.00 51.07           C  
+ATOM   2571  O   MET A 332      74.531  86.302  62.534  1.00 51.07           O  
+ATOM   2572  CB  MET A 332      73.484  84.392  60.620  1.00 51.07           C  
+ATOM   2573  CG  MET A 332      72.196  85.194  60.647  1.00 51.07           C  
+ATOM   2574  SD  MET A 332      70.738  84.139  60.595  1.00 51.07           S  
+ATOM   2575  CE  MET A 332      70.870  83.473  58.938  1.00 51.07           C  
+ATOM   2576  N   LEU A 333      75.141  87.590  60.787  1.00 51.54           N  
+ATOM   2577  CA  LEU A 333      75.284  88.804  61.576  1.00 51.54           C  
+ATOM   2578  C   LEU A 333      74.053  89.699  61.534  1.00 51.54           C  
+ATOM   2579  O   LEU A 333      73.987  90.665  62.299  1.00 51.54           O  
+ATOM   2580  CB  LEU A 333      76.504  89.600  61.098  1.00 51.54           C  
+ATOM   2581  CG  LEU A 333      77.832  88.843  61.078  1.00 51.54           C  
+ATOM   2582  CD1 LEU A 333      78.927  89.694  60.460  1.00 51.54           C  
+ATOM   2583  CD2 LEU A 333      78.217  88.411  62.481  1.00 51.54           C  
+ATOM   2584  N   THR A 334      73.084  89.406  60.670  1.00 60.65           N  
+ATOM   2585  CA  THR A 334      71.889  90.224  60.540  1.00 60.65           C  
+ATOM   2586  C   THR A 334      70.661  89.325  60.515  1.00 60.65           C  
+ATOM   2587  O   THR A 334      70.756  88.114  60.308  1.00 60.65           O  
+ATOM   2588  CB  THR A 334      71.928  91.090  59.273  1.00 60.65           C  
+ATOM   2589  OG1 THR A 334      72.424  90.312  58.176  1.00 60.65           O  
+ATOM   2590  CG2 THR A 334      72.828  92.296  59.478  1.00 60.65           C  
+ATOM   2591  N   ASP A 335      69.506  89.936  60.733  1.00 71.77           N  
+ATOM   2592  CA  ASP A 335      68.244  89.209  60.675  1.00 71.77           C  
+ATOM   2593  C   ASP A 335      67.966  88.797  59.236  1.00 71.77           C  
+ATOM   2594  O   ASP A 335      67.847  89.668  58.365  1.00 71.77           O  
+ATOM   2595  CB  ASP A 335      67.110  90.072  61.215  1.00 71.77           C  
+ATOM   2596  CG  ASP A 335      65.987  89.252  61.819  1.00 71.77           C  
+ATOM   2597  OD1 ASP A 335      65.697  88.157  61.296  1.00 71.77           O  
+ATOM   2598  OD2 ASP A 335      65.392  89.706  62.819  1.00 71.77           O  
+ATOM   2599  N   PRO A 336      67.855  87.502  58.935  1.00 76.30           N  
+ATOM   2600  CA  PRO A 336      67.691  87.055  57.539  1.00 76.30           C  
+ATOM   2601  C   PRO A 336      66.291  87.321  56.994  1.00 76.30           C  
+ATOM   2602  O   PRO A 336      65.557  86.407  56.608  1.00 76.30           O  
+ATOM   2603  CB  PRO A 336      68.010  85.558  57.639  1.00 76.30           C  
+ATOM   2604  CG  PRO A 336      67.575  85.185  59.011  1.00 76.30           C  
+ATOM   2605  CD  PRO A 336      67.903  86.370  59.877  1.00 76.30           C  
+ATOM   2606  N   GLY A 337      65.913  88.597  56.955  1.00 85.59           N  
+ATOM   2607  CA  GLY A 337      64.629  88.971  56.398  1.00 85.59           C  
+ATOM   2608  C   GLY A 337      63.465  88.425  57.206  1.00 85.59           C  
+ATOM   2609  O   GLY A 337      63.535  88.257  58.427  1.00 85.59           O  
+ATOM   2610  N   ASN A 338      62.369  88.139  56.500  1.00 96.96           N  
+ATOM   2611  CA  ASN A 338      61.162  87.612  57.116  1.00 96.96           C  
+ATOM   2612  C   ASN A 338      60.647  86.347  56.447  1.00 96.96           C  
+ATOM   2613  O   ASN A 338      59.819  85.649  57.043  1.00 96.96           O  
+ATOM   2614  CB  ASN A 338      60.050  88.675  57.100  1.00 96.96           C  
+ATOM   2615  CG  ASN A 338      59.062  88.519  58.246  1.00 96.96           C  
+ATOM   2616  OD1 ASN A 338      58.777  87.411  58.698  1.00 96.96           O  
+ATOM   2617  ND2 ASN A 338      58.533  89.640  58.719  1.00 96.96           N  
+ATOM   2618  N   VAL A 339      61.118  86.022  55.240  1.00 97.63           N  
+ATOM   2619  CA  VAL A 339      60.641  84.826  54.550  1.00 97.63           C  
+ATOM   2620  C   VAL A 339      61.028  83.572  55.323  1.00 97.63           C  
+ATOM   2621  O   VAL A 339      60.266  82.599  55.379  1.00 97.63           O  
+ATOM   2622  CB  VAL A 339      61.171  84.799  53.103  1.00 97.63           C  
+ATOM   2623  CG1 VAL A 339      62.688  84.947  53.080  1.00 97.63           C  
+ATOM   2624  CG2 VAL A 339      60.739  83.522  52.395  1.00 97.63           C  
+ATOM   2625  N   GLN A 340      62.205  83.577  55.945  1.00 90.23           N  
+ATOM   2626  CA  GLN A 340      62.663  82.466  56.764  1.00 90.23           C  
+ATOM   2627  C   GLN A 340      62.912  82.949  58.185  1.00 90.23           C  
+ATOM   2628  O   GLN A 340      63.454  84.038  58.397  1.00 90.23           O  
+ATOM   2629  CB  GLN A 340      63.935  81.829  56.188  1.00 90.23           C  
+ATOM   2630  CG  GLN A 340      65.114  82.775  56.045  1.00 90.23           C  
+ATOM   2631  CD  GLN A 340      66.386  82.062  55.632  1.00 90.23           C  
+ATOM   2632  OE1 GLN A 340      66.370  80.870  55.323  1.00 90.23           O  
+ATOM   2633  NE2 GLN A 340      67.498  82.786  55.627  1.00 90.23           N  
+ATOM   2634  N   LYS A 341      62.504  82.139  59.155  1.00 90.71           N  
+ATOM   2635  CA  LYS A 341      62.676  82.456  60.564  1.00 90.71           C  
+ATOM   2636  C   LYS A 341      64.007  81.907  61.057  1.00 90.71           C  
+ATOM   2637  O   LYS A 341      64.575  80.990  60.456  1.00 90.71           O  
+ATOM   2638  CB  LYS A 341      61.532  81.882  61.401  1.00 90.71           C  
+ATOM   2639  CG  LYS A 341      60.144  82.180  60.860  1.00 90.71           C  
+ATOM   2640  CD  LYS A 341      59.810  83.656  60.973  1.00 90.71           C  
+ATOM   2641  CE  LYS A 341      58.406  83.935  60.471  1.00 90.71           C  
+ATOM   2642  NZ  LYS A 341      58.211  83.439  59.081  1.00 90.71           N  
+ATOM   2643  N   ALA A 342      64.502  82.477  62.151  1.00 82.36           N  
+ATOM   2644  CA  ALA A 342      65.739  82.036  62.773  1.00 82.36           C  
+ATOM   2645  C   ALA A 342      65.761  82.481  64.228  1.00 82.36           C  
+ATOM   2646  O   ALA A 342      65.427  83.620  64.557  1.00 82.36           O  
+ATOM   2647  CB  ALA A 342      66.970  82.583  62.038  1.00 82.36           C  
+ATOM   2648  N   VAL A 343      66.158  81.556  65.100  1.00 74.66           N  
+ATOM   2649  CA  VAL A 343      66.308  81.849  66.527  1.00 74.66           C  
+ATOM   2650  C   VAL A 343      67.690  82.475  66.698  1.00 74.66           C  
+ATOM   2651  O   VAL A 343      68.700  81.798  66.890  1.00 74.66           O  
+ATOM   2652  CB  VAL A 343      66.082  80.606  67.394  1.00 74.66           C  
+ATOM   2653  CG1 VAL A 343      66.995  79.448  66.987  1.00 74.66           C  
+ATOM   2654  CG2 VAL A 343      66.267  80.948  68.868  1.00 74.66           C  
+ATOM   2655  N   CYS A 344      67.732  83.803  66.618  1.00 71.08           N  
+ATOM   2656  CA  CYS A 344      69.025  84.483  66.573  1.00 71.08           C  
+ATOM   2657  C   CYS A 344      69.459  85.050  67.909  1.00 71.08           C  
+ATOM   2658  O   CYS A 344      70.019  86.155  67.923  1.00 71.08           O  
+ATOM   2659  CB  CYS A 344      69.011  85.587  65.514  1.00 71.08           C  
+ATOM   2660  SG  CYS A 344      67.786  86.886  65.739  1.00 71.08           S  
+ATOM   2661  N   HIS A 345      69.204  84.359  69.010  1.00 60.90           N  
+ATOM   2662  CA  HIS A 345      69.824  84.710  70.280  1.00 60.90           C  
+ATOM   2663  C   HIS A 345      71.336  84.742  70.096  1.00 60.90           C  
+ATOM   2664  O   HIS A 345      71.892  83.824  69.481  1.00 60.90           O  
+ATOM   2665  CB  HIS A 345      69.433  83.703  71.357  1.00 60.90           C  
+ATOM   2666  CG  HIS A 345      69.870  84.088  72.734  1.00 60.90           C  
+ATOM   2667  ND1 HIS A 345      69.417  85.225  73.367  1.00 60.90           N  
+ATOM   2668  CD2 HIS A 345      70.717  83.486  73.602  1.00 60.90           C  
+ATOM   2669  CE1 HIS A 345      69.968  85.308  74.565  1.00 60.90           C  
+ATOM   2670  NE2 HIS A 345      70.762  84.267  74.732  1.00 60.90           N  
+ATOM   2671  N   PRO A 346      72.034  85.769  70.583  1.00 51.38           N  
+ATOM   2672  CA  PRO A 346      73.476  85.888  70.306  1.00 51.38           C  
+ATOM   2673  C   PRO A 346      74.255  84.752  70.954  1.00 51.38           C  
+ATOM   2674  O   PRO A 346      74.361  84.675  72.179  1.00 51.38           O  
+ATOM   2675  CB  PRO A 346      73.845  87.246  70.914  1.00 51.38           C  
+ATOM   2676  CG  PRO A 346      72.543  87.965  71.100  1.00 51.38           C  
+ATOM   2677  CD  PRO A 346      71.528  86.904  71.368  1.00 51.38           C  
+ATOM   2678  N   THR A 347      74.799  83.868  70.120  1.00 41.47           N  
+ATOM   2679  CA  THR A 347      75.637  82.767  70.572  1.00 41.47           C  
+ATOM   2680  C   THR A 347      76.904  82.713  69.732  1.00 41.47           C  
+ATOM   2681  O   THR A 347      76.915  83.119  68.567  1.00 41.47           O  
+ATOM   2682  CB  THR A 347      74.914  81.409  70.493  1.00 41.47           C  
+ATOM   2683  OG1 THR A 347      74.902  80.945  69.138  1.00 41.47           O  
+ATOM   2684  CG2 THR A 347      73.486  81.507  71.010  1.00 41.47           C  
+ATOM   2685  N   ALA A 348      77.973  82.208  70.339  1.00 33.03           N  
+ATOM   2686  CA  ALA A 348      79.256  82.022  69.671  1.00 33.03           C  
+ATOM   2687  C   ALA A 348      79.406  80.541  69.352  1.00 33.03           C  
+ATOM   2688  O   ALA A 348      79.493  79.710  70.262  1.00 33.03           O  
+ATOM   2689  CB  ALA A 348      80.403  82.519  70.545  1.00 33.03           C  
+ATOM   2690  N   TRP A 349      79.438  80.213  68.065  1.00 39.83           N  
+ATOM   2691  CA  TRP A 349      79.429  78.829  67.608  1.00 39.83           C  
+ATOM   2692  C   TRP A 349      80.855  78.340  67.400  1.00 39.83           C  
+ATOM   2693  O   TRP A 349      81.620  78.942  66.642  1.00 39.83           O  
+ATOM   2694  CB  TRP A 349      78.626  78.691  66.316  1.00 39.83           C  
+ATOM   2695  CG  TRP A 349      77.156  78.683  66.541  1.00 39.83           C  
+ATOM   2696  CD1 TRP A 349      76.368  79.752  66.833  1.00 39.83           C  
+ATOM   2697  CD2 TRP A 349      76.290  77.544  66.505  1.00 39.83           C  
+ATOM   2698  NE1 TRP A 349      75.062  79.354  66.979  1.00 39.83           N  
+ATOM   2699  CE2 TRP A 349      74.988  78.001  66.781  1.00 39.83           C  
+ATOM   2700  CE3 TRP A 349      76.490  76.182  66.264  1.00 39.83           C  
+ATOM   2701  CZ2 TRP A 349      73.892  77.148  66.821  1.00 39.83           C  
+ATOM   2702  CZ3 TRP A 349      75.401  75.338  66.305  1.00 39.83           C  
+ATOM   2703  CH2 TRP A 349      74.118  75.822  66.581  1.00 39.83           C  
+ATOM   2704  N   ASP A 350      81.203  77.251  68.073  1.00 32.77           N  
+ATOM   2705  CA  ASP A 350      82.454  76.533  67.849  1.00 32.77           C  
+ATOM   2706  C   ASP A 350      82.062  75.158  67.317  1.00 32.77           C  
+ATOM   2707  O   ASP A 350      81.934  74.194  68.073  1.00 32.77           O  
+ATOM   2708  CB  ASP A 350      83.275  76.435  69.130  1.00 32.77           C  
+ATOM   2709  CG  ASP A 350      84.619  75.770  68.914  1.00 32.77           C  
+ATOM   2710  OD1 ASP A 350      85.310  75.489  69.917  1.00 32.77           O  
+ATOM   2711  OD2 ASP A 350      84.991  75.533  67.745  1.00 32.77           O  
+ATOM   2712  N   LEU A 351      81.866  75.075  66.000  1.00 35.27           N  
+ATOM   2713  CA  LEU A 351      81.413  73.839  65.379  1.00 35.27           C  
+ATOM   2714  C   LEU A 351      82.512  72.794  65.276  1.00 35.27           C  
+ATOM   2715  O   LEU A 351      82.213  71.633  64.978  1.00 35.27           O  
+ATOM   2716  CB  LEU A 351      80.851  74.123  63.984  1.00 35.27           C  
+ATOM   2717  CG  LEU A 351      79.680  75.100  63.885  1.00 35.27           C  
+ATOM   2718  CD1 LEU A 351      80.176  76.504  63.592  1.00 35.27           C  
+ATOM   2719  CD2 LEU A 351      78.697  74.648  62.820  1.00 35.27           C  
+ATOM   2720  N   GLY A 352      83.762  73.169  65.516  1.00 34.49           N  
+ATOM   2721  CA  GLY A 352      84.873  72.258  65.363  1.00 34.49           C  
+ATOM   2722  C   GLY A 352      85.470  72.309  63.970  1.00 34.49           C  
+ATOM   2723  O   GLY A 352      84.908  72.876  63.030  1.00 34.49           O  
+ATOM   2724  N   LYS A 353      86.648  71.700  63.848  1.00 39.51           N  
+ATOM   2725  CA  LYS A 353      87.394  71.658  62.590  1.00 39.51           C  
+ATOM   2726  C   LYS A 353      87.663  73.064  62.058  1.00 39.51           C  
+ATOM   2727  O   LYS A 353      87.671  73.306  60.850  1.00 39.51           O  
+ATOM   2728  CB  LYS A 353      86.670  70.800  61.549  1.00 39.51           C  
+ATOM   2729  CG  LYS A 353      86.173  69.471  62.091  1.00 39.51           C  
+ATOM   2730  CD  LYS A 353      85.725  68.539  60.979  1.00 39.51           C  
+ATOM   2731  CE  LYS A 353      86.903  67.818  60.350  1.00 39.51           C  
+ATOM   2732  NZ  LYS A 353      86.457  66.722  59.445  1.00 39.51           N  
+ATOM   2733  N   GLY A 354      87.888  74.002  62.975  1.00 32.49           N  
+ATOM   2734  CA  GLY A 354      88.263  75.350  62.606  1.00 32.49           C  
+ATOM   2735  C   GLY A 354      87.136  76.239  62.137  1.00 32.49           C  
+ATOM   2736  O   GLY A 354      87.406  77.273  61.519  1.00 32.49           O  
+ATOM   2737  N   ASP A 355      85.887  75.880  62.413  1.00 38.98           N  
+ATOM   2738  CA  ASP A 355      84.729  76.654  61.975  1.00 38.98           C  
+ATOM   2739  C   ASP A 355      84.142  77.376  63.181  1.00 38.98           C  
+ATOM   2740  O   ASP A 355      83.502  76.751  64.034  1.00 38.98           O  
+ATOM   2741  CB  ASP A 355      83.691  75.751  61.313  1.00 38.98           C  
+ATOM   2742  CG  ASP A 355      82.652  76.531  60.536  1.00 38.98           C  
+ATOM   2743  OD1 ASP A 355      82.821  77.758  60.379  1.00 38.98           O  
+ATOM   2744  OD2 ASP A 355      81.666  75.918  60.080  1.00 38.98           O  
+ATOM   2745  N   PHE A 356      84.357  78.685  63.248  1.00 31.46           N  
+ATOM   2746  CA  PHE A 356      83.821  79.527  64.309  1.00 31.46           C  
+ATOM   2747  C   PHE A 356      82.868  80.544  63.699  1.00 31.46           C  
+ATOM   2748  O   PHE A 356      83.182  81.154  62.672  1.00 31.46           O  
+ATOM   2749  CB  PHE A 356      84.944  80.239  65.067  1.00 31.46           C  
+ATOM   2750  CG  PHE A 356      86.125  79.359  65.367  1.00 31.46           C  
+ATOM   2751  CD1 PHE A 356      86.112  78.507  66.455  1.00 31.46           C  
+ATOM   2752  CD2 PHE A 356      87.249  79.388  64.559  1.00 31.46           C  
+ATOM   2753  CE1 PHE A 356      87.196  77.698  66.730  1.00 31.46           C  
+ATOM   2754  CE2 PHE A 356      88.336  78.582  64.831  1.00 31.46           C  
+ATOM   2755  CZ  PHE A 356      88.309  77.737  65.917  1.00 31.46           C  
+ATOM   2756  N   ARG A 357      81.708  80.725  64.328  1.00 37.37           N  
+ATOM   2757  CA  ARG A 357      80.674  81.606  63.805  1.00 37.37           C  
+ATOM   2758  C   ARG A 357      80.012  82.367  64.943  1.00 37.37           C  
+ATOM   2759  O   ARG A 357      80.133  81.997  66.113  1.00 37.37           O  
+ATOM   2760  CB  ARG A 357      79.604  80.829  63.031  1.00 37.37           C  
+ATOM   2761  CG  ARG A 357      80.106  80.142  61.785  1.00 37.37           C  
+ATOM   2762  CD  ARG A 357      79.094  79.136  61.281  1.00 37.37           C  
+ATOM   2763  NE  ARG A 357      79.594  78.404  60.125  1.00 37.37           N  
+ATOM   2764  CZ  ARG A 357      78.966  77.378  59.567  1.00 37.37           C  
+ATOM   2765  NH1 ARG A 357      79.492  76.769  58.515  1.00 37.37           N  
+ATOM   2766  NH2 ARG A 357      77.816  76.955  60.065  1.00 37.37           N  
+ATOM   2767  N   ILE A 358      79.302  83.431  64.582  1.00 41.40           N  
+ATOM   2768  CA  ILE A 358      78.480  84.197  65.511  1.00 41.40           C  
+ATOM   2769  C   ILE A 358      77.110  84.374  64.874  1.00 41.40           C  
+ATOM   2770  O   ILE A 358      76.994  84.954  63.787  1.00 41.40           O  
+ATOM   2771  CB  ILE A 358      79.107  85.556  65.855  1.00 41.40           C  
+ATOM   2772  CG1 ILE A 358      80.297  85.373  66.796  1.00 41.40           C  
+ATOM   2773  CG2 ILE A 358      78.075  86.472  66.492  1.00 41.40           C  
+ATOM   2774  CD1 ILE A 358      81.013  86.659  67.130  1.00 41.40           C  
+ATOM   2775  N   LEU A 359      76.079  83.876  65.547  1.00 47.21           N  
+ATOM   2776  CA  LEU A 359      74.703  83.944  65.063  1.00 47.21           C  
+ATOM   2777  C   LEU A 359      73.944  84.934  65.938  1.00 47.21           C  
+ATOM   2778  O   LEU A 359      73.598  84.630  67.082  1.00 47.21           O  
+ATOM   2779  CB  LEU A 359      74.065  82.558  65.087  1.00 47.21           C  
+ATOM   2780  CG  LEU A 359      72.630  82.409  64.589  1.00 47.21           C  
+ATOM   2781  CD1 LEU A 359      72.522  81.208  63.676  1.00 47.21           C  
+ATOM   2782  CD2 LEU A 359      71.697  82.249  65.768  1.00 47.21           C  
+ATOM   2783  N   MET A 360      73.681  86.123  65.396  1.00 54.08           N  
+ATOM   2784  CA  MET A 360      73.077  87.193  66.177  1.00 54.08           C  
+ATOM   2785  C   MET A 360      72.430  88.209  65.250  1.00 54.08           C  
+ATOM   2786  O   MET A 360      73.046  88.638  64.270  1.00 54.08           O  
+ATOM   2787  CB  MET A 360      74.128  87.876  67.060  1.00 54.08           C  
+ATOM   2788  CG  MET A 360      73.670  89.172  67.697  1.00 54.08           C  
+ATOM   2789  SD  MET A 360      75.007  90.014  68.561  1.00 54.08           S  
+ATOM   2790  CE  MET A 360      74.177  91.510  69.087  1.00 54.08           C  
+ATOM   2791  N   CYS A 361      71.192  88.591  65.564  1.00 62.94           N  
+ATOM   2792  CA  CYS A 361      70.508  89.684  64.872  1.00 62.94           C  
+ATOM   2793  C   CYS A 361      71.053  90.989  65.435  1.00 62.94           C  
+ATOM   2794  O   CYS A 361      70.615  91.475  66.478  1.00 62.94           O  
+ATOM   2795  CB  CYS A 361      68.998  89.585  65.048  1.00 62.94           C  
+ATOM   2796  SG  CYS A 361      68.216  88.174  64.231  1.00 62.94           S  
+ATOM   2797  N   THR A 362      72.024  91.567  64.734  1.00 57.16           N  
+ATOM   2798  CA  THR A 362      72.711  92.755  65.225  1.00 57.16           C  
+ATOM   2799  C   THR A 362      71.957  94.008  64.801  1.00 57.16           C  
+ATOM   2800  O   THR A 362      71.853  94.305  63.606  1.00 57.16           O  
+ATOM   2801  CB  THR A 362      74.145  92.796  64.704  1.00 57.16           C  
+ATOM   2802  OG1 THR A 362      74.727  91.490  64.795  1.00 57.16           O  
+ATOM   2803  CG2 THR A 362      74.978  93.772  65.517  1.00 57.16           C  
+ATOM   2804  N   LYS A 363      71.432  94.739  65.778  1.00 57.83           N  
+ATOM   2805  CA  LYS A 363      70.843  96.049  65.557  1.00 57.83           C  
+ATOM   2806  C   LYS A 363      71.887  97.127  65.815  1.00 57.83           C  
+ATOM   2807  O   LYS A 363      72.932  96.880  66.421  1.00 57.83           O  
+ATOM   2808  CB  LYS A 363      69.627  96.263  66.462  1.00 57.83           C  
+ATOM   2809  CG  LYS A 363      68.624  95.123  66.437  1.00 57.83           C  
+ATOM   2810  CD  LYS A 363      68.127  94.856  65.026  1.00 57.83           C  
+ATOM   2811  CE  LYS A 363      67.154  93.690  64.994  1.00 57.83           C  
+ATOM   2812  NZ  LYS A 363      66.695  93.389  63.611  1.00 57.83           N  
+ATOM   2813  N   VAL A 364      71.595  98.337  65.345  1.00 60.05           N  
+ATOM   2814  CA  VAL A 364      72.531  99.462  65.497  1.00 60.05           C  
+ATOM   2815  C   VAL A 364      72.194 100.115  66.832  1.00 60.05           C  
+ATOM   2816  O   VAL A 364      71.487 101.122  66.921  1.00 60.05           O  
+ATOM   2817  CB  VAL A 364      72.461 100.436  64.320  1.00 60.05           C  
+ATOM   2818  CG1 VAL A 364      73.600 101.438  64.397  1.00 60.05           C  
+ATOM   2819  CG2 VAL A 364      72.503  99.675  63.004  1.00 60.05           C  
+ATOM   2820  N   THR A 365      72.722  99.525  67.903  1.00 56.43           N  
+ATOM   2821  CA  THR A 365      72.597 100.061  69.251  1.00 56.43           C  
+ATOM   2822  C   THR A 365      73.930  99.888  69.964  1.00 56.43           C  
+ATOM   2823  O   THR A 365      74.861  99.269  69.444  1.00 56.43           O  
+ATOM   2824  CB  THR A 365      71.482  99.373  70.057  1.00 56.43           C  
+ATOM   2825  OG1 THR A 365      71.855  98.017  70.336  1.00 56.43           O  
+ATOM   2826  CG2 THR A 365      70.157  99.392  69.308  1.00 56.43           C  
+ATOM   2827  N   MET A 366      74.018 100.445  71.173  1.00 54.54           N  
+ATOM   2828  CA  MET A 366      75.214 100.242  71.983  1.00 54.54           C  
+ATOM   2829  C   MET A 366      75.175  98.900  72.704  1.00 54.54           C  
+ATOM   2830  O   MET A 366      76.225  98.284  72.923  1.00 54.54           O  
+ATOM   2831  CB  MET A 366      75.375 101.382  72.987  1.00 54.54           C  
+ATOM   2832  CG  MET A 366      76.776 101.501  73.564  1.00 54.54           C  
+ATOM   2833  SD  MET A 366      76.842 102.570  75.012  1.00 54.54           S  
+ATOM   2834  CE  MET A 366      75.871 101.617  76.175  1.00 54.54           C  
+ATOM   2835  N   ASP A 367      73.980  98.436  73.079  1.00 51.74           N  
+ATOM   2836  CA  ASP A 367      73.856  97.126  73.708  1.00 51.74           C  
+ATOM   2837  C   ASP A 367      74.354  96.025  72.779  1.00 51.74           C  
+ATOM   2838  O   ASP A 367      75.126  95.151  73.187  1.00 51.74           O  
+ATOM   2839  CB  ASP A 367      72.403  96.874  74.113  1.00 51.74           C  
+ATOM   2840  CG  ASP A 367      72.089  97.388  75.504  1.00 51.74           C  
+ATOM   2841  OD1 ASP A 367      73.039  97.715  76.246  1.00 51.74           O  
+ATOM   2842  OD2 ASP A 367      70.893  97.463  75.855  1.00 51.74           O  
+ATOM   2843  N   ASP A 368      73.920  96.055  71.517  1.00 51.39           N  
+ATOM   2844  CA  ASP A 368      74.435  95.100  70.546  1.00 51.39           C  
+ATOM   2845  C   ASP A 368      75.906  95.349  70.247  1.00 51.39           C  
+ATOM   2846  O   ASP A 368      76.642  94.404  69.946  1.00 51.39           O  
+ATOM   2847  CB  ASP A 368      73.611  95.156  69.261  1.00 51.39           C  
+ATOM   2848  CG  ASP A 368      72.206  94.618  69.448  1.00 51.39           C  
+ATOM   2849  OD1 ASP A 368      71.795  94.415  70.610  1.00 51.39           O  
+ATOM   2850  OD2 ASP A 368      71.513  94.392  68.434  1.00 51.39           O  
+ATOM   2851  N   PHE A 369      76.354  96.603  70.345  1.00 45.92           N  
+ATOM   2852  CA  PHE A 369      77.771  96.903  70.165  1.00 45.92           C  
+ATOM   2853  C   PHE A 369      78.620  96.204  71.220  1.00 45.92           C  
+ATOM   2854  O   PHE A 369      79.733  95.751  70.932  1.00 45.92           O  
+ATOM   2855  CB  PHE A 369      77.987  98.416  70.208  1.00 45.92           C  
+ATOM   2856  CG  PHE A 369      79.429  98.831  70.138  1.00 45.92           C  
+ATOM   2857  CD1 PHE A 369      80.115  98.797  68.938  1.00 45.92           C  
+ATOM   2858  CD2 PHE A 369      80.094  99.268  71.271  1.00 45.92           C  
+ATOM   2859  CE1 PHE A 369      81.439  99.183  68.871  1.00 45.92           C  
+ATOM   2860  CE2 PHE A 369      81.417  99.654  71.209  1.00 45.92           C  
+ATOM   2861  CZ  PHE A 369      82.090  99.612  70.008  1.00 45.92           C  
+ATOM   2862  N   LEU A 370      78.108  96.102  72.448  1.00 42.94           N  
+ATOM   2863  CA  LEU A 370      78.841  95.409  73.505  1.00 42.94           C  
+ATOM   2864  C   LEU A 370      78.659  93.897  73.420  1.00 42.94           C  
+ATOM   2865  O   LEU A 370      79.590  93.136  73.719  1.00 42.94           O  
+ATOM   2866  CB  LEU A 370      78.396  95.921  74.875  1.00 42.94           C  
+ATOM   2867  CG  LEU A 370      78.521  97.424  75.117  1.00 42.94           C  
+ATOM   2868  CD1 LEU A 370      78.298  97.746  76.584  1.00 42.94           C  
+ATOM   2869  CD2 LEU A 370      79.874  97.934  74.653  1.00 42.94           C  
+ATOM   2870  N   THR A 371      77.465  93.442  73.033  1.00 40.48           N  
+ATOM   2871  CA  THR A 371      77.242  92.011  72.860  1.00 40.48           C  
+ATOM   2872  C   THR A 371      78.123  91.447  71.754  1.00 40.48           C  
+ATOM   2873  O   THR A 371      78.572  90.297  71.841  1.00 40.48           O  
+ATOM   2874  CB  THR A 371      75.765  91.745  72.564  1.00 40.48           C  
+ATOM   2875  OG1 THR A 371      74.971  92.199  73.666  1.00 40.48           O  
+ATOM   2876  CG2 THR A 371      75.515  90.261  72.359  1.00 40.48           C  
+ATOM   2877  N   ALA A 372      78.394  92.243  70.718  1.00 36.38           N  
+ATOM   2878  CA  ALA A 372      79.331  91.816  69.687  1.00 36.38           C  
+ATOM   2879  C   ALA A 372      80.712  91.571  70.276  1.00 36.38           C  
+ATOM   2880  O   ALA A 372      81.353  90.565  69.963  1.00 36.38           O  
+ATOM   2881  CB  ALA A 372      79.398  92.856  68.571  1.00 36.38           C  
+ATOM   2882  N   HIS A 373      81.180  92.471  71.142  1.00 37.84           N  
+ATOM   2883  CA  HIS A 373      82.482  92.282  71.775  1.00 37.84           C  
+ATOM   2884  C   HIS A 373      82.481  91.056  72.681  1.00 37.84           C  
+ATOM   2885  O   HIS A 373      83.468  90.316  72.733  1.00 37.84           O  
+ATOM   2886  CB  HIS A 373      82.868  93.532  72.561  1.00 37.84           C  
+ATOM   2887  CG  HIS A 373      83.396  94.643  71.706  1.00 37.84           C  
+ATOM   2888  ND1 HIS A 373      82.589  95.391  70.877  1.00 37.84           N  
+ATOM   2889  CD2 HIS A 373      84.649  95.129  71.550  1.00 37.84           C  
+ATOM   2890  CE1 HIS A 373      83.323  96.290  70.247  1.00 37.84           C  
+ATOM   2891  NE2 HIS A 373      84.577  96.153  70.638  1.00 37.84           N  
+ATOM   2892  N   HIS A 374      81.378  90.825  73.392  1.00 29.96           N  
+ATOM   2893  CA  HIS A 374      81.265  89.639  74.238  1.00 29.96           C  
+ATOM   2894  C   HIS A 374      81.385  88.358  73.413  1.00 29.96           C  
+ATOM   2895  O   HIS A 374      82.158  87.448  73.749  1.00 29.96           O  
+ATOM   2896  CB  HIS A 374      79.936  89.677  74.993  1.00 29.96           C  
+ATOM   2897  CG  HIS A 374      79.764  88.570  75.985  1.00 29.96           C  
+ATOM   2898  ND1 HIS A 374      79.832  88.775  77.346  1.00 29.96           N  
+ATOM   2899  CD2 HIS A 374      79.507  87.252  75.816  1.00 29.96           C  
+ATOM   2900  CE1 HIS A 374      79.635  87.629  77.972  1.00 29.96           C  
+ATOM   2901  NE2 HIS A 374      79.437  86.690  77.067  1.00 29.96           N  
+ATOM   2902  N   GLU A 375      80.625  88.273  72.320  1.00 36.24           N  
+ATOM   2903  CA  GLU A 375      80.656  87.067  71.500  1.00 36.24           C  
+ATOM   2904  C   GLU A 375      81.995  86.914  70.789  1.00 36.24           C  
+ATOM   2905  O   GLU A 375      82.472  85.793  70.588  1.00 36.24           O  
+ATOM   2906  CB  GLU A 375      79.506  87.081  70.496  1.00 36.24           C  
+ATOM   2907  CG  GLU A 375      78.134  87.231  71.134  1.00 36.24           C  
+ATOM   2908  CD  GLU A 375      77.872  86.204  72.219  1.00 36.24           C  
+ATOM   2909  OE1 GLU A 375      78.262  85.032  72.041  1.00 36.24           O  
+ATOM   2910  OE2 GLU A 375      77.275  86.570  73.252  1.00 36.24           O  
+ATOM   2911  N   MET A 376      82.627  88.026  70.413  1.00 35.98           N  
+ATOM   2912  CA  MET A 376      83.954  87.936  69.818  1.00 35.98           C  
+ATOM   2913  C   MET A 376      84.984  87.469  70.835  1.00 35.98           C  
+ATOM   2914  O   MET A 376      85.928  86.763  70.473  1.00 35.98           O  
+ATOM   2915  CB  MET A 376      84.361  89.279  69.217  1.00 35.98           C  
+ATOM   2916  CG  MET A 376      83.523  89.700  68.023  1.00 35.98           C  
+ATOM   2917  SD  MET A 376      84.104  89.026  66.461  1.00 35.98           S  
+ATOM   2918  CE  MET A 376      85.500  90.096  66.151  1.00 35.98           C  
+ATOM   2919  N   GLY A 377      84.817  87.836  72.106  1.00 28.93           N  
+ATOM   2920  CA  GLY A 377      85.684  87.291  73.137  1.00 28.93           C  
+ATOM   2921  C   GLY A 377      85.496  85.799  73.310  1.00 28.93           C  
+ATOM   2922  O   GLY A 377      86.470  85.051  73.457  1.00 28.93           O  
+ATOM   2923  N   HIS A 378      84.241  85.343  73.300  1.00 36.57           N  
+ATOM   2924  CA  HIS A 378      83.984  83.903  73.308  1.00 36.57           C  
+ATOM   2925  C   HIS A 378      84.660  83.213  72.128  1.00 36.57           C  
+ATOM   2926  O   HIS A 378      85.281  82.154  72.287  1.00 36.57           O  
+ATOM   2927  CB  HIS A 378      82.482  83.629  73.284  1.00 36.57           C  
+ATOM   2928  CG  HIS A 378      81.844  83.618  74.636  1.00 36.57           C  
+ATOM   2929  ND1 HIS A 378      82.043  82.602  75.544  1.00 36.57           N  
+ATOM   2930  CD2 HIS A 378      80.996  84.493  75.228  1.00 36.57           C  
+ATOM   2931  CE1 HIS A 378      81.353  82.856  76.642  1.00 36.57           C  
+ATOM   2932  NE2 HIS A 378      80.709  83.995  76.475  1.00 36.57           N  
+ATOM   2933  N   ILE A 379      84.551  83.800  70.935  1.00 34.31           N  
+ATOM   2934  CA  ILE A 379      85.127  83.182  69.743  1.00 34.31           C  
+ATOM   2935  C   ILE A 379      86.649  83.181  69.817  1.00 34.31           C  
+ATOM   2936  O   ILE A 379      87.303  82.233  69.373  1.00 34.31           O  
+ATOM   2937  CB  ILE A 379      84.613  83.892  68.478  1.00 34.31           C  
+ATOM   2938  CG1 ILE A 379      83.132  83.582  68.270  1.00 34.31           C  
+ATOM   2939  CG2 ILE A 379      85.404  83.465  67.255  1.00 34.31           C  
+ATOM   2940  CD1 ILE A 379      82.866  82.144  67.904  1.00 34.31           C  
+ATOM   2941  N   GLN A 380      87.239  84.233  70.386  1.00 35.88           N  
+ATOM   2942  CA  GLN A 380      88.689  84.269  70.543  1.00 35.88           C  
+ATOM   2943  C   GLN A 380      89.157  83.206  71.527  1.00 35.88           C  
+ATOM   2944  O   GLN A 380      90.182  82.548  71.305  1.00 35.88           O  
+ATOM   2945  CB  GLN A 380      89.133  85.657  70.999  1.00 35.88           C  
+ATOM   2946  CG  GLN A 380      89.198  86.682  69.884  1.00 35.88           C  
+ATOM   2947  CD  GLN A 380      90.430  86.522  69.021  1.00 35.88           C  
+ATOM   2948  OE1 GLN A 380      91.376  85.829  69.393  1.00 35.88           O  
+ATOM   2949  NE2 GLN A 380      90.428  87.166  67.860  1.00 35.88           N  
+ATOM   2950  N   TYR A 381      88.415  83.019  72.619  1.00 30.08           N  
+ATOM   2951  CA  TYR A 381      88.764  81.963  73.562  1.00 30.08           C  
+ATOM   2952  C   TYR A 381      88.621  80.588  72.921  1.00 30.08           C  
+ATOM   2953  O   TYR A 381      89.420  79.685  73.192  1.00 30.08           O  
+ATOM   2954  CB  TYR A 381      87.904  82.081  74.820  1.00 30.08           C  
+ATOM   2955  CG  TYR A 381      88.375  81.222  75.971  1.00 30.08           C  
+ATOM   2956  CD1 TYR A 381      89.715  81.157  76.305  1.00 30.08           C  
+ATOM   2957  CD2 TYR A 381      87.475  80.520  76.754  1.00 30.08           C  
+ATOM   2958  CE1 TYR A 381      90.151  80.389  77.362  1.00 30.08           C  
+ATOM   2959  CE2 TYR A 381      87.903  79.749  77.816  1.00 30.08           C  
+ATOM   2960  CZ  TYR A 381      89.243  79.689  78.115  1.00 30.08           C  
+ATOM   2961  OH  TYR A 381      89.682  78.927  79.171  1.00 30.08           O  
+ATOM   2962  N   ASP A 382      87.621  80.418  72.054  1.00 42.07           N  
+ATOM   2963  CA  ASP A 382      87.486  79.162  71.321  1.00 42.07           C  
+ATOM   2964  C   ASP A 382      88.657  78.945  70.370  1.00 42.07           C  
+ATOM   2965  O   ASP A 382      89.175  77.828  70.253  1.00 42.07           O  
+ATOM   2966  CB  ASP A 382      86.166  79.141  70.551  1.00 42.07           C  
+ATOM   2967  CG  ASP A 382      84.964  79.031  71.461  1.00 42.07           C  
+ATOM   2968  OD1 ASP A 382      85.106  78.455  72.557  1.00 42.07           O  
+ATOM   2969  OD2 ASP A 382      83.878  79.519  71.084  1.00 42.07           O  
+ATOM   2970  N   MET A 383      89.083  80.002  69.678  1.00 35.95           N  
+ATOM   2971  CA  MET A 383      90.202  79.886  68.749  1.00 35.95           C  
+ATOM   2972  C   MET A 383      91.515  79.657  69.480  1.00 35.95           C  
+ATOM   2973  O   MET A 383      92.472  79.141  68.890  1.00 35.95           O  
+ATOM   2974  CB  MET A 383      90.306  81.145  67.888  1.00 35.95           C  
+ATOM   2975  CG  MET A 383      89.142  81.367  66.945  1.00 35.95           C  
+ATOM   2976  SD  MET A 383      89.143  83.022  66.233  1.00 35.95           S  
+ATOM   2977  CE  MET A 383      90.820  83.123  65.618  1.00 35.95           C  
+ATOM   2978  N   ALA A 384      91.583  80.038  70.757  1.00 35.87           N  
+ATOM   2979  CA  ALA A 384      92.844  79.962  71.485  1.00 35.87           C  
+ATOM   2980  C   ALA A 384      93.289  78.520  71.697  1.00 35.87           C  
+ATOM   2981  O   ALA A 384      94.441  78.172  71.417  1.00 35.87           O  
+ATOM   2982  CB  ALA A 384      92.714  80.680  72.823  1.00 35.87           C  
+ATOM   2983  N   TYR A 385      92.395  77.665  72.195  1.00 51.98           N  
+ATOM   2984  CA  TYR A 385      92.754  76.300  72.555  1.00 51.98           C  
+ATOM   2985  C   TYR A 385      92.348  75.281  71.496  1.00 51.98           C  
+ATOM   2986  O   TYR A 385      92.136  74.109  71.821  1.00 51.98           O  
+ATOM   2987  CB  TYR A 385      92.151  75.928  73.912  1.00 51.98           C  
+ATOM   2988  CG  TYR A 385      90.660  76.145  74.045  1.00 51.98           C  
+ATOM   2989  CD1 TYR A 385      90.155  77.093  74.920  1.00 51.98           C  
+ATOM   2990  CD2 TYR A 385      89.757  75.380  73.321  1.00 51.98           C  
+ATOM   2991  CE1 TYR A 385      88.796  77.284  75.056  1.00 51.98           C  
+ATOM   2992  CE2 TYR A 385      88.400  75.567  73.448  1.00 51.98           C  
+ATOM   2993  CZ  TYR A 385      87.924  76.519  74.316  1.00 51.98           C  
+ATOM   2994  OH  TYR A 385      86.568  76.698  74.441  1.00 51.98           O  
+ATOM   2995  N   ALA A 386      92.241  75.700  70.234  1.00 41.37           N  
+ATOM   2996  CA  ALA A 386      91.914  74.758  69.169  1.00 41.37           C  
+ATOM   2997  C   ALA A 386      92.983  73.688  68.998  1.00 41.37           C  
+ATOM   2998  O   ALA A 386      92.689  72.615  68.460  1.00 41.37           O  
+ATOM   2999  CB  ALA A 386      91.709  75.505  67.852  1.00 41.37           C  
+ATOM   3000  N   ALA A 387      94.214  73.951  69.442  1.00 31.94           N  
+ATOM   3001  CA  ALA A 387      95.288  72.973  69.334  1.00 31.94           C  
+ATOM   3002  C   ALA A 387      95.188  71.867  70.373  1.00 31.94           C  
+ATOM   3003  O   ALA A 387      95.925  70.880  70.272  1.00 31.94           O  
+ATOM   3004  CB  ALA A 387      96.643  73.669  69.456  1.00 31.94           C  
+ATOM   3005  N   GLN A 388      94.311  72.005  71.362  1.00 34.13           N  
+ATOM   3006  CA  GLN A 388      94.148  70.978  72.377  1.00 34.13           C  
+ATOM   3007  C   GLN A 388      93.349  69.801  71.819  1.00 34.13           C  
+ATOM   3008  O   GLN A 388      92.580  69.962  70.868  1.00 34.13           O  
+ATOM   3009  CB  GLN A 388      93.437  71.550  73.599  1.00 34.13           C  
+ATOM   3010  CG  GLN A 388      94.094  72.789  74.176  1.00 34.13           C  
+ATOM   3011  CD  GLN A 388      95.420  72.493  74.843  1.00 34.13           C  
+ATOM   3012  OE1 GLN A 388      95.569  71.485  75.533  1.00 34.13           O  
+ATOM   3013  NE2 GLN A 388      96.394  73.369  74.637  1.00 34.13           N  
+ATOM   3014  N   PRO A 389      93.522  68.606  72.384  1.00 34.71           N  
+ATOM   3015  CA  PRO A 389      92.715  67.463  71.946  1.00 34.71           C  
+ATOM   3016  C   PRO A 389      91.231  67.706  72.174  1.00 34.71           C  
+ATOM   3017  O   PRO A 389      90.825  68.620  72.894  1.00 34.71           O  
+ATOM   3018  CB  PRO A 389      93.233  66.305  72.808  1.00 34.71           C  
+ATOM   3019  CG  PRO A 389      93.991  66.947  73.922  1.00 34.71           C  
+ATOM   3020  CD  PRO A 389      94.547  68.212  73.363  1.00 34.71           C  
+ATOM   3021  N   PHE A 390      90.415  66.856  71.542  1.00 40.95           N  
+ATOM   3022  CA  PHE A 390      88.976  67.097  71.486  1.00 40.95           C  
+ATOM   3023  C   PHE A 390      88.362  67.207  72.875  1.00 40.95           C  
+ATOM   3024  O   PHE A 390      87.500  68.058  73.114  1.00 40.95           O  
+ATOM   3025  CB  PHE A 390      88.290  65.990  70.688  1.00 40.95           C  
+ATOM   3026  CG  PHE A 390      86.823  66.218  70.478  1.00 40.95           C  
+ATOM   3027  CD1 PHE A 390      85.890  65.620  71.306  1.00 40.95           C  
+ATOM   3028  CD2 PHE A 390      86.377  67.035  69.456  1.00 40.95           C  
+ATOM   3029  CE1 PHE A 390      84.540  65.832  71.116  1.00 40.95           C  
+ATOM   3030  CE2 PHE A 390      85.028  67.251  69.261  1.00 40.95           C  
+ATOM   3031  CZ  PHE A 390      84.109  66.648  70.092  1.00 40.95           C  
+ATOM   3032  N   LEU A 391      88.786  66.353  73.805  1.00 36.73           N  
+ATOM   3033  CA  LEU A 391      88.218  66.380  75.145  1.00 36.73           C  
+ATOM   3034  C   LEU A 391      88.745  67.529  75.993  1.00 36.73           C  
+ATOM   3035  O   LEU A 391      88.141  67.840  77.024  1.00 36.73           O  
+ATOM   3036  CB  LEU A 391      88.483  65.053  75.856  1.00 36.73           C  
+ATOM   3037  CG  LEU A 391      87.630  63.879  75.379  1.00 36.73           C  
+ATOM   3038  CD1 LEU A 391      87.991  62.614  76.134  1.00 36.73           C  
+ATOM   3039  CD2 LEU A 391      86.151  64.192  75.524  1.00 36.73           C  
+ATOM   3040  N   LEU A 392      89.845  68.163  75.587  1.00 37.24           N  
+ATOM   3041  CA  LEU A 392      90.429  69.275  76.325  1.00 37.24           C  
+ATOM   3042  C   LEU A 392      90.165  70.617  75.652  1.00 37.24           C  
+ATOM   3043  O   LEU A 392      90.946  71.561  75.818  1.00 37.24           O  
+ATOM   3044  CB  LEU A 392      91.929  69.056  76.511  1.00 37.24           C  
+ATOM   3045  CG  LEU A 392      92.315  67.764  77.231  1.00 37.24           C  
+ATOM   3046  CD1 LEU A 392      93.807  67.722  77.503  1.00 37.24           C  
+ATOM   3047  CD2 LEU A 392      91.528  67.614  78.522  1.00 37.24           C  
+ATOM   3048  N   ARG A 393      89.080  70.719  74.884  1.00 37.23           N  
+ATOM   3049  CA  ARG A 393      88.695  71.968  74.233  1.00 37.23           C  
+ATOM   3050  C   ARG A 393      87.531  72.576  75.010  1.00 37.23           C  
+ATOM   3051  O   ARG A 393      86.362  72.435  74.654  1.00 37.23           O  
+ATOM   3052  CB  ARG A 393      88.340  71.725  72.771  1.00 37.23           C  
+ATOM   3053  CG  ARG A 393      89.535  71.421  71.897  1.00 37.23           C  
+ATOM   3054  CD  ARG A 393      89.338  71.956  70.496  1.00 37.23           C  
+ATOM   3055  NE  ARG A 393      88.472  71.094  69.699  1.00 37.23           N  
+ATOM   3056  CZ  ARG A 393      88.916  70.178  68.847  1.00 37.23           C  
+ATOM   3057  NH1 ARG A 393      90.219  70.002  68.683  1.00 37.23           N  
+ATOM   3058  NH2 ARG A 393      88.058  69.438  68.159  1.00 37.23           N  
+ATOM   3059  N   ASN A 394      87.873  73.275  76.087  1.00 39.71           N  
+ATOM   3060  CA  ASN A 394      86.892  73.953  76.925  1.00 39.71           C  
+ATOM   3061  C   ASN A 394      87.647  74.862  77.882  1.00 39.71           C  
+ATOM   3062  O   ASN A 394      88.877  74.818  77.970  1.00 39.71           O  
+ATOM   3063  CB  ASN A 394      86.015  72.958  77.689  1.00 39.71           C  
+ATOM   3064  CG  ASN A 394      84.666  73.536  78.058  1.00 39.71           C  
+ATOM   3065  OD1 ASN A 394      84.541  74.733  78.318  1.00 39.71           O  
+ATOM   3066  ND2 ASN A 394      83.646  72.688  78.082  1.00 39.71           N  
+ATOM   3067  N   GLY A 395      86.894  75.692  78.600  1.00 27.88           N  
+ATOM   3068  CA  GLY A 395      87.510  76.580  79.566  1.00 27.88           C  
+ATOM   3069  C   GLY A 395      88.157  75.814  80.703  1.00 27.88           C  
+ATOM   3070  O   GLY A 395      87.923  74.620  80.891  1.00 27.88           O  
+ATOM   3071  N   ALA A 396      88.998  76.519  81.465  1.00 34.24           N  
+ATOM   3072  CA  ALA A 396      89.658  75.895  82.608  1.00 34.24           C  
+ATOM   3073  C   ALA A 396      88.638  75.329  83.587  1.00 34.24           C  
+ATOM   3074  O   ALA A 396      88.826  74.234  84.129  1.00 34.24           O  
+ATOM   3075  CB  ALA A 396      90.573  76.903  83.300  1.00 34.24           C  
+ATOM   3076  N   ASN A 397      87.554  76.060  83.825  1.00 32.75           N  
+ATOM   3077  CA  ASN A 397      86.393  75.529  84.523  1.00 32.75           C  
+ATOM   3078  C   ASN A 397      85.153  76.142  83.880  1.00 32.75           C  
+ATOM   3079  O   ASN A 397      85.223  76.757  82.812  1.00 32.75           O  
+ATOM   3080  CB  ASN A 397      86.485  75.788  86.035  1.00 32.75           C  
+ATOM   3081  CG  ASN A 397      86.648  77.255  86.378  1.00 32.75           C  
+ATOM   3082  OD1 ASN A 397      85.944  78.114  85.852  1.00 32.75           O  
+ATOM   3083  ND2 ASN A 397      87.577  77.546  87.278  1.00 32.75           N  
+ATOM   3084  N   GLU A 398      84.005  75.980  84.536  1.00 34.83           N  
+ATOM   3085  CA  GLU A 398      82.754  76.463  83.966  1.00 34.83           C  
+ATOM   3086  C   GLU A 398      82.554  77.961  84.150  1.00 34.83           C  
+ATOM   3087  O   GLU A 398      81.429  78.440  83.978  1.00 34.83           O  
+ATOM   3088  CB  GLU A 398      81.576  75.704  84.577  1.00 34.83           C  
+ATOM   3089  CG  GLU A 398      81.603  75.635  86.091  1.00 34.83           C  
+ATOM   3090  CD  GLU A 398      80.436  74.854  86.657  1.00 34.83           C  
+ATOM   3091  OE1 GLU A 398      79.844  74.046  85.912  1.00 34.83           O  
+ATOM   3092  OE2 GLU A 398      80.107  75.050  87.845  1.00 34.83           O  
+ATOM   3093  N   GLY A 399      83.600  78.708  84.489  1.00 33.19           N  
+ATOM   3094  CA  GLY A 399      83.505  80.138  84.683  1.00 33.19           C  
+ATOM   3095  C   GLY A 399      84.532  80.972  83.951  1.00 33.19           C  
+ATOM   3096  O   GLY A 399      84.609  82.182  84.199  1.00 33.19           O  
+ATOM   3097  N   PHE A 400      85.320  80.380  83.056  1.00 51.98           N  
+ATOM   3098  CA  PHE A 400      86.363  81.120  82.355  1.00 51.98           C  
+ATOM   3099  C   PHE A 400      85.875  81.706  81.037  1.00 51.98           C  
+ATOM   3100  O   PHE A 400      86.256  82.828  80.683  1.00 51.98           O  
+ATOM   3101  CB  PHE A 400      87.572  80.216  82.105  1.00 51.98           C  
+ATOM   3102  CG  PHE A 400      88.554  80.188  83.240  1.00 51.98           C  
+ATOM   3103  CD1 PHE A 400      88.144  79.876  84.522  1.00 51.98           C  
+ATOM   3104  CD2 PHE A 400      89.891  80.468  83.023  1.00 51.98           C  
+ATOM   3105  CE1 PHE A 400      89.047  79.846  85.564  1.00 51.98           C  
+ATOM   3106  CE2 PHE A 400      90.796  80.438  84.064  1.00 51.98           C  
+ATOM   3107  CZ  PHE A 400      90.373  80.127  85.335  1.00 51.98           C  
+ATOM   3108  N   HIS A 401      85.045  80.966  80.299  1.00 38.36           N  
+ATOM   3109  CA  HIS A 401      84.480  81.484  79.056  1.00 38.36           C  
+ATOM   3110  C   HIS A 401      83.741  82.794  79.285  1.00 38.36           C  
+ATOM   3111  O   HIS A 401      84.014  83.801  78.620  1.00 38.36           O  
+ATOM   3112  CB  HIS A 401      83.540  80.453  78.436  1.00 38.36           C  
+ATOM   3113  CG  HIS A 401      84.196  79.565  77.430  1.00 38.36           C  
+ATOM   3114  ND1 HIS A 401      84.327  79.919  76.106  1.00 38.36           N  
+ATOM   3115  CD2 HIS A 401      84.753  78.337  77.550  1.00 38.36           C  
+ATOM   3116  CE1 HIS A 401      84.936  78.947  75.452  1.00 38.36           C  
+ATOM   3117  NE2 HIS A 401      85.208  77.977  76.305  1.00 38.36           N  
+ATOM   3118  N   GLU A 402      82.790  82.797  80.217  1.00 35.76           N  
+ATOM   3119  CA  GLU A 402      81.976  83.987  80.415  1.00 35.76           C  
+ATOM   3120  C   GLU A 402      82.788  85.136  80.998  1.00 35.76           C  
+ATOM   3121  O   GLU A 402      82.512  86.299  80.690  1.00 35.76           O  
+ATOM   3122  CB  GLU A 402      80.780  83.659  81.303  1.00 35.76           C  
+ATOM   3123  CG  GLU A 402      79.539  83.245  80.531  1.00 35.76           C  
+ATOM   3124  CD  GLU A 402      79.019  84.343  79.625  1.00 35.76           C  
+ATOM   3125  OE1 GLU A 402      79.137  84.204  78.390  1.00 35.76           O  
+ATOM   3126  OE2 GLU A 402      78.496  85.350  80.148  1.00 35.76           O  
+ATOM   3127  N   ALA A 403      83.804  84.844  81.811  1.00 27.16           N  
+ATOM   3128  CA  ALA A 403      84.656  85.910  82.332  1.00 27.16           C  
+ATOM   3129  C   ALA A 403      85.476  86.551  81.218  1.00 27.16           C  
+ATOM   3130  O   ALA A 403      85.585  87.785  81.138  1.00 27.16           O  
+ATOM   3131  CB  ALA A 403      85.569  85.364  83.428  1.00 27.16           C  
+ATOM   3132  N   VAL A 404      86.074  85.725  80.355  1.00 27.70           N  
+ATOM   3133  CA  VAL A 404      86.824  86.245  79.217  1.00 27.70           C  
+ATOM   3134  C   VAL A 404      85.907  87.017  78.281  1.00 27.70           C  
+ATOM   3135  O   VAL A 404      86.331  87.984  77.638  1.00 27.70           O  
+ATOM   3136  CB  VAL A 404      87.549  85.092  78.493  1.00 27.70           C  
+ATOM   3137  CG1 VAL A 404      88.151  85.563  77.184  1.00 27.70           C  
+ATOM   3138  CG2 VAL A 404      88.629  84.510  79.387  1.00 27.70           C  
+ATOM   3139  N   GLY A 405      84.637  86.624  78.200  1.00 26.81           N  
+ATOM   3140  CA  GLY A 405      83.699  87.380  77.388  1.00 26.81           C  
+ATOM   3141  C   GLY A 405      83.317  88.708  78.016  1.00 26.81           C  
+ATOM   3142  O   GLY A 405      83.140  89.707  77.315  1.00 26.81           O  
+ATOM   3143  N   GLU A 406      83.189  88.738  79.344  1.00 28.05           N  
+ATOM   3144  CA  GLU A 406      82.708  89.941  80.015  1.00 28.05           C  
+ATOM   3145  C   GLU A 406      83.797  91.001  80.125  1.00 28.05           C  
+ATOM   3146  O   GLU A 406      83.501  92.201  80.118  1.00 28.05           O  
+ATOM   3147  CB  GLU A 406      82.166  89.590  81.401  1.00 28.05           C  
+ATOM   3148  CG  GLU A 406      80.846  88.839  81.390  1.00 28.05           C  
+ATOM   3149  CD  GLU A 406      79.647  89.755  81.259  1.00 28.05           C  
+ATOM   3150  OE1 GLU A 406      78.506  89.257  81.362  1.00 28.05           O  
+ATOM   3151  OE2 GLU A 406      79.841  90.971  81.057  1.00 28.05           O  
+ATOM   3152  N   ILE A 407      85.061  90.583  80.246  1.00 27.02           N  
+ATOM   3153  CA  ILE A 407      86.120  91.578  80.402  1.00 27.02           C  
+ATOM   3154  C   ILE A 407      86.261  92.434  79.145  1.00 27.02           C  
+ATOM   3155  O   ILE A 407      86.541  93.638  79.233  1.00 27.02           O  
+ATOM   3156  CB  ILE A 407      87.453  90.909  80.783  1.00 27.02           C  
+ATOM   3157  CG1 ILE A 407      87.846  89.842  79.763  1.00 27.02           C  
+ATOM   3158  CG2 ILE A 407      87.361  90.301  82.163  1.00 27.02           C  
+ATOM   3159  CD1 ILE A 407      89.260  89.340  79.929  1.00 27.02           C  
+ATOM   3160  N   MET A 408      86.054  91.847  77.964  1.00 30.22           N  
+ATOM   3161  CA  MET A 408      86.162  92.621  76.730  1.00 30.22           C  
+ATOM   3162  C   MET A 408      85.054  93.662  76.639  1.00 30.22           C  
+ATOM   3163  O   MET A 408      85.291  94.805  76.232  1.00 30.22           O  
+ATOM   3164  CB  MET A 408      86.130  91.688  75.520  1.00 30.22           C  
+ATOM   3165  CG  MET A 408      86.915  90.403  75.703  1.00 30.22           C  
+ATOM   3166  SD  MET A 408      88.534  90.651  76.453  1.00 30.22           S  
+ATOM   3167  CE  MET A 408      89.399  91.517  75.149  1.00 30.22           C  
+ATOM   3168  N   SER A 409      83.832  93.287  77.020  1.00 29.52           N  
+ATOM   3169  CA  SER A 409      82.743  94.257  77.033  1.00 29.52           C  
+ATOM   3170  C   SER A 409      82.997  95.350  78.062  1.00 29.52           C  
+ATOM   3171  O   SER A 409      82.680  96.522  77.823  1.00 29.52           O  
+ATOM   3172  CB  SER A 409      81.413  93.556  77.309  1.00 29.52           C  
+ATOM   3173  OG  SER A 409      81.166  93.465  78.701  1.00 29.52           O  
+ATOM   3174  N   LEU A 410      83.570  94.986  79.213  1.00 30.31           N  
+ATOM   3175  CA  LEU A 410      83.941  95.990  80.206  1.00 30.31           C  
+ATOM   3176  C   LEU A 410      84.930  96.990  79.623  1.00 30.31           C  
+ATOM   3177  O   LEU A 410      84.798  98.203  79.822  1.00 30.31           O  
+ATOM   3178  CB  LEU A 410      84.534  95.322  81.445  1.00 30.31           C  
+ATOM   3179  CG  LEU A 410      83.573  94.621  82.401  1.00 30.31           C  
+ATOM   3180  CD1 LEU A 410      84.242  94.406  83.748  1.00 30.31           C  
+ATOM   3181  CD2 LEU A 410      82.297  95.421  82.550  1.00 30.31           C  
+ATOM   3182  N   SER A 411      85.934  96.493  78.900  1.00 34.62           N  
+ATOM   3183  CA  SER A 411      86.920  97.388  78.304  1.00 34.62           C  
+ATOM   3184  C   SER A 411      86.296  98.252  77.217  1.00 34.62           C  
+ATOM   3185  O   SER A 411      86.690  99.409  77.032  1.00 34.62           O  
+ATOM   3186  CB  SER A 411      88.084  96.586  77.731  1.00 34.62           C  
+ATOM   3187  OG  SER A 411      87.827  96.216  76.390  1.00 34.62           O  
+ATOM   3188  N   ALA A 412      85.329  97.707  76.479  1.00 32.42           N  
+ATOM   3189  CA  ALA A 412      84.738  98.460  75.378  1.00 32.42           C  
+ATOM   3190  C   ALA A 412      83.740  99.502  75.867  1.00 32.42           C  
+ATOM   3191  O   ALA A 412      83.498 100.496  75.175  1.00 32.42           O  
+ATOM   3192  CB  ALA A 412      84.066  97.507  74.390  1.00 32.42           C  
+ATOM   3193  N   ALA A 413      83.155  99.300  77.048  1.00 40.02           N  
+ATOM   3194  CA  ALA A 413      82.107 100.189  77.535  1.00 40.02           C  
+ATOM   3195  C   ALA A 413      82.630 101.493  78.126  1.00 40.02           C  
+ATOM   3196  O   ALA A 413      81.819 102.344  78.506  1.00 40.02           O  
+ATOM   3197  CB  ALA A 413      81.255  99.466  78.581  1.00 40.02           C  
+ATOM   3198  N   THR A 414      83.944 101.678  78.213  1.00 46.56           N  
+ATOM   3199  CA  THR A 414      84.472 102.886  78.832  1.00 46.56           C  
+ATOM   3200  C   THR A 414      84.321 104.076  77.885  1.00 46.56           C  
+ATOM   3201  O   THR A 414      84.377 103.909  76.662  1.00 46.56           O  
+ATOM   3202  CB  THR A 414      85.944 102.710  79.211  1.00 46.56           C  
+ATOM   3203  OG1 THR A 414      86.453 103.939  79.741  1.00 46.56           O  
+ATOM   3204  CG2 THR A 414      86.764 102.334  77.998  1.00 46.56           C  
+ATOM   3205  N   PRO A 415      84.112 105.283  78.415  1.00 50.19           N  
+ATOM   3206  CA  PRO A 415      84.039 106.460  77.535  1.00 50.19           C  
+ATOM   3207  C   PRO A 415      85.327 106.730  76.779  1.00 50.19           C  
+ATOM   3208  O   PRO A 415      85.288 107.365  75.719  1.00 50.19           O  
+ATOM   3209  CB  PRO A 415      83.705 107.602  78.506  1.00 50.19           C  
+ATOM   3210  CG  PRO A 415      83.069 106.932  79.675  1.00 50.19           C  
+ATOM   3211  CD  PRO A 415      83.758 105.609  79.806  1.00 50.19           C  
+ATOM   3212  N   LYS A 416      86.470 106.267  77.290  1.00 48.01           N  
+ATOM   3213  CA  LYS A 416      87.730 106.475  76.584  1.00 48.01           C  
+ATOM   3214  C   LYS A 416      87.748 105.727  75.256  1.00 48.01           C  
+ATOM   3215  O   LYS A 416      88.155 106.281  74.227  1.00 48.01           O  
+ATOM   3216  CB  LYS A 416      88.899 106.037  77.465  1.00 48.01           C  
+ATOM   3217  CG  LYS A 416      90.261 106.210  76.819  1.00 48.01           C  
+ATOM   3218  CD  LYS A 416      91.329 105.432  77.567  1.00 48.01           C  
+ATOM   3219  CE  LYS A 416      91.386 105.834  79.030  1.00 48.01           C  
+ATOM   3220  NZ  LYS A 416      92.428 105.071  79.771  1.00 48.01           N  
+ATOM   3221  N   HIS A 417      87.307 104.468  75.256  1.00 45.28           N  
+ATOM   3222  CA  HIS A 417      87.272 103.701  74.015  1.00 45.28           C  
+ATOM   3223  C   HIS A 417      86.259 104.281  73.039  1.00 45.28           C  
+ATOM   3224  O   HIS A 417      86.492 104.289  71.825  1.00 45.28           O  
+ATOM   3225  CB  HIS A 417      86.951 102.237  74.310  1.00 45.28           C  
+ATOM   3226  CG  HIS A 417      87.183 101.323  73.149  1.00 45.28           C  
+ATOM   3227  ND1 HIS A 417      88.392 101.245  72.494  1.00 45.28           N  
+ATOM   3228  CD2 HIS A 417      86.362 100.442  72.530  1.00 45.28           C  
+ATOM   3229  CE1 HIS A 417      88.306 100.359  71.518  1.00 45.28           C  
+ATOM   3230  NE2 HIS A 417      87.084  99.856  71.519  1.00 45.28           N  
+ATOM   3231  N   LEU A 418      85.129 104.770  73.551  1.00 50.57           N  
+ATOM   3232  CA  LEU A 418      84.137 105.395  72.685  1.00 50.57           C  
+ATOM   3233  C   LEU A 418      84.673 106.688  72.083  1.00 50.57           C  
+ATOM   3234  O   LEU A 418      84.343 107.035  70.944  1.00 50.57           O  
+ATOM   3235  CB  LEU A 418      82.852 105.651  73.470  1.00 50.57           C  
+ATOM   3236  CG  LEU A 418      82.238 104.409  74.117  1.00 50.57           C  
+ATOM   3237  CD1 LEU A 418      81.071 104.782  75.009  1.00 50.57           C  
+ATOM   3238  CD2 LEU A 418      81.802 103.419  73.053  1.00 50.57           C  
+ATOM   3239  N   LYS A 419      85.504 107.412  72.835  1.00 57.01           N  
+ATOM   3240  CA  LYS A 419      86.150 108.600  72.288  1.00 57.01           C  
+ATOM   3241  C   LYS A 419      87.182 108.227  71.233  1.00 57.01           C  
+ATOM   3242  O   LYS A 419      87.347 108.938  70.236  1.00 57.01           O  
+ATOM   3243  CB  LYS A 419      86.809 109.406  73.406  1.00 57.01           C  
+ATOM   3244  CG  LYS A 419      85.855 110.262  74.219  1.00 57.01           C  
+ATOM   3245  CD  LYS A 419      86.624 111.219  75.112  1.00 57.01           C  
+ATOM   3246  CE  LYS A 419      85.688 112.078  75.940  1.00 57.01           C  
+ATOM   3247  NZ  LYS A 419      86.433 113.064  76.770  1.00 57.01           N  
+ATOM   3248  N   SER A 420      87.890 107.114  71.438  1.00 50.99           N  
+ATOM   3249  CA  SER A 420      88.948 106.736  70.507  1.00 50.99           C  
+ATOM   3250  C   SER A 420      88.380 106.299  69.162  1.00 50.99           C  
+ATOM   3251  O   SER A 420      88.933 106.638  68.109  1.00 50.99           O  
+ATOM   3252  CB  SER A 420      89.808 105.627  71.110  1.00 50.99           C  
+ATOM   3253  OG  SER A 420      90.920 105.347  70.279  1.00 50.99           O  
+ATOM   3254  N   ILE A 421      87.275 105.546  69.173  1.00 51.83           N  
+ATOM   3255  CA  ILE A 421      86.679 105.060  67.932  1.00 51.83           C  
+ATOM   3256  C   ILE A 421      85.758 106.082  67.284  1.00 51.83           C  
+ATOM   3257  O   ILE A 421      85.107 105.766  66.279  1.00 51.83           O  
+ATOM   3258  CB  ILE A 421      85.908 103.744  68.163  1.00 51.83           C  
+ATOM   3259  CG1 ILE A 421      84.763 103.959  69.152  1.00 51.83           C  
+ATOM   3260  CG2 ILE A 421      86.846 102.656  68.653  1.00 51.83           C  
+ATOM   3261  CD1 ILE A 421      84.043 102.686  69.533  1.00 51.83           C  
+ATOM   3262  N   GLY A 422      85.678 107.297  67.824  1.00 56.80           N  
+ATOM   3263  CA  GLY A 422      84.884 108.350  67.236  1.00 56.80           C  
+ATOM   3264  C   GLY A 422      83.440 108.401  67.682  1.00 56.80           C  
+ATOM   3265  O   GLY A 422      82.767 109.409  67.426  1.00 56.80           O  
+ATOM   3266  N   LEU A 423      82.941 107.361  68.344  1.00 59.16           N  
+ATOM   3267  CA  LEU A 423      81.549 107.326  68.772  1.00 59.16           C  
+ATOM   3268  C   LEU A 423      81.245 108.306  69.896  1.00 59.16           C  
+ATOM   3269  O   LEU A 423      80.072 108.478  70.244  1.00 59.16           O  
+ATOM   3270  CB  LEU A 423      81.171 105.907  69.206  1.00 59.16           C  
+ATOM   3271  CG  LEU A 423      81.209 104.850  68.102  1.00 59.16           C  
+ATOM   3272  CD1 LEU A 423      80.606 103.546  68.588  1.00 59.16           C  
+ATOM   3273  CD2 LEU A 423      80.487 105.349  66.863  1.00 59.16           C  
+ATOM   3274  N   LEU A 424      82.260 108.945  70.473  1.00 63.94           N  
+ATOM   3275  CA  LEU A 424      82.073 109.960  71.499  1.00 63.94           C  
+ATOM   3276  C   LEU A 424      82.878 111.192  71.115  1.00 63.94           C  
+ATOM   3277  O   LEU A 424      84.062 111.084  70.783  1.00 63.94           O  
+ATOM   3278  CB  LEU A 424      82.502 109.445  72.877  1.00 63.94           C  
+ATOM   3279  CG  LEU A 424      81.685 109.938  74.074  1.00 63.94           C  
+ATOM   3280  CD1 LEU A 424      80.244 109.460  73.978  1.00 63.94           C  
+ATOM   3281  CD2 LEU A 424      82.314 109.481  75.380  1.00 63.94           C  
+ATOM   3282  N   SER A 425      82.234 112.356  71.153  1.00 77.33           N  
+ATOM   3283  CA  SER A 425      82.905 113.588  70.779  1.00 77.33           C  
+ATOM   3284  C   SER A 425      83.996 113.930  71.793  1.00 77.33           C  
+ATOM   3285  O   SER A 425      83.854 113.653  72.987  1.00 77.33           O  
+ATOM   3286  CB  SER A 425      81.905 114.737  70.686  1.00 77.33           C  
+ATOM   3287  OG  SER A 425      81.733 115.364  71.945  1.00 77.33           O  
+ATOM   3288  N   PRO A 426      85.100 114.528  71.340  1.00 82.15           N  
+ATOM   3289  CA  PRO A 426      86.174 114.883  72.282  1.00 82.15           C  
+ATOM   3290  C   PRO A 426      85.745 115.894  73.330  1.00 82.15           C  
+ATOM   3291  O   PRO A 426      86.365 115.966  74.399  1.00 82.15           O  
+ATOM   3292  CB  PRO A 426      87.270 115.448  71.367  1.00 82.15           C  
+ATOM   3293  CG  PRO A 426      86.957 114.909  70.008  1.00 82.15           C  
+ATOM   3294  CD  PRO A 426      85.466 114.826  69.946  1.00 82.15           C  
+ATOM   3295  N   ASP A 427      84.701 116.675  73.060  1.00 87.88           N  
+ATOM   3296  CA  ASP A 427      84.202 117.668  74.002  1.00 87.88           C  
+ATOM   3297  C   ASP A 427      83.375 117.058  75.127  1.00 87.88           C  
+ATOM   3298  O   ASP A 427      82.785 117.805  75.916  1.00 87.88           O  
+ATOM   3299  CB  ASP A 427      83.374 118.722  73.261  1.00 87.88           C  
+ATOM   3300  CG  ASP A 427      84.057 119.216  72.001  1.00 87.88           C  
+ATOM   3301  OD1 ASP A 427      85.305 119.254  71.977  1.00 87.88           O  
+ATOM   3302  OD2 ASP A 427      83.347 119.564  71.035  1.00 87.88           O  
+ATOM   3303  N   PHE A 428      83.314 115.731  75.218  1.00 78.17           N  
+ATOM   3304  CA  PHE A 428      82.593 115.088  76.306  1.00 78.17           C  
+ATOM   3305  C   PHE A 428      83.345 115.276  77.617  1.00 78.17           C  
+ATOM   3306  O   PHE A 428      84.556 115.053  77.696  1.00 78.17           O  
+ATOM   3307  CB  PHE A 428      82.405 113.602  76.008  1.00 78.17           C  
+ATOM   3308  CG  PHE A 428      81.446 112.912  76.935  1.00 78.17           C  
+ATOM   3309  CD1 PHE A 428      80.079 113.025  76.747  1.00 78.17           C  
+ATOM   3310  CD2 PHE A 428      81.911 112.142  77.988  1.00 78.17           C  
+ATOM   3311  CE1 PHE A 428      79.194 112.388  77.595  1.00 78.17           C  
+ATOM   3312  CE2 PHE A 428      81.032 111.504  78.839  1.00 78.17           C  
+ATOM   3313  CZ  PHE A 428      79.671 111.626  78.643  1.00 78.17           C  
+ATOM   3314  N   GLN A 429      82.617 115.686  78.652  1.00 85.20           N  
+ATOM   3315  CA  GLN A 429      83.203 116.019  79.948  1.00 85.20           C  
+ATOM   3316  C   GLN A 429      82.960 114.856  80.905  1.00 85.20           C  
+ATOM   3317  O   GLN A 429      81.904 114.766  81.535  1.00 85.20           O  
+ATOM   3318  CB  GLN A 429      82.615 117.318  80.489  1.00 85.20           C  
+ATOM   3319  CG  GLN A 429      82.729 118.496  79.535  1.00 85.20           C  
+ATOM   3320  CD  GLN A 429      84.166 118.915  79.294  1.00 85.20           C  
+ATOM   3321  OE1 GLN A 429      84.980 118.942  80.217  1.00 85.20           O  
+ATOM   3322  NE2 GLN A 429      84.485 119.246  78.048  1.00 85.20           N  
+ATOM   3323  N   GLU A 430      83.945 113.968  81.011  1.00 77.55           N  
+ATOM   3324  CA  GLU A 430      83.862 112.871  81.965  1.00 77.55           C  
+ATOM   3325  C   GLU A 430      84.071 113.397  83.379  1.00 77.55           C  
+ATOM   3326  O   GLU A 430      85.180 113.796  83.747  1.00 77.55           O  
+ATOM   3327  CB  GLU A 430      84.906 111.805  81.638  1.00 77.55           C  
+ATOM   3328  CG  GLU A 430      84.719 111.135  80.287  1.00 77.55           C  
+ATOM   3329  CD  GLU A 430      85.943 110.350  79.851  1.00 77.55           C  
+ATOM   3330  OE1 GLU A 430      86.489 110.650  78.769  1.00 77.55           O  
+ATOM   3331  OE2 GLU A 430      86.362 109.438  80.593  1.00 77.55           O  
+ATOM   3332  N   ASP A 431      83.004 113.397  84.176  1.00 74.45           N  
+ATOM   3333  CA  ASP A 431      83.063 113.904  85.537  1.00 74.45           C  
+ATOM   3334  C   ASP A 431      82.640 112.808  86.505  1.00 74.45           C  
+ATOM   3335  O   ASP A 431      82.339 111.680  86.110  1.00 74.45           O  
+ATOM   3336  CB  ASP A 431      82.189 115.154  85.714  1.00 74.45           C  
+ATOM   3337  CG  ASP A 431      80.752 114.927  85.291  1.00 74.45           C  
+ATOM   3338  OD1 ASP A 431      80.453 113.844  84.751  1.00 74.45           O  
+ATOM   3339  OD2 ASP A 431      79.920 115.835  85.499  1.00 74.45           O  
+ATOM   3340  N   ASN A 432      82.618 113.162  87.792  1.00 71.50           N  
+ATOM   3341  CA  ASN A 432      82.330 112.174  88.827  1.00 71.50           C  
+ATOM   3342  C   ASN A 432      80.887 111.692  88.754  1.00 71.50           C  
+ATOM   3343  O   ASN A 432      80.569 110.594  89.221  1.00 71.50           O  
+ATOM   3344  CB  ASN A 432      82.626 112.764  90.205  1.00 71.50           C  
+ATOM   3345  CG  ASN A 432      84.014 113.362  90.296  1.00 71.50           C  
+ATOM   3346  OD1 ASN A 432      84.970 112.829  89.733  1.00 71.50           O  
+ATOM   3347  ND2 ASN A 432      84.131 114.480  91.004  1.00 71.50           N  
+ATOM   3348  N   GLU A 433      80.000 112.493  88.164  1.00 67.66           N  
+ATOM   3349  CA  GLU A 433      78.581 112.155  88.171  1.00 67.66           C  
+ATOM   3350  C   GLU A 433      78.278 111.010  87.210  1.00 67.66           C  
+ATOM   3351  O   GLU A 433      77.641 110.019  87.590  1.00 67.66           O  
+ATOM   3352  CB  GLU A 433      77.755 113.395  87.836  1.00 67.66           C  
+ATOM   3353  CG  GLU A 433      77.951 114.522  88.840  1.00 67.66           C  
+ATOM   3354  CD  GLU A 433      77.024 115.694  88.604  1.00 67.66           C  
+ATOM   3355  OE1 GLU A 433      76.321 115.701  87.574  1.00 67.66           O  
+ATOM   3356  OE2 GLU A 433      76.994 116.608  89.455  1.00 67.66           O  
+ATOM   3357  N   THR A 434      78.724 111.126  85.956  1.00 66.19           N  
+ATOM   3358  CA  THR A 434      78.566 110.019  85.021  1.00 66.19           C  
+ATOM   3359  C   THR A 434      79.344 108.793  85.476  1.00 66.19           C  
+ATOM   3360  O   THR A 434      78.898 107.661  85.255  1.00 66.19           O  
+ATOM   3361  CB  THR A 434      79.010 110.430  83.618  1.00 66.19           C  
+ATOM   3362  OG1 THR A 434      80.440 110.406  83.539  1.00 66.19           O  
+ATOM   3363  CG2 THR A 434      78.502 111.823  83.281  1.00 66.19           C  
+ATOM   3364  N   GLU A 435      80.494 108.995  86.121  1.00 59.84           N  
+ATOM   3365  CA  GLU A 435      81.250 107.865  86.651  1.00 59.84           C  
+ATOM   3366  C   GLU A 435      80.455 107.126  87.718  1.00 59.84           C  
+ATOM   3367  O   GLU A 435      80.394 105.891  87.710  1.00 59.84           O  
+ATOM   3368  CB  GLU A 435      82.586 108.346  87.216  1.00 59.84           C  
+ATOM   3369  CG  GLU A 435      83.629 108.657  86.158  1.00 59.84           C  
+ATOM   3370  CD  GLU A 435      84.952 109.088  86.756  1.00 59.84           C  
+ATOM   3371  OE1 GLU A 435      85.082 109.058  87.997  1.00 59.84           O  
+ATOM   3372  OE2 GLU A 435      85.861 109.457  85.985  1.00 59.84           O  
+ATOM   3373  N   ILE A 436      79.830 107.863  88.638  1.00 55.23           N  
+ATOM   3374  CA  ILE A 436      79.036 107.227  89.683  1.00 55.23           C  
+ATOM   3375  C   ILE A 436      77.817 106.537  89.084  1.00 55.23           C  
+ATOM   3376  O   ILE A 436      77.437 105.442  89.511  1.00 55.23           O  
+ATOM   3377  CB  ILE A 436      78.641 108.260  90.754  1.00 55.23           C  
+ATOM   3378  CG1 ILE A 436      79.837 108.575  91.652  1.00 55.23           C  
+ATOM   3379  CG2 ILE A 436      77.478 107.757  91.593  1.00 55.23           C  
+ATOM   3380  CD1 ILE A 436      80.374 107.370  92.388  1.00 55.23           C  
+ATOM   3381  N   ASN A 437      77.193 107.156  88.078  1.00 52.80           N  
+ATOM   3382  CA  ASN A 437      76.045 106.529  87.427  1.00 52.80           C  
+ATOM   3383  C   ASN A 437      76.435 105.206  86.776  1.00 52.80           C  
+ATOM   3384  O   ASN A 437      75.768 104.180  86.971  1.00 52.80           O  
+ATOM   3385  CB  ASN A 437      75.446 107.484  86.394  1.00 52.80           C  
+ATOM   3386  CG  ASN A 437      74.715 108.647  87.031  1.00 52.80           C  
+ATOM   3387  OD1 ASN A 437      74.926 108.962  88.202  1.00 52.80           O  
+ATOM   3388  ND2 ASN A 437      73.849 109.296  86.262  1.00 52.80           N  
+ATOM   3389  N   PHE A 438      77.520 105.213  85.997  1.00 46.20           N  
+ATOM   3390  CA  PHE A 438      77.974 103.992  85.339  1.00 46.20           C  
+ATOM   3391  C   PHE A 438      78.383 102.936  86.356  1.00 46.20           C  
+ATOM   3392  O   PHE A 438      78.087 101.746  86.182  1.00 46.20           O  
+ATOM   3393  CB  PHE A 438      79.135 104.308  84.398  1.00 46.20           C  
+ATOM   3394  CG  PHE A 438      79.795 103.094  83.819  1.00 46.20           C  
+ATOM   3395  CD1 PHE A 438      79.217 102.412  82.762  1.00 46.20           C  
+ATOM   3396  CD2 PHE A 438      80.999 102.635  84.325  1.00 46.20           C  
+ATOM   3397  CE1 PHE A 438      79.824 101.296  82.226  1.00 46.20           C  
+ATOM   3398  CE2 PHE A 438      81.609 101.519  83.793  1.00 46.20           C  
+ATOM   3399  CZ  PHE A 438      81.021 100.850  82.741  1.00 46.20           C  
+ATOM   3400  N   LEU A 439      79.065 103.349  87.427  1.00 43.83           N  
+ATOM   3401  CA  LEU A 439      79.468 102.397  88.456  1.00 43.83           C  
+ATOM   3402  C   LEU A 439      78.258 101.770  89.129  1.00 43.83           C  
+ATOM   3403  O   LEU A 439      78.239 100.561  89.378  1.00 43.83           O  
+ATOM   3404  CB  LEU A 439      80.358 103.087  89.490  1.00 43.83           C  
+ATOM   3405  CG  LEU A 439      81.864 103.049  89.233  1.00 43.83           C  
+ATOM   3406  CD1 LEU A 439      82.600 103.861  90.283  1.00 43.83           C  
+ATOM   3407  CD2 LEU A 439      82.365 101.617  89.212  1.00 43.83           C  
+ATOM   3408  N   LEU A 440      77.236 102.572  89.433  1.00 39.32           N  
+ATOM   3409  CA  LEU A 440      76.051 102.025  90.081  1.00 39.32           C  
+ATOM   3410  C   LEU A 440      75.291 101.093  89.154  1.00 39.32           C  
+ATOM   3411  O   LEU A 440      74.744 100.082  89.610  1.00 39.32           O  
+ATOM   3412  CB  LEU A 440      75.143 103.153  90.568  1.00 39.32           C  
+ATOM   3413  CG  LEU A 440      74.013 102.727  91.506  1.00 39.32           C  
+ATOM   3414  CD1 LEU A 440      73.888 103.703  92.657  1.00 39.32           C  
+ATOM   3415  CD2 LEU A 440      72.697 102.624  90.755  1.00 39.32           C  
+ATOM   3416  N   LYS A 441      75.249 101.401  87.856  1.00 36.57           N  
+ATOM   3417  CA  LYS A 441      74.638 100.472  86.909  1.00 36.57           C  
+ATOM   3418  C   LYS A 441      75.403  99.153  86.874  1.00 36.57           C  
+ATOM   3419  O   LYS A 441      74.805  98.070  86.908  1.00 36.57           O  
+ATOM   3420  CB  LYS A 441      74.577 101.102  85.519  1.00 36.57           C  
+ATOM   3421  CG  LYS A 441      73.629 100.394  84.567  1.00 36.57           C  
+ATOM   3422  CD  LYS A 441      73.454 101.178  83.280  1.00 36.57           C  
+ATOM   3423  CE  LYS A 441      72.448 100.507  82.362  1.00 36.57           C  
+ATOM   3424  NZ  LYS A 441      72.278 101.254  81.087  1.00 36.57           N  
+ATOM   3425  N   GLN A 442      76.736  99.230  86.823  1.00 34.54           N  
+ATOM   3426  CA  GLN A 442      77.549  98.017  86.815  1.00 34.54           C  
+ATOM   3427  C   GLN A 442      77.376  97.224  88.104  1.00 34.54           C  
+ATOM   3428  O   GLN A 442      77.424  95.990  88.092  1.00 34.54           O  
+ATOM   3429  CB  GLN A 442      79.017  98.377  86.601  1.00 34.54           C  
+ATOM   3430  CG  GLN A 442      79.388  98.632  85.154  1.00 34.54           C  
+ATOM   3431  CD  GLN A 442      79.417  97.362  84.335  1.00 34.54           C  
+ATOM   3432  OE1 GLN A 442      80.153  96.428  84.647  1.00 34.54           O  
+ATOM   3433  NE2 GLN A 442      78.614  97.317  83.279  1.00 34.54           N  
+ATOM   3434  N   ALA A 443      77.170  97.915  89.226  1.00 32.98           N  
+ATOM   3435  CA  ALA A 443      77.005  97.224  90.501  1.00 32.98           C  
+ATOM   3436  C   ALA A 443      75.639  96.562  90.597  1.00 32.98           C  
+ATOM   3437  O   ALA A 443      75.515  95.459  91.139  1.00 32.98           O  
+ATOM   3438  CB  ALA A 443      77.207  98.198  91.659  1.00 32.98           C  
+ATOM   3439  N   LEU A 444      74.601  97.230  90.093  1.00 30.57           N  
+ATOM   3440  CA  LEU A 444      73.284  96.609  90.037  1.00 30.57           C  
+ATOM   3441  C   LEU A 444      73.306  95.383  89.137  1.00 30.57           C  
+ATOM   3442  O   LEU A 444      72.640  94.379  89.414  1.00 30.57           O  
+ATOM   3443  CB  LEU A 444      72.248  97.620  89.548  1.00 30.57           C  
+ATOM   3444  CG  LEU A 444      71.865  98.728  90.527  1.00 30.57           C  
+ATOM   3445  CD1 LEU A 444      70.708  99.540  89.978  1.00 30.57           C  
+ATOM   3446  CD2 LEU A 444      71.518  98.146  91.884  1.00 30.57           C  
+ATOM   3447  N   THR A 445      74.076  95.445  88.050  1.00 28.63           N  
+ATOM   3448  CA  THR A 445      74.184  94.291  87.163  1.00 28.63           C  
+ATOM   3449  C   THR A 445      74.980  93.164  87.810  1.00 28.63           C  
+ATOM   3450  O   THR A 445      74.635  91.987  87.658  1.00 28.63           O  
+ATOM   3451  CB  THR A 445      74.832  94.707  85.841  1.00 28.63           C  
+ATOM   3452  OG1 THR A 445      74.006  95.674  85.182  1.00 28.63           O  
+ATOM   3453  CG2 THR A 445      75.014  93.504  84.929  1.00 28.63           C  
+ATOM   3454  N   ILE A 446      76.033  93.502  88.552  1.00 29.32           N  
+ATOM   3455  CA  ILE A 446      77.036  92.526  88.964  1.00 29.32           C  
+ATOM   3456  C   ILE A 446      76.957  92.221  90.455  1.00 29.32           C  
+ATOM   3457  O   ILE A 446      76.745  91.071  90.850  1.00 29.32           O  
+ATOM   3458  CB  ILE A 446      78.442  93.020  88.584  1.00 29.32           C  
+ATOM   3459  CG1 ILE A 446      78.606  93.020  87.064  1.00 29.32           C  
+ATOM   3460  CG2 ILE A 446      79.502  92.168  89.246  1.00 29.32           C  
+ATOM   3461  CD1 ILE A 446      79.892  93.642  86.588  1.00 29.32           C  
+ATOM   3462  N   VAL A 447      77.139  93.243  91.294  1.00 31.43           N  
+ATOM   3463  CA  VAL A 447      77.227  93.002  92.732  1.00 31.43           C  
+ATOM   3464  C   VAL A 447      75.894  92.523  93.294  1.00 31.43           C  
+ATOM   3465  O   VAL A 447      75.853  91.877  94.348  1.00 31.43           O  
+ATOM   3466  CB  VAL A 447      77.721  94.273  93.450  1.00 31.43           C  
+ATOM   3467  CG1 VAL A 447      78.093  93.968  94.892  1.00 31.43           C  
+ATOM   3468  CG2 VAL A 447      78.907  94.866  92.712  1.00 31.43           C  
+ATOM   3469  N   GLY A 448      74.789  92.809  92.605  1.00 33.01           N  
+ATOM   3470  CA  GLY A 448      73.487  92.422  93.121  1.00 33.01           C  
+ATOM   3471  C   GLY A 448      73.185  90.945  92.980  1.00 33.01           C  
+ATOM   3472  O   GLY A 448      72.296  90.426  93.661  1.00 33.01           O  
+ATOM   3473  N   THR A 449      73.911  90.246  92.107  1.00 30.04           N  
+ATOM   3474  CA  THR A 449      73.623  88.842  91.842  1.00 30.04           C  
+ATOM   3475  C   THR A 449      74.467  87.883  92.670  1.00 30.04           C  
+ATOM   3476  O   THR A 449      74.132  86.697  92.744  1.00 30.04           O  
+ATOM   3477  CB  THR A 449      73.830  88.523  90.356  1.00 30.04           C  
+ATOM   3478  OG1 THR A 449      73.179  87.288  90.040  1.00 30.04           O  
+ATOM   3479  CG2 THR A 449      75.307  88.391  90.033  1.00 30.04           C  
+ATOM   3480  N   LEU A 450      75.545  88.366  93.294  1.00 27.88           N  
+ATOM   3481  CA  LEU A 450      76.439  87.457  94.011  1.00 27.88           C  
+ATOM   3482  C   LEU A 450      75.795  86.873  95.261  1.00 27.88           C  
+ATOM   3483  O   LEU A 450      75.913  85.653  95.475  1.00 27.88           O  
+ATOM   3484  CB  LEU A 450      77.758  88.166  94.322  1.00 27.88           C  
+ATOM   3485  CG  LEU A 450      78.583  88.481  93.079  1.00 27.88           C  
+ATOM   3486  CD1 LEU A 450      79.878  89.175  93.448  1.00 27.88           C  
+ATOM   3487  CD2 LEU A 450      78.852  87.201  92.319  1.00 27.88           C  
+ATOM   3488  N   PRO A 451      75.135  87.650  96.129  1.00 34.86           N  
+ATOM   3489  CA  PRO A 451      74.454  87.017  97.270  1.00 34.86           C  
+ATOM   3490  C   PRO A 451      73.375  86.035  96.852  1.00 34.86           C  
+ATOM   3491  O   PRO A 451      73.258  84.963  97.454  1.00 34.86           O  
+ATOM   3492  CB  PRO A 451      73.874  88.212  98.036  1.00 34.86           C  
+ATOM   3493  CG  PRO A 451      74.748  89.344  97.665  1.00 34.86           C  
+ATOM   3494  CD  PRO A 451      75.092  89.120  96.231  1.00 34.86           C  
+ATOM   3495  N   PHE A 452      72.584  86.371  95.831  1.00 33.65           N  
+ATOM   3496  CA  PHE A 452      71.550  85.457  95.358  1.00 33.65           C  
+ATOM   3497  C   PHE A 452      72.161  84.157  94.847  1.00 33.65           C  
+ATOM   3498  O   PHE A 452      71.689  83.063  95.177  1.00 33.65           O  
+ATOM   3499  CB  PHE A 452      70.719  86.132  94.267  1.00 33.65           C  
+ATOM   3500  CG  PHE A 452      69.676  85.240  93.659  1.00 33.65           C  
+ATOM   3501  CD1 PHE A 452      69.863  84.688  92.404  1.00 33.65           C  
+ATOM   3502  CD2 PHE A 452      68.508  84.955  94.341  1.00 33.65           C  
+ATOM   3503  CE1 PHE A 452      68.906  83.870  91.843  1.00 33.65           C  
+ATOM   3504  CE2 PHE A 452      67.547  84.136  93.785  1.00 33.65           C  
+ATOM   3505  CZ  PHE A 452      67.746  83.594  92.534  1.00 33.65           C  
+ATOM   3506  N   THR A 453      73.219  84.263  94.040  1.00 33.70           N  
+ATOM   3507  CA  THR A 453      73.867  83.071  93.503  1.00 33.70           C  
+ATOM   3508  C   THR A 453      74.452  82.210  94.615  1.00 33.70           C  
+ATOM   3509  O   THR A 453      74.276  80.983  94.622  1.00 33.70           O  
+ATOM   3510  CB  THR A 453      74.957  83.477  92.512  1.00 33.70           C  
+ATOM   3511  OG1 THR A 453      74.360  84.139  91.391  1.00 33.70           O  
+ATOM   3512  CG2 THR A 453      75.722  82.261  92.028  1.00 33.70           C  
+ATOM   3513  N   TYR A 454      75.153  82.835  95.563  1.00 34.07           N  
+ATOM   3514  CA  TYR A 454      75.751  82.081  96.658  1.00 34.07           C  
+ATOM   3515  C   TYR A 454      74.681  81.398  97.496  1.00 34.07           C  
+ATOM   3516  O   TYR A 454      74.819  80.227  97.861  1.00 34.07           O  
+ATOM   3517  CB  TYR A 454      76.609  83.002  97.523  1.00 34.07           C  
+ATOM   3518  CG  TYR A 454      76.961  82.422  98.873  1.00 34.07           C  
+ATOM   3519  CD1 TYR A 454      77.731  81.273  98.977  1.00 34.07           C  
+ATOM   3520  CD2 TYR A 454      76.525  83.026 100.044  1.00 34.07           C  
+ATOM   3521  CE1 TYR A 454      78.057  80.741 100.209  1.00 34.07           C  
+ATOM   3522  CE2 TYR A 454      76.846  82.501 101.280  1.00 34.07           C  
+ATOM   3523  CZ  TYR A 454      77.611  81.359 101.357  1.00 34.07           C  
+ATOM   3524  OH  TYR A 454      77.933  80.834 102.587  1.00 34.07           O  
+ATOM   3525  N   MET A 455      73.598  82.115  97.804  1.00 35.57           N  
+ATOM   3526  CA  MET A 455      72.515  81.533  98.587  1.00 35.57           C  
+ATOM   3527  C   MET A 455      71.893  80.347  97.866  1.00 35.57           C  
+ATOM   3528  O   MET A 455      71.645  79.302  98.477  1.00 35.57           O  
+ATOM   3529  CB  MET A 455      71.461  82.599  98.884  1.00 35.57           C  
+ATOM   3530  CG  MET A 455      70.282  82.144  99.733  1.00 35.57           C  
+ATOM   3531  SD  MET A 455      68.988  81.315  98.792  1.00 35.57           S  
+ATOM   3532  CE  MET A 455      68.659  82.544  97.535  1.00 35.57           C  
+ATOM   3533  N   LEU A 456      71.628  80.490  96.566  1.00 34.11           N  
+ATOM   3534  CA  LEU A 456      70.986  79.407  95.828  1.00 34.11           C  
+ATOM   3535  C   LEU A 456      71.881  78.177  95.762  1.00 34.11           C  
+ATOM   3536  O   LEU A 456      71.416  77.052  95.990  1.00 34.11           O  
+ATOM   3537  CB  LEU A 456      70.607  79.883  94.427  1.00 34.11           C  
+ATOM   3538  CG  LEU A 456      69.655  78.989  93.633  1.00 34.11           C  
+ATOM   3539  CD1 LEU A 456      68.669  79.841  92.860  1.00 34.11           C  
+ATOM   3540  CD2 LEU A 456      70.423  78.082  92.687  1.00 34.11           C  
+ATOM   3541  N   GLU A 457      73.169  78.365  95.465  1.00 35.97           N  
+ATOM   3542  CA  GLU A 457      74.061  77.213  95.389  1.00 35.97           C  
+ATOM   3543  C   GLU A 457      74.268  76.575  96.756  1.00 35.97           C  
+ATOM   3544  O   GLU A 457      74.354  75.347  96.863  1.00 35.97           O  
+ATOM   3545  CB  GLU A 457      75.397  77.611  94.774  1.00 35.97           C  
+ATOM   3546  CG  GLU A 457      75.437  77.401  93.281  1.00 35.97           C  
+ATOM   3547  CD  GLU A 457      75.428  75.934  92.904  1.00 35.97           C  
+ATOM   3548  OE1 GLU A 457      75.994  75.121  93.662  1.00 35.97           O  
+ATOM   3549  OE2 GLU A 457      74.854  75.591  91.851  1.00 35.97           O  
+ATOM   3550  N   LYS A 458      74.340  77.384  97.816  1.00 38.78           N  
+ATOM   3551  CA  LYS A 458      74.481  76.830  99.156  1.00 38.78           C  
+ATOM   3552  C   LYS A 458      73.249  76.026  99.547  1.00 38.78           C  
+ATOM   3553  O   LYS A 458      73.365  74.946 100.138  1.00 38.78           O  
+ATOM   3554  CB  LYS A 458      74.735  77.956 100.157  1.00 38.78           C  
+ATOM   3555  CG  LYS A 458      75.189  77.496 101.529  1.00 38.78           C  
+ATOM   3556  CD  LYS A 458      75.473  78.689 102.427  1.00 38.78           C  
+ATOM   3557  CE  LYS A 458      75.958  78.250 103.795  1.00 38.78           C  
+ATOM   3558  NZ  LYS A 458      77.161  77.379 103.700  1.00 38.78           N  
+ATOM   3559  N   TRP A 459      72.059  76.529  99.213  1.00 40.70           N  
+ATOM   3560  CA  TRP A 459      70.837  75.791  99.507  1.00 40.70           C  
+ATOM   3561  C   TRP A 459      70.800  74.475  98.747  1.00 40.70           C  
+ATOM   3562  O   TRP A 459      70.463  73.430  99.312  1.00 40.70           O  
+ATOM   3563  CB  TRP A 459      69.612  76.639  99.169  1.00 40.70           C  
+ATOM   3564  CG  TRP A 459      68.317  75.910  99.361  1.00 40.70           C  
+ATOM   3565  CD1 TRP A 459      67.567  75.862 100.497  1.00 40.70           C  
+ATOM   3566  CD2 TRP A 459      67.623  75.120  98.389  1.00 40.70           C  
+ATOM   3567  NE1 TRP A 459      66.448  75.094 100.294  1.00 40.70           N  
+ATOM   3568  CE2 TRP A 459      66.460  74.624  99.007  1.00 40.70           C  
+ATOM   3569  CE3 TRP A 459      67.873  74.783  97.056  1.00 40.70           C  
+ATOM   3570  CZ2 TRP A 459      65.548  73.813  98.340  1.00 40.70           C  
+ATOM   3571  CZ3 TRP A 459      66.967  73.976  96.395  1.00 40.70           C  
+ATOM   3572  CH2 TRP A 459      65.819  73.500  97.037  1.00 40.70           C  
+ATOM   3573  N   ARG A 460      71.140  74.505  97.456  1.00 31.73           N  
+ATOM   3574  CA  ARG A 460      71.124  73.274  96.673  1.00 31.73           C  
+ATOM   3575  C   ARG A 460      72.138  72.269  97.207  1.00 31.73           C  
+ATOM   3576  O   ARG A 460      71.847  71.069  97.297  1.00 31.73           O  
+ATOM   3577  CB  ARG A 460      71.393  73.582  95.201  1.00 31.73           C  
+ATOM   3578  CG  ARG A 460      70.823  72.550  94.249  1.00 31.73           C  
+ATOM   3579  CD  ARG A 460      70.304  73.194  92.978  1.00 31.73           C  
+ATOM   3580  NE  ARG A 460      71.358  73.886  92.247  1.00 31.73           N  
+ATOM   3581  CZ  ARG A 460      71.232  74.330  91.002  1.00 31.73           C  
+ATOM   3582  NH1 ARG A 460      70.094  74.148  90.347  1.00 31.73           N  
+ATOM   3583  NH2 ARG A 460      72.242  74.949  90.409  1.00 31.73           N  
+ATOM   3584  N   TRP A 461      73.330  72.743  97.576  1.00 32.70           N  
+ATOM   3585  CA  TRP A 461      74.345  71.862  98.143  1.00 32.70           C  
+ATOM   3586  C   TRP A 461      73.862  71.231  99.440  1.00 32.70           C  
+ATOM   3587  O   TRP A 461      74.003  70.020  99.645  1.00 32.70           O  
+ATOM   3588  CB  TRP A 461      75.635  72.646  98.381  1.00 32.70           C  
+ATOM   3589  CG  TRP A 461      76.461  72.852  97.157  1.00 32.70           C  
+ATOM   3590  CD1 TRP A 461      76.543  72.030  96.075  1.00 32.70           C  
+ATOM   3591  CD2 TRP A 461      77.335  73.954  96.891  1.00 32.70           C  
+ATOM   3592  NE1 TRP A 461      77.412  72.550  95.148  1.00 32.70           N  
+ATOM   3593  CE2 TRP A 461      77.912  73.733  95.627  1.00 32.70           C  
+ATOM   3594  CE3 TRP A 461      77.682  75.108  97.598  1.00 32.70           C  
+ATOM   3595  CZ2 TRP A 461      78.819  74.621  95.056  1.00 32.70           C  
+ATOM   3596  CZ3 TRP A 461      78.582  75.987  97.030  1.00 32.70           C  
+ATOM   3597  CH2 TRP A 461      79.140  75.740  95.772  1.00 32.70           C  
+ATOM   3598  N   MET A 462      73.288  72.039 100.333  1.00 44.99           N  
+ATOM   3599  CA  MET A 462      72.839  71.520 101.619  1.00 44.99           C  
+ATOM   3600  C   MET A 462      71.674  70.553 101.449  1.00 44.99           C  
+ATOM   3601  O   MET A 462      71.534  69.597 102.221  1.00 44.99           O  
+ATOM   3602  CB  MET A 462      72.454  72.674 102.541  1.00 44.99           C  
+ATOM   3603  CG  MET A 462      73.637  73.443 103.100  1.00 44.99           C  
+ATOM   3604  SD  MET A 462      73.130  74.791 104.182  1.00 44.99           S  
+ATOM   3605  CE  MET A 462      74.657  75.109 105.061  1.00 44.99           C  
+ATOM   3606  N   VAL A 463      70.826  70.783 100.445  1.00 43.81           N  
+ATOM   3607  CA  VAL A 463      69.724  69.862 100.180  1.00 43.81           C  
+ATOM   3608  C   VAL A 463      70.257  68.534  99.662  1.00 43.81           C  
+ATOM   3609  O   VAL A 463      69.847  67.460 100.118  1.00 43.81           O  
+ATOM   3610  CB  VAL A 463      68.723  70.493  99.196  1.00 43.81           C  
+ATOM   3611  CG1 VAL A 463      67.802  69.431  98.631  1.00 43.81           C  
+ATOM   3612  CG2 VAL A 463      67.913  71.567  99.891  1.00 43.81           C  
+ATOM   3613  N   PHE A 464      71.183  68.586  98.701  1.00 45.52           N  
+ATOM   3614  CA  PHE A 464      71.746  67.353  98.161  1.00 45.52           C  
+ATOM   3615  C   PHE A 464      72.544  66.599  99.217  1.00 45.52           C  
+ATOM   3616  O   PHE A 464      72.647  65.367  99.164  1.00 45.52           O  
+ATOM   3617  CB  PHE A 464      72.622  67.662  96.948  1.00 45.52           C  
+ATOM   3618  CG  PHE A 464      71.845  68.007  95.710  1.00 45.52           C  
+ATOM   3619  CD1 PHE A 464      70.463  67.946  95.702  1.00 45.52           C  
+ATOM   3620  CD2 PHE A 464      72.499  68.395  94.556  1.00 45.52           C  
+ATOM   3621  CE1 PHE A 464      69.750  68.266  94.564  1.00 45.52           C  
+ATOM   3622  CE2 PHE A 464      71.790  68.715  93.417  1.00 45.52           C  
+ATOM   3623  CZ  PHE A 464      70.415  68.649  93.421  1.00 45.52           C  
+ATOM   3624  N   LYS A 465      73.111  67.318 100.187  1.00 47.54           N  
+ATOM   3625  CA  LYS A 465      73.901  66.689 101.236  1.00 47.54           C  
+ATOM   3626  C   LYS A 465      73.048  66.103 102.351  1.00 47.54           C  
+ATOM   3627  O   LYS A 465      73.600  65.502 103.279  1.00 47.54           O  
+ATOM   3628  CB  LYS A 465      74.890  67.702 101.816  1.00 47.54           C  
+ATOM   3629  CG  LYS A 465      76.224  67.108 102.230  1.00 47.54           C  
+ATOM   3630  CD  LYS A 465      77.208  68.194 102.633  1.00 47.54           C  
+ATOM   3631  CE  LYS A 465      77.393  69.213 101.521  1.00 47.54           C  
+ATOM   3632  NZ  LYS A 465      78.322  70.305 101.920  1.00 47.54           N  
+ATOM   3633  N   GLY A 466      71.729  66.258 102.288  1.00 54.01           N  
+ATOM   3634  CA  GLY A 466      70.854  65.740 103.314  1.00 54.01           C  
+ATOM   3635  C   GLY A 466      70.761  66.585 104.564  1.00 54.01           C  
+ATOM   3636  O   GLY A 466      70.042  66.203 105.497  1.00 54.01           O  
+ATOM   3637  N   GLU A 467      71.460  67.719 104.617  1.00 54.28           N  
+ATOM   3638  CA  GLU A 467      71.395  68.589 105.785  1.00 54.28           C  
+ATOM   3639  C   GLU A 467      70.054  69.293 105.921  1.00 54.28           C  
+ATOM   3640  O   GLU A 467      69.793  69.895 106.967  1.00 54.28           O  
+ATOM   3641  CB  GLU A 467      72.517  69.627 105.729  1.00 54.28           C  
+ATOM   3642  CG  GLU A 467      73.902  69.035 105.542  1.00 54.28           C  
+ATOM   3643  CD  GLU A 467      75.000  70.068 105.697  1.00 54.28           C  
+ATOM   3644  OE1 GLU A 467      74.747  71.115 106.330  1.00 54.28           O  
+ATOM   3645  OE2 GLU A 467      76.115  69.836 105.186  1.00 54.28           O  
+ATOM   3646  N   ILE A 468      69.206  69.237 104.899  1.00 55.29           N  
+ATOM   3647  CA  ILE A 468      67.889  69.865 104.944  1.00 55.29           C  
+ATOM   3648  C   ILE A 468      66.831  68.800 104.687  1.00 55.29           C  
+ATOM   3649  O   ILE A 468      66.740  68.276 103.567  1.00 55.29           O  
+ATOM   3650  CB  ILE A 468      67.776  71.007 103.922  1.00 55.29           C  
+ATOM   3651  CG1 ILE A 468      68.919  72.005 104.100  1.00 55.29           C  
+ATOM   3652  CG2 ILE A 468      66.435  71.709 104.060  1.00 55.29           C  
+ATOM   3653  CD1 ILE A 468      68.933  73.096 103.058  1.00 55.29           C  
+ATOM   3654  N   PRO A 469      66.027  68.439 105.683  1.00 62.34           N  
+ATOM   3655  CA  PRO A 469      64.949  67.475 105.446  1.00 62.34           C  
+ATOM   3656  C   PRO A 469      63.857  68.071 104.572  1.00 62.34           C  
+ATOM   3657  O   PRO A 469      63.791  69.281 104.343  1.00 62.34           O  
+ATOM   3658  CB  PRO A 469      64.427  67.165 106.854  1.00 62.34           C  
+ATOM   3659  CG  PRO A 469      65.512  67.624 107.784  1.00 62.34           C  
+ATOM   3660  CD  PRO A 469      66.146  68.794 107.105  1.00 62.34           C  
+ATOM   3661  N   LYS A 470      62.985  67.187 104.081  1.00 62.31           N  
+ATOM   3662  CA  LYS A 470      61.932  67.615 103.166  1.00 62.31           C  
+ATOM   3663  C   LYS A 470      60.967  68.585 103.837  1.00 62.31           C  
+ATOM   3664  O   LYS A 470      60.457  69.508 103.193  1.00 62.31           O  
+ATOM   3665  CB  LYS A 470      61.179  66.401 102.628  1.00 62.31           C  
+ATOM   3666  CG  LYS A 470      61.962  65.574 101.625  1.00 62.31           C  
+ATOM   3667  CD  LYS A 470      61.297  64.227 101.393  1.00 62.31           C  
+ATOM   3668  CE  LYS A 470      59.810  64.385 101.121  1.00 62.31           C  
+ATOM   3669  NZ  LYS A 470      59.120  63.071 101.011  1.00 62.31           N  
+ATOM   3670  N   ASP A 471      60.703  68.394 105.126  1.00 69.36           N  
+ATOM   3671  CA  ASP A 471      59.760  69.264 105.826  1.00 69.36           C  
+ATOM   3672  C   ASP A 471      60.351  70.617 106.196  1.00 69.36           C  
+ATOM   3673  O   ASP A 471      59.705  71.355 106.951  1.00 69.36           O  
+ATOM   3674  CB  ASP A 471      59.236  68.568 107.083  1.00 69.36           C  
+ATOM   3675  CG  ASP A 471      60.322  68.327 108.111  1.00 69.36           C  
+ATOM   3676  OD1 ASP A 471      60.141  68.740 109.275  1.00 69.36           O  
+ATOM   3677  OD2 ASP A 471      61.355  67.722 107.756  1.00 69.36           O  
+ATOM   3678  N   GLN A 472      61.541  70.975 105.708  1.00 65.98           N  
+ATOM   3679  CA  GLN A 472      62.147  72.264 106.019  1.00 65.98           C  
+ATOM   3680  C   GLN A 472      62.781  72.925 104.802  1.00 65.98           C  
+ATOM   3681  O   GLN A 472      63.553  73.877 104.966  1.00 65.98           O  
+ATOM   3682  CB  GLN A 472      63.198  72.111 107.125  1.00 65.98           C  
+ATOM   3683  CG  GLN A 472      62.620  71.951 108.518  1.00 65.98           C  
+ATOM   3684  CD  GLN A 472      63.692  71.934 109.587  1.00 65.98           C  
+ATOM   3685  OE1 GLN A 472      63.865  72.904 110.323  1.00 65.98           O  
+ATOM   3686  NE2 GLN A 472      64.421  70.828 109.678  1.00 65.98           N  
+ATOM   3687  N   TRP A 473      62.468  72.458 103.591  1.00 58.05           N  
+ATOM   3688  CA  TRP A 473      63.104  72.996 102.391  1.00 58.05           C  
+ATOM   3689  C   TRP A 473      62.857  74.493 102.255  1.00 58.05           C  
+ATOM   3690  O   TRP A 473      63.803  75.289 102.240  1.00 58.05           O  
+ATOM   3691  CB  TRP A 473      62.594  72.255 101.154  1.00 58.05           C  
+ATOM   3692  CG  TRP A 473      63.417  71.064 100.778  1.00 58.05           C  
+ATOM   3693  CD1 TRP A 473      64.379  70.462 101.531  1.00 58.05           C  
+ATOM   3694  CD2 TRP A 473      63.348  70.328  99.551  1.00 58.05           C  
+ATOM   3695  NE1 TRP A 473      64.915  69.395 100.850  1.00 58.05           N  
+ATOM   3696  CE2 TRP A 473      64.298  69.293  99.631  1.00 58.05           C  
+ATOM   3697  CE3 TRP A 473      62.575  70.445  98.393  1.00 58.05           C  
+ATOM   3698  CZ2 TRP A 473      64.496  68.380  98.598  1.00 58.05           C  
+ATOM   3699  CZ3 TRP A 473      62.774  69.539  97.368  1.00 58.05           C  
+ATOM   3700  CH2 TRP A 473      63.726  68.520  97.477  1.00 58.05           C  
+ATOM   3701  N   MET A 474      61.587  74.894 102.153  1.00 61.43           N  
+ATOM   3702  CA  MET A 474      61.270  76.303 101.945  1.00 61.43           C  
+ATOM   3703  C   MET A 474      61.655  77.145 103.153  1.00 61.43           C  
+ATOM   3704  O   MET A 474      62.075  78.297 103.002  1.00 61.43           O  
+ATOM   3705  CB  MET A 474      59.784  76.468 101.633  1.00 61.43           C  
+ATOM   3706  CG  MET A 474      59.329  75.757 100.372  1.00 61.43           C  
+ATOM   3707  SD  MET A 474      60.328  76.179  98.935  1.00 61.43           S  
+ATOM   3708  CE  MET A 474      61.228  74.650  98.691  1.00 61.43           C  
+ATOM   3709  N   LYS A 475      61.522  76.592 104.359  1.00 61.42           N  
+ATOM   3710  CA  LYS A 475      61.885  77.338 105.559  1.00 61.42           C  
+ATOM   3711  C   LYS A 475      63.370  77.678 105.559  1.00 61.42           C  
+ATOM   3712  O   LYS A 475      63.755  78.841 105.753  1.00 61.42           O  
+ATOM   3713  CB  LYS A 475      61.507  76.535 106.805  1.00 61.42           C  
+ATOM   3714  CG  LYS A 475      61.914  77.184 108.117  1.00 61.42           C  
+ATOM   3715  CD  LYS A 475      63.096  76.462 108.741  1.00 61.42           C  
+ATOM   3716  CE  LYS A 475      63.651  77.230 109.926  1.00 61.42           C  
+ATOM   3717  NZ  LYS A 475      64.921  76.633 110.419  1.00 61.42           N  
+ATOM   3718  N   LYS A 476      64.223  76.674 105.341  1.00 57.87           N  
+ATOM   3719  CA  LYS A 476      65.657  76.922 105.278  1.00 57.87           C  
+ATOM   3720  C   LYS A 476      66.006  77.831 104.108  1.00 57.87           C  
+ATOM   3721  O   LYS A 476      66.868  78.706 104.237  1.00 57.87           O  
+ATOM   3722  CB  LYS A 476      66.415  75.600 105.175  1.00 57.87           C  
+ATOM   3723  CG  LYS A 476      67.928  75.743 105.200  1.00 57.87           C  
+ATOM   3724  CD  LYS A 476      68.434  76.091 106.589  1.00 57.87           C  
+ATOM   3725  CE  LYS A 476      67.983  75.064 107.618  1.00 57.87           C  
+ATOM   3726  NZ  LYS A 476      68.531  73.709 107.340  1.00 57.87           N  
+ATOM   3727  N   TRP A 477      65.337  77.654 102.966  1.00 51.39           N  
+ATOM   3728  CA  TRP A 477      65.610  78.492 101.803  1.00 51.39           C  
+ATOM   3729  C   TRP A 477      65.337  79.959 102.109  1.00 51.39           C  
+ATOM   3730  O   TRP A 477      66.165  80.832 101.824  1.00 51.39           O  
+ATOM   3731  CB  TRP A 477      64.770  78.011 100.618  1.00 51.39           C  
+ATOM   3732  CG  TRP A 477      64.591  79.011  99.517  1.00 51.39           C  
+ATOM   3733  CD1 TRP A 477      63.589  79.928  99.398  1.00 51.39           C  
+ATOM   3734  CD2 TRP A 477      65.421  79.174  98.361  1.00 51.39           C  
+ATOM   3735  NE1 TRP A 477      63.750  80.660  98.248  1.00 51.39           N  
+ATOM   3736  CE2 TRP A 477      64.868  80.216  97.593  1.00 51.39           C  
+ATOM   3737  CE3 TRP A 477      66.583  78.544  97.905  1.00 51.39           C  
+ATOM   3738  CZ2 TRP A 477      65.435  80.642  96.396  1.00 51.39           C  
+ATOM   3739  CZ3 TRP A 477      67.143  78.969  96.715  1.00 51.39           C  
+ATOM   3740  CH2 TRP A 477      66.570  80.007  95.975  1.00 51.39           C  
+ATOM   3741  N   TRP A 478      64.191  80.250 102.722  1.00 56.41           N  
+ATOM   3742  CA  TRP A 478      63.839  81.640 102.979  1.00 56.41           C  
+ATOM   3743  C   TRP A 478      64.638  82.239 104.128  1.00 56.41           C  
+ATOM   3744  O   TRP A 478      64.954  83.434 104.091  1.00 56.41           O  
+ATOM   3745  CB  TRP A 478      62.339  81.767 103.243  1.00 56.41           C  
+ATOM   3746  CG  TRP A 478      61.538  81.782 101.978  1.00 56.41           C  
+ATOM   3747  CD1 TRP A 478      60.542  80.919 101.631  1.00 56.41           C  
+ATOM   3748  CD2 TRP A 478      61.679  82.696 100.881  1.00 56.41           C  
+ATOM   3749  NE1 TRP A 478      60.048  81.243 100.391  1.00 56.41           N  
+ATOM   3750  CE2 TRP A 478      60.729  82.329  99.910  1.00 56.41           C  
+ATOM   3751  CE3 TRP A 478      62.513  83.790 100.629  1.00 56.41           C  
+ATOM   3752  CZ2 TRP A 478      60.590  83.017  98.707  1.00 56.41           C  
+ATOM   3753  CZ3 TRP A 478      62.373  84.469  99.435  1.00 56.41           C  
+ATOM   3754  CH2 TRP A 478      61.419  84.081  98.489  1.00 56.41           C  
+ATOM   3755  N   GLU A 479      64.998  81.450 105.144  1.00 56.97           N  
+ATOM   3756  CA  GLU A 479      65.847  82.025 106.182  1.00 56.97           C  
+ATOM   3757  C   GLU A 479      67.265  82.249 105.673  1.00 56.97           C  
+ATOM   3758  O   GLU A 479      67.915  83.224 106.071  1.00 56.97           O  
+ATOM   3759  CB  GLU A 479      65.845  81.158 107.442  1.00 56.97           C  
+ATOM   3760  CG  GLU A 479      66.518  79.811 107.328  1.00 56.97           C  
+ATOM   3761  CD  GLU A 479      66.464  79.047 108.636  1.00 56.97           C  
+ATOM   3762  OE1 GLU A 479      65.882  79.575 109.607  1.00 56.97           O  
+ATOM   3763  OE2 GLU A 479      67.003  77.925 108.701  1.00 56.97           O  
+ATOM   3764  N   MET A 480      67.749  81.395 104.766  1.00 50.96           N  
+ATOM   3765  CA  MET A 480      69.022  81.665 104.108  1.00 50.96           C  
+ATOM   3766  C   MET A 480      68.932  82.919 103.251  1.00 50.96           C  
+ATOM   3767  O   MET A 480      69.880  83.708 103.195  1.00 50.96           O  
+ATOM   3768  CB  MET A 480      69.442  80.467 103.259  1.00 50.96           C  
+ATOM   3769  CG  MET A 480      70.017  79.309 104.053  1.00 50.96           C  
+ATOM   3770  SD  MET A 480      70.453  77.916 102.999  1.00 50.96           S  
+ATOM   3771  CE  MET A 480      71.488  78.725 101.785  1.00 50.96           C  
+ATOM   3772  N   LYS A 481      67.800  83.112 102.570  1.00 49.24           N  
+ATOM   3773  CA  LYS A 481      67.567  84.358 101.844  1.00 49.24           C  
+ATOM   3774  C   LYS A 481      67.698  85.559 102.770  1.00 49.24           C  
+ATOM   3775  O   LYS A 481      68.477  86.481 102.507  1.00 49.24           O  
+ATOM   3776  CB  LYS A 481      66.181  84.333 101.197  1.00 49.24           C  
+ATOM   3777  CG  LYS A 481      66.159  83.835  99.765  1.00 49.24           C  
+ATOM   3778  CD  LYS A 481      66.234  84.984  98.776  1.00 49.24           C  
+ATOM   3779  CE  LYS A 481      65.681  84.576  97.421  1.00 49.24           C  
+ATOM   3780  NZ  LYS A 481      65.660  85.712  96.461  1.00 49.24           N  
+ATOM   3781  N   ARG A 482      66.949  85.550 103.875  1.00 57.39           N  
+ATOM   3782  CA  ARG A 482      66.976  86.672 104.809  1.00 57.39           C  
+ATOM   3783  C   ARG A 482      68.376  86.909 105.365  1.00 57.39           C  
+ATOM   3784  O   ARG A 482      68.789  88.059 105.554  1.00 57.39           O  
+ATOM   3785  CB  ARG A 482      65.993  86.430 105.953  1.00 57.39           C  
+ATOM   3786  CG  ARG A 482      64.542  86.312 105.533  1.00 57.39           C  
+ATOM   3787  CD  ARG A 482      63.717  85.703 106.652  1.00 57.39           C  
+ATOM   3788  NE  ARG A 482      62.318  85.525 106.280  1.00 57.39           N  
+ATOM   3789  CZ  ARG A 482      61.341  86.343 106.653  1.00 57.39           C  
+ATOM   3790  NH1 ARG A 482      61.612  87.398 107.406  1.00 57.39           N  
+ATOM   3791  NH2 ARG A 482      60.094  86.106 106.273  1.00 57.39           N  
+ATOM   3792  N   GLU A 483      69.122  85.836 105.635  1.00 56.24           N  
+ATOM   3793  CA  GLU A 483      70.418  85.993 106.287  1.00 56.24           C  
+ATOM   3794  C   GLU A 483      71.495  86.446 105.307  1.00 56.24           C  
+ATOM   3795  O   GLU A 483      72.336  87.285 105.649  1.00 56.24           O  
+ATOM   3796  CB  GLU A 483      70.827  84.683 106.958  1.00 56.24           C  
+ATOM   3797  CG  GLU A 483      72.096  84.782 107.785  1.00 56.24           C  
+ATOM   3798  CD  GLU A 483      72.561  83.436 108.297  1.00 56.24           C  
+ATOM   3799  OE1 GLU A 483      72.450  82.443 107.548  1.00 56.24           O  
+ATOM   3800  OE2 GLU A 483      73.038  83.370 109.449  1.00 56.24           O  
+ATOM   3801  N   ILE A 484      71.491  85.908 104.093  1.00 46.36           N  
+ATOM   3802  CA  ILE A 484      72.570  86.116 103.138  1.00 46.36           C  
+ATOM   3803  C   ILE A 484      72.230  87.204 102.131  1.00 46.36           C  
+ATOM   3804  O   ILE A 484      72.973  88.172 101.978  1.00 46.36           O  
+ATOM   3805  CB  ILE A 484      72.903  84.782 102.434  1.00 46.36           C  
+ATOM   3806  CG1 ILE A 484      73.544  83.806 103.422  1.00 46.36           C  
+ATOM   3807  CG2 ILE A 484      73.795  85.013 101.228  1.00 46.36           C  
+ATOM   3808  CD1 ILE A 484      73.671  82.400 102.892  1.00 46.36           C  
+ATOM   3809  N   VAL A 485      71.107  87.060 101.432  1.00 43.06           N  
+ATOM   3810  CA  VAL A 485      70.759  88.002 100.377  1.00 43.06           C  
+ATOM   3811  C   VAL A 485      70.143  89.279 100.940  1.00 43.06           C  
+ATOM   3812  O   VAL A 485      70.325  90.358 100.369  1.00 43.06           O  
+ATOM   3813  CB  VAL A 485      69.811  87.326  99.372  1.00 43.06           C  
+ATOM   3814  CG1 VAL A 485      69.392  88.294  98.279  1.00 43.06           C  
+ATOM   3815  CG2 VAL A 485      70.463  86.094  98.779  1.00 43.06           C  
+ATOM   3816  N   GLY A 486      69.436  89.188 102.061  1.00 50.48           N  
+ATOM   3817  CA  GLY A 486      68.716  90.335 102.572  1.00 50.48           C  
+ATOM   3818  C   GLY A 486      67.404  90.580 101.870  1.00 50.48           C  
+ATOM   3819  O   GLY A 486      66.984  91.733 101.736  1.00 50.48           O  
+ATOM   3820  N   VAL A 487      66.746  89.522 101.407  1.00 53.67           N  
+ATOM   3821  CA  VAL A 487      65.490  89.617 100.675  1.00 53.67           C  
+ATOM   3822  C   VAL A 487      64.456  88.772 101.404  1.00 53.67           C  
+ATOM   3823  O   VAL A 487      64.648  87.564 101.585  1.00 53.67           O  
+ATOM   3824  CB  VAL A 487      65.646  89.162  99.217  1.00 53.67           C  
+ATOM   3825  CG1 VAL A 487      64.292  88.847  98.614  1.00 53.67           C  
+ATOM   3826  CG2 VAL A 487      66.352  90.235  98.408  1.00 53.67           C  
+ATOM   3827  N   VAL A 488      63.365  89.406 101.821  1.00 62.39           N  
+ATOM   3828  CA  VAL A 488      62.295  88.749 102.559  1.00 62.39           C  
+ATOM   3829  C   VAL A 488      61.140  88.483 101.603  1.00 62.39           C  
+ATOM   3830  O   VAL A 488      60.818  89.322 100.754  1.00 62.39           O  
+ATOM   3831  CB  VAL A 488      61.845  89.598 103.765  1.00 62.39           C  
+ATOM   3832  CG1 VAL A 488      61.463  91.005 103.324  1.00 62.39           C  
+ATOM   3833  CG2 VAL A 488      60.696  88.929 104.499  1.00 62.39           C  
+ATOM   3834  N   GLU A 489      60.533  87.308 101.730  1.00 66.40           N  
+ATOM   3835  CA  GLU A 489      59.422  86.954 100.860  1.00 66.40           C  
+ATOM   3836  C   GLU A 489      58.201  87.808 101.195  1.00 66.40           C  
+ATOM   3837  O   GLU A 489      57.965  88.127 102.364  1.00 66.40           O  
+ATOM   3838  CB  GLU A 489      59.084  85.469 100.993  1.00 66.40           C  
+ATOM   3839  CG  GLU A 489      58.534  85.056 102.351  1.00 66.40           C  
+ATOM   3840  CD  GLU A 489      59.617  84.840 103.387  1.00 66.40           C  
+ATOM   3841  OE1 GLU A 489      60.810  84.903 103.026  1.00 66.40           O  
+ATOM   3842  OE2 GLU A 489      59.275  84.609 104.564  1.00 66.40           O  
+ATOM   3843  N   PRO A 490      57.415  88.208 100.191  1.00 68.24           N  
+ATOM   3844  CA  PRO A 490      56.249  89.058 100.469  1.00 68.24           C  
+ATOM   3845  C   PRO A 490      55.043  88.307 101.006  1.00 68.24           C  
+ATOM   3846  O   PRO A 490      54.193  88.932 101.654  1.00 68.24           O  
+ATOM   3847  CB  PRO A 490      55.941  89.684  99.104  1.00 68.24           C  
+ATOM   3848  CG  PRO A 490      56.437  88.683  98.123  1.00 68.24           C  
+ATOM   3849  CD  PRO A 490      57.635  88.020  98.747  1.00 68.24           C  
+ATOM   3850  N   VAL A 491      54.931  87.005 100.756  1.00 73.88           N  
+ATOM   3851  CA  VAL A 491      53.819  86.215 101.279  1.00 73.88           C  
+ATOM   3852  C   VAL A 491      54.377  85.013 102.032  1.00 73.88           C  
+ATOM   3853  O   VAL A 491      55.458  84.513 101.687  1.00 73.88           O  
+ATOM   3854  CB  VAL A 491      52.863  85.773 100.158  1.00 73.88           C  
+ATOM   3855  CG1 VAL A 491      52.357  86.978  99.383  1.00 73.88           C  
+ATOM   3856  CG2 VAL A 491      53.543  84.782  99.227  1.00 73.88           C  
+ATOM   3857  N   PRO A 492      53.692  84.523 103.065  1.00 78.81           N  
+ATOM   3858  CA  PRO A 492      54.191  83.343 103.782  1.00 78.81           C  
+ATOM   3859  C   PRO A 492      54.026  82.088 102.937  1.00 78.81           C  
+ATOM   3860  O   PRO A 492      52.949  81.821 102.399  1.00 78.81           O  
+ATOM   3861  CB  PRO A 492      53.320  83.297 105.041  1.00 78.81           C  
+ATOM   3862  CG  PRO A 492      52.058  83.980 104.642  1.00 78.81           C  
+ATOM   3863  CD  PRO A 492      52.449  85.047 103.656  1.00 78.81           C  
+ATOM   3864  N   HIS A 493      55.105  81.320 102.823  1.00 74.25           N  
+ATOM   3865  CA  HIS A 493      55.131  80.109 102.016  1.00 74.25           C  
+ATOM   3866  C   HIS A 493      55.313  78.901 102.922  1.00 74.25           C  
+ATOM   3867  O   HIS A 493      56.235  78.870 103.743  1.00 74.25           O  
+ATOM   3868  CB  HIS A 493      56.252  80.164 100.975  1.00 74.25           C  
+ATOM   3869  CG  HIS A 493      55.851  80.816  99.689  1.00 74.25           C  
+ATOM   3870  ND1 HIS A 493      56.738  81.035  98.658  1.00 74.25           N  
+ATOM   3871  CD2 HIS A 493      54.657  81.294  99.267  1.00 74.25           C  
+ATOM   3872  CE1 HIS A 493      56.108  81.622  97.655  1.00 74.25           C  
+ATOM   3873  NE2 HIS A 493      54.844  81.790  97.999  1.00 74.25           N  
+ATOM   3874  N   ASP A 494      54.436  77.913 102.770  1.00 77.39           N  
+ATOM   3875  CA  ASP A 494      54.532  76.674 103.522  1.00 77.39           C  
+ATOM   3876  C   ASP A 494      55.357  75.662 102.725  1.00 77.39           C  
+ATOM   3877  O   ASP A 494      56.010  76.004 101.735  1.00 77.39           O  
+ATOM   3878  CB  ASP A 494      53.137  76.160 103.866  1.00 77.39           C  
+ATOM   3879  CG  ASP A 494      52.375  75.682 102.650  1.00 77.39           C  
+ATOM   3880  OD1 ASP A 494      52.607  74.537 102.216  1.00 77.39           O  
+ATOM   3881  OD2 ASP A 494      51.543  76.454 102.129  1.00 77.39           O  
+ATOM   3882  N   GLU A 495      55.339  74.401 103.152  1.00 70.69           N  
+ATOM   3883  CA  GLU A 495      56.187  73.386 102.543  1.00 70.69           C  
+ATOM   3884  C   GLU A 495      55.651  72.858 101.219  1.00 70.69           C  
+ATOM   3885  O   GLU A 495      56.373  72.129 100.529  1.00 70.69           O  
+ATOM   3886  CB  GLU A 495      56.387  72.219 103.513  1.00 70.69           C  
+ATOM   3887  CG  GLU A 495      57.072  72.605 104.813  1.00 70.69           C  
+ATOM   3888  CD  GLU A 495      58.521  73.005 104.613  1.00 70.69           C  
+ATOM   3889  OE1 GLU A 495      59.135  72.549 103.626  1.00 70.69           O  
+ATOM   3890  OE2 GLU A 495      59.046  73.776 105.443  1.00 70.69           O  
+ATOM   3891  N   THR A 496      54.417  73.197 100.841  1.00 73.98           N  
+ATOM   3892  CA  THR A 496      53.889  72.725  99.566  1.00 73.98           C  
+ATOM   3893  C   THR A 496      54.481  73.467  98.376  1.00 73.98           C  
+ATOM   3894  O   THR A 496      54.275  73.034  97.237  1.00 73.98           O  
+ATOM   3895  CB  THR A 496      52.365  72.853  99.538  1.00 73.98           C  
+ATOM   3896  OG1 THR A 496      51.982  74.145 100.019  1.00 73.98           O  
+ATOM   3897  CG2 THR A 496      51.728  71.782 100.411  1.00 73.98           C  
+ATOM   3898  N   TYR A 497      55.200  74.559  98.606  1.00 71.05           N  
+ATOM   3899  CA  TYR A 497      55.825  75.321  97.538  1.00 71.05           C  
+ATOM   3900  C   TYR A 497      57.209  74.764  97.223  1.00 71.05           C  
+ATOM   3901  O   TYR A 497      57.833  74.080  98.037  1.00 71.05           O  
+ATOM   3902  CB  TYR A 497      55.937  76.797  97.922  1.00 71.05           C  
+ATOM   3903  CG  TYR A 497      54.612  77.514  98.031  1.00 71.05           C  
+ATOM   3904  CD1 TYR A 497      54.143  78.307  96.994  1.00 71.05           C  
+ATOM   3905  CD2 TYR A 497      53.833  77.401  99.173  1.00 71.05           C  
+ATOM   3906  CE1 TYR A 497      52.934  78.967  97.090  1.00 71.05           C  
+ATOM   3907  CE2 TYR A 497      52.622  78.056  99.279  1.00 71.05           C  
+ATOM   3908  CZ  TYR A 497      52.177  78.837  98.235  1.00 71.05           C  
+ATOM   3909  OH  TYR A 497      50.971  79.490  98.339  1.00 71.05           O  
+ATOM   3910  N   CYS A 498      57.681  75.059  96.016  1.00 60.99           N  
+ATOM   3911  CA  CYS A 498      59.030  74.696  95.593  1.00 60.99           C  
+ATOM   3912  C   CYS A 498      59.669  75.880  94.874  1.00 60.99           C  
+ATOM   3913  O   CYS A 498      60.196  75.758  93.768  1.00 60.99           O  
+ATOM   3914  CB  CYS A 498      59.019  73.446  94.718  1.00 60.99           C  
+ATOM   3915  SG  CYS A 498      60.651  72.714  94.460  1.00 60.99           S  
+ATOM   3916  N   ASP A 499      59.601  77.053  95.509  1.00 61.22           N  
+ATOM   3917  CA  ASP A 499      60.093  78.329  94.992  1.00 61.22           C  
+ATOM   3918  C   ASP A 499      61.458  78.240  94.310  1.00 61.22           C  
+ATOM   3919  O   ASP A 499      61.644  78.867  93.259  1.00 61.22           O  
+ATOM   3920  CB  ASP A 499      60.144  79.365  96.119  1.00 61.22           C  
+ATOM   3921  CG  ASP A 499      58.804  79.553  96.797  1.00 61.22           C  
+ATOM   3922  OD1 ASP A 499      57.766  79.327  96.142  1.00 61.22           O  
+ATOM   3923  OD2 ASP A 499      58.787  79.933  97.987  1.00 61.22           O  
+ATOM   3924  N   PRO A 500      62.442  77.509  94.856  1.00 50.61           N  
+ATOM   3925  CA  PRO A 500      63.717  77.384  94.127  1.00 50.61           C  
+ATOM   3926  C   PRO A 500      63.568  76.807  92.731  1.00 50.61           C  
+ATOM   3927  O   PRO A 500      64.308  77.203  91.823  1.00 50.61           O  
+ATOM   3928  CB  PRO A 500      64.545  76.463  95.032  1.00 50.61           C  
+ATOM   3929  CG  PRO A 500      64.012  76.700  96.380  1.00 50.61           C  
+ATOM   3930  CD  PRO A 500      62.546  76.933  96.210  1.00 50.61           C  
+ATOM   3931  N   ALA A 501      62.625  75.883  92.530  1.00 47.13           N  
+ATOM   3932  CA  ALA A 501      62.464  75.260  91.222  1.00 47.13           C  
+ATOM   3933  C   ALA A 501      61.832  76.196  90.202  1.00 47.13           C  
+ATOM   3934  O   ALA A 501      61.816  75.869  89.011  1.00 47.13           O  
+ATOM   3935  CB  ALA A 501      61.627  73.987  91.341  1.00 47.13           C  
+ATOM   3936  N   SER A 502      61.308  77.343  90.636  1.00 47.94           N  
+ATOM   3937  CA  SER A 502      60.716  78.284  89.692  1.00 47.94           C  
+ATOM   3938  C   SER A 502      61.761  78.861  88.748  1.00 47.94           C  
+ATOM   3939  O   SER A 502      61.426  79.275  87.632  1.00 47.94           O  
+ATOM   3940  CB  SER A 502      60.002  79.404  90.445  1.00 47.94           C  
+ATOM   3941  OG  SER A 502      60.898  80.455  90.760  1.00 47.94           O  
+ATOM   3942  N   LEU A 503      63.022  78.898  89.170  1.00 43.23           N  
+ATOM   3943  CA  LEU A 503      64.094  79.404  88.326  1.00 43.23           C  
+ATOM   3944  C   LEU A 503      64.408  78.409  87.218  1.00 43.23           C  
+ATOM   3945  O   LEU A 503      64.257  77.197  87.391  1.00 43.23           O  
+ATOM   3946  CB  LEU A 503      65.345  79.679  89.161  1.00 43.23           C  
+ATOM   3947  CG  LEU A 503      66.520  80.359  88.454  1.00 43.23           C  
+ATOM   3948  CD1 LEU A 503      66.131  81.747  87.976  1.00 43.23           C  
+ATOM   3949  CD2 LEU A 503      67.733  80.423  89.364  1.00 43.23           C  
+ATOM   3950  N   PHE A 504      64.845  78.930  86.071  1.00 41.52           N  
+ATOM   3951  CA  PHE A 504      65.142  78.068  84.932  1.00 41.52           C  
+ATOM   3952  C   PHE A 504      66.315  77.143  85.229  1.00 41.52           C  
+ATOM   3953  O   PHE A 504      66.249  75.936  84.973  1.00 41.52           O  
+ATOM   3954  CB  PHE A 504      65.430  78.915  83.694  1.00 41.52           C  
+ATOM   3955  CG  PHE A 504      66.131  78.165  82.600  1.00 41.52           C  
+ATOM   3956  CD1 PHE A 504      65.456  77.219  81.850  1.00 41.52           C  
+ATOM   3957  CD2 PHE A 504      67.463  78.406  82.322  1.00 41.52           C  
+ATOM   3958  CE1 PHE A 504      66.096  76.529  80.845  1.00 41.52           C  
+ATOM   3959  CE2 PHE A 504      68.109  77.716  81.318  1.00 41.52           C  
+ATOM   3960  CZ  PHE A 504      67.424  76.776  80.579  1.00 41.52           C  
+ATOM   3961  N   HIS A 505      67.403  77.694  85.771  1.00 36.70           N  
+ATOM   3962  CA  HIS A 505      68.611  76.904  85.981  1.00 36.70           C  
+ATOM   3963  C   HIS A 505      68.428  75.817  87.028  1.00 36.70           C  
+ATOM   3964  O   HIS A 505      69.243  74.889  87.089  1.00 36.70           O  
+ATOM   3965  CB  HIS A 505      69.767  77.821  86.380  1.00 36.70           C  
+ATOM   3966  CG  HIS A 505      70.238  78.711  85.274  1.00 36.70           C  
+ATOM   3967  ND1 HIS A 505      69.606  79.891  84.949  1.00 36.70           N  
+ATOM   3968  CD2 HIS A 505      71.272  78.586  84.410  1.00 36.70           C  
+ATOM   3969  CE1 HIS A 505      70.235  80.460  83.936  1.00 36.70           C  
+ATOM   3970  NE2 HIS A 505      71.249  79.688  83.590  1.00 36.70           N  
+ATOM   3971  N   VAL A 506      67.385  75.901  87.850  1.00 39.84           N  
+ATOM   3972  CA  VAL A 506      67.149  74.915  88.897  1.00 39.84           C  
+ATOM   3973  C   VAL A 506      66.298  73.781  88.345  1.00 39.84           C  
+ATOM   3974  O   VAL A 506      66.659  72.603  88.463  1.00 39.84           O  
+ATOM   3975  CB  VAL A 506      66.480  75.559  90.124  1.00 39.84           C  
+ATOM   3976  CG1 VAL A 506      66.130  74.502  91.154  1.00 39.84           C  
+ATOM   3977  CG2 VAL A 506      67.391  76.615  90.725  1.00 39.84           C  
+ATOM   3978  N   SER A 507      65.163  74.127  87.735  1.00 39.37           N  
+ATOM   3979  CA  SER A 507      64.248  73.115  87.223  1.00 39.37           C  
+ATOM   3980  C   SER A 507      64.816  72.361  86.029  1.00 39.37           C  
+ATOM   3981  O   SER A 507      64.299  71.292  85.688  1.00 39.37           O  
+ATOM   3982  CB  SER A 507      62.917  73.758  86.837  1.00 39.37           C  
+ATOM   3983  OG  SER A 507      63.054  74.532  85.659  1.00 39.37           O  
+ATOM   3984  N   ASN A 508      65.857  72.885  85.387  1.00 43.08           N  
+ATOM   3985  CA  ASN A 508      66.447  72.249  84.218  1.00 43.08           C  
+ATOM   3986  C   ASN A 508      67.786  71.586  84.515  1.00 43.08           C  
+ATOM   3987  O   ASN A 508      68.531  71.283  83.577  1.00 43.08           O  
+ATOM   3988  CB  ASN A 508      66.607  73.270  83.092  1.00 43.08           C  
+ATOM   3989  CG  ASN A 508      65.302  73.561  82.381  1.00 43.08           C  
+ATOM   3990  OD1 ASN A 508      65.081  73.111  81.256  1.00 43.08           O  
+ATOM   3991  ND2 ASN A 508      64.424  74.310  83.037  1.00 43.08           N  
+ATOM   3992  N   ASP A 509      68.106  71.355  85.790  1.00 46.34           N  
+ATOM   3993  CA  ASP A 509      69.304  70.620  86.199  1.00 46.34           C  
+ATOM   3994  C   ASP A 509      70.569  71.292  85.654  1.00 46.34           C  
+ATOM   3995  O   ASP A 509      71.274  70.770  84.789  1.00 46.34           O  
+ATOM   3996  CB  ASP A 509      69.207  69.150  85.765  1.00 46.34           C  
+ATOM   3997  CG  ASP A 509      70.354  68.303  86.287  1.00 46.34           C  
+ATOM   3998  OD1 ASP A 509      70.189  67.674  87.351  1.00 46.34           O  
+ATOM   3999  OD2 ASP A 509      71.410  68.240  85.624  1.00 46.34           O  
+ATOM   4000  N   TYR A 510      70.819  72.493  86.167  1.00 40.59           N  
+ATOM   4001  CA  TYR A 510      71.992  73.268  85.791  1.00 40.59           C  
+ATOM   4002  C   TYR A 510      72.683  73.806  87.035  1.00 40.59           C  
+ATOM   4003  O   TYR A 510      72.031  74.340  87.937  1.00 40.59           O  
+ATOM   4004  CB  TYR A 510      71.621  74.425  84.857  1.00 40.59           C  
+ATOM   4005  CG  TYR A 510      71.526  74.029  83.401  1.00 40.59           C  
+ATOM   4006  CD1 TYR A 510      72.669  73.790  82.653  1.00 40.59           C  
+ATOM   4007  CD2 TYR A 510      70.294  73.898  82.776  1.00 40.59           C  
+ATOM   4008  CE1 TYR A 510      72.589  73.428  81.323  1.00 40.59           C  
+ATOM   4009  CE2 TYR A 510      70.204  73.537  81.446  1.00 40.59           C  
+ATOM   4010  CZ  TYR A 510      71.355  73.304  80.724  1.00 40.59           C  
+ATOM   4011  OH  TYR A 510      71.272  72.945  79.398  1.00 40.59           O  
+ATOM   4012  N   SER A 511      74.005  73.660  87.077  1.00 35.21           N  
+ATOM   4013  CA  SER A 511      74.792  74.222  88.164  1.00 35.21           C  
+ATOM   4014  C   SER A 511      74.745  75.746  88.114  1.00 35.21           C  
+ATOM   4015  O   SER A 511      74.514  76.347  87.062  1.00 35.21           O  
+ATOM   4016  CB  SER A 511      76.237  73.736  88.087  1.00 35.21           C  
+ATOM   4017  OG  SER A 511      76.721  73.797  86.757  1.00 35.21           O  
+ATOM   4018  N   PHE A 512      74.976  76.374  89.268  1.00 33.40           N  
+ATOM   4019  CA  PHE A 512      74.747  77.803  89.399  1.00 33.40           C  
+ATOM   4020  C   PHE A 512      75.919  78.573  89.994  1.00 33.40           C  
+ATOM   4021  O   PHE A 512      75.889  79.807  89.986  1.00 33.40           O  
+ATOM   4022  CB  PHE A 512      73.489  78.055  90.245  1.00 33.40           C  
+ATOM   4023  CG  PHE A 512      72.818  79.362  89.961  1.00 33.40           C  
+ATOM   4024  CD1 PHE A 512      72.134  79.558  88.775  1.00 33.40           C  
+ATOM   4025  CD2 PHE A 512      72.849  80.389  90.886  1.00 33.40           C  
+ATOM   4026  CE1 PHE A 512      71.508  80.756  88.509  1.00 33.40           C  
+ATOM   4027  CE2 PHE A 512      72.222  81.592  90.625  1.00 33.40           C  
+ATOM   4028  CZ  PHE A 512      71.551  81.775  89.436  1.00 33.40           C  
+ATOM   4029  N   ILE A 513      76.951  77.893  90.504  1.00 27.93           N  
+ATOM   4030  CA  ILE A 513      78.111  78.594  91.052  1.00 27.93           C  
+ATOM   4031  C   ILE A 513      79.025  79.131  89.963  1.00 27.93           C  
+ATOM   4032  O   ILE A 513      79.909  79.956  90.249  1.00 27.93           O  
+ATOM   4033  CB  ILE A 513      78.901  77.674  92.001  1.00 27.93           C  
+ATOM   4034  CG1 ILE A 513      79.619  78.496  93.071  1.00 27.93           C  
+ATOM   4035  CG2 ILE A 513      79.883  76.815  91.224  1.00 27.93           C  
+ATOM   4036  CD1 ILE A 513      78.681  79.249  93.989  1.00 27.93           C  
+ATOM   4037  N   ARG A 514      78.826  78.689  88.718  1.00 31.51           N  
+ATOM   4038  CA  ARG A 514      79.634  79.190  87.617  1.00 31.51           C  
+ATOM   4039  C   ARG A 514      79.508  80.698  87.476  1.00 31.51           C  
+ATOM   4040  O   ARG A 514      80.465  81.359  87.071  1.00 31.51           O  
+ATOM   4041  CB  ARG A 514      79.240  78.496  86.313  1.00 31.51           C  
+ATOM   4042  CG  ARG A 514      77.799  78.717  85.891  1.00 31.51           C  
+ATOM   4043  CD  ARG A 514      77.278  77.541  85.086  1.00 31.51           C  
+ATOM   4044  NE  ARG A 514      78.177  77.194  83.991  1.00 31.51           N  
+ATOM   4045  CZ  ARG A 514      78.058  76.099  83.248  1.00 31.51           C  
+ATOM   4046  NH1 ARG A 514      77.076  75.241  83.485  1.00 31.51           N  
+ATOM   4047  NH2 ARG A 514      78.922  75.861  82.270  1.00 31.51           N  
+ATOM   4048  N   TYR A 515      78.360  81.267  87.843  1.00 31.38           N  
+ATOM   4049  CA  TYR A 515      78.197  82.713  87.737  1.00 31.38           C  
+ATOM   4050  C   TYR A 515      79.002  83.442  88.807  1.00 31.38           C  
+ATOM   4051  O   TYR A 515      79.587  84.498  88.538  1.00 31.38           O  
+ATOM   4052  CB  TYR A 515      76.716  83.074  87.819  1.00 31.38           C  
+ATOM   4053  CG  TYR A 515      75.887  82.353  86.783  1.00 31.38           C  
+ATOM   4054  CD1 TYR A 515      76.093  82.576  85.429  1.00 31.38           C  
+ATOM   4055  CD2 TYR A 515      74.911  81.441  87.154  1.00 31.38           C  
+ATOM   4056  CE1 TYR A 515      75.347  81.918  84.476  1.00 31.38           C  
+ATOM   4057  CE2 TYR A 515      74.159  80.777  86.206  1.00 31.38           C  
+ATOM   4058  CZ  TYR A 515      74.382  81.020  84.869  1.00 31.38           C  
+ATOM   4059  OH  TYR A 515      73.638  80.365  83.918  1.00 31.38           O  
+ATOM   4060  N   TYR A 516      79.063  82.885  90.017  1.00 26.61           N  
+ATOM   4061  CA  TYR A 516      79.906  83.461  91.061  1.00 26.61           C  
+ATOM   4062  C   TYR A 516      81.375  83.420  90.656  1.00 26.61           C  
+ATOM   4063  O   TYR A 516      82.093  84.428  90.748  1.00 26.61           O  
+ATOM   4064  CB  TYR A 516      79.682  82.709  92.373  1.00 26.61           C  
+ATOM   4065  CG  TYR A 516      80.275  83.370  93.595  1.00 26.61           C  
+ATOM   4066  CD1 TYR A 516      81.577  83.101  93.990  1.00 26.61           C  
+ATOM   4067  CD2 TYR A 516      79.526  84.246  94.364  1.00 26.61           C  
+ATOM   4068  CE1 TYR A 516      82.120  83.697  95.108  1.00 26.61           C  
+ATOM   4069  CE2 TYR A 516      80.061  84.846  95.483  1.00 26.61           C  
+ATOM   4070  CZ  TYR A 516      81.357  84.568  95.851  1.00 26.61           C  
+ATOM   4071  OH  TYR A 516      81.893  85.165  96.966  1.00 26.61           O  
+ATOM   4072  N   THR A 517      81.842  82.252  90.202  1.00 28.74           N  
+ATOM   4073  CA  THR A 517      83.231  82.160  89.766  1.00 28.74           C  
+ATOM   4074  C   THR A 517      83.505  83.056  88.564  1.00 28.74           C  
+ATOM   4075  O   THR A 517      84.593  83.629  88.465  1.00 28.74           O  
+ATOM   4076  CB  THR A 517      83.604  80.713  89.449  1.00 28.74           C  
+ATOM   4077  OG1 THR A 517      83.083  80.348  88.165  1.00 28.74           O  
+ATOM   4078  CG2 THR A 517      83.061  79.776  90.511  1.00 28.74           C  
+ATOM   4079  N   ARG A 518      82.537  83.206  87.657  1.00 32.40           N  
+ATOM   4080  CA  ARG A 518      82.695  84.118  86.531  1.00 32.40           C  
+ATOM   4081  C   ARG A 518      82.865  85.552  87.009  1.00 32.40           C  
+ATOM   4082  O   ARG A 518      83.755  86.273  86.545  1.00 32.40           O  
+ATOM   4083  CB  ARG A 518      81.483  84.011  85.605  1.00 32.40           C  
+ATOM   4084  CG  ARG A 518      81.346  85.166  84.626  1.00 32.40           C  
+ATOM   4085  CD  ARG A 518      79.904  85.344  84.176  1.00 32.40           C  
+ATOM   4086  NE  ARG A 518      79.047  85.869  85.231  1.00 32.40           N  
+ATOM   4087  CZ  ARG A 518      78.893  87.163  85.488  1.00 32.40           C  
+ATOM   4088  NH1 ARG A 518      78.092  87.556  86.468  1.00 32.40           N  
+ATOM   4089  NH2 ARG A 518      79.538  88.064  84.762  1.00 32.40           N  
+ATOM   4090  N   THR A 519      82.001  85.985  87.929  1.00 29.37           N  
+ATOM   4091  CA  THR A 519      82.071  87.352  88.429  1.00 29.37           C  
+ATOM   4092  C   THR A 519      83.409  87.627  89.100  1.00 29.37           C  
+ATOM   4093  O   THR A 519      83.986  88.708  88.930  1.00 29.37           O  
+ATOM   4094  CB  THR A 519      80.921  87.609  89.400  1.00 29.37           C  
+ATOM   4095  OG1 THR A 519      79.673  87.448  88.715  1.00 29.37           O  
+ATOM   4096  CG2 THR A 519      81.003  89.013  89.957  1.00 29.37           C  
+ATOM   4097  N   LEU A 520      83.928  86.661  89.858  1.00 23.24           N  
+ATOM   4098  CA  LEU A 520      85.219  86.888  90.506  1.00 23.24           C  
+ATOM   4099  C   LEU A 520      86.367  86.862  89.498  1.00 23.24           C  
+ATOM   4100  O   LEU A 520      87.247  87.737  89.523  1.00 23.24           O  
+ATOM   4101  CB  LEU A 520      85.439  85.859  91.612  1.00 23.24           C  
+ATOM   4102  CG  LEU A 520      84.989  86.303  93.007  1.00 23.24           C  
+ATOM   4103  CD1 LEU A 520      83.483  86.464  93.081  1.00 23.24           C  
+ATOM   4104  CD2 LEU A 520      85.467  85.314  94.052  1.00 23.24           C  
+ATOM   4105  N   TYR A 521      86.368  85.879  88.593  1.00 30.85           N  
+ATOM   4106  CA  TYR A 521      87.472  85.733  87.654  1.00 30.85           C  
+ATOM   4107  C   TYR A 521      87.535  86.889  86.670  1.00 30.85           C  
+ATOM   4108  O   TYR A 521      88.628  87.267  86.240  1.00 30.85           O  
+ATOM   4109  CB  TYR A 521      87.355  84.410  86.896  1.00 30.85           C  
+ATOM   4110  CG  TYR A 521      87.475  83.181  87.766  1.00 30.85           C  
+ATOM   4111  CD1 TYR A 521      88.114  83.234  88.996  1.00 30.85           C  
+ATOM   4112  CD2 TYR A 521      86.944  81.968  87.357  1.00 30.85           C  
+ATOM   4113  CE1 TYR A 521      88.220  82.115  89.792  1.00 30.85           C  
+ATOM   4114  CE2 TYR A 521      87.045  80.844  88.147  1.00 30.85           C  
+ATOM   4115  CZ  TYR A 521      87.684  80.922  89.363  1.00 30.85           C  
+ATOM   4116  OH  TYR A 521      87.785  79.803  90.150  1.00 30.85           O  
+ATOM   4117  N   GLN A 522      86.390  87.464  86.295  1.00 29.18           N  
+ATOM   4118  CA  GLN A 522      86.424  88.557  85.330  1.00 29.18           C  
+ATOM   4119  C   GLN A 522      87.107  89.785  85.918  1.00 29.18           C  
+ATOM   4120  O   GLN A 522      87.918  90.429  85.246  1.00 29.18           O  
+ATOM   4121  CB  GLN A 522      85.010  88.885  84.840  1.00 29.18           C  
+ATOM   4122  CG  GLN A 522      84.119  89.612  85.830  1.00 29.18           C  
+ATOM   4123  CD  GLN A 522      82.898  90.218  85.175  1.00 29.18           C  
+ATOM   4124  OE1 GLN A 522      81.913  89.530  84.916  1.00 29.18           O  
+ATOM   4125  NE2 GLN A 522      82.959  91.512  84.896  1.00 29.18           N  
+ATOM   4126  N   PHE A 523      86.834  90.099  87.183  1.00 28.17           N  
+ATOM   4127  CA  PHE A 523      87.507  91.231  87.803  1.00 28.17           C  
+ATOM   4128  C   PHE A 523      88.965  90.921  88.103  1.00 28.17           C  
+ATOM   4129  O   PHE A 523      89.813  91.815  88.003  1.00 28.17           O  
+ATOM   4130  CB  PHE A 523      86.771  91.653  89.072  1.00 28.17           C  
+ATOM   4131  CG  PHE A 523      85.450  92.306  88.804  1.00 28.17           C  
+ATOM   4132  CD1 PHE A 523      85.364  93.395  87.958  1.00 28.17           C  
+ATOM   4133  CD2 PHE A 523      84.293  91.824  89.385  1.00 28.17           C  
+ATOM   4134  CE1 PHE A 523      84.151  93.996  87.703  1.00 28.17           C  
+ATOM   4135  CE2 PHE A 523      83.077  92.422  89.135  1.00 28.17           C  
+ATOM   4136  CZ  PHE A 523      83.006  93.508  88.292  1.00 28.17           C  
+ATOM   4137  N   GLN A 524      89.283  89.669  88.446  1.00 33.75           N  
+ATOM   4138  CA  GLN A 524      90.687  89.294  88.587  1.00 33.75           C  
+ATOM   4139  C   GLN A 524      91.444  89.514  87.281  1.00 33.75           C  
+ATOM   4140  O   GLN A 524      92.516  90.135  87.266  1.00 33.75           O  
+ATOM   4141  CB  GLN A 524      90.802  87.841  89.041  1.00 33.75           C  
+ATOM   4142  CG  GLN A 524      90.336  87.600  90.462  1.00 33.75           C  
+ATOM   4143  CD  GLN A 524      90.658  86.206  90.949  1.00 33.75           C  
+ATOM   4144  OE1 GLN A 524      89.920  85.630  91.746  1.00 33.75           O  
+ATOM   4145  NE2 GLN A 524      91.765  85.654  90.471  1.00 33.75           N  
+ATOM   4146  N   PHE A 525      90.891  89.020  86.170  1.00 35.52           N  
+ATOM   4147  CA  PHE A 525      91.516  89.211  84.865  1.00 35.52           C  
+ATOM   4148  C   PHE A 525      91.631  90.688  84.520  1.00 35.52           C  
+ATOM   4149  O   PHE A 525      92.658  91.130  83.996  1.00 35.52           O  
+ATOM   4150  CB  PHE A 525      90.718  88.487  83.778  1.00 35.52           C  
+ATOM   4151  CG  PHE A 525      90.629  87.001  83.964  1.00 35.52           C  
+ATOM   4152  CD1 PHE A 525      91.629  86.303  84.615  1.00 35.52           C  
+ATOM   4153  CD2 PHE A 525      89.541  86.299  83.475  1.00 35.52           C  
+ATOM   4154  CE1 PHE A 525      91.540  84.934  84.780  1.00 35.52           C  
+ATOM   4155  CE2 PHE A 525      89.448  84.934  83.638  1.00 35.52           C  
+ATOM   4156  CZ  PHE A 525      90.449  84.252  84.292  1.00 35.52           C  
+ATOM   4157  N   GLN A 526      90.580  91.464  84.793  1.00 33.42           N  
+ATOM   4158  CA  GLN A 526      90.598  92.882  84.453  1.00 33.42           C  
+ATOM   4159  C   GLN A 526      91.693  93.612  85.216  1.00 33.42           C  
+ATOM   4160  O   GLN A 526      92.464  94.380  84.630  1.00 33.42           O  
+ATOM   4161  CB  GLN A 526      89.230  93.502  84.733  1.00 33.42           C  
+ATOM   4162  CG  GLN A 526      89.162  95.004  84.503  1.00 33.42           C  
+ATOM   4163  CD  GLN A 526      88.951  95.373  83.045  1.00 33.42           C  
+ATOM   4164  OE1 GLN A 526      89.202  94.572  82.144  1.00 33.42           O  
+ATOM   4165  NE2 GLN A 526      88.483  96.591  82.808  1.00 33.42           N  
+ATOM   4166  N   GLU A 527      91.784  93.382  86.528  1.00 36.52           N  
+ATOM   4167  CA  GLU A 527      92.815  94.049  87.314  1.00 36.52           C  
+ATOM   4168  C   GLU A 527      94.208  93.604  86.890  1.00 36.52           C  
+ATOM   4169  O   GLU A 527      95.131  94.422  86.814  1.00 36.52           O  
+ATOM   4170  CB  GLU A 527      92.603  93.794  88.805  1.00 36.52           C  
+ATOM   4171  CG  GLU A 527      93.328  94.788  89.696  1.00 36.52           C  
+ATOM   4172  CD  GLU A 527      93.388  94.347  91.144  1.00 36.52           C  
+ATOM   4173  OE1 GLU A 527      93.952  93.268  91.416  1.00 36.52           O  
+ATOM   4174  OE2 GLU A 527      92.870  95.082  92.011  1.00 36.52           O  
+ATOM   4175  N   ALA A 528      94.379  92.312  86.592  1.00 34.78           N  
+ATOM   4176  CA  ALA A 528      95.686  91.830  86.157  1.00 34.78           C  
+ATOM   4177  C   ALA A 528      96.100  92.477  84.840  1.00 34.78           C  
+ATOM   4178  O   ALA A 528      97.245  92.919  84.682  1.00 34.78           O  
+ATOM   4179  CB  ALA A 528      95.664  90.308  86.030  1.00 34.78           C  
+ATOM   4180  N   LEU A 529      95.174  92.552  83.881  1.00 38.02           N  
+ATOM   4181  CA  LEU A 529      95.501  93.133  82.584  1.00 38.02           C  
+ATOM   4182  C   LEU A 529      95.743  94.633  82.696  1.00 38.02           C  
+ATOM   4183  O   LEU A 529      96.609  95.181  82.006  1.00 38.02           O  
+ATOM   4184  CB  LEU A 529      94.388  92.841  81.580  1.00 38.02           C  
+ATOM   4185  CG  LEU A 529      94.150  91.365  81.249  1.00 38.02           C  
+ATOM   4186  CD1 LEU A 529      93.140  91.218  80.123  1.00 38.02           C  
+ATOM   4187  CD2 LEU A 529      95.454  90.669  80.902  1.00 38.02           C  
+ATOM   4188  N   CYS A 530      94.989  95.317  83.561  1.00 42.87           N  
+ATOM   4189  CA  CYS A 530      95.202  96.746  83.745  1.00 42.87           C  
+ATOM   4190  C   CYS A 530      96.527  97.028  84.437  1.00 42.87           C  
+ATOM   4191  O   CYS A 530      97.164  98.049  84.158  1.00 42.87           O  
+ATOM   4192  CB  CYS A 530      94.045  97.353  84.534  1.00 42.87           C  
+ATOM   4193  SG  CYS A 530      92.468  97.308  83.660  1.00 42.87           S  
+ATOM   4194  N   GLN A 531      96.957  96.147  85.341  1.00 43.52           N  
+ATOM   4195  CA  GLN A 531      98.298  96.272  85.899  1.00 43.52           C  
+ATOM   4196  C   GLN A 531      99.353  96.004  84.836  1.00 43.52           C  
+ATOM   4197  O   GLN A 531     100.413  96.641  84.826  1.00 43.52           O  
+ATOM   4198  CB  GLN A 531      98.470  95.320  87.081  1.00 43.52           C  
+ATOM   4199  CG  GLN A 531      97.724  95.743  88.333  1.00 43.52           C  
+ATOM   4200  CD  GLN A 531      98.211  95.019  89.571  1.00 43.52           C  
+ATOM   4201  OE1 GLN A 531      99.224  94.323  89.537  1.00 43.52           O  
+ATOM   4202  NE2 GLN A 531      97.490  95.181  90.673  1.00 43.52           N  
+ATOM   4203  N   ALA A 532      99.079  95.064  83.928  1.00 42.86           N  
+ATOM   4204  CA  ALA A 532     100.013  94.799  82.840  1.00 42.86           C  
+ATOM   4205  C   ALA A 532     100.021  95.928  81.818  1.00 42.86           C  
+ATOM   4206  O   ALA A 532     101.068  96.222  81.230  1.00 42.86           O  
+ATOM   4207  CB  ALA A 532      99.671  93.475  82.162  1.00 42.86           C  
+ATOM   4208  N   ALA A 533      98.876  96.570  81.594  1.00 42.61           N  
+ATOM   4209  CA  ALA A 533      98.782  97.675  80.649  1.00 42.61           C  
+ATOM   4210  C   ALA A 533      99.224  99.004  81.244  1.00 42.61           C  
+ATOM   4211  O   ALA A 533      99.157 100.025  80.549  1.00 42.61           O  
+ATOM   4212  CB  ALA A 533      97.350  97.800  80.124  1.00 42.61           C  
+ATOM   4213  N   LYS A 534      99.665  99.014  82.503  1.00 49.56           N  
+ATOM   4214  CA  LYS A 534     100.111 100.228  83.188  1.00 49.56           C  
+ATOM   4215  C   LYS A 534      99.030 101.303  83.198  1.00 49.56           C  
+ATOM   4216  O   LYS A 534      99.319 102.492  83.038  1.00 49.56           O  
+ATOM   4217  CB  LYS A 534     101.404 100.772  82.575  1.00 49.56           C  
+ATOM   4218  CG  LYS A 534     102.561  99.787  82.601  1.00 49.56           C  
+ATOM   4219  CD  LYS A 534     102.788  99.231  83.999  1.00 49.56           C  
+ATOM   4220  CE  LYS A 534     103.219 100.317  84.972  1.00 49.56           C  
+ATOM   4221  NZ  LYS A 534     103.408  99.784  86.348  1.00 49.56           N  
+ATOM   4222  N   HIS A 535      97.778 100.895  83.382  1.00 55.77           N  
+ATOM   4223  CA  HIS A 535      96.690 101.856  83.477  1.00 55.77           C  
+ATOM   4224  C   HIS A 535      96.799 102.644  84.774  1.00 55.77           C  
+ATOM   4225  O   HIS A 535      96.928 102.067  85.858  1.00 55.77           O  
+ATOM   4226  CB  HIS A 535      95.343 101.140  83.403  1.00 55.77           C  
+ATOM   4227  CG  HIS A 535      94.195 101.959  83.905  1.00 55.77           C  
+ATOM   4228  ND1 HIS A 535      93.687 103.034  83.208  1.00 55.77           N  
+ATOM   4229  CD2 HIS A 535      93.461 101.864  85.038  1.00 55.77           C  
+ATOM   4230  CE1 HIS A 535      92.687 103.564  83.889  1.00 55.77           C  
+ATOM   4231  NE2 HIS A 535      92.529 102.873  85.003  1.00 55.77           N  
+ATOM   4232  N   GLU A 536      96.752 103.968  84.660  1.00 58.74           N  
+ATOM   4233  CA  GLU A 536      96.835 104.864  85.804  1.00 58.74           C  
+ATOM   4234  C   GLU A 536      95.446 105.388  86.134  1.00 58.74           C  
+ATOM   4235  O   GLU A 536      94.711 105.816  85.238  1.00 58.74           O  
+ATOM   4236  CB  GLU A 536      97.790 106.026  85.523  1.00 58.74           C  
+ATOM   4237  CG  GLU A 536      99.243 105.614  85.350  1.00 58.74           C  
+ATOM   4238  CD  GLU A 536      99.633 105.436  83.895  1.00 58.74           C  
+ATOM   4239  OE1 GLU A 536     100.842 105.301  83.615  1.00 58.74           O  
+ATOM   4240  OE2 GLU A 536      98.730 105.433  83.032  1.00 58.74           O  
+ATOM   4241  N   GLY A 537      95.091 105.355  87.415  1.00 58.16           N  
+ATOM   4242  CA  GLY A 537      93.816 105.858  87.863  1.00 58.16           C  
+ATOM   4243  C   GLY A 537      92.893 104.758  88.345  1.00 58.16           C  
+ATOM   4244  O   GLY A 537      93.325 103.647  88.668  1.00 58.16           O  
+ATOM   4245  N   PRO A 538      91.596 105.055  88.410  1.00 52.12           N  
+ATOM   4246  CA  PRO A 538      90.631 104.046  88.860  1.00 52.12           C  
+ATOM   4247  C   PRO A 538      90.549 102.879  87.889  1.00 52.12           C  
+ATOM   4248  O   PRO A 538      90.988 102.963  86.740  1.00 52.12           O  
+ATOM   4249  CB  PRO A 538      89.308 104.820  88.918  1.00 52.12           C  
+ATOM   4250  CG  PRO A 538      89.703 106.260  88.972  1.00 52.12           C  
+ATOM   4251  CD  PRO A 538      90.959 106.359  88.171  1.00 52.12           C  
+ATOM   4252  N   LEU A 539      89.971 101.775  88.368  1.00 46.63           N  
+ATOM   4253  CA  LEU A 539      89.874 100.581  87.539  1.00 46.63           C  
+ATOM   4254  C   LEU A 539      88.692 100.650  86.580  1.00 46.63           C  
+ATOM   4255  O   LEU A 539      88.759 100.097  85.477  1.00 46.63           O  
+ATOM   4256  CB  LEU A 539      89.770  99.338  88.421  1.00 46.63           C  
+ATOM   4257  CG  LEU A 539      89.954  98.001  87.702  1.00 46.63           C  
+ATOM   4258  CD1 LEU A 539      91.318  97.948  87.041  1.00 46.63           C  
+ATOM   4259  CD2 LEU A 539      89.776  96.838  88.663  1.00 46.63           C  
+ATOM   4260  N   HIS A 540      87.610 101.324  86.973  1.00 47.18           N  
+ATOM   4261  CA  HIS A 540      86.436 101.418  86.114  1.00 47.18           C  
+ATOM   4262  C   HIS A 540      86.670 102.281  84.883  1.00 47.18           C  
+ATOM   4263  O   HIS A 540      85.813 102.302  83.993  1.00 47.18           O  
+ATOM   4264  CB  HIS A 540      85.247 101.960  86.908  1.00 47.18           C  
+ATOM   4265  CG  HIS A 540      85.350 103.416  87.234  1.00 47.18           C  
+ATOM   4266  ND1 HIS A 540      85.979 103.883  88.367  1.00 47.18           N  
+ATOM   4267  CD2 HIS A 540      84.894 104.510  86.580  1.00 47.18           C  
+ATOM   4268  CE1 HIS A 540      85.911 105.203  88.394  1.00 47.18           C  
+ATOM   4269  NE2 HIS A 540      85.258 105.608  87.320  1.00 47.18           N  
+ATOM   4270  N   LYS A 541      87.791 102.995  84.811  1.00 51.10           N  
+ATOM   4271  CA  LYS A 541      88.162 103.767  83.635  1.00 51.10           C  
+ATOM   4272  C   LYS A 541      89.279 103.109  82.839  1.00 51.10           C  
+ATOM   4273  O   LYS A 541      89.907 103.770  82.007  1.00 51.10           O  
+ATOM   4274  CB  LYS A 541      88.579 105.183  84.040  1.00 51.10           C  
+ATOM   4275  CG  LYS A 541      87.538 105.931  84.851  1.00 51.10           C  
+ATOM   4276  CD  LYS A 541      88.134 107.166  85.505  1.00 51.10           C  
+ATOM   4277  CE  LYS A 541      88.640 108.151  84.467  1.00 51.10           C  
+ATOM   4278  NZ  LYS A 541      87.541 108.639  83.589  1.00 51.10           N  
+ATOM   4279  N   CYS A 542      89.538 101.828  83.074  1.00 52.06           N  
+ATOM   4280  CA  CYS A 542      90.654 101.145  82.437  1.00 52.06           C  
+ATOM   4281  C   CYS A 542      90.266 100.624  81.063  1.00 52.06           C  
+ATOM   4282  O   CYS A 542      89.092 100.368  80.784  1.00 52.06           O  
+ATOM   4283  CB  CYS A 542      91.137  99.987  83.307  1.00 52.06           C  
+ATOM   4284  SG  CYS A 542      92.459  99.016  82.566  1.00 52.06           S  
+ATOM   4285  N   ASP A 543      91.269 100.466  80.203  1.00 43.34           N  
+ATOM   4286  CA  ASP A 543      91.072  99.921  78.869  1.00 43.34           C  
+ATOM   4287  C   ASP A 543      92.329  99.169  78.466  1.00 43.34           C  
+ATOM   4288  O   ASP A 543      93.442  99.644  78.705  1.00 43.34           O  
+ATOM   4289  CB  ASP A 543      90.765 101.028  77.857  1.00 43.34           C  
+ATOM   4290  CG  ASP A 543      90.186 100.487  76.572  1.00 43.34           C  
+ATOM   4291  OD1 ASP A 543      90.776  99.552  75.998  1.00 43.34           O  
+ATOM   4292  OD2 ASP A 543      89.137 100.998  76.135  1.00 43.34           O  
+ATOM   4293  N   ILE A 544      92.148  97.999  77.856  1.00 40.95           N  
+ATOM   4294  CA  ILE A 544      93.262  97.124  77.510  1.00 40.95           C  
+ATOM   4295  C   ILE A 544      93.670  97.358  76.058  1.00 40.95           C  
+ATOM   4296  O   ILE A 544      94.691  96.837  75.597  1.00 40.95           O  
+ATOM   4297  CB  ILE A 544      92.901  95.648  77.782  1.00 40.95           C  
+ATOM   4298  CG1 ILE A 544      92.424  95.469  79.226  1.00 40.95           C  
+ATOM   4299  CG2 ILE A 544      94.082  94.725  77.557  1.00 40.95           C  
+ATOM   4300  CD1 ILE A 544      90.929  95.478  79.409  1.00 40.95           C  
+ATOM   4301  N   SER A 545      92.899  98.168  75.335  1.00 40.66           N  
+ATOM   4302  CA  SER A 545      93.218  98.441  73.939  1.00 40.66           C  
+ATOM   4303  C   SER A 545      94.603  99.064  73.813  1.00 40.66           C  
+ATOM   4304  O   SER A 545      95.063  99.795  74.694  1.00 40.66           O  
+ATOM   4305  CB  SER A 545      92.178  99.371  73.317  1.00 40.66           C  
+ATOM   4306  OG  SER A 545      90.869  98.871  73.507  1.00 40.66           O  
+ATOM   4307  N   ASN A 546      95.269  98.758  72.698  1.00 46.21           N  
+ATOM   4308  CA  ASN A 546      96.619  99.249  72.415  1.00 46.21           C  
+ATOM   4309  C   ASN A 546      97.612  98.825  73.493  1.00 46.21           C  
+ATOM   4310  O   ASN A 546      98.470  99.609  73.904  1.00 46.21           O  
+ATOM   4311  CB  ASN A 546      96.638 100.770  72.246  1.00 46.21           C  
+ATOM   4312  CG  ASN A 546      96.360 101.204  70.823  1.00 46.21           C  
+ATOM   4313  OD1 ASN A 546      96.459 100.412  69.886  1.00 46.21           O  
+ATOM   4314  ND2 ASN A 546      96.012 102.474  70.654  1.00 46.21           N  
+ATOM   4315  N   SER A 547      97.504  97.582  73.963  1.00 40.57           N  
+ATOM   4316  CA  SER A 547      98.404  97.031  74.977  1.00 40.57           C  
+ATOM   4317  C   SER A 547      98.652  95.564  74.638  1.00 40.57           C  
+ATOM   4318  O   SER A 547      97.874  94.689  75.026  1.00 40.57           O  
+ATOM   4319  CB  SER A 547      97.823  97.197  76.377  1.00 40.57           C  
+ATOM   4320  OG  SER A 547      98.521  96.397  77.315  1.00 40.57           O  
+ATOM   4321  N   THR A 548      99.743  95.299  73.917  1.00 40.13           N  
+ATOM   4322  CA  THR A 548     100.071  93.928  73.545  1.00 40.13           C  
+ATOM   4323  C   THR A 548     100.535  93.100  74.735  1.00 40.13           C  
+ATOM   4324  O   THR A 548     100.419  91.871  74.698  1.00 40.13           O  
+ATOM   4325  CB  THR A 548     101.146  93.916  72.457  1.00 40.13           C  
+ATOM   4326  OG1 THR A 548     102.230  94.770  72.844  1.00 40.13           O  
+ATOM   4327  CG2 THR A 548     100.572  94.406  71.138  1.00 40.13           C  
+ATOM   4328  N   GLU A 549     101.051  93.741  75.785  1.00 43.82           N  
+ATOM   4329  CA  GLU A 549     101.505  93.001  76.960  1.00 43.82           C  
+ATOM   4330  C   GLU A 549     100.341  92.301  77.650  1.00 43.82           C  
+ATOM   4331  O   GLU A 549     100.404  91.100  77.939  1.00 43.82           O  
+ATOM   4332  CB  GLU A 549     102.217  93.945  77.931  1.00 43.82           C  
+ATOM   4333  CG  GLU A 549     103.497  94.556  77.385  1.00 43.82           C  
+ATOM   4334  CD  GLU A 549     103.252  95.840  76.614  1.00 43.82           C  
+ATOM   4335  OE1 GLU A 549     102.089  96.292  76.560  1.00 43.82           O  
+ATOM   4336  OE2 GLU A 549     104.224  96.397  76.063  1.00 43.82           O  
+ATOM   4337  N   ALA A 550      99.265  93.041  77.925  1.00 36.76           N  
+ATOM   4338  CA  ALA A 550      98.101  92.434  78.559  1.00 36.76           C  
+ATOM   4339  C   ALA A 550      97.428  91.436  77.628  1.00 36.76           C  
+ATOM   4340  O   ALA A 550      96.893  90.416  78.080  1.00 36.76           O  
+ATOM   4341  CB  ALA A 550      97.116  93.517  78.995  1.00 36.76           C  
+ATOM   4342  N   GLY A 551      97.451  91.703  76.322  1.00 32.74           N  
+ATOM   4343  CA  GLY A 551      96.913  90.739  75.377  1.00 32.74           C  
+ATOM   4344  C   GLY A 551      97.652  89.416  75.414  1.00 32.74           C  
+ATOM   4345  O   GLY A 551      97.037  88.347  75.397  1.00 32.74           O  
+ATOM   4346  N   GLN A 552      98.984  89.467  75.479  1.00 30.84           N  
+ATOM   4347  CA  GLN A 552      99.763  88.237  75.576  1.00 30.84           C  
+ATOM   4348  C   GLN A 552      99.545  87.553  76.919  1.00 30.84           C  
+ATOM   4349  O   GLN A 552      99.464  86.320  76.988  1.00 30.84           O  
+ATOM   4350  CB  GLN A 552     101.245  88.535  75.357  1.00 30.84           C  
+ATOM   4351  CG  GLN A 552     102.134  87.307  75.422  1.00 30.84           C  
+ATOM   4352  CD  GLN A 552     101.687  86.213  74.474  1.00 30.84           C  
+ATOM   4353  OE1 GLN A 552     101.353  86.474  73.318  1.00 30.84           O  
+ATOM   4354  NE2 GLN A 552     101.675  84.978  74.960  1.00 30.84           N  
+ATOM   4355  N   LYS A 553      99.450  88.336  77.996  1.00 33.44           N  
+ATOM   4356  CA  LYS A 553      99.170  87.754  79.305  1.00 33.44           C  
+ATOM   4357  C   LYS A 553      97.836  87.020  79.305  1.00 33.44           C  
+ATOM   4358  O   LYS A 553      97.703  85.956  79.917  1.00 33.44           O  
+ATOM   4359  CB  LYS A 553      99.185  88.840  80.379  1.00 33.44           C  
+ATOM   4360  CG  LYS A 553      99.433  88.316  81.782  1.00 33.44           C  
+ATOM   4361  CD  LYS A 553      99.662  89.451  82.764  1.00 33.44           C  
+ATOM   4362  CE  LYS A 553     100.325  88.951  84.035  1.00 33.44           C  
+ATOM   4363  NZ  LYS A 553     101.658  88.350  83.762  1.00 33.44           N  
+ATOM   4364  N   LEU A 554      96.835  87.576  78.617  1.00 29.99           N  
+ATOM   4365  CA  LEU A 554      95.538  86.911  78.532  1.00 29.99           C  
+ATOM   4366  C   LEU A 554      95.612  85.666  77.659  1.00 29.99           C  
+ATOM   4367  O   LEU A 554      95.084  84.612  78.029  1.00 29.99           O  
+ATOM   4368  CB  LEU A 554      94.487  87.880  77.994  1.00 29.99           C  
+ATOM   4369  CG  LEU A 554      93.042  87.382  77.998  1.00 29.99           C  
+ATOM   4370  CD1 LEU A 554      92.533  87.218  79.420  1.00 29.99           C  
+ATOM   4371  CD2 LEU A 554      92.149  88.323  77.207  1.00 29.99           C  
+ATOM   4372  N   PHE A 555      96.266  85.767  76.499  1.00 27.29           N  
+ATOM   4373  CA  PHE A 555      96.368  84.615  75.606  1.00 27.29           C  
+ATOM   4374  C   PHE A 555      97.111  83.459  76.257  1.00 27.29           C  
+ATOM   4375  O   PHE A 555      96.825  82.293  75.956  1.00 27.29           O  
+ATOM   4376  CB  PHE A 555      97.057  85.019  74.304  1.00 27.29           C  
+ATOM   4377  CG  PHE A 555      97.186  83.895  73.317  1.00 27.29           C  
+ATOM   4378  CD1 PHE A 555      96.120  83.541  72.511  1.00 27.29           C  
+ATOM   4379  CD2 PHE A 555      98.374  83.195  73.194  1.00 27.29           C  
+ATOM   4380  CE1 PHE A 555      96.234  82.510  71.602  1.00 27.29           C  
+ATOM   4381  CE2 PHE A 555      98.493  82.162  72.287  1.00 27.29           C  
+ATOM   4382  CZ  PHE A 555      97.421  81.819  71.490  1.00 27.29           C  
+ATOM   4383  N   ASN A 556      98.068  83.755  77.143  1.00 30.36           N  
+ATOM   4384  CA  ASN A 556      98.802  82.696  77.828  1.00 30.36           C  
+ATOM   4385  C   ASN A 556      97.878  81.803  78.645  1.00 30.36           C  
+ATOM   4386  O   ASN A 556      98.149  80.609  78.801  1.00 30.36           O  
+ATOM   4387  CB  ASN A 556      99.883  83.299  78.723  1.00 30.36           C  
+ATOM   4388  CG  ASN A 556     101.177  83.550  77.981  1.00 30.36           C  
+ATOM   4389  OD1 ASN A 556     101.236  83.431  76.758  1.00 30.36           O  
+ATOM   4390  ND2 ASN A 556     102.223  83.903  78.718  1.00 30.36           N  
+ATOM   4391  N   MET A 557      96.796  82.361  79.181  1.00 29.95           N  
+ATOM   4392  CA  MET A 557      95.782  81.561  79.851  1.00 29.95           C  
+ATOM   4393  C   MET A 557      94.734  81.037  78.884  1.00 29.95           C  
+ATOM   4394  O   MET A 557      94.173  79.959  79.111  1.00 29.95           O  
+ATOM   4395  CB  MET A 557      95.100  82.380  80.947  1.00 29.95           C  
+ATOM   4396  CG  MET A 557      94.062  81.617  81.745  1.00 29.95           C  
+ATOM   4397  SD  MET A 557      92.595  82.602  82.085  1.00 29.95           S  
+ATOM   4398  CE  MET A 557      91.736  82.474  80.524  1.00 29.95           C  
+ATOM   4399  N   LEU A 558      94.462  81.779  77.811  1.00 28.02           N  
+ATOM   4400  CA  LEU A 558      93.452  81.349  76.849  1.00 28.02           C  
+ATOM   4401  C   LEU A 558      93.843  80.033  76.189  1.00 28.02           C  
+ATOM   4402  O   LEU A 558      93.045  79.091  76.142  1.00 28.02           O  
+ATOM   4403  CB  LEU A 558      93.229  82.427  75.787  1.00 28.02           C  
+ATOM   4404  CG  LEU A 558      92.751  83.834  76.153  1.00 28.02           C  
+ATOM   4405  CD1 LEU A 558      92.307  84.575  74.902  1.00 28.02           C  
+ATOM   4406  CD2 LEU A 558      91.641  83.804  77.182  1.00 28.02           C  
+ATOM   4407  N   ARG A 559      95.074  79.941  75.681  1.00 31.12           N  
+ATOM   4408  CA  ARG A 559      95.410  78.769  74.874  1.00 31.12           C  
+ATOM   4409  C   ARG A 559      95.635  77.516  75.711  1.00 31.12           C  
+ATOM   4410  O   ARG A 559      95.951  76.465  75.143  1.00 31.12           O  
+ATOM   4411  CB  ARG A 559      96.638  79.034  73.992  1.00 31.12           C  
+ATOM   4412  CG  ARG A 559      98.014  78.764  74.602  1.00 31.12           C  
+ATOM   4413  CD  ARG A 559      98.376  79.719  75.710  1.00 31.12           C  
+ATOM   4414  NE  ARG A 559      99.752  79.540  76.165  1.00 31.12           N  
+ATOM   4415  CZ  ARG A 559     100.138  78.625  77.047  1.00 31.12           C  
+ATOM   4416  NH1 ARG A 559      99.251  77.794  77.567  1.00 31.12           N  
+ATOM   4417  NH2 ARG A 559     101.412  78.538  77.404  1.00 31.12           N  
+ATOM   4418  N   LEU A 560      95.465  77.590  77.032  1.00 28.85           N  
+ATOM   4419  CA  LEU A 560      95.648  76.410  77.868  1.00 28.85           C  
+ATOM   4420  C   LEU A 560      94.522  75.404  77.671  1.00 28.85           C  
+ATOM   4421  O   LEU A 560      94.755  74.191  77.690  1.00 28.85           O  
+ATOM   4422  CB  LEU A 560      95.735  76.815  79.339  1.00 28.85           C  
+ATOM   4423  CG  LEU A 560      97.116  77.117  79.912  1.00 28.85           C  
+ATOM   4424  CD1 LEU A 560      96.993  77.635  81.330  1.00 28.85           C  
+ATOM   4425  CD2 LEU A 560      97.985  75.877  79.866  1.00 28.85           C  
+ATOM   4426  N   GLY A 561      93.295  75.885  77.480  1.00 27.25           N  
+ATOM   4427  CA  GLY A 561      92.167  74.981  77.516  1.00 27.25           C  
+ATOM   4428  C   GLY A 561      91.945  74.481  78.933  1.00 27.25           C  
+ATOM   4429  O   GLY A 561      92.220  75.175  79.916  1.00 27.25           O  
+ATOM   4430  N   LYS A 562      91.440  73.254  79.041  1.00 28.80           N  
+ATOM   4431  CA  LYS A 562      91.303  72.582  80.327  1.00 28.80           C  
+ATOM   4432  C   LYS A 562      92.338  71.478  80.506  1.00 28.80           C  
+ATOM   4433  O   LYS A 562      92.093  70.503  81.226  1.00 28.80           O  
+ATOM   4434  CB  LYS A 562      89.889  72.026  80.494  1.00 28.80           C  
+ATOM   4435  CG  LYS A 562      89.461  71.055  79.414  1.00 28.80           C  
+ATOM   4436  CD  LYS A 562      88.097  70.464  79.723  1.00 28.80           C  
+ATOM   4437  CE  LYS A 562      88.098  69.751  81.064  1.00 28.80           C  
+ATOM   4438  NZ  LYS A 562      86.756  69.203  81.407  1.00 28.80           N  
+ATOM   4439  N   SER A 563      93.500  71.618  79.865  1.00 30.16           N  
+ATOM   4440  CA  SER A 563      94.553  70.617  79.965  1.00 30.16           C  
+ATOM   4441  C   SER A 563      95.371  70.747  81.240  1.00 30.16           C  
+ATOM   4442  O   SER A 563      96.032  69.782  81.638  1.00 30.16           O  
+ATOM   4443  CB  SER A 563      95.480  70.710  78.753  1.00 30.16           C  
+ATOM   4444  OG  SER A 563      96.505  71.662  78.972  1.00 30.16           O  
+ATOM   4445  N   GLU A 564      95.345  71.906  81.881  1.00 35.54           N  
+ATOM   4446  CA  GLU A 564      96.062  72.166  83.117  1.00 35.54           C  
+ATOM   4447  C   GLU A 564      95.072  72.523  84.215  1.00 35.54           C  
+ATOM   4448  O   GLU A 564      93.936  72.921  83.931  1.00 35.54           O  
+ATOM   4449  CB  GLU A 564      97.072  73.308  82.931  1.00 35.54           C  
+ATOM   4450  CG  GLU A 564      98.184  72.999  81.940  1.00 35.54           C  
+ATOM   4451  CD  GLU A 564      99.383  72.333  82.584  1.00 35.54           C  
+ATOM   4452  OE1 GLU A 564      99.196  71.343  83.323  1.00 35.54           O  
+ATOM   4453  OE2 GLU A 564     100.517  72.801  82.353  1.00 35.54           O  
+ATOM   4454  N   PRO A 565      95.457  72.371  85.483  1.00 36.92           N  
+ATOM   4455  CA  PRO A 565      94.562  72.773  86.574  1.00 36.92           C  
+ATOM   4456  C   PRO A 565      94.181  74.240  86.457  1.00 36.92           C  
+ATOM   4457  O   PRO A 565      95.017  75.098  86.164  1.00 36.92           O  
+ATOM   4458  CB  PRO A 565      95.395  72.508  87.832  1.00 36.92           C  
+ATOM   4459  CG  PRO A 565      96.362  71.461  87.426  1.00 36.92           C  
+ATOM   4460  CD  PRO A 565      96.680  71.719  85.985  1.00 36.92           C  
+ATOM   4461  N   TRP A 566      92.896  74.523  86.684  1.00 34.56           N  
+ATOM   4462  CA  TRP A 566      92.405  75.891  86.566  1.00 34.56           C  
+ATOM   4463  C   TRP A 566      93.121  76.844  87.511  1.00 34.56           C  
+ATOM   4464  O   TRP A 566      93.184  78.046  87.230  1.00 34.56           O  
+ATOM   4465  CB  TRP A 566      90.899  75.934  86.818  1.00 34.56           C  
+ATOM   4466  CG  TRP A 566      90.507  75.630  88.223  1.00 34.56           C  
+ATOM   4467  CD1 TRP A 566      90.145  74.419  88.727  1.00 34.56           C  
+ATOM   4468  CD2 TRP A 566      90.424  76.559  89.309  1.00 34.56           C  
+ATOM   4469  NE1 TRP A 566      89.845  74.532  90.061  1.00 34.56           N  
+ATOM   4470  CE2 TRP A 566      90.009  75.838  90.443  1.00 34.56           C  
+ATOM   4471  CE3 TRP A 566      90.662  77.931  89.432  1.00 34.56           C  
+ATOM   4472  CZ2 TRP A 566      89.828  76.440  91.685  1.00 34.56           C  
+ATOM   4473  CZ3 TRP A 566      90.484  78.526  90.665  1.00 34.56           C  
+ATOM   4474  CH2 TRP A 566      90.069  77.782  91.775  1.00 34.56           C  
+ATOM   4475  N   THR A 567      93.662  76.340  88.622  1.00 40.13           N  
+ATOM   4476  CA  THR A 567      94.468  77.185  89.496  1.00 40.13           C  
+ATOM   4477  C   THR A 567      95.725  77.665  88.782  1.00 40.13           C  
+ATOM   4478  O   THR A 567      96.132  78.823  88.933  1.00 40.13           O  
+ATOM   4479  CB  THR A 567      94.830  76.423  90.769  1.00 40.13           C  
+ATOM   4480  OG1 THR A 567      95.595  75.262  90.429  1.00 40.13           O  
+ATOM   4481  CG2 THR A 567      93.571  75.988  91.498  1.00 40.13           C  
+ATOM   4482  N   LEU A 568      96.346  76.794  87.983  1.00 36.30           N  
+ATOM   4483  CA  LEU A 568      97.515  77.203  87.212  1.00 36.30           C  
+ATOM   4484  C   LEU A 568      97.141  78.227  86.147  1.00 36.30           C  
+ATOM   4485  O   LEU A 568      97.874  79.198  85.923  1.00 36.30           O  
+ATOM   4486  CB  LEU A 568      98.173  75.980  86.574  1.00 36.30           C  
+ATOM   4487  CG  LEU A 568      99.329  76.246  85.610  1.00 36.30           C  
+ATOM   4488  CD1 LEU A 568     100.457  76.981  86.314  1.00 36.30           C  
+ATOM   4489  CD2 LEU A 568      99.827  74.944  85.012  1.00 36.30           C  
+ATOM   4490  N   ALA A 569      96.002  78.027  85.481  1.00 35.22           N  
+ATOM   4491  CA  ALA A 569      95.550  78.994  84.487  1.00 35.22           C  
+ATOM   4492  C   ALA A 569      95.265  80.345  85.128  1.00 35.22           C  
+ATOM   4493  O   ALA A 569      95.529  81.394  84.531  1.00 35.22           O  
+ATOM   4494  CB  ALA A 569      94.310  78.467  83.767  1.00 35.22           C  
+ATOM   4495  N   LEU A 570      94.729  80.339  86.349  1.00 37.50           N  
+ATOM   4496  CA  LEU A 570      94.489  81.594  87.050  1.00 37.50           C  
+ATOM   4497  C   LEU A 570      95.801  82.263  87.445  1.00 37.50           C  
+ATOM   4498  O   LEU A 570      95.951  83.481  87.301  1.00 37.50           O  
+ATOM   4499  CB  LEU A 570      93.614  81.344  88.277  1.00 37.50           C  
+ATOM   4500  CG  LEU A 570      93.001  82.576  88.939  1.00 37.50           C  
+ATOM   4501  CD1 LEU A 570      92.222  83.386  87.923  1.00 37.50           C  
+ATOM   4502  CD2 LEU A 570      92.106  82.160  90.090  1.00 37.50           C  
+ATOM   4503  N   GLU A 571      96.765  81.478  87.933  1.00 39.93           N  
+ATOM   4504  CA  GLU A 571      98.070  82.032  88.280  1.00 39.93           C  
+ATOM   4505  C   GLU A 571      98.774  82.615  87.063  1.00 39.93           C  
+ATOM   4506  O   GLU A 571      99.516  83.597  87.185  1.00 39.93           O  
+ATOM   4507  CB  GLU A 571      98.937  80.953  88.932  1.00 39.93           C  
+ATOM   4508  CG  GLU A 571     100.411  81.308  89.036  1.00 39.93           C  
+ATOM   4509  CD  GLU A 571     101.195  80.297  89.844  1.00 39.93           C  
+ATOM   4510  OE1 GLU A 571     100.597  79.660  90.735  1.00 39.93           O  
+ATOM   4511  OE2 GLU A 571     102.407  80.139  89.588  1.00 39.93           O  
+ATOM   4512  N   ASN A 572      98.542  82.037  85.882  1.00 39.13           N  
+ATOM   4513  CA  ASN A 572      99.200  82.519  84.672  1.00 39.13           C  
+ATOM   4514  C   ASN A 572      98.856  83.967  84.345  1.00 39.13           C  
+ATOM   4515  O   ASN A 572      99.527  84.570  83.501  1.00 39.13           O  
+ATOM   4516  CB  ASN A 572      98.838  81.626  83.485  1.00 39.13           C  
+ATOM   4517  CG  ASN A 572      99.632  80.338  83.462  1.00 39.13           C  
+ATOM   4518  OD1 ASN A 572      99.071  79.252  83.324  1.00 39.13           O  
+ATOM   4519  ND2 ASN A 572     100.947  80.452  83.596  1.00 39.13           N  
+ATOM   4520  N   VAL A 573      97.833  84.544  84.981  1.00 37.06           N  
+ATOM   4521  CA  VAL A 573      97.424  85.921  84.732  1.00 37.06           C  
+ATOM   4522  C   VAL A 573      97.455  86.764  86.004  1.00 37.06           C  
+ATOM   4523  O   VAL A 573      97.963  87.889  86.000  1.00 37.06           O  
+ATOM   4524  CB  VAL A 573      96.036  85.989  84.055  1.00 37.06           C  
+ATOM   4525  CG1 VAL A 573      96.102  85.374  82.674  1.00 37.06           C  
+ATOM   4526  CG2 VAL A 573      94.993  85.269  84.879  1.00 37.06           C  
+ATOM   4527  N   VAL A 574      96.914  86.239  87.110  1.00 36.68           N  
+ATOM   4528  CA  VAL A 574      96.817  87.047  88.325  1.00 36.68           C  
+ATOM   4529  C   VAL A 574      97.881  86.707  89.358  1.00 36.68           C  
+ATOM   4530  O   VAL A 574      97.977  87.401  90.382  1.00 36.68           O  
+ATOM   4531  CB  VAL A 574      95.432  86.926  88.992  1.00 36.68           C  
+ATOM   4532  CG1 VAL A 574      94.337  87.359  88.029  1.00 36.68           C  
+ATOM   4533  CG2 VAL A 574      95.197  85.520  89.507  1.00 36.68           C  
+ATOM   4534  N   GLY A 575      98.679  85.666  89.131  1.00 41.01           N  
+ATOM   4535  CA  GLY A 575      99.724  85.293  90.058  1.00 41.01           C  
+ATOM   4536  C   GLY A 575      99.262  84.550  91.292  1.00 41.01           C  
+ATOM   4537  O   GLY A 575     100.107  84.152  92.104  1.00 41.01           O  
+ATOM   4538  N   ALA A 576      97.961  84.347  91.465  1.00 40.50           N  
+ATOM   4539  CA  ALA A 576      97.419  83.643  92.616  1.00 40.50           C  
+ATOM   4540  C   ALA A 576      96.904  82.270  92.199  1.00 40.50           C  
+ATOM   4541  O   ALA A 576      96.513  82.050  91.051  1.00 40.50           O  
+ATOM   4542  CB  ALA A 576      96.295  84.448  93.275  1.00 40.50           C  
+ATOM   4543  N   LYS A 577      96.903  81.347  93.157  1.00 43.98           N  
+ATOM   4544  CA  LYS A 577      96.466  79.978  92.922  1.00 43.98           C  
+ATOM   4545  C   LYS A 577      95.004  79.752  93.276  1.00 43.98           C  
+ATOM   4546  O   LYS A 577      94.529  78.617  93.185  1.00 43.98           O  
+ATOM   4547  CB  LYS A 577      97.340  79.003  93.717  1.00 43.98           C  
+ATOM   4548  CG  LYS A 577      98.478  78.388  92.920  1.00 43.98           C  
+ATOM   4549  CD  LYS A 577      99.468  77.681  93.833  1.00 43.98           C  
+ATOM   4550  CE  LYS A 577     100.903  77.949  93.408  1.00 43.98           C  
+ATOM   4551  NZ  LYS A 577     101.884  77.191  94.231  1.00 43.98           N  
+ATOM   4552  N   ASN A 578      94.281  80.793  93.677  1.00 39.10           N  
+ATOM   4553  CA  ASN A 578      92.900  80.647  94.104  1.00 39.10           C  
+ATOM   4554  C   ASN A 578      92.118  81.906  93.760  1.00 39.10           C  
+ATOM   4555  O   ASN A 578      92.663  82.872  93.221  1.00 39.10           O  
+ATOM   4556  CB  ASN A 578      92.813  80.339  95.607  1.00 39.10           C  
+ATOM   4557  CG  ASN A 578      93.435  81.425  96.471  1.00 39.10           C  
+ATOM   4558  OD1 ASN A 578      93.852  82.474  95.980  1.00 39.10           O  
+ATOM   4559  ND2 ASN A 578      93.501  81.173  97.772  1.00 39.10           N  
+ATOM   4560  N   MET A 579      90.826  81.880  94.080  1.00 40.24           N  
+ATOM   4561  CA  MET A 579      89.974  83.032  93.826  1.00 40.24           C  
+ATOM   4562  C   MET A 579      90.440  84.228  94.642  1.00 40.24           C  
+ATOM   4563  O   MET A 579      90.907  84.088  95.775  1.00 40.24           O  
+ATOM   4564  CB  MET A 579      88.520  82.708  94.168  1.00 40.24           C  
+ATOM   4565  CG  MET A 579      87.918  81.589  93.349  1.00 40.24           C  
+ATOM   4566  SD  MET A 579      86.205  81.268  93.800  1.00 40.24           S  
+ATOM   4567  CE  MET A 579      85.911  79.744  92.909  1.00 40.24           C  
+ATOM   4568  N   ASN A 580      90.309  85.413  94.057  1.00 35.14           N  
+ATOM   4569  CA  ASN A 580      90.661  86.654  94.730  1.00 35.14           C  
+ATOM   4570  C   ASN A 580      89.531  87.650  94.534  1.00 35.14           C  
+ATOM   4571  O   ASN A 580      89.037  87.828  93.418  1.00 35.14           O  
+ATOM   4572  CB  ASN A 580      91.978  87.230  94.196  1.00 35.14           C  
+ATOM   4573  CG  ASN A 580      92.603  88.229  95.145  1.00 35.14           C  
+ATOM   4574  OD1 ASN A 580      92.078  88.486  96.228  1.00 35.14           O  
+ATOM   4575  ND2 ASN A 580      93.731  88.801  94.743  1.00 35.14           N  
+ATOM   4576  N   VAL A 581      89.120  88.292  95.625  1.00 35.92           N  
+ATOM   4577  CA  VAL A 581      88.029  89.255  95.598  1.00 35.92           C  
+ATOM   4578  C   VAL A 581      88.523  90.686  95.728  1.00 35.92           C  
+ATOM   4579  O   VAL A 581      87.733  91.625  95.549  1.00 35.92           O  
+ATOM   4580  CB  VAL A 581      86.990  88.944  96.689  1.00 35.92           C  
+ATOM   4581  CG1 VAL A 581      87.494  89.401  98.039  1.00 35.92           C  
+ATOM   4582  CG2 VAL A 581      85.654  89.568  96.352  1.00 35.92           C  
+ATOM   4583  N   ARG A 582      89.804  90.885  96.031  1.00 38.59           N  
+ATOM   4584  CA  ARG A 582      90.358  92.235  96.047  1.00 38.59           C  
+ATOM   4585  C   ARG A 582      90.167  92.988  94.734  1.00 38.59           C  
+ATOM   4586  O   ARG A 582      89.923  94.206  94.793  1.00 38.59           O  
+ATOM   4587  CB  ARG A 582      91.844  92.178  96.425  1.00 38.59           C  
+ATOM   4588  CG  ARG A 582      92.110  91.677  97.834  1.00 38.59           C  
+ATOM   4589  CD  ARG A 582      91.267  92.422  98.857  1.00 38.59           C  
+ATOM   4590  NE  ARG A 582      91.430  93.868  98.749  1.00 38.59           N  
+ATOM   4591  CZ  ARG A 582      90.773  94.751  99.494  1.00 38.59           C  
+ATOM   4592  NH1 ARG A 582      89.907  94.337 100.408  1.00 38.59           N  
+ATOM   4593  NH2 ARG A 582      90.984  96.049  99.326  1.00 38.59           N  
+ATOM   4594  N   PRO A 583      90.279  92.373  93.547  1.00 37.95           N  
+ATOM   4595  CA  PRO A 583      90.021  93.144  92.318  1.00 37.95           C  
+ATOM   4596  C   PRO A 583      88.616  93.716  92.231  1.00 37.95           C  
+ATOM   4597  O   PRO A 583      88.444  94.835  91.734  1.00 37.95           O  
+ATOM   4598  CB  PRO A 583      90.290  92.120  91.209  1.00 37.95           C  
+ATOM   4599  CG  PRO A 583      91.282  91.204  91.798  1.00 37.95           C  
+ATOM   4600  CD  PRO A 583      90.889  91.067  93.236  1.00 37.95           C  
+ATOM   4601  N   LEU A 584      87.602  92.986  92.702  1.00 36.15           N  
+ATOM   4602  CA  LEU A 584      86.239  93.511  92.673  1.00 36.15           C  
+ATOM   4603  C   LEU A 584      86.122  94.766  93.529  1.00 36.15           C  
+ATOM   4604  O   LEU A 584      85.508  95.763  93.122  1.00 36.15           O  
+ATOM   4605  CB  LEU A 584      85.259  92.436  93.147  1.00 36.15           C  
+ATOM   4606  CG  LEU A 584      83.760  92.653  92.921  1.00 36.15           C  
+ATOM   4607  CD1 LEU A 584      83.072  91.328  92.661  1.00 36.15           C  
+ATOM   4608  CD2 LEU A 584      83.117  93.350  94.107  1.00 36.15           C  
+ATOM   4609  N   LEU A 585      86.714  94.739  94.723  1.00 38.09           N  
+ATOM   4610  CA  LEU A 585      86.652  95.901  95.599  1.00 38.09           C  
+ATOM   4611  C   LEU A 585      87.474  97.055  95.041  1.00 38.09           C  
+ATOM   4612  O   LEU A 585      87.085  98.219  95.173  1.00 38.09           O  
+ATOM   4613  CB  LEU A 585      87.122  95.524  97.002  1.00 38.09           C  
+ATOM   4614  CG  LEU A 585      86.432  94.305  97.618  1.00 38.09           C  
+ATOM   4615  CD1 LEU A 585      86.832  94.141  99.075  1.00 38.09           C  
+ATOM   4616  CD2 LEU A 585      84.920  94.406  97.483  1.00 38.09           C  
+ATOM   4617  N   ASN A 586      88.614  96.757  94.414  1.00 39.36           N  
+ATOM   4618  CA  ASN A 586      89.384  97.811  93.759  1.00 39.36           C  
+ATOM   4619  C   ASN A 586      88.591  98.431  92.617  1.00 39.36           C  
+ATOM   4620  O   ASN A 586      88.735  99.624  92.324  1.00 39.36           O  
+ATOM   4621  CB  ASN A 586      90.711  97.251  93.250  1.00 39.36           C  
+ATOM   4622  CG  ASN A 586      91.605  96.763  94.371  1.00 39.36           C  
+ATOM   4623  OD1 ASN A 586      91.182  96.671  95.522  1.00 39.36           O  
+ATOM   4624  ND2 ASN A 586      92.850  96.442  94.038  1.00 39.36           N  
+ATOM   4625  N   TYR A 587      87.750  97.632  91.960  1.00 41.22           N  
+ATOM   4626  CA  TYR A 587      86.912  98.147  90.884  1.00 41.22           C  
+ATOM   4627  C   TYR A 587      85.805  99.041  91.425  1.00 41.22           C  
+ATOM   4628  O   TYR A 587      85.520 100.103  90.858  1.00 41.22           O  
+ATOM   4629  CB  TYR A 587      86.324  96.981  90.089  1.00 41.22           C  
+ATOM   4630  CG  TYR A 587      85.604  97.368  88.817  1.00 41.22           C  
+ATOM   4631  CD1 TYR A 587      84.254  97.692  88.831  1.00 41.22           C  
+ATOM   4632  CD2 TYR A 587      86.267  97.388  87.600  1.00 41.22           C  
+ATOM   4633  CE1 TYR A 587      83.591  98.040  87.672  1.00 41.22           C  
+ATOM   4634  CE2 TYR A 587      85.612  97.731  86.436  1.00 41.22           C  
+ATOM   4635  CZ  TYR A 587      84.274  98.058  86.477  1.00 41.22           C  
+ATOM   4636  OH  TYR A 587      83.618  98.401  85.319  1.00 41.22           O  
+ATOM   4637  N   PHE A 588      85.169  98.635  92.522  1.00 42.70           N  
+ATOM   4638  CA  PHE A 588      83.988  99.326  93.025  1.00 42.70           C  
+ATOM   4639  C   PHE A 588      84.273 100.252  94.206  1.00 42.70           C  
+ATOM   4640  O   PHE A 588      83.327 100.716  94.850  1.00 42.70           O  
+ATOM   4641  CB  PHE A 588      82.913  98.311  93.414  1.00 42.70           C  
+ATOM   4642  CG  PHE A 588      82.216  97.690  92.239  1.00 42.70           C  
+ATOM   4643  CD1 PHE A 588      81.194  98.358  91.590  1.00 42.70           C  
+ATOM   4644  CD2 PHE A 588      82.583  96.436  91.783  1.00 42.70           C  
+ATOM   4645  CE1 PHE A 588      80.554  97.789  90.508  1.00 42.70           C  
+ATOM   4646  CE2 PHE A 588      81.944  95.862  90.702  1.00 42.70           C  
+ATOM   4647  CZ  PHE A 588      80.929  96.540  90.065  1.00 42.70           C  
+ATOM   4648  N   GLU A 589      85.541 100.535  94.508  1.00 48.14           N  
+ATOM   4649  CA  GLU A 589      85.846 101.385  95.657  1.00 48.14           C  
+ATOM   4650  C   GLU A 589      85.406 102.844  95.523  1.00 48.14           C  
+ATOM   4651  O   GLU A 589      85.081 103.456  96.550  1.00 48.14           O  
+ATOM   4652  CB  GLU A 589      87.344 101.305  95.991  1.00 48.14           C  
+ATOM   4653  CG  GLU A 589      88.299 102.023  95.053  1.00 48.14           C  
+ATOM   4654  CD  GLU A 589      88.553 103.462  95.465  1.00 48.14           C  
+ATOM   4655  OE1 GLU A 589      88.136 103.844  96.577  1.00 48.14           O  
+ATOM   4656  OE2 GLU A 589      89.171 104.208  94.677  1.00 48.14           O  
+ATOM   4657  N   PRO A 590      85.370 103.463  94.331  1.00 48.21           N  
+ATOM   4658  CA  PRO A 590      84.788 104.817  94.281  1.00 48.21           C  
+ATOM   4659  C   PRO A 590      83.309 104.811  94.610  1.00 48.21           C  
+ATOM   4660  O   PRO A 590      82.831 105.657  95.378  1.00 48.21           O  
+ATOM   4661  CB  PRO A 590      85.056 105.267  92.837  1.00 48.21           C  
+ATOM   4662  CG  PRO A 590      86.126 104.365  92.340  1.00 48.21           C  
+ATOM   4663  CD  PRO A 590      85.853 103.059  92.998  1.00 48.21           C  
+ATOM   4664  N   LEU A 591      82.573 103.853  94.050  1.00 48.74           N  
+ATOM   4665  CA  LEU A 591      81.177 103.666  94.422  1.00 48.74           C  
+ATOM   4666  C   LEU A 591      81.053 103.359  95.908  1.00 48.74           C  
+ATOM   4667  O   LEU A 591      80.101 103.796  96.565  1.00 48.74           O  
+ATOM   4668  CB  LEU A 591      80.579 102.537  93.587  1.00 48.74           C  
+ATOM   4669  CG  LEU A 591      79.087 102.463  93.265  1.00 48.74           C  
+ATOM   4670  CD1 LEU A 591      78.879 101.296  92.342  1.00 48.74           C  
+ATOM   4671  CD2 LEU A 591      78.208 102.320  94.478  1.00 48.74           C  
+ATOM   4672  N   PHE A 592      82.012 102.609  96.456  1.00 51.27           N  
+ATOM   4673  CA  PHE A 592      81.971 102.270  97.875  1.00 51.27           C  
+ATOM   4674  C   PHE A 592      82.117 103.513  98.744  1.00 51.27           C  
+ATOM   4675  O   PHE A 592      81.377 103.681  99.720  1.00 51.27           O  
+ATOM   4676  CB  PHE A 592      83.061 101.251  98.200  1.00 51.27           C  
+ATOM   4677  CG  PHE A 592      82.894 100.591  99.538  1.00 51.27           C  
+ATOM   4678  CD1 PHE A 592      81.687 100.016  99.895  1.00 51.27           C  
+ATOM   4679  CD2 PHE A 592      83.946 100.537 100.435  1.00 51.27           C  
+ATOM   4680  CE1 PHE A 592      81.530  99.406 101.123  1.00 51.27           C  
+ATOM   4681  CE2 PHE A 592      83.795  99.928 101.665  1.00 51.27           C  
+ATOM   4682  CZ  PHE A 592      82.585  99.362 102.008  1.00 51.27           C  
+ATOM   4683  N   THR A 593      83.060 104.394  98.406  1.00 53.34           N  
+ATOM   4684  CA  THR A 593      83.196 105.642  99.151  1.00 53.34           C  
+ATOM   4685  C   THR A 593      81.964 106.522  98.977  1.00 53.34           C  
+ATOM   4686  O   THR A 593      81.534 107.195  99.922  1.00 53.34           O  
+ATOM   4687  CB  THR A 593      84.454 106.391  98.710  1.00 53.34           C  
+ATOM   4688  OG1 THR A 593      84.364 106.695  97.313  1.00 53.34           O  
+ATOM   4689  CG2 THR A 593      85.691 105.545  98.963  1.00 53.34           C  
+ATOM   4690  N   TRP A 594      81.376 106.519  97.778  1.00 56.95           N  
+ATOM   4691  CA  TRP A 594      80.152 107.282  97.560  1.00 56.95           C  
+ATOM   4692  C   TRP A 594      79.031 106.799  98.472  1.00 56.95           C  
+ATOM   4693  O   TRP A 594      78.341 107.609  99.103  1.00 56.95           O  
+ATOM   4694  CB  TRP A 594      79.734 107.195  96.093  1.00 56.95           C  
+ATOM   4695  CG  TRP A 594      78.706 108.207  95.702  1.00 56.95           C  
+ATOM   4696  CD1 TRP A 594      78.935 109.475  95.259  1.00 56.95           C  
+ATOM   4697  CD2 TRP A 594      77.285 108.037  95.717  1.00 56.95           C  
+ATOM   4698  NE1 TRP A 594      77.744 110.108  94.998  1.00 56.95           N  
+ATOM   4699  CE2 TRP A 594      76.715 109.245  95.271  1.00 56.95           C  
+ATOM   4700  CE3 TRP A 594      76.438 106.981  96.065  1.00 56.95           C  
+ATOM   4701  CZ2 TRP A 594      75.339 109.425  95.164  1.00 56.95           C  
+ATOM   4702  CZ3 TRP A 594      75.072 107.162  95.958  1.00 56.95           C  
+ATOM   4703  CH2 TRP A 594      74.536 108.376  95.511  1.00 56.95           C  
+ATOM   4704  N   LEU A 595      78.841 105.481  98.569  1.00 56.40           N  
+ATOM   4705  CA  LEU A 595      77.809 104.958  99.461  1.00 56.40           C  
+ATOM   4706  C   LEU A 595      78.152 105.213 100.921  1.00 56.40           C  
+ATOM   4707  O   LEU A 595      77.257 105.454 101.737  1.00 56.40           O  
+ATOM   4708  CB  LEU A 595      77.593 103.463  99.240  1.00 56.40           C  
+ATOM   4709  CG  LEU A 595      77.354 102.927  97.835  1.00 56.40           C  
+ATOM   4710  CD1 LEU A 595      77.563 101.424  97.825  1.00 56.40           C  
+ATOM   4711  CD2 LEU A 595      75.958 103.285  97.362  1.00 56.40           C  
+ATOM   4712  N   LYS A 596      79.436 105.150 101.276  1.00 61.15           N  
+ATOM   4713  CA  LYS A 596      79.816 105.404 102.660  1.00 61.15           C  
+ATOM   4714  C   LYS A 596      79.564 106.853 103.046  1.00 61.15           C  
+ATOM   4715  O   LYS A 596      79.307 107.150 104.218  1.00 61.15           O  
+ATOM   4716  CB  LYS A 596      81.282 105.029 102.879  1.00 61.15           C  
+ATOM   4717  CG  LYS A 596      81.516 103.531 102.998  1.00 61.15           C  
+ATOM   4718  CD  LYS A 596      82.938 103.218 103.427  1.00 61.15           C  
+ATOM   4719  CE  LYS A 596      83.938 103.638 102.366  1.00 61.15           C  
+ATOM   4720  NZ  LYS A 596      85.327 103.256 102.739  1.00 61.15           N  
+ATOM   4721  N   ASP A 597      79.628 107.769 102.076  1.00 67.78           N  
+ATOM   4722  CA  ASP A 597      79.302 109.162 102.364  1.00 67.78           C  
+ATOM   4723  C   ASP A 597      77.799 109.409 102.299  1.00 67.78           C  
+ATOM   4724  O   ASP A 597      77.288 110.331 102.946  1.00 67.78           O  
+ATOM   4725  CB  ASP A 597      80.038 110.085 101.395  1.00 67.78           C  
+ATOM   4726  CG  ASP A 597      79.992 111.537 101.829  1.00 67.78           C  
+ATOM   4727  OD1 ASP A 597      79.500 112.379 101.047  1.00 67.78           O  
+ATOM   4728  OD2 ASP A 597      80.447 111.838 102.953  1.00 67.78           O  
+ATOM   4729  N   GLN A 598      77.074 108.605 101.518  1.00 66.77           N  
+ATOM   4730  CA  GLN A 598      75.639 108.832 101.361  1.00 66.77           C  
+ATOM   4731  C   GLN A 598      74.828 108.199 102.486  1.00 66.77           C  
+ATOM   4732  O   GLN A 598      73.767 108.719 102.848  1.00 66.77           O  
+ATOM   4733  CB  GLN A 598      75.169 108.293 100.010  1.00 66.77           C  
+ATOM   4734  CG  GLN A 598      75.535 109.174  98.829  1.00 66.77           C  
+ATOM   4735  CD  GLN A 598      74.558 110.314  98.627  1.00 66.77           C  
+ATOM   4736  OE1 GLN A 598      73.414 110.252  99.076  1.00 66.77           O  
+ATOM   4737  NE2 GLN A 598      75.005 111.362  97.946  1.00 66.77           N  
+ATOM   4738  N   ASN A 599      75.297 107.087 103.044  1.00 70.13           N  
+ATOM   4739  CA  ASN A 599      74.559 106.353 104.061  1.00 70.13           C  
+ATOM   4740  C   ASN A 599      74.905 106.788 105.478  1.00 70.13           C  
+ATOM   4741  O   ASN A 599      74.585 106.067 106.429  1.00 70.13           O  
+ATOM   4742  CB  ASN A 599      74.809 104.850 103.907  1.00 70.13           C  
+ATOM   4743  CG  ASN A 599      74.350 104.317 102.565  1.00 70.13           C  
+ATOM   4744  OD1 ASN A 599      75.082 103.597 101.885  1.00 70.13           O  
+ATOM   4745  ND2 ASN A 599      73.129 104.664 102.177  1.00 70.13           N  
+ATOM   4746  N   LYS A 600      75.548 107.945 105.644  1.00 78.12           N  
+ATOM   4747  CA  LYS A 600      75.894 108.404 106.984  1.00 78.12           C  
+ATOM   4748  C   LYS A 600      74.653 108.838 107.755  1.00 78.12           C  
+ATOM   4749  O   LYS A 600      74.631 108.784 108.990  1.00 78.12           O  
+ATOM   4750  CB  LYS A 600      76.908 109.546 106.904  1.00 78.12           C  
+ATOM   4751  CG  LYS A 600      76.465 110.713 106.039  1.00 78.12           C  
+ATOM   4752  CD  LYS A 600      77.395 111.909 106.191  1.00 78.12           C  
+ATOM   4753  CE  LYS A 600      78.854 111.484 106.218  1.00 78.12           C  
+ATOM   4754  NZ  LYS A 600      79.760 112.642 106.448  1.00 78.12           N  
+ATOM   4755  N   ASN A 601      73.611 109.269 107.046  1.00 82.92           N  
+ATOM   4756  CA  ASN A 601      72.354 109.666 107.664  1.00 82.92           C  
+ATOM   4757  C   ASN A 601      71.288 108.579 107.589  1.00 82.92           C  
+ATOM   4758  O   ASN A 601      70.108 108.864 107.820  1.00 82.92           O  
+ATOM   4759  CB  ASN A 601      71.832 110.954 107.020  1.00 82.92           C  
+ATOM   4760  CG  ASN A 601      72.706 112.153 107.324  1.00 82.92           C  
+ATOM   4761  OD1 ASN A 601      73.929 112.043 107.398  1.00 82.92           O  
+ATOM   4762  ND2 ASN A 601      72.080 113.311 107.502  1.00 82.92           N  
+ATOM   4763  N   SER A 602      71.674 107.344 107.275  1.00 77.43           N  
+ATOM   4764  CA  SER A 602      70.735 106.239 107.172  1.00 77.43           C  
+ATOM   4765  C   SER A 602      71.344 104.986 107.785  1.00 77.43           C  
+ATOM   4766  O   SER A 602      72.493 104.980 108.232  1.00 77.43           O  
+ATOM   4767  CB  SER A 602      70.337 105.971 105.714  1.00 77.43           C  
+ATOM   4768  OG  SER A 602      71.468 105.986 104.862  1.00 77.43           O  
+ATOM   4769  N   PHE A 603      70.550 103.919 107.800  1.00 73.13           N  
+ATOM   4770  CA  PHE A 603      70.961 102.647 108.371  1.00 73.13           C  
+ATOM   4771  C   PHE A 603      71.536 101.737 107.293  1.00 73.13           C  
+ATOM   4772  O   PHE A 603      71.127 101.780 106.130  1.00 73.13           O  
+ATOM   4773  CB  PHE A 603      69.779 101.961 109.058  1.00 73.13           C  
+ATOM   4774  CG  PHE A 603      70.154 100.719 109.817  1.00 73.13           C  
+ATOM   4775  CD1 PHE A 603      70.662 100.807 111.102  1.00 73.13           C  
+ATOM   4776  CD2 PHE A 603      69.994  99.468 109.249  1.00 73.13           C  
+ATOM   4777  CE1 PHE A 603      71.006  99.668 111.804  1.00 73.13           C  
+ATOM   4778  CE2 PHE A 603      70.336  98.326 109.946  1.00 73.13           C  
+ATOM   4779  CZ  PHE A 603      70.843  98.425 111.225  1.00 73.13           C  
+ATOM   4780  N   VAL A 604      72.499 100.910 107.693  1.00 65.01           N  
+ATOM   4781  CA  VAL A 604      73.145  99.954 106.801  1.00 65.01           C  
+ATOM   4782  C   VAL A 604      73.079  98.582 107.457  1.00 65.01           C  
+ATOM   4783  O   VAL A 604      73.751  98.340 108.467  1.00 65.01           O  
+ATOM   4784  CB  VAL A 604      74.602 100.341 106.496  1.00 65.01           C  
+ATOM   4785  CG1 VAL A 604      75.269  99.275 105.647  1.00 65.01           C  
+ATOM   4786  CG2 VAL A 604      74.656 101.686 105.795  1.00 65.01           C  
+ATOM   4787  N   GLY A 605      72.275  97.689 106.887  1.00 60.46           N  
+ATOM   4788  CA  GLY A 605      72.060  96.353 107.394  1.00 60.46           C  
+ATOM   4789  C   GLY A 605      70.620  95.941 107.215  1.00 60.46           C  
+ATOM   4790  O   GLY A 605      69.832  96.611 106.540  1.00 60.46           O  
+ATOM   4791  N   TRP A 606      70.261  94.814 107.825  1.00 58.38           N  
+ATOM   4792  CA  TRP A 606      68.889  94.332 107.762  1.00 58.38           C  
+ATOM   4793  C   TRP A 606      68.622  93.415 108.946  1.00 58.38           C  
+ATOM   4794  O   TRP A 606      69.545  92.829 109.515  1.00 58.38           O  
+ATOM   4795  CB  TRP A 606      68.603  93.603 106.441  1.00 58.38           C  
+ATOM   4796  CG  TRP A 606      69.508  92.437 106.160  1.00 58.38           C  
+ATOM   4797  CD1 TRP A 606      69.545  91.247 106.825  1.00 58.38           C  
+ATOM   4798  CD2 TRP A 606      70.493  92.347 105.124  1.00 58.38           C  
+ATOM   4799  NE1 TRP A 606      70.498  90.426 106.276  1.00 58.38           N  
+ATOM   4800  CE2 TRP A 606      71.093  91.078 105.228  1.00 58.38           C  
+ATOM   4801  CE3 TRP A 606      70.927  93.217 104.122  1.00 58.38           C  
+ATOM   4802  CZ2 TRP A 606      72.104  90.657 104.370  1.00 58.38           C  
+ATOM   4803  CZ3 TRP A 606      71.931  92.797 103.271  1.00 58.38           C  
+ATOM   4804  CH2 TRP A 606      72.508  91.531 103.400  1.00 58.38           C  
+ATOM   4805  N   SER A 607      67.347  93.305 109.307  1.00 80.56           N  
+ATOM   4806  CA  SER A 607      66.893  92.408 110.357  1.00 80.56           C  
+ATOM   4807  C   SER A 607      65.948  91.367 109.772  1.00 80.56           C  
+ATOM   4808  O   SER A 607      65.194  91.645 108.836  1.00 80.56           O  
+ATOM   4809  CB  SER A 607      66.192  93.178 111.480  1.00 80.56           C  
+ATOM   4810  OG  SER A 607      67.130  93.705 112.402  1.00 80.56           O  
+ATOM   4811  N   THR A 608      65.992  90.162 110.339  1.00 89.01           N  
+ATOM   4812  CA  THR A 608      65.195  89.053 109.830  1.00 89.01           C  
+ATOM   4813  C   THR A 608      63.790  89.007 110.413  1.00 89.01           C  
+ATOM   4814  O   THR A 608      62.959  88.239 109.916  1.00 89.01           O  
+ATOM   4815  CB  THR A 608      65.902  87.727 110.112  1.00 89.01           C  
+ATOM   4816  OG1 THR A 608      65.699  87.358 111.481  1.00 89.01           O  
+ATOM   4817  CG2 THR A 608      67.393  87.853 109.845  1.00 89.01           C  
+ATOM   4818  N   ASP A 609      63.500  89.803 111.443  1.00 96.77           N  
+ATOM   4819  CA  ASP A 609      62.202  89.724 112.103  1.00 96.77           C  
+ATOM   4820  C   ASP A 609      61.091  90.371 111.285  1.00 96.77           C  
+ATOM   4821  O   ASP A 609      59.954  89.886 111.305  1.00 96.77           O  
+ATOM   4822  CB  ASP A 609      62.278  90.371 113.486  1.00 96.77           C  
+ATOM   4823  CG  ASP A 609      63.479  89.905 114.283  1.00 96.77           C  
+ATOM   4824  OD1 ASP A 609      63.566  88.693 114.572  1.00 96.77           O  
+ATOM   4825  OD2 ASP A 609      64.336  90.748 114.620  1.00 96.77           O  
+ATOM   4826  N   TRP A 610      61.390  91.451 110.568  1.00 97.90           N  
+ATOM   4827  CA  TRP A 610      60.358  92.152 109.818  1.00 97.90           C  
+ATOM   4828  C   TRP A 610      60.007  91.400 108.540  1.00 97.90           C  
+ATOM   4829  O   TRP A 610      60.871  90.808 107.888  1.00 97.90           O  
+ATOM   4830  CB  TRP A 610      60.813  93.570 109.479  1.00 97.90           C  
+ATOM   4831  CG  TRP A 610      59.797  94.341 108.697  1.00 97.90           C  
+ATOM   4832  CD1 TRP A 610      59.915  94.782 107.412  1.00 97.90           C  
+ATOM   4833  CD2 TRP A 610      58.501  94.757 109.147  1.00 97.90           C  
+ATOM   4834  NE1 TRP A 610      58.776  95.451 107.035  1.00 97.90           N  
+ATOM   4835  CE2 TRP A 610      57.893  95.450 108.082  1.00 97.90           C  
+ATOM   4836  CE3 TRP A 610      57.798  94.614 110.347  1.00 97.90           C  
+ATOM   4837  CZ2 TRP A 610      56.616  95.996 108.180  1.00 97.90           C  
+ATOM   4838  CZ3 TRP A 610      56.531  95.157 110.442  1.00 97.90           C  
+ATOM   4839  CH2 TRP A 610      55.953  95.841 109.366  1.00 97.90           C  
+ATOM   4840  N   SER A 611      58.726  91.428 108.186  1.00 94.89           N  
+ATOM   4841  CA  SER A 611      58.215  90.794 106.982  1.00 94.89           C  
+ATOM   4842  C   SER A 611      57.147  91.686 106.367  1.00 94.89           C  
+ATOM   4843  O   SER A 611      56.485  92.447 107.082  1.00 94.89           O  
+ATOM   4844  CB  SER A 611      57.627  89.406 107.281  1.00 94.89           C  
+ATOM   4845  OG  SER A 611      56.653  89.472 108.307  1.00 94.89           O  
+ATOM   4846  N   PRO A 612      56.963  91.619 105.046  1.00 88.58           N  
+ATOM   4847  CA  PRO A 612      55.941  92.464 104.407  1.00 88.58           C  
+ATOM   4848  C   PRO A 612      54.520  92.118 104.812  1.00 88.58           C  
+ATOM   4849  O   PRO A 612      53.617  92.936 104.600  1.00 88.58           O  
+ATOM   4850  CB  PRO A 612      56.168  92.220 102.908  1.00 88.58           C  
+ATOM   4851  CG  PRO A 612      57.554  91.669 102.808  1.00 88.58           C  
+ATOM   4852  CD  PRO A 612      57.754  90.873 104.056  1.00 88.58           C  
+ATOM   4853  N   TYR A 613      54.287  90.937 105.383  1.00 92.22           N  
+ATOM   4854  CA  TYR A 613      52.957  90.529 105.814  1.00 92.22           C  
+ATOM   4855  C   TYR A 613      52.767  90.653 107.320  1.00 92.22           C  
+ATOM   4856  O   TYR A 613      51.751  90.187 107.847  1.00 92.22           O  
+ATOM   4857  CB  TYR A 613      52.665  89.096 105.363  1.00 92.22           C  
+ATOM   4858  CG  TYR A 613      53.812  88.130 105.560  1.00 92.22           C  
+ATOM   4859  CD1 TYR A 613      53.994  87.474 106.769  1.00 92.22           C  
+ATOM   4860  CD2 TYR A 613      54.707  87.868 104.531  1.00 92.22           C  
+ATOM   4861  CE1 TYR A 613      55.039  86.588 106.949  1.00 92.22           C  
+ATOM   4862  CE2 TYR A 613      55.754  86.984 104.701  1.00 92.22           C  
+ATOM   4863  CZ  TYR A 613      55.916  86.347 105.912  1.00 92.22           C  
+ATOM   4864  OH  TYR A 613      56.958  85.465 106.085  1.00 92.22           O  
+ATOM   4865  N   ALA A 614      53.715  91.267 108.023  1.00102.98           N  
+ATOM   4866  CA  ALA A 614      53.586  91.462 109.460  1.00102.98           C  
+ATOM   4867  C   ALA A 614      52.790  92.729 109.743  1.00102.98           C  
+ATOM   4868  O   ALA A 614      53.146  93.814 109.274  1.00102.98           O  
+ATOM   4869  CB  ALA A 614      54.964  91.543 110.116  1.00102.98           C  
+ATOM   4870  N   ASP A 615      51.714  92.588 110.509  1.00109.34           N  
+ATOM   4871  CA  ASP A 615      50.868  93.722 110.856  1.00109.34           C  
+ATOM   4872  C   ASP A 615      50.667  93.812 112.365  1.00109.34           C  
+ATOM   4873  O   ASP A 615      50.300  92.832 113.012  1.00109.34           O  
+ATOM   4874  CB  ASP A 615      49.515  93.621 110.148  1.00109.34           C  
+ATOM   4875  CG  ASP A 615      49.632  93.752 108.643  1.00109.34           C  
+ATOM   4876  OD1 ASP A 615      50.569  94.431 108.174  1.00109.34           O  
+ATOM   4877  OD2 ASP A 615      48.784  93.179 107.927  1.00109.34           O  
+TER    4878      ASP A 615                                                      
+ATOM   4879  N   THR C 333     112.696  66.249  22.840  1.00128.56           N  
+ATOM   4880  CA  THR C 333     112.589  67.677  23.119  1.00128.56           C  
+ATOM   4881  C   THR C 333     111.131  68.097  23.277  1.00128.56           C  
+ATOM   4882  O   THR C 333     110.694  69.090  22.695  1.00128.56           O  
+ATOM   4883  CB  THR C 333     113.240  68.520  22.007  1.00128.56           C  
+ATOM   4884  OG1 THR C 333     112.878  67.990  20.726  1.00128.56           O  
+ATOM   4885  CG2 THR C 333     114.755  68.507  22.147  1.00128.56           C  
+ATOM   4886  N   ASN C 334     110.385  67.335  24.068  1.00126.40           N  
+ATOM   4887  CA  ASN C 334     108.984  67.609  24.348  1.00126.40           C  
+ATOM   4888  C   ASN C 334     108.825  68.077  25.789  1.00126.40           C  
+ATOM   4889  O   ASN C 334     109.716  67.912  26.624  1.00126.40           O  
+ATOM   4890  CB  ASN C 334     108.124  66.367  24.087  1.00126.40           C  
+ATOM   4891  CG  ASN C 334     106.677  66.710  23.799  1.00126.40           C  
+ATOM   4892  OD1 ASN C 334     106.280  67.874  23.853  1.00126.40           O  
+ATOM   4893  ND2 ASN C 334     105.878  65.695  23.490  1.00126.40           N  
+ATOM   4894  N   LEU C 335     107.667  68.669  26.073  1.00121.86           N  
+ATOM   4895  CA  LEU C 335     107.391  69.196  27.402  1.00121.86           C  
+ATOM   4896  C   LEU C 335     107.035  68.064  28.359  1.00121.86           C  
+ATOM   4897  O   LEU C 335     106.387  67.088  27.967  1.00121.86           O  
+ATOM   4898  CB  LEU C 335     106.264  70.231  27.339  1.00121.86           C  
+ATOM   4899  CG  LEU C 335     104.886  69.828  26.802  1.00121.86           C  
+ATOM   4900  CD1 LEU C 335     103.979  69.269  27.894  1.00121.86           C  
+ATOM   4901  CD2 LEU C 335     104.223  71.008  26.106  1.00121.86           C  
+ATOM   4902  N   CYS C 336     107.466  68.195  29.607  1.00118.10           N  
+ATOM   4903  CA  CYS C 336     107.165  67.178  30.609  1.00118.10           C  
+ATOM   4904  C   CYS C 336     105.700  67.273  31.021  1.00118.10           C  
+ATOM   4905  O   CYS C 336     105.186  68.382  31.215  1.00118.10           O  
+ATOM   4906  CB  CYS C 336     108.071  67.343  31.827  1.00118.10           C  
+ATOM   4907  SG  CYS C 336     109.822  66.983  31.524  1.00118.10           S  
+ATOM   4908  N   PRO C 337     104.997  66.150  31.166  1.00106.38           N  
+ATOM   4909  CA  PRO C 337     103.552  66.175  31.488  1.00106.38           C  
+ATOM   4910  C   PRO C 337     103.277  66.592  32.929  1.00106.38           C  
+ATOM   4911  O   PRO C 337     102.868  65.803  33.787  1.00106.38           O  
+ATOM   4912  CB  PRO C 337     103.122  64.730  31.200  1.00106.38           C  
+ATOM   4913  CG  PRO C 337     104.266  64.090  30.458  1.00106.38           C  
+ATOM   4914  CD  PRO C 337     105.485  64.782  30.944  1.00106.38           C  
+ATOM   4915  N   PHE C 338     103.504  67.875  33.216  1.00100.07           N  
+ATOM   4916  CA  PHE C 338     103.190  68.413  34.533  1.00100.07           C  
+ATOM   4917  C   PHE C 338     101.706  68.691  34.715  1.00100.07           C  
+ATOM   4918  O   PHE C 338     101.235  68.718  35.857  1.00100.07           O  
+ATOM   4919  CB  PHE C 338     103.985  69.694  34.782  1.00100.07           C  
+ATOM   4920  CG  PHE C 338     105.396  69.453  35.227  1.00100.07           C  
+ATOM   4921  CD1 PHE C 338     106.449  69.597  34.342  1.00100.07           C  
+ATOM   4922  CD2 PHE C 338     105.669  69.080  36.531  1.00100.07           C  
+ATOM   4923  CE1 PHE C 338     107.748  69.374  34.750  1.00100.07           C  
+ATOM   4924  CE2 PHE C 338     106.967  68.855  36.944  1.00100.07           C  
+ATOM   4925  CZ  PHE C 338     108.008  69.004  36.053  1.00100.07           C  
+ATOM   4926  N   GLY C 339     100.964  68.898  33.627  1.00 98.45           N  
+ATOM   4927  CA  GLY C 339      99.538  69.151  33.756  1.00 98.45           C  
+ATOM   4928  C   GLY C 339      98.779  67.935  34.252  1.00 98.45           C  
+ATOM   4929  O   GLY C 339      97.807  68.056  35.001  1.00 98.45           O  
+ATOM   4930  N   GLU C 340      99.215  66.743  33.840  1.00 97.85           N  
+ATOM   4931  CA  GLU C 340      98.540  65.522  34.257  1.00 97.85           C  
+ATOM   4932  C   GLU C 340      98.708  65.240  35.745  1.00 97.85           C  
+ATOM   4933  O   GLU C 340      97.878  64.535  36.325  1.00 97.85           O  
+ATOM   4934  CB  GLU C 340      99.053  64.332  33.441  1.00 97.85           C  
+ATOM   4935  CG  GLU C 340      98.665  64.344  31.961  1.00 97.85           C  
+ATOM   4936  CD  GLU C 340      97.236  64.803  31.699  1.00 97.85           C  
+ATOM   4937  OE1 GLU C 340      97.015  65.481  30.672  1.00 97.85           O  
+ATOM   4938  OE2 GLU C 340      96.327  64.456  32.483  1.00 97.85           O  
+ATOM   4939  N   VAL C 341      99.755  65.773  36.373  1.00 93.46           N  
+ATOM   4940  CA  VAL C 341      99.965  65.543  37.800  1.00 93.46           C  
+ATOM   4941  C   VAL C 341      99.488  66.740  38.615  1.00 93.46           C  
+ATOM   4942  O   VAL C 341      99.161  66.616  39.800  1.00 93.46           O  
+ATOM   4943  CB  VAL C 341     101.444  65.219  38.084  1.00 93.46           C  
+ATOM   4944  CG1 VAL C 341     101.900  64.044  37.232  1.00 93.46           C  
+ATOM   4945  CG2 VAL C 341     102.322  66.435  37.840  1.00 93.46           C  
+ATOM   4946  N   PHE C 342      99.437  67.918  37.989  1.00 87.12           N  
+ATOM   4947  CA  PHE C 342      98.994  69.111  38.700  1.00 87.12           C  
+ATOM   4948  C   PHE C 342      97.505  69.362  38.501  1.00 87.12           C  
+ATOM   4949  O   PHE C 342      96.815  69.785  39.436  1.00 87.12           O  
+ATOM   4950  CB  PHE C 342      99.801  70.325  38.242  1.00 87.12           C  
+ATOM   4951  CG  PHE C 342     101.052  70.556  39.037  1.00 87.12           C  
+ATOM   4952  CD1 PHE C 342     101.022  71.311  40.197  1.00 87.12           C  
+ATOM   4953  CD2 PHE C 342     102.260  70.020  38.623  1.00 87.12           C  
+ATOM   4954  CE1 PHE C 342     102.171  71.526  40.930  1.00 87.12           C  
+ATOM   4955  CE2 PHE C 342     103.414  70.234  39.352  1.00 87.12           C  
+ATOM   4956  CZ  PHE C 342     103.369  70.987  40.507  1.00 87.12           C  
+ATOM   4957  N   ASN C 343      96.993  69.106  37.300  1.00 92.10           N  
+ATOM   4958  CA  ASN C 343      95.607  69.393  36.950  1.00 92.10           C  
+ATOM   4959  C   ASN C 343      94.789  68.115  36.785  1.00 92.10           C  
+ATOM   4960  O   ASN C 343      93.936  68.015  35.901  1.00 92.10           O  
+ATOM   4961  CB  ASN C 343      95.537  70.239  35.682  1.00 92.10           C  
+ATOM   4962  CG  ASN C 343      95.686  71.721  35.960  1.00 92.10           C  
+ATOM   4963  OD1 ASN C 343      95.176  72.231  36.958  1.00 92.10           O  
+ATOM   4964  ND2 ASN C 343      96.387  72.420  35.078  1.00 92.10           N  
+ATOM   4965  N   ALA C 344      95.043  67.124  37.634  1.00 82.59           N  
+ATOM   4966  CA  ALA C 344      94.250  65.904  37.628  1.00 82.59           C  
+ATOM   4967  C   ALA C 344      92.924  66.136  38.341  1.00 82.59           C  
+ATOM   4968  O   ALA C 344      92.857  66.865  39.335  1.00 82.59           O  
+ATOM   4969  CB  ALA C 344      95.015  64.763  38.295  1.00 82.59           C  
+ATOM   4970  N   THR C 345      91.864  65.511  37.824  1.00 82.28           N  
+ATOM   4971  CA  THR C 345      90.536  65.724  38.391  1.00 82.28           C  
+ATOM   4972  C   THR C 345      90.410  65.123  39.785  1.00 82.28           C  
+ATOM   4973  O   THR C 345      89.572  65.570  40.577  1.00 82.28           O  
+ATOM   4974  CB  THR C 345      89.464  65.148  37.462  1.00 82.28           C  
+ATOM   4975  OG1 THR C 345      88.166  65.543  37.922  1.00 82.28           O  
+ATOM   4976  CG2 THR C 345      89.543  63.627  37.413  1.00 82.28           C  
+ATOM   4977  N   THR C 346      91.224  64.121  40.105  1.00 78.75           N  
+ATOM   4978  CA  THR C 346      91.220  63.489  41.416  1.00 78.75           C  
+ATOM   4979  C   THR C 346      92.657  63.288  41.873  1.00 78.75           C  
+ATOM   4980  O   THR C 346      93.563  63.138  41.046  1.00 78.75           O  
+ATOM   4981  CB  THR C 346      90.472  62.151  41.392  1.00 78.75           C  
+ATOM   4982  OG1 THR C 346      90.311  61.665  42.730  1.00 78.75           O  
+ATOM   4983  CG2 THR C 346      91.229  61.117  40.569  1.00 78.75           C  
+ATOM   4984  N   PHE C 347      92.863  63.308  43.183  1.00 70.85           N  
+ATOM   4985  CA  PHE C 347      94.175  63.094  43.771  1.00 70.85           C  
+ATOM   4986  C   PHE C 347      94.148  61.880  44.691  1.00 70.85           C  
+ATOM   4987  O   PHE C 347      93.120  61.537  45.279  1.00 70.85           O  
+ATOM   4988  CB  PHE C 347      94.633  64.336  44.540  1.00 70.85           C  
+ATOM   4989  CG  PHE C 347      95.491  65.267  43.731  1.00 70.85           C  
+ATOM   4990  CD1 PHE C 347      95.165  65.567  42.419  1.00 70.85           C  
+ATOM   4991  CD2 PHE C 347      96.623  65.843  44.280  1.00 70.85           C  
+ATOM   4992  CE1 PHE C 347      95.951  66.422  41.673  1.00 70.85           C  
+ATOM   4993  CE2 PHE C 347      97.413  66.699  43.538  1.00 70.85           C  
+ATOM   4994  CZ  PHE C 347      97.076  66.987  42.233  1.00 70.85           C  
+ATOM   4995  N   ALA C 348      95.299  61.227  44.803  1.00 69.78           N  
+ATOM   4996  CA  ALA C 348      95.399  60.026  45.618  1.00 69.78           C  
+ATOM   4997  C   ALA C 348      95.309  60.366  47.100  1.00 69.78           C  
+ATOM   4998  O   ALA C 348      95.542  61.502  47.518  1.00 69.78           O  
+ATOM   4999  CB  ALA C 348      96.708  59.294  45.331  1.00 69.78           C  
+ATOM   5000  N   SER C 349      94.959  59.363  47.898  1.00 68.03           N  
+ATOM   5001  CA  SER C 349      94.957  59.527  49.342  1.00 68.03           C  
+ATOM   5002  C   SER C 349      96.387  59.627  49.858  1.00 68.03           C  
+ATOM   5003  O   SER C 349      97.344  59.237  49.184  1.00 68.03           O  
+ATOM   5004  CB  SER C 349      94.234  58.361  50.014  1.00 68.03           C  
+ATOM   5005  OG  SER C 349      92.867  58.328  49.643  1.00 68.03           O  
+ATOM   5006  N   VAL C 350      96.529  60.159  51.072  1.00 62.16           N  
+ATOM   5007  CA  VAL C 350      97.862  60.369  51.626  1.00 62.16           C  
+ATOM   5008  C   VAL C 350      98.516  59.037  51.973  1.00 62.16           C  
+ATOM   5009  O   VAL C 350      99.730  58.865  51.805  1.00 62.16           O  
+ATOM   5010  CB  VAL C 350      97.789  61.314  52.839  1.00 62.16           C  
+ATOM   5011  CG1 VAL C 350      96.750  60.831  53.823  1.00 62.16           C  
+ATOM   5012  CG2 VAL C 350      99.148  61.439  53.505  1.00 62.16           C  
+ATOM   5013  N   TYR C 351      97.728  58.067  52.440  1.00 64.80           N  
+ATOM   5014  CA  TYR C 351      98.282  56.754  52.747  1.00 64.80           C  
+ATOM   5015  C   TYR C 351      98.555  55.939  51.492  1.00 64.80           C  
+ATOM   5016  O   TYR C 351      99.371  55.013  51.534  1.00 64.80           O  
+ATOM   5017  CB  TYR C 351      97.340  55.986  53.676  1.00 64.80           C  
+ATOM   5018  CG  TYR C 351      96.240  55.237  52.959  1.00 64.80           C  
+ATOM   5019  CD1 TYR C 351      95.131  55.905  52.460  1.00 64.80           C  
+ATOM   5020  CD2 TYR C 351      96.305  53.860  52.790  1.00 64.80           C  
+ATOM   5021  CE1 TYR C 351      94.122  55.225  51.807  1.00 64.80           C  
+ATOM   5022  CE2 TYR C 351      95.302  53.172  52.138  1.00 64.80           C  
+ATOM   5023  CZ  TYR C 351      94.212  53.860  51.649  1.00 64.80           C  
+ATOM   5024  OH  TYR C 351      93.208  53.179  50.999  1.00 64.80           O  
+ATOM   5025  N   ALA C 352      97.895  56.263  50.382  1.00 67.44           N  
+ATOM   5026  CA  ALA C 352      98.114  55.569  49.121  1.00 67.44           C  
+ATOM   5027  C   ALA C 352      98.547  56.552  48.043  1.00 67.44           C  
+ATOM   5028  O   ALA C 352      98.022  56.528  46.926  1.00 67.44           O  
+ATOM   5029  CB  ALA C 352      96.851  54.823  48.690  1.00 67.44           C  
+ATOM   5030  N   TRP C 353      99.493  57.428  48.376  1.00 72.46           N  
+ATOM   5031  CA  TRP C 353      99.938  58.453  47.441  1.00 72.46           C  
+ATOM   5032  C   TRP C 353     100.534  57.824  46.188  1.00 72.46           C  
+ATOM   5033  O   TRP C 353     101.199  56.785  46.240  1.00 72.46           O  
+ATOM   5034  CB  TRP C 353     100.964  59.373  48.104  1.00 72.46           C  
+ATOM   5035  CG  TRP C 353     102.088  58.648  48.790  1.00 72.46           C  
+ATOM   5036  CD1 TRP C 353     102.076  58.119  50.046  1.00 72.46           C  
+ATOM   5037  CD2 TRP C 353     103.392  58.386  48.258  1.00 72.46           C  
+ATOM   5038  NE1 TRP C 353     103.288  57.540  50.328  1.00 72.46           N  
+ATOM   5039  CE2 TRP C 353     104.114  57.690  49.246  1.00 72.46           C  
+ATOM   5040  CE3 TRP C 353     104.018  58.671  47.041  1.00 72.46           C  
+ATOM   5041  CZ2 TRP C 353     105.429  57.273  49.056  1.00 72.46           C  
+ATOM   5042  CZ3 TRP C 353     105.325  58.255  46.854  1.00 72.46           C  
+ATOM   5043  CH2 TRP C 353     106.016  57.566  47.855  1.00 72.46           C  
+ATOM   5044  N   ASN C 354     100.285  58.465  45.049  1.00 79.52           N  
+ATOM   5045  CA  ASN C 354     100.790  57.990  43.770  1.00 79.52           C  
+ATOM   5046  C   ASN C 354     102.076  58.718  43.406  1.00 79.52           C  
+ATOM   5047  O   ASN C 354     102.192  59.933  43.590  1.00 79.52           O  
+ATOM   5048  CB  ASN C 354      99.749  58.190  42.666  1.00 79.52           C  
+ATOM   5049  CG  ASN C 354      98.440  57.486  42.964  1.00 79.52           C  
+ATOM   5050  OD1 ASN C 354      98.315  56.779  43.964  1.00 79.52           O  
+ATOM   5051  ND2 ASN C 354      97.454  57.677  42.095  1.00 79.52           N  
+ATOM   5052  N   ARG C 355     103.039  57.967  42.886  1.00 88.36           N  
+ATOM   5053  CA  ARG C 355     104.315  58.507  42.441  1.00 88.36           C  
+ATOM   5054  C   ARG C 355     104.391  58.416  40.924  1.00 88.36           C  
+ATOM   5055  O   ARG C 355     104.223  57.332  40.353  1.00 88.36           O  
+ATOM   5056  CB  ARG C 355     105.482  57.752  43.082  1.00 88.36           C  
+ATOM   5057  CG  ARG C 355     106.769  57.788  42.277  1.00 88.36           C  
+ATOM   5058  CD  ARG C 355     107.942  57.276  43.093  1.00 88.36           C  
+ATOM   5059  NE  ARG C 355     108.426  58.273  44.043  1.00 88.36           N  
+ATOM   5060  CZ  ARG C 355     109.493  58.106  44.817  1.00 88.36           C  
+ATOM   5061  NH1 ARG C 355     110.190  56.978  44.753  1.00 88.36           N  
+ATOM   5062  NH2 ARG C 355     109.865  59.062  45.655  1.00 88.36           N  
+ATOM   5063  N   LYS C 356     104.638  59.550  40.275  1.00 90.10           N  
+ATOM   5064  CA  LYS C 356     104.723  59.626  38.821  1.00 90.10           C  
+ATOM   5065  C   LYS C 356     106.178  59.821  38.423  1.00 90.10           C  
+ATOM   5066  O   LYS C 356     106.863  60.692  38.968  1.00 90.10           O  
+ATOM   5067  CB  LYS C 356     103.854  60.757  38.263  1.00 90.10           C  
+ATOM   5068  CG  LYS C 356     102.376  60.409  38.083  1.00 90.10           C  
+ATOM   5069  CD  LYS C 356     101.679  60.106  39.399  1.00 90.10           C  
+ATOM   5070  CE  LYS C 356     101.711  61.306  40.327  1.00 90.10           C  
+ATOM   5071  NZ  LYS C 356     100.900  61.078  41.553  1.00 90.10           N  
+ATOM   5072  N   ARG C 357     106.644  59.005  37.482  1.00105.75           N  
+ATOM   5073  CA  ARG C 357     108.010  59.090  36.981  1.00105.75           C  
+ATOM   5074  C   ARG C 357     108.016  59.907  35.696  1.00105.75           C  
+ATOM   5075  O   ARG C 357     107.462  59.477  34.678  1.00105.75           O  
+ATOM   5076  CB  ARG C 357     108.580  57.694  36.738  1.00105.75           C  
+ATOM   5077  CG  ARG C 357     110.092  57.604  36.853  1.00105.75           C  
+ATOM   5078  CD  ARG C 357     110.589  56.157  36.820  1.00105.75           C  
+ATOM   5079  NE  ARG C 357     110.079  55.352  37.928  1.00105.75           N  
+ATOM   5080  CZ  ARG C 357     108.997  54.579  37.866  1.00105.75           C  
+ATOM   5081  NH1 ARG C 357     108.613  53.887  38.929  1.00105.75           N  
+ATOM   5082  NH2 ARG C 357     108.304  54.492  36.739  1.00105.75           N  
+ATOM   5083  N   ILE C 358     108.640  61.081  35.742  1.00107.48           N  
+ATOM   5084  CA  ILE C 358     108.689  61.998  34.610  1.00107.48           C  
+ATOM   5085  C   ILE C 358     110.125  62.053  34.110  1.00107.48           C  
+ATOM   5086  O   ILE C 358     111.040  62.397  34.869  1.00107.48           O  
+ATOM   5087  CB  ILE C 358     108.184  63.401  34.982  1.00107.48           C  
+ATOM   5088  CG1 ILE C 358     106.694  63.371  35.342  1.00107.48           C  
+ATOM   5089  CG2 ILE C 358     108.436  64.374  33.846  1.00107.48           C  
+ATOM   5090  CD1 ILE C 358     106.404  63.085  36.801  1.00107.48           C  
+ATOM   5091  N   SER C 359     110.320  61.716  32.838  1.00118.22           N  
+ATOM   5092  CA  SER C 359     111.645  61.724  32.232  1.00118.22           C  
+ATOM   5093  C   SER C 359     111.489  61.841  30.722  1.00118.22           C  
+ATOM   5094  O   SER C 359     110.380  61.779  30.185  1.00118.22           O  
+ATOM   5095  CB  SER C 359     112.438  60.467  32.606  1.00118.22           C  
+ATOM   5096  OG  SER C 359     113.823  60.649  32.367  1.00118.22           O  
+ATOM   5097  N   ASN C 360     112.627  62.013  30.046  1.00126.78           N  
+ATOM   5098  CA  ASN C 360     112.685  62.115  28.585  1.00126.78           C  
+ATOM   5099  C   ASN C 360     111.803  63.252  28.070  1.00126.78           C  
+ATOM   5100  O   ASN C 360     110.928  63.059  27.223  1.00126.78           O  
+ATOM   5101  CB  ASN C 360     112.308  60.785  27.927  1.00126.78           C  
+ATOM   5102  CG  ASN C 360     113.423  59.761  28.002  1.00126.78           C  
+ATOM   5103  OD1 ASN C 360     114.255  59.797  28.909  1.00126.78           O  
+ATOM   5104  ND2 ASN C 360     113.448  58.842  27.044  1.00126.78           N  
+ATOM   5105  N   CYS C 361     112.047  64.453  28.588  1.00126.10           N  
+ATOM   5106  CA  CYS C 361     111.283  65.630  28.198  1.00126.10           C  
+ATOM   5107  C   CYS C 361     112.055  66.871  28.623  1.00126.10           C  
+ATOM   5108  O   CYS C 361     113.212  66.794  29.040  1.00126.10           O  
+ATOM   5109  CB  CYS C 361     109.879  65.615  28.814  1.00126.10           C  
+ATOM   5110  SG  CYS C 361     109.824  65.189  30.570  1.00126.10           S  
+ATOM   5111  N   VAL C 362     111.401  68.025  28.499  1.00119.32           N  
+ATOM   5112  CA  VAL C 362     111.937  69.294  28.978  1.00119.32           C  
+ATOM   5113  C   VAL C 362     110.952  69.873  29.984  1.00119.32           C  
+ATOM   5114  O   VAL C 362     109.736  69.678  29.862  1.00119.32           O  
+ATOM   5115  CB  VAL C 362     112.208  70.282  27.824  1.00119.32           C  
+ATOM   5116  CG1 VAL C 362     110.909  70.754  27.184  1.00119.32           C  
+ATOM   5117  CG2 VAL C 362     113.034  71.466  28.312  1.00119.32           C  
+ATOM   5118  N   ALA C 363     111.477  70.572  30.987  1.00115.90           N  
+ATOM   5119  CA  ALA C 363     110.671  71.093  32.079  1.00115.90           C  
+ATOM   5120  C   ALA C 363     111.067  72.529  32.384  1.00115.90           C  
+ATOM   5121  O   ALA C 363     112.253  72.871  32.375  1.00115.90           O  
+ATOM   5122  CB  ALA C 363     110.826  70.232  33.337  1.00115.90           C  
+ATOM   5123  N   ASP C 364     110.066  73.364  32.655  1.00113.59           N  
+ATOM   5124  CA  ASP C 364     110.271  74.758  33.031  1.00113.59           C  
+ATOM   5125  C   ASP C 364     109.435  75.048  34.270  1.00113.59           C  
+ATOM   5126  O   ASP C 364     108.211  75.189  34.182  1.00113.59           O  
+ATOM   5127  CB  ASP C 364     109.904  75.701  31.885  1.00113.59           C  
+ATOM   5128  CG  ASP C 364     110.591  77.047  31.998  1.00113.59           C  
+ATOM   5129  OD1 ASP C 364     110.135  78.007  31.341  1.00113.59           O  
+ATOM   5130  OD2 ASP C 364     111.586  77.145  32.746  1.00113.59           O  
+ATOM   5131  N   TYR C 365     110.098  75.138  35.421  1.00112.96           N  
+ATOM   5132  CA  TYR C 365     109.433  75.392  36.693  1.00112.96           C  
+ATOM   5133  C   TYR C 365     109.172  76.871  36.942  1.00112.96           C  
+ATOM   5134  O   TYR C 365     108.659  77.224  38.012  1.00112.96           O  
+ATOM   5135  CB  TYR C 365     110.267  74.812  37.841  1.00112.96           C  
+ATOM   5136  CG  TYR C 365     110.639  73.355  37.660  1.00112.96           C  
+ATOM   5137  CD1 TYR C 365     109.888  72.349  38.253  1.00112.96           C  
+ATOM   5138  CD2 TYR C 365     111.743  72.986  36.899  1.00112.96           C  
+ATOM   5139  CE1 TYR C 365     110.224  71.017  38.091  1.00112.96           C  
+ATOM   5140  CE2 TYR C 365     112.086  71.658  36.732  1.00112.96           C  
+ATOM   5141  CZ  TYR C 365     111.324  70.677  37.330  1.00112.96           C  
+ATOM   5142  OH  TYR C 365     111.662  69.355  37.165  1.00112.96           O  
+ATOM   5143  N   SER C 366     109.505  77.740  35.984  1.00110.65           N  
+ATOM   5144  CA  SER C 366     109.305  79.174  36.176  1.00110.65           C  
+ATOM   5145  C   SER C 366     107.825  79.510  36.295  1.00110.65           C  
+ATOM   5146  O   SER C 366     107.420  80.282  37.172  1.00110.65           O  
+ATOM   5147  CB  SER C 366     109.945  79.951  35.026  1.00110.65           C  
+ATOM   5148  OG  SER C 366     109.376  81.242  34.905  1.00110.65           O  
+ATOM   5149  N   VAL C 367     106.998  78.944  35.412  1.00109.88           N  
+ATOM   5150  CA  VAL C 367     105.562  79.193  35.494  1.00109.88           C  
+ATOM   5151  C   VAL C 367     104.983  78.570  36.756  1.00109.88           C  
+ATOM   5152  O   VAL C 367     104.038  79.108  37.347  1.00109.88           O  
+ATOM   5153  CB  VAL C 367     104.854  78.685  34.218  1.00109.88           C  
+ATOM   5154  CG1 VAL C 367     104.792  77.164  34.186  1.00109.88           C  
+ATOM   5155  CG2 VAL C 367     103.460  79.286  34.108  1.00109.88           C  
+ATOM   5156  N   LEU C 368     105.556  77.452  37.212  1.00107.95           N  
+ATOM   5157  CA  LEU C 368     105.079  76.822  38.438  1.00107.95           C  
+ATOM   5158  C   LEU C 368     105.371  77.698  39.649  1.00107.95           C  
+ATOM   5159  O   LEU C 368     104.565  77.779  40.582  1.00107.95           O  
+ATOM   5160  CB  LEU C 368     105.716  75.442  38.603  1.00107.95           C  
+ATOM   5161  CG  LEU C 368     105.868  74.573  37.351  1.00107.95           C  
+ATOM   5162  CD1 LEU C 368     106.466  73.224  37.712  1.00107.95           C  
+ATOM   5163  CD2 LEU C 368     104.530  74.391  36.650  1.00107.95           C  
+ATOM   5164  N   TYR C 369     106.526  78.368  39.650  1.00109.18           N  
+ATOM   5165  CA  TYR C 369     106.850  79.246  40.769  1.00109.18           C  
+ATOM   5166  C   TYR C 369     106.055  80.544  40.704  1.00109.18           C  
+ATOM   5167  O   TYR C 369     105.545  81.017  41.727  1.00109.18           O  
+ATOM   5168  CB  TYR C 369     108.350  79.536  40.802  1.00109.18           C  
+ATOM   5169  CG  TYR C 369     108.808  80.159  42.100  1.00109.18           C  
+ATOM   5170  CD1 TYR C 369     108.572  79.528  43.315  1.00109.18           C  
+ATOM   5171  CD2 TYR C 369     109.470  81.379  42.114  1.00109.18           C  
+ATOM   5172  CE1 TYR C 369     108.985  80.092  44.506  1.00109.18           C  
+ATOM   5173  CE2 TYR C 369     109.888  81.952  43.301  1.00109.18           C  
+ATOM   5174  CZ  TYR C 369     109.642  81.303  44.495  1.00109.18           C  
+ATOM   5175  OH  TYR C 369     110.055  81.867  45.680  1.00109.18           O  
+ATOM   5176  N   ASN C 370     105.934  81.133  39.515  1.00110.04           N  
+ATOM   5177  CA  ASN C 370     105.219  82.392  39.350  1.00110.04           C  
+ATOM   5178  C   ASN C 370     103.711  82.215  39.213  1.00110.04           C  
+ATOM   5179  O   ASN C 370     103.017  83.198  38.931  1.00110.04           O  
+ATOM   5180  CB  ASN C 370     105.763  83.150  38.135  1.00110.04           C  
+ATOM   5181  CG  ASN C 370     107.240  83.478  38.264  1.00110.04           C  
+ATOM   5182  OD1 ASN C 370     108.070  82.597  38.486  1.00110.04           O  
+ATOM   5183  ND2 ASN C 370     107.574  84.755  38.120  1.00110.04           N  
+ATOM   5184  N   SER C 371     103.190  80.998  39.394  1.00 98.63           N  
+ATOM   5185  CA  SER C 371     101.743  80.810  39.388  1.00 98.63           C  
+ATOM   5186  C   SER C 371     101.078  81.598  40.510  1.00 98.63           C  
+ATOM   5187  O   SER C 371      99.940  82.059  40.365  1.00 98.63           O  
+ATOM   5188  CB  SER C 371     101.405  79.323  39.504  1.00 98.63           C  
+ATOM   5189  OG  SER C 371     102.209  78.548  38.633  1.00 98.63           O  
+ATOM   5190  N   THR C 372     101.772  81.758  41.637  1.00 89.67           N  
+ATOM   5191  CA  THR C 372     101.338  82.523  42.807  1.00 89.67           C  
+ATOM   5192  C   THR C 372     100.016  82.034  43.389  1.00 89.67           C  
+ATOM   5193  O   THR C 372      99.441  82.706  44.253  1.00 89.67           O  
+ATOM   5194  CB  THR C 372     101.244  84.032  42.516  1.00 89.67           C  
+ATOM   5195  OG1 THR C 372     100.564  84.262  41.275  1.00 89.67           O  
+ATOM   5196  CG2 THR C 372     102.633  84.648  42.451  1.00 89.67           C  
+ATOM   5197  N   SER C 373      99.517  80.884  42.945  1.00 79.88           N  
+ATOM   5198  CA  SER C 373      98.307  80.297  43.502  1.00 79.88           C  
+ATOM   5199  C   SER C 373      98.603  79.266  44.583  1.00 79.88           C  
+ATOM   5200  O   SER C 373      97.668  78.761  45.214  1.00 79.88           O  
+ATOM   5201  CB  SER C 373      97.472  79.655  42.391  1.00 79.88           C  
+ATOM   5202  OG  SER C 373      98.288  78.903  41.510  1.00 79.88           O  
+ATOM   5203  N   PHE C 374      99.874  78.950  44.812  1.00 71.29           N  
+ATOM   5204  CA  PHE C 374     100.271  77.967  45.808  1.00 71.29           C  
+ATOM   5205  C   PHE C 374     100.603  78.667  47.119  1.00 71.29           C  
+ATOM   5206  O   PHE C 374     101.306  79.681  47.128  1.00 71.29           O  
+ATOM   5207  CB  PHE C 374     101.471  77.165  45.309  1.00 71.29           C  
+ATOM   5208  CG  PHE C 374     101.290  76.609  43.929  1.00 71.29           C  
+ATOM   5209  CD1 PHE C 374     100.127  75.942  43.587  1.00 71.29           C  
+ATOM   5210  CD2 PHE C 374     102.276  76.760  42.970  1.00 71.29           C  
+ATOM   5211  CE1 PHE C 374      99.954  75.428  42.318  1.00 71.29           C  
+ATOM   5212  CE2 PHE C 374     102.109  76.248  41.699  1.00 71.29           C  
+ATOM   5213  CZ  PHE C 374     100.946  75.583  41.373  1.00 71.29           C  
+ATOM   5214  N   SER C 375     100.095  78.120  48.224  1.00 68.16           N  
+ATOM   5215  CA  SER C 375     100.264  78.755  49.524  1.00 68.16           C  
+ATOM   5216  C   SER C 375     101.516  78.298  50.261  1.00 68.16           C  
+ATOM   5217  O   SER C 375     101.796  78.826  51.342  1.00 68.16           O  
+ATOM   5218  CB  SER C 375      99.035  78.490  50.395  1.00 68.16           C  
+ATOM   5219  OG  SER C 375      99.346  78.632  51.770  1.00 68.16           O  
+ATOM   5220  N   THR C 376     102.271  77.344  49.720  1.00 74.33           N  
+ATOM   5221  CA  THR C 376     103.437  76.822  50.425  1.00 74.33           C  
+ATOM   5222  C   THR C 376     104.455  76.314  49.418  1.00 74.33           C  
+ATOM   5223  O   THR C 376     104.137  75.456  48.590  1.00 74.33           O  
+ATOM   5224  CB  THR C 376     103.040  75.702  51.390  1.00 74.33           C  
+ATOM   5225  OG1 THR C 376     102.226  76.237  52.441  1.00 74.33           O  
+ATOM   5226  CG2 THR C 376     104.277  75.053  51.992  1.00 74.33           C  
+ATOM   5227  N   PHE C 377     105.677  76.846  49.494  1.00 88.09           N  
+ATOM   5228  CA  PHE C 377     106.811  76.368  48.697  1.00 88.09           C  
+ATOM   5229  C   PHE C 377     108.067  76.665  49.516  1.00 88.09           C  
+ATOM   5230  O   PHE C 377     108.603  77.776  49.468  1.00 88.09           O  
+ATOM   5231  CB  PHE C 377     106.846  77.038  47.329  1.00 88.09           C  
+ATOM   5232  CG  PHE C 377     107.806  76.404  46.367  1.00 88.09           C  
+ATOM   5233  CD1 PHE C 377     107.464  75.245  45.692  1.00 88.09           C  
+ATOM   5234  CD2 PHE C 377     109.050  76.964  46.137  1.00 88.09           C  
+ATOM   5235  CE1 PHE C 377     108.345  74.657  44.806  1.00 88.09           C  
+ATOM   5236  CE2 PHE C 377     109.936  76.380  45.251  1.00 88.09           C  
+ATOM   5237  CZ  PHE C 377     109.582  75.225  44.584  1.00 88.09           C  
+ATOM   5238  N   LYS C 378     108.535  75.667  50.266  1.00 92.63           N  
+ATOM   5239  CA  LYS C 378     109.623  75.841  51.225  1.00 92.63           C  
+ATOM   5240  C   LYS C 378     110.590  74.669  51.106  1.00 92.63           C  
+ATOM   5241  O   LYS C 378     110.222  73.526  51.394  1.00 92.63           O  
+ATOM   5242  CB  LYS C 378     109.085  75.943  52.652  1.00 92.63           C  
+ATOM   5243  CG  LYS C 378     107.989  76.975  52.853  1.00 92.63           C  
+ATOM   5244  CD  LYS C 378     107.389  76.870  54.246  1.00 92.63           C  
+ATOM   5245  CE  LYS C 378     106.269  77.877  54.445  1.00 92.63           C  
+ATOM   5246  NZ  LYS C 378     105.642  77.751  55.787  1.00 92.63           N  
+ATOM   5247  N   CYS C 379     111.827  74.957  50.707  1.00108.33           N  
+ATOM   5248  CA  CYS C 379     112.881  73.956  50.636  1.00108.33           C  
+ATOM   5249  C   CYS C 379     114.252  74.556  50.911  1.00108.33           C  
+ATOM   5250  O   CYS C 379     114.463  75.767  50.787  1.00108.33           O  
+ATOM   5251  CB  CYS C 379     112.887  73.246  49.278  1.00108.33           C  
+ATOM   5252  SG  CYS C 379     112.430  74.240  47.840  1.00108.33           S  
+ATOM   5253  N   TYR C 380     115.180  73.678  51.290  1.00123.98           N  
+ATOM   5254  CA  TYR C 380     116.549  74.035  51.659  1.00123.98           C  
+ATOM   5255  C   TYR C 380     117.462  73.079  50.896  1.00123.98           C  
+ATOM   5256  O   TYR C 380     117.407  71.862  51.094  1.00123.98           O  
+ATOM   5257  CB  TYR C 380     116.740  73.947  53.179  1.00123.98           C  
+ATOM   5258  CG  TYR C 380     118.148  74.198  53.682  1.00123.98           C  
+ATOM   5259  CD1 TYR C 380     118.468  75.383  54.331  1.00123.98           C  
+ATOM   5260  CD2 TYR C 380     119.144  73.237  53.550  1.00123.98           C  
+ATOM   5261  CE1 TYR C 380     119.746  75.618  54.805  1.00123.98           C  
+ATOM   5262  CE2 TYR C 380     120.425  73.463  54.019  1.00123.98           C  
+ATOM   5263  CZ  TYR C 380     120.720  74.654  54.647  1.00123.98           C  
+ATOM   5264  OH  TYR C 380     121.993  74.880  55.119  1.00123.98           O  
+ATOM   5265  N   GLY C 381     118.293  73.630  50.017  1.00119.35           N  
+ATOM   5266  CA  GLY C 381     119.203  72.827  49.227  1.00119.35           C  
+ATOM   5267  C   GLY C 381     119.284  73.293  47.790  1.00119.35           C  
+ATOM   5268  O   GLY C 381     120.302  73.097  47.118  1.00119.35           O  
+ATOM   5269  N   VAL C 382     118.211  73.915  47.310  1.00111.13           N  
+ATOM   5270  CA  VAL C 382     118.171  74.478  45.966  1.00111.13           C  
+ATOM   5271  C   VAL C 382     117.148  75.606  45.955  1.00111.13           C  
+ATOM   5272  O   VAL C 382     116.127  75.544  46.646  1.00111.13           O  
+ATOM   5273  CB  VAL C 382     117.853  73.401  44.904  1.00111.13           C  
+ATOM   5274  CG1 VAL C 382     116.390  72.978  44.969  1.00111.13           C  
+ATOM   5275  CG2 VAL C 382     118.210  73.901  43.513  1.00111.13           C  
+ATOM   5276  N   SER C 383     117.443  76.651  45.192  1.00112.88           N  
+ATOM   5277  CA  SER C 383     116.512  77.762  45.077  1.00112.88           C  
+ATOM   5278  C   SER C 383     115.536  77.505  43.930  1.00112.88           C  
+ATOM   5279  O   SER C 383     115.874  76.797  42.976  1.00112.88           O  
+ATOM   5280  CB  SER C 383     117.264  79.073  44.850  1.00112.88           C  
+ATOM   5281  OG  SER C 383     118.372  79.183  45.726  1.00112.88           O  
+ATOM   5282  N   PRO C 384     114.321  78.057  43.997  1.00110.53           N  
+ATOM   5283  CA  PRO C 384     113.345  77.796  42.923  1.00110.53           C  
+ATOM   5284  C   PRO C 384     113.794  78.284  41.557  1.00110.53           C  
+ATOM   5285  O   PRO C 384     113.360  77.734  40.537  1.00110.53           O  
+ATOM   5286  CB  PRO C 384     112.087  78.532  43.408  1.00110.53           C  
+ATOM   5287  CG  PRO C 384     112.575  79.511  44.428  1.00110.53           C  
+ATOM   5288  CD  PRO C 384     113.742  78.858  45.087  1.00110.53           C  
+ATOM   5289  N   THR C 385     114.655  79.302  41.504  1.00114.78           N  
+ATOM   5290  CA  THR C 385     115.095  79.821  40.213  1.00114.78           C  
+ATOM   5291  C   THR C 385     116.378  79.143  39.746  1.00114.78           C  
+ATOM   5292  O   THR C 385     116.700  79.169  38.552  1.00114.78           O  
+ATOM   5293  CB  THR C 385     115.283  81.337  40.290  1.00114.78           C  
+ATOM   5294  OG1 THR C 385     115.485  81.864  38.972  1.00114.78           O  
+ATOM   5295  CG2 THR C 385     116.479  81.689  41.163  1.00114.78           C  
+ATOM   5296  N   LYS C 386     117.123  78.529  40.668  1.00117.83           N  
+ATOM   5297  CA  LYS C 386     118.383  77.895  40.289  1.00117.83           C  
+ATOM   5298  C   LYS C 386     118.171  76.456  39.838  1.00117.83           C  
+ATOM   5299  O   LYS C 386     119.007  75.898  39.119  1.00117.83           O  
+ATOM   5300  CB  LYS C 386     119.375  77.957  41.450  1.00117.83           C  
+ATOM   5301  CG  LYS C 386     119.492  79.326  42.094  1.00117.83           C  
+ATOM   5302  CD  LYS C 386     120.688  79.397  43.028  1.00117.83           C  
+ATOM   5303  CE  LYS C 386     121.076  80.837  43.319  1.00117.83           C  
+ATOM   5304  NZ  LYS C 386     122.333  81.229  42.625  1.00117.83           N  
+ATOM   5305  N   LEU C 387     117.064  75.835  40.251  1.00116.00           N  
+ATOM   5306  CA  LEU C 387     116.795  74.466  39.826  1.00116.00           C  
+ATOM   5307  C   LEU C 387     116.353  74.391  38.371  1.00116.00           C  
+ATOM   5308  O   LEU C 387     116.239  73.287  37.827  1.00116.00           O  
+ATOM   5309  CB  LEU C 387     115.746  73.822  40.738  1.00116.00           C  
+ATOM   5310  CG  LEU C 387     114.357  74.452  40.863  1.00116.00           C  
+ATOM   5311  CD1 LEU C 387     113.379  73.833  39.881  1.00116.00           C  
+ATOM   5312  CD2 LEU C 387     113.845  74.289  42.283  1.00116.00           C  
+ATOM   5313  N   ASN C 388     116.100  75.534  37.730  1.00121.72           N  
+ATOM   5314  CA  ASN C 388     115.733  75.515  36.318  1.00121.72           C  
+ATOM   5315  C   ASN C 388     116.929  75.188  35.434  1.00121.72           C  
+ATOM   5316  O   ASN C 388     116.851  74.281  34.598  1.00121.72           O  
+ATOM   5317  CB  ASN C 388     115.121  76.857  35.913  1.00121.72           C  
+ATOM   5318  CG  ASN C 388     114.307  76.766  34.634  1.00121.72           C  
+ATOM   5319  OD1 ASN C 388     114.493  75.855  33.827  1.00121.72           O  
+ATOM   5320  ND2 ASN C 388     113.397  77.713  34.445  1.00121.72           N  
+ATOM   5321  N   ASP C 389     118.038  75.905  35.602  1.00126.20           N  
+ATOM   5322  CA  ASP C 389     119.246  75.656  34.815  1.00126.20           C  
+ATOM   5323  C   ASP C 389     120.114  74.610  35.514  1.00126.20           C  
+ATOM   5324  O   ASP C 389     121.313  74.786  35.739  1.00126.20           O  
+ATOM   5325  CB  ASP C 389     120.003  76.962  34.577  1.00126.20           C  
+ATOM   5326  CG  ASP C 389     120.221  77.761  35.852  1.00126.20           C  
+ATOM   5327  OD1 ASP C 389     120.286  77.160  36.945  1.00126.20           O  
+ATOM   5328  OD2 ASP C 389     120.330  79.002  35.759  1.00126.20           O  
+ATOM   5329  N   LEU C 390     119.472  73.493  35.848  1.00123.04           N  
+ATOM   5330  CA  LEU C 390     120.131  72.372  36.502  1.00123.04           C  
+ATOM   5331  C   LEU C 390     119.224  71.157  36.380  1.00123.04           C  
+ATOM   5332  O   LEU C 390     118.066  71.184  36.805  1.00123.04           O  
+ATOM   5333  CB  LEU C 390     120.441  72.682  37.971  1.00123.04           C  
+ATOM   5334  CG  LEU C 390     120.767  71.514  38.904  1.00123.04           C  
+ATOM   5335  CD1 LEU C 390     121.933  70.690  38.372  1.00123.04           C  
+ATOM   5336  CD2 LEU C 390     121.060  72.025  40.305  1.00123.04           C  
+ATOM   5337  N   CYS C 391     119.760  70.089  35.793  1.00128.94           N  
+ATOM   5338  CA  CYS C 391     118.977  68.895  35.508  1.00128.94           C  
+ATOM   5339  C   CYS C 391     119.630  67.657  36.103  1.00128.94           C  
+ATOM   5340  O   CYS C 391     120.835  67.640  36.372  1.00128.94           O  
+ATOM   5341  CB  CYS C 391     118.779  68.692  34.006  1.00128.94           C  
+ATOM   5342  SG  CYS C 391     120.261  68.545  32.998  1.00128.94           S  
+ATOM   5343  N   PHE C 392     118.816  66.622  36.290  1.00126.25           N  
+ATOM   5344  CA  PHE C 392     119.200  65.400  36.974  1.00126.25           C  
+ATOM   5345  C   PHE C 392     118.897  64.208  36.074  1.00126.25           C  
+ATOM   5346  O   PHE C 392     118.679  64.351  34.868  1.00126.25           O  
+ATOM   5347  CB  PHE C 392     118.461  65.270  38.311  1.00126.25           C  
+ATOM   5348  CG  PHE C 392     118.209  66.589  38.989  1.00126.25           C  
+ATOM   5349  CD1 PHE C 392     116.915  67.041  39.189  1.00126.25           C  
+ATOM   5350  CD2 PHE C 392     119.262  67.371  39.434  1.00126.25           C  
+ATOM   5351  CE1 PHE C 392     116.678  68.252  39.809  1.00126.25           C  
+ATOM   5352  CE2 PHE C 392     119.029  68.583  40.060  1.00126.25           C  
+ATOM   5353  CZ  PHE C 392     117.734  69.022  40.249  1.00126.25           C  
+ATOM   5354  N   THR C 393     118.894  63.017  36.673  1.00124.10           N  
+ATOM   5355  CA  THR C 393     118.562  61.799  35.940  1.00124.10           C  
+ATOM   5356  C   THR C 393     117.051  61.590  35.863  1.00124.10           C  
+ATOM   5357  O   THR C 393     116.483  61.505  34.769  1.00124.10           O  
+ATOM   5358  CB  THR C 393     119.231  60.582  36.592  1.00124.10           C  
+ATOM   5359  OG1 THR C 393     118.472  60.177  37.738  1.00124.10           O  
+ATOM   5360  CG2 THR C 393     120.655  60.913  37.019  1.00124.10           C  
+ATOM   5361  N   ASN C 394     116.389  61.509  37.016  1.00119.62           N  
+ATOM   5362  CA  ASN C 394     114.953  61.277  37.072  1.00119.62           C  
+ATOM   5363  C   ASN C 394     114.352  62.088  38.211  1.00119.62           C  
+ATOM   5364  O   ASN C 394     115.039  62.412  39.184  1.00119.62           O  
+ATOM   5365  CB  ASN C 394     114.632  59.788  37.259  1.00119.62           C  
+ATOM   5366  CG  ASN C 394     113.358  59.373  36.550  1.00119.62           C  
+ATOM   5367  OD1 ASN C 394     112.350  60.079  36.595  1.00119.62           O  
+ATOM   5368  ND2 ASN C 394     113.395  58.221  35.891  1.00119.62           N  
+ATOM   5369  N   VAL C 395     113.069  62.419  38.079  1.00113.58           N  
+ATOM   5370  CA  VAL C 395     112.336  63.172  39.088  1.00113.58           C  
+ATOM   5371  C   VAL C 395     111.075  62.398  39.444  1.00113.58           C  
+ATOM   5372  O   VAL C 395     110.567  61.622  38.628  1.00113.58           O  
+ATOM   5373  CB  VAL C 395     111.981  64.593  38.605  1.00113.58           C  
+ATOM   5374  CG1 VAL C 395     113.233  65.340  38.170  1.00113.58           C  
+ATOM   5375  CG2 VAL C 395     110.967  64.537  37.471  1.00113.58           C  
+ATOM   5376  N   TYR C 396     110.582  62.599  40.662  1.00104.50           N  
+ATOM   5377  CA  TYR C 396     109.361  61.962  41.134  1.00104.50           C  
+ATOM   5378  C   TYR C 396     108.428  63.020  41.705  1.00104.50           C  
+ATOM   5379  O   TYR C 396     108.850  63.855  42.512  1.00104.50           O  
+ATOM   5380  CB  TYR C 396     109.667  60.898  42.190  1.00104.50           C  
+ATOM   5381  CG  TYR C 396     110.609  59.819  41.712  1.00104.50           C  
+ATOM   5382  CD1 TYR C 396     111.913  59.748  42.186  1.00104.50           C  
+ATOM   5383  CD2 TYR C 396     110.197  58.870  40.785  1.00104.50           C  
+ATOM   5384  CE1 TYR C 396     112.777  58.761  41.752  1.00104.50           C  
+ATOM   5385  CE2 TYR C 396     111.055  57.882  40.345  1.00104.50           C  
+ATOM   5386  CZ  TYR C 396     112.344  57.833  40.832  1.00104.50           C  
+ATOM   5387  OH  TYR C 396     113.204  56.851  40.397  1.00104.50           O  
+ATOM   5388  N   ALA C 397     107.165  62.978  41.289  1.00 87.18           N  
+ATOM   5389  CA  ALA C 397     106.151  63.927  41.734  1.00 87.18           C  
+ATOM   5390  C   ALA C 397     105.073  63.160  42.486  1.00 87.18           C  
+ATOM   5391  O   ALA C 397     104.243  62.483  41.871  1.00 87.18           O  
+ATOM   5392  CB  ALA C 397     105.558  64.694  40.554  1.00 87.18           C  
+ATOM   5393  N   ASP C 398     105.090  63.260  43.811  1.00 80.80           N  
+ATOM   5394  CA  ASP C 398     104.105  62.609  44.660  1.00 80.80           C  
+ATOM   5395  C   ASP C 398     102.976  63.580  44.978  1.00 80.80           C  
+ATOM   5396  O   ASP C 398     103.220  64.746  45.299  1.00 80.80           O  
+ATOM   5397  CB  ASP C 398     104.748  62.112  45.955  1.00 80.80           C  
+ATOM   5398  CG  ASP C 398     106.018  61.326  45.707  1.00 80.80           C  
+ATOM   5399  OD1 ASP C 398     106.075  60.594  44.698  1.00 80.80           O  
+ATOM   5400  OD2 ASP C 398     106.958  61.439  46.520  1.00 80.80           O  
+ATOM   5401  N   SER C 399     101.741  63.092  44.889  1.00 71.64           N  
+ATOM   5402  CA  SER C 399     100.558  63.916  45.091  1.00 71.64           C  
+ATOM   5403  C   SER C 399      99.611  63.234  46.065  1.00 71.64           C  
+ATOM   5404  O   SER C 399      99.446  62.011  46.030  1.00 71.64           O  
+ATOM   5405  CB  SER C 399      99.839  64.184  43.764  1.00 71.64           C  
+ATOM   5406  OG  SER C 399      98.922  63.147  43.462  1.00 71.64           O  
+ATOM   5407  N   PHE C 400      98.987  64.031  46.926  1.00 61.36           N  
+ATOM   5408  CA  PHE C 400      98.039  63.535  47.919  1.00 61.36           C  
+ATOM   5409  C   PHE C 400      97.283  64.731  48.484  1.00 61.36           C  
+ATOM   5410  O   PHE C 400      97.490  65.874  48.066  1.00 61.36           O  
+ATOM   5411  CB  PHE C 400      98.740  62.737  49.021  1.00 61.36           C  
+ATOM   5412  CG  PHE C 400      99.895  63.458  49.653  1.00 61.36           C  
+ATOM   5413  CD1 PHE C 400      99.714  64.205  50.804  1.00 61.36           C  
+ATOM   5414  CD2 PHE C 400     101.163  63.382  49.103  1.00 61.36           C  
+ATOM   5415  CE1 PHE C 400     100.773  64.867  51.389  1.00 61.36           C  
+ATOM   5416  CE2 PHE C 400     102.225  64.041  49.684  1.00 61.36           C  
+ATOM   5417  CZ  PHE C 400     102.030  64.785  50.828  1.00 61.36           C  
+ATOM   5418  N   VAL C 401      96.396  64.460  49.438  1.00 51.03           N  
+ATOM   5419  CA  VAL C 401      95.559  65.481  50.054  1.00 51.03           C  
+ATOM   5420  C   VAL C 401      95.605  65.306  51.564  1.00 51.03           C  
+ATOM   5421  O   VAL C 401      95.430  64.195  52.076  1.00 51.03           O  
+ATOM   5422  CB  VAL C 401      94.104  65.411  49.544  1.00 51.03           C  
+ATOM   5423  CG1 VAL C 401      93.209  66.329  50.358  1.00 51.03           C  
+ATOM   5424  CG2 VAL C 401      94.040  65.773  48.070  1.00 51.03           C  
+ATOM   5425  N   VAL C 402      95.841  66.407  52.277  1.00 44.06           N  
+ATOM   5426  CA  VAL C 402      95.917  66.416  53.732  1.00 44.06           C  
+ATOM   5427  C   VAL C 402      95.072  67.571  54.255  1.00 44.06           C  
+ATOM   5428  O   VAL C 402      94.381  68.258  53.502  1.00 44.06           O  
+ATOM   5429  CB  VAL C 402      97.366  66.540  54.246  1.00 44.06           C  
+ATOM   5430  CG1 VAL C 402      98.182  65.328  53.837  1.00 44.06           C  
+ATOM   5431  CG2 VAL C 402      98.002  67.814  53.724  1.00 44.06           C  
+ATOM   5432  N   ARG C 403      95.128  67.770  55.568  1.00 46.53           N  
+ATOM   5433  CA  ARG C 403      94.445  68.889  56.196  1.00 46.53           C  
+ATOM   5434  C   ARG C 403      95.238  70.177  55.977  1.00 46.53           C  
+ATOM   5435  O   ARG C 403      96.204  70.228  55.212  1.00 46.53           O  
+ATOM   5436  CB  ARG C 403      94.253  68.629  57.686  1.00 46.53           C  
+ATOM   5437  CG  ARG C 403      93.019  67.827  58.029  1.00 46.53           C  
+ATOM   5438  CD  ARG C 403      93.009  67.483  59.505  1.00 46.53           C  
+ATOM   5439  NE  ARG C 403      93.567  68.565  60.310  1.00 46.53           N  
+ATOM   5440  CZ  ARG C 403      93.813  68.478  61.612  1.00 46.53           C  
+ATOM   5441  NH1 ARG C 403      93.549  67.355  62.264  1.00 46.53           N  
+ATOM   5442  NH2 ARG C 403      94.321  69.514  62.263  1.00 46.53           N  
+ATOM   5443  N   GLY C 404      94.817  71.234  56.663  1.00 45.65           N  
+ATOM   5444  CA  GLY C 404      95.516  72.502  56.591  1.00 45.65           C  
+ATOM   5445  C   GLY C 404      96.608  72.626  57.632  1.00 45.65           C  
+ATOM   5446  O   GLY C 404      97.680  73.172  57.358  1.00 45.65           O  
+ATOM   5447  N   ASP C 405      96.343  72.123  58.840  1.00 50.86           N  
+ATOM   5448  CA  ASP C 405      97.360  72.150  59.885  1.00 50.86           C  
+ATOM   5449  C   ASP C 405      98.399  71.056  59.684  1.00 50.86           C  
+ATOM   5450  O   ASP C 405      99.457  71.081  60.320  1.00 50.86           O  
+ATOM   5451  CB  ASP C 405      96.705  72.008  61.259  1.00 50.86           C  
+ATOM   5452  CG  ASP C 405      96.431  73.347  61.914  1.00 50.86           C  
+ATOM   5453  OD1 ASP C 405      95.433  73.455  62.657  1.00 50.86           O  
+ATOM   5454  OD2 ASP C 405      97.214  74.294  61.688  1.00 50.86           O  
+ATOM   5455  N   GLU C 406      98.119  70.094  58.810  1.00 51.04           N  
+ATOM   5456  CA  GLU C 406      98.990  68.948  58.596  1.00 51.04           C  
+ATOM   5457  C   GLU C 406      99.928  69.124  57.407  1.00 51.04           C  
+ATOM   5458  O   GLU C 406     100.590  68.163  57.009  1.00 51.04           O  
+ATOM   5459  CB  GLU C 406      98.146  67.684  58.411  1.00 51.04           C  
+ATOM   5460  CG  GLU C 406      97.792  66.989  59.715  1.00 51.04           C  
+ATOM   5461  CD  GLU C 406      97.453  65.526  59.525  1.00 51.04           C  
+ATOM   5462  OE1 GLU C 406      96.916  65.175  58.455  1.00 51.04           O  
+ATOM   5463  OE2 GLU C 406      97.727  64.725  60.444  1.00 51.04           O  
+ATOM   5464  N   VAL C 407     100.001  70.328  56.833  1.00 51.22           N  
+ATOM   5465  CA  VAL C 407     100.887  70.547  55.694  1.00 51.22           C  
+ATOM   5466  C   VAL C 407     102.331  70.675  56.158  1.00 51.22           C  
+ATOM   5467  O   VAL C 407     103.266  70.291  55.445  1.00 51.22           O  
+ATOM   5468  CB  VAL C 407     100.440  71.784  54.895  1.00 51.22           C  
+ATOM   5469  CG1 VAL C 407     101.121  71.812  53.535  1.00 51.22           C  
+ATOM   5470  CG2 VAL C 407      98.933  71.797  54.739  1.00 51.22           C  
+ATOM   5471  N   ARG C 408     102.538  71.219  57.360  1.00 54.37           N  
+ATOM   5472  CA  ARG C 408     103.891  71.428  57.860  1.00 54.37           C  
+ATOM   5473  C   ARG C 408     104.635  70.121  58.091  1.00 54.37           C  
+ATOM   5474  O   ARG C 408     105.870  70.115  58.079  1.00 54.37           O  
+ATOM   5475  CB  ARG C 408     103.852  72.237  59.156  1.00 54.37           C  
+ATOM   5476  CG  ARG C 408     103.136  71.541  60.300  1.00 54.37           C  
+ATOM   5477  CD  ARG C 408     102.955  72.481  61.477  1.00 54.37           C  
+ATOM   5478  NE  ARG C 408     102.497  73.797  61.047  1.00 54.37           N  
+ATOM   5479  CZ  ARG C 408     101.220  74.139  60.922  1.00 54.37           C  
+ATOM   5480  NH1 ARG C 408     100.268  73.258  61.196  1.00 54.37           N  
+ATOM   5481  NH2 ARG C 408     100.893  75.359  60.523  1.00 54.37           N  
+ATOM   5482  N   GLN C 409     103.917  69.017  58.297  1.00 58.77           N  
+ATOM   5483  CA  GLN C 409     104.570  67.737  58.531  1.00 58.77           C  
+ATOM   5484  C   GLN C 409     105.229  67.173  57.280  1.00 58.77           C  
+ATOM   5485  O   GLN C 409     106.027  66.237  57.393  1.00 58.77           O  
+ATOM   5486  CB  GLN C 409     103.563  66.728  59.083  1.00 58.77           C  
+ATOM   5487  CG  GLN C 409     102.818  67.214  60.312  1.00 58.77           C  
+ATOM   5488  CD  GLN C 409     101.999  66.121  60.962  1.00 58.77           C  
+ATOM   5489  OE1 GLN C 409     102.324  64.940  60.853  1.00 58.77           O  
+ATOM   5490  NE2 GLN C 409     100.927  66.508  61.643  1.00 58.77           N  
+ATOM   5491  N   ILE C 410     104.922  67.710  56.104  1.00 60.85           N  
+ATOM   5492  CA  ILE C 410     105.550  67.243  54.857  1.00 60.85           C  
+ATOM   5493  C   ILE C 410     106.801  68.094  54.674  1.00 60.85           C  
+ATOM   5494  O   ILE C 410     106.831  69.084  53.939  1.00 60.85           O  
+ATOM   5495  CB  ILE C 410     104.595  67.318  53.663  1.00 60.85           C  
+ATOM   5496  CG1 ILE C 410     103.277  66.618  53.985  1.00 60.85           C  
+ATOM   5497  CG2 ILE C 410     105.213  66.646  52.457  1.00 60.85           C  
+ATOM   5498  CD1 ILE C 410     103.455  65.239  54.569  1.00 60.85           C  
+ATOM   5499  N   ALA C 411     107.870  67.684  55.355  1.00 70.24           N  
+ATOM   5500  CA  ALA C 411     109.145  68.389  55.365  1.00 70.24           C  
+ATOM   5501  C   ALA C 411     110.187  67.516  56.053  1.00 70.24           C  
+ATOM   5502  O   ALA C 411     109.832  66.681  56.896  1.00 70.24           O  
+ATOM   5503  CB  ALA C 411     109.018  69.740  56.072  1.00 70.24           C  
+ATOM   5504  N   PRO C 412     111.470  67.665  55.725  1.00 76.26           N  
+ATOM   5505  CA  PRO C 412     112.489  66.829  56.368  1.00 76.26           C  
+ATOM   5506  C   PRO C 412     112.596  67.118  57.857  1.00 76.26           C  
+ATOM   5507  O   PRO C 412     112.435  68.255  58.307  1.00 76.26           O  
+ATOM   5508  CB  PRO C 412     113.779  67.208  55.630  1.00 76.26           C  
+ATOM   5509  CG  PRO C 412     113.505  68.553  55.047  1.00 76.26           C  
+ATOM   5510  CD  PRO C 412     112.049  68.555  54.705  1.00 76.26           C  
+ATOM   5511  N   GLY C 413     112.869  66.065  58.624  1.00 75.58           N  
+ATOM   5512  CA  GLY C 413     113.038  66.205  60.056  1.00 75.58           C  
+ATOM   5513  C   GLY C 413     111.781  66.538  60.822  1.00 75.58           C  
+ATOM   5514  O   GLY C 413     111.865  67.117  61.908  1.00 75.58           O  
+ATOM   5515  N   GLN C 414     110.613  66.196  60.289  1.00 70.73           N  
+ATOM   5516  CA  GLN C 414     109.346  66.457  60.953  1.00 70.73           C  
+ATOM   5517  C   GLN C 414     108.742  65.157  61.469  1.00 70.73           C  
+ATOM   5518  O   GLN C 414     109.001  64.075  60.936  1.00 70.73           O  
+ATOM   5519  CB  GLN C 414     108.363  67.145  60.005  1.00 70.73           C  
+ATOM   5520  CG  GLN C 414     108.849  68.479  59.472  1.00 70.73           C  
+ATOM   5521  CD  GLN C 414     108.821  69.572  60.520  1.00 70.73           C  
+ATOM   5522  OE1 GLN C 414     108.087  69.484  61.505  1.00 70.73           O  
+ATOM   5523  NE2 GLN C 414     109.622  70.609  60.312  1.00 70.73           N  
+ATOM   5524  N   THR C 415     107.936  65.276  62.517  1.00 68.61           N  
+ATOM   5525  CA  THR C 415     107.239  64.147  63.110  1.00 68.61           C  
+ATOM   5526  C   THR C 415     105.738  64.404  63.088  1.00 68.61           C  
+ATOM   5527  O   THR C 415     105.273  65.487  62.722  1.00 68.61           O  
+ATOM   5528  CB  THR C 415     107.714  63.892  64.546  1.00 68.61           C  
+ATOM   5529  OG1 THR C 415     107.222  62.624  64.996  1.00 68.61           O  
+ATOM   5530  CG2 THR C 415     107.208  64.984  65.476  1.00 68.61           C  
+ATOM   5531  N   GLY C 416     104.977  63.392  63.490  1.00 67.74           N  
+ATOM   5532  CA  GLY C 416     103.534  63.463  63.520  1.00 67.74           C  
+ATOM   5533  C   GLY C 416     102.904  62.254  62.868  1.00 67.74           C  
+ATOM   5534  O   GLY C 416     103.557  61.253  62.577  1.00 67.74           O  
+ATOM   5535  N   ARG C 417     101.594  62.359  62.640  1.00 65.07           N  
+ATOM   5536  CA  ARG C 417     100.865  61.255  62.024  1.00 65.07           C  
+ATOM   5537  C   ARG C 417     101.293  61.046  60.578  1.00 65.07           C  
+ATOM   5538  O   ARG C 417     101.637  59.927  60.181  1.00 65.07           O  
+ATOM   5539  CB  ARG C 417      99.360  61.506  62.104  1.00 65.07           C  
+ATOM   5540  CG  ARG C 417      98.742  61.156  63.444  1.00 65.07           C  
+ATOM   5541  CD  ARG C 417      97.824  62.261  63.931  1.00 65.07           C  
+ATOM   5542  NE  ARG C 417      97.435  62.071  65.325  1.00 65.07           N  
+ATOM   5543  CZ  ARG C 417      97.039  63.049  66.130  1.00 65.07           C  
+ATOM   5544  NH1 ARG C 417      96.978  64.296  65.683  1.00 65.07           N  
+ATOM   5545  NH2 ARG C 417      96.707  62.782  67.385  1.00 65.07           N  
+ATOM   5546  N   ILE C 418     101.283  62.111  59.775  1.00 60.57           N  
+ATOM   5547  CA  ILE C 418     101.592  61.967  58.356  1.00 60.57           C  
+ATOM   5548  C   ILE C 418     103.075  61.696  58.151  1.00 60.57           C  
+ATOM   5549  O   ILE C 418     103.462  60.946  57.247  1.00 60.57           O  
+ATOM   5550  CB  ILE C 418     101.134  63.214  57.581  1.00 60.57           C  
+ATOM   5551  CG1 ILE C 418      99.716  63.599  57.990  1.00 60.57           C  
+ATOM   5552  CG2 ILE C 418     101.189  62.956  56.093  1.00 60.57           C  
+ATOM   5553  CD1 ILE C 418      98.699  62.505  57.762  1.00 60.57           C  
+ATOM   5554  N   ALA C 419     103.928  62.297  58.979  1.00 64.99           N  
+ATOM   5555  CA  ALA C 419     105.366  62.127  58.804  1.00 64.99           C  
+ATOM   5556  C   ALA C 419     105.800  60.706  59.138  1.00 64.99           C  
+ATOM   5557  O   ALA C 419     106.721  60.166  58.515  1.00 64.99           O  
+ATOM   5558  CB  ALA C 419     106.121  63.139  59.666  1.00 64.99           C  
+ATOM   5559  N   ASP C 420     105.143  60.081  60.115  1.00 66.97           N  
+ATOM   5560  CA  ASP C 420     105.563  58.757  60.559  1.00 66.97           C  
+ATOM   5561  C   ASP C 420     104.789  57.648  59.854  1.00 66.97           C  
+ATOM   5562  O   ASP C 420     105.388  56.753  59.250  1.00 66.97           O  
+ATOM   5563  CB  ASP C 420     105.400  58.637  62.075  1.00 66.97           C  
+ATOM   5564  CG  ASP C 420     106.190  59.684  62.831  1.00 66.97           C  
+ATOM   5565  OD1 ASP C 420     106.140  59.683  64.078  1.00 66.97           O  
+ATOM   5566  OD2 ASP C 420     106.858  60.512  62.177  1.00 66.97           O  
+ATOM   5567  N   TYR C 421     103.458  57.691  59.921  1.00 62.88           N  
+ATOM   5568  CA  TYR C 421     102.633  56.572  59.489  1.00 62.88           C  
+ATOM   5569  C   TYR C 421     102.137  56.683  58.053  1.00 62.88           C  
+ATOM   5570  O   TYR C 421     101.688  55.675  57.497  1.00 62.88           O  
+ATOM   5571  CB  TYR C 421     101.420  56.422  60.416  1.00 62.88           C  
+ATOM   5572  CG  TYR C 421     101.772  56.284  61.879  1.00 62.88           C  
+ATOM   5573  CD1 TYR C 421     102.940  55.649  62.277  1.00 62.88           C  
+ATOM   5574  CD2 TYR C 421     100.933  56.786  62.863  1.00 62.88           C  
+ATOM   5575  CE1 TYR C 421     103.262  55.519  63.613  1.00 62.88           C  
+ATOM   5576  CE2 TYR C 421     101.246  56.661  64.201  1.00 62.88           C  
+ATOM   5577  CZ  TYR C 421     102.412  56.027  64.571  1.00 62.88           C  
+ATOM   5578  OH  TYR C 421     102.727  55.900  65.904  1.00 62.88           O  
+ATOM   5579  N   ASN C 422     102.191  57.865  57.441  1.00 59.96           N  
+ATOM   5580  CA  ASN C 422     101.624  58.052  56.109  1.00 59.96           C  
+ATOM   5581  C   ASN C 422     102.674  58.426  55.071  1.00 59.96           C  
+ATOM   5582  O   ASN C 422     102.773  57.754  54.040  1.00 59.96           O  
+ATOM   5583  CB  ASN C 422     100.515  59.109  56.161  1.00 59.96           C  
+ATOM   5584  CG  ASN C 422      99.300  58.636  56.930  1.00 59.96           C  
+ATOM   5585  OD1 ASN C 422      98.351  58.109  56.351  1.00 59.96           O  
+ATOM   5586  ND2 ASN C 422      99.325  58.819  58.244  1.00 59.96           N  
+ATOM   5587  N   TYR C 423     103.464  59.470  55.307  1.00 67.23           N  
+ATOM   5588  CA  TYR C 423     104.400  59.974  54.304  1.00 67.23           C  
+ATOM   5589  C   TYR C 423     105.682  60.399  55.005  1.00 67.23           C  
+ATOM   5590  O   TYR C 423     105.723  61.458  55.637  1.00 67.23           O  
+ATOM   5591  CB  TYR C 423     103.792  61.140  53.524  1.00 67.23           C  
+ATOM   5592  CG  TYR C 423     104.520  61.470  52.243  1.00 67.23           C  
+ATOM   5593  CD1 TYR C 423     104.309  60.727  51.092  1.00 67.23           C  
+ATOM   5594  CD2 TYR C 423     105.419  62.525  52.186  1.00 67.23           C  
+ATOM   5595  CE1 TYR C 423     104.973  61.025  49.919  1.00 67.23           C  
+ATOM   5596  CE2 TYR C 423     106.087  62.830  51.018  1.00 67.23           C  
+ATOM   5597  CZ  TYR C 423     105.861  62.077  49.888  1.00 67.23           C  
+ATOM   5598  OH  TYR C 423     106.524  62.376  48.722  1.00 67.23           O  
+ATOM   5599  N   LYS C 424     106.725  59.584  54.886  1.00 76.10           N  
+ATOM   5600  CA  LYS C 424     108.012  59.852  55.515  1.00 76.10           C  
+ATOM   5601  C   LYS C 424     108.964  60.422  54.473  1.00 76.10           C  
+ATOM   5602  O   LYS C 424     109.181  59.808  53.423  1.00 76.10           O  
+ATOM   5603  CB  LYS C 424     108.595  58.584  56.139  1.00 76.10           C  
+ATOM   5604  CG  LYS C 424     110.052  58.713  56.559  1.00 76.10           C  
+ATOM   5605  CD  LYS C 424     110.231  59.765  57.643  1.00 76.10           C  
+ATOM   5606  CE  LYS C 424     109.771  59.249  58.996  1.00 76.10           C  
+ATOM   5607  NZ  LYS C 424     109.870  60.294  60.051  1.00 76.10           N  
+ATOM   5608  N   LEU C 425     109.524  61.593  54.766  1.00 84.73           N  
+ATOM   5609  CA  LEU C 425     110.503  62.243  53.915  1.00 84.73           C  
+ATOM   5610  C   LEU C 425     111.856  62.288  54.612  1.00 84.73           C  
+ATOM   5611  O   LEU C 425     111.934  62.669  55.785  1.00 84.73           O  
+ATOM   5612  CB  LEU C 425     110.066  63.669  53.563  1.00 84.73           C  
+ATOM   5613  CG  LEU C 425     109.368  63.861  52.216  1.00 84.73           C  
+ATOM   5614  CD1 LEU C 425     109.041  65.327  51.992  1.00 84.73           C  
+ATOM   5615  CD2 LEU C 425     110.221  63.322  51.081  1.00 84.73           C  
+ATOM   5616  N   PRO C 426     112.932  61.907  53.929  1.00 92.38           N  
+ATOM   5617  CA  PRO C 426     114.245  61.864  54.580  1.00 92.38           C  
+ATOM   5618  C   PRO C 426     114.774  63.263  54.857  1.00 92.38           C  
+ATOM   5619  O   PRO C 426     114.266  64.270  54.360  1.00 92.38           O  
+ATOM   5620  CB  PRO C 426     115.118  61.126  53.564  1.00 92.38           C  
+ATOM   5621  CG  PRO C 426     114.483  61.425  52.253  1.00 92.38           C  
+ATOM   5622  CD  PRO C 426     113.003  61.512  52.512  1.00 92.38           C  
+ATOM   5623  N   ASP C 427     115.826  63.309  55.677  1.00 98.43           N  
+ATOM   5624  CA  ASP C 427     116.440  64.588  56.017  1.00 98.43           C  
+ATOM   5625  C   ASP C 427     117.193  65.169  54.828  1.00 98.43           C  
+ATOM   5626  O   ASP C 427     117.302  66.394  54.690  1.00 98.43           O  
+ATOM   5627  CB  ASP C 427     117.374  64.416  57.213  1.00 98.43           C  
+ATOM   5628  CG  ASP C 427     116.629  64.078  58.488  1.00 98.43           C  
+ATOM   5629  OD1 ASP C 427     115.457  64.487  58.620  1.00 98.43           O  
+ATOM   5630  OD2 ASP C 427     117.216  63.401  59.358  1.00 98.43           O  
+ATOM   5631  N   ASP C 428     117.720  64.311  53.962  1.00103.30           N  
+ATOM   5632  CA  ASP C 428     118.467  64.743  52.781  1.00103.30           C  
+ATOM   5633  C   ASP C 428     117.556  64.953  51.573  1.00103.30           C  
+ATOM   5634  O   ASP C 428     117.814  64.467  50.473  1.00103.30           O  
+ATOM   5635  CB  ASP C 428     119.571  63.734  52.483  1.00103.30           C  
+ATOM   5636  CG  ASP C 428     119.051  62.309  52.374  1.00103.30           C  
+ATOM   5637  OD1 ASP C 428     119.511  61.455  53.160  1.00103.30           O  
+ATOM   5638  OD2 ASP C 428     118.192  62.035  51.511  1.00103.30           O  
+ATOM   5639  N   PHE C 429     116.487  65.718  51.774  1.00102.77           N  
+ATOM   5640  CA  PHE C 429     115.531  65.993  50.709  1.00102.77           C  
+ATOM   5641  C   PHE C 429     116.063  67.111  49.820  1.00102.77           C  
+ATOM   5642  O   PHE C 429     116.276  68.234  50.286  1.00102.77           O  
+ATOM   5643  CB  PHE C 429     114.174  66.368  51.301  1.00102.77           C  
+ATOM   5644  CG  PHE C 429     113.058  66.370  50.299  1.00102.77           C  
+ATOM   5645  CD1 PHE C 429     113.131  65.584  49.162  1.00102.77           C  
+ATOM   5646  CD2 PHE C 429     111.934  67.153  50.495  1.00102.77           C  
+ATOM   5647  CE1 PHE C 429     112.108  65.583  48.238  1.00102.77           C  
+ATOM   5648  CE2 PHE C 429     110.907  67.157  49.572  1.00102.77           C  
+ATOM   5649  CZ  PHE C 429     110.995  66.370  48.443  1.00102.77           C  
+ATOM   5650  N   THR C 430     116.272  66.803  48.539  1.00107.61           N  
+ATOM   5651  CA  THR C 430     116.823  67.752  47.580  1.00107.61           C  
+ATOM   5652  C   THR C 430     115.744  68.572  46.882  1.00107.61           C  
+ATOM   5653  O   THR C 430     116.064  69.415  46.038  1.00107.61           O  
+ATOM   5654  CB  THR C 430     117.676  67.017  46.545  1.00107.61           C  
+ATOM   5655  OG1 THR C 430     116.860  66.083  45.831  1.00107.61           O  
+ATOM   5656  CG2 THR C 430     118.815  66.273  47.225  1.00107.61           C  
+ATOM   5657  N   GLY C 431     114.474  68.340  47.213  1.00103.89           N  
+ATOM   5658  CA  GLY C 431     113.373  69.094  46.677  1.00103.89           C  
+ATOM   5659  C   GLY C 431     112.478  69.657  47.760  1.00103.89           C  
+ATOM   5660  O   GLY C 431     112.821  69.669  48.950  1.00103.89           O  
+ATOM   5661  N   CYS C 432     111.312  70.145  47.342  1.00 93.89           N  
+ATOM   5662  CA  CYS C 432     110.311  70.645  48.273  1.00 93.89           C  
+ATOM   5663  C   CYS C 432     108.906  70.452  47.728  1.00 93.89           C  
+ATOM   5664  O   CYS C 432     108.709  69.946  46.621  1.00 93.89           O  
+ATOM   5665  CB  CYS C 432     110.541  72.115  48.625  1.00 93.89           C  
+ATOM   5666  SG  CYS C 432     110.734  73.285  47.264  1.00 93.89           S  
+ATOM   5667  N   VAL C 433     107.933  70.871  48.531  1.00 76.52           N  
+ATOM   5668  CA  VAL C 433     106.534  70.516  48.346  1.00 76.52           C  
+ATOM   5669  C   VAL C 433     105.790  71.734  47.820  1.00 76.52           C  
+ATOM   5670  O   VAL C 433     106.126  72.874  48.163  1.00 76.52           O  
+ATOM   5671  CB  VAL C 433     105.909  70.002  49.653  1.00 76.52           C  
+ATOM   5672  CG1 VAL C 433     106.796  68.934  50.259  1.00 76.52           C  
+ATOM   5673  CG2 VAL C 433     105.709  71.138  50.643  1.00 76.52           C  
+ATOM   5674  N   ILE C 434     104.802  71.490  46.966  1.00 69.78           N  
+ATOM   5675  CA  ILE C 434     103.914  72.525  46.453  1.00 69.78           C  
+ATOM   5676  C   ILE C 434     102.526  72.265  47.016  1.00 69.78           C  
+ATOM   5677  O   ILE C 434     101.928  71.218  46.743  1.00 69.78           O  
+ATOM   5678  CB  ILE C 434     103.890  72.543  44.914  1.00 69.78           C  
+ATOM   5679  CG1 ILE C 434     105.311  72.647  44.357  1.00 69.78           C  
+ATOM   5680  CG2 ILE C 434     103.027  73.680  44.412  1.00 69.78           C  
+ATOM   5681  CD1 ILE C 434     105.837  71.352  43.778  1.00 69.78           C  
+ATOM   5682  N   ALA C 435     102.018  73.211  47.800  1.00 60.01           N  
+ATOM   5683  CA  ALA C 435     100.731  73.050  48.457  1.00 60.01           C  
+ATOM   5684  C   ALA C 435      99.831  74.221  48.104  1.00 60.01           C  
+ATOM   5685  O   ALA C 435     100.297  75.344  47.902  1.00 60.01           O  
+ATOM   5686  CB  ALA C 435     100.883  72.945  49.979  1.00 60.01           C  
+ATOM   5687  N   TRP C 436      98.532  73.944  48.029  1.00 55.73           N  
+ATOM   5688  CA  TRP C 436      97.547  74.975  47.744  1.00 55.73           C  
+ATOM   5689  C   TRP C 436      96.197  74.525  48.275  1.00 55.73           C  
+ATOM   5690  O   TRP C 436      95.881  73.332  48.269  1.00 55.73           O  
+ATOM   5691  CB  TRP C 436      97.460  75.276  46.244  1.00 55.73           C  
+ATOM   5692  CG  TRP C 436      96.841  74.178  45.431  1.00 55.73           C  
+ATOM   5693  CD1 TRP C 436      95.511  73.978  45.201  1.00 55.73           C  
+ATOM   5694  CD2 TRP C 436      97.530  73.138  44.727  1.00 55.73           C  
+ATOM   5695  NE1 TRP C 436      95.329  72.876  44.404  1.00 55.73           N  
+ATOM   5696  CE2 TRP C 436      96.553  72.342  44.099  1.00 55.73           C  
+ATOM   5697  CE3 TRP C 436      98.877  72.801  44.570  1.00 55.73           C  
+ATOM   5698  CZ2 TRP C 436      96.881  71.231  43.326  1.00 55.73           C  
+ATOM   5699  CZ3 TRP C 436      99.200  71.699  43.803  1.00 55.73           C  
+ATOM   5700  CH2 TRP C 436      98.206  70.927  43.191  1.00 55.73           C  
+ATOM   5701  N   ASN C 437      95.408  75.490  48.735  1.00 46.37           N  
+ATOM   5702  CA  ASN C 437      94.076  75.188  49.237  1.00 46.37           C  
+ATOM   5703  C   ASN C 437      93.194  74.665  48.111  1.00 46.37           C  
+ATOM   5704  O   ASN C 437      93.218  75.178  46.990  1.00 46.37           O  
+ATOM   5705  CB  ASN C 437      93.447  76.430  49.864  1.00 46.37           C  
+ATOM   5706  CG  ASN C 437      92.151  76.124  50.588  1.00 46.37           C  
+ATOM   5707  OD1 ASN C 437      91.121  75.877  49.963  1.00 46.37           O  
+ATOM   5708  ND2 ASN C 437      92.195  76.144  51.915  1.00 46.37           N  
+ATOM   5709  N   SER C 438      92.416  73.630  48.416  1.00 45.32           N  
+ATOM   5710  CA  SER C 438      91.506  73.026  47.452  1.00 45.32           C  
+ATOM   5711  C   SER C 438      90.152  72.767  48.097  1.00 45.32           C  
+ATOM   5712  O   SER C 438      89.553  71.702  47.926  1.00 45.32           O  
+ATOM   5713  CB  SER C 438      92.088  71.736  46.876  1.00 45.32           C  
+ATOM   5714  OG  SER C 438      91.775  70.627  47.697  1.00 45.32           O  
+ATOM   5715  N   ASN C 439      89.654  73.748  48.853  1.00 47.67           N  
+ATOM   5716  CA  ASN C 439      88.361  73.594  49.511  1.00 47.67           C  
+ATOM   5717  C   ASN C 439      87.217  73.586  48.507  1.00 47.67           C  
+ATOM   5718  O   ASN C 439      86.148  73.032  48.789  1.00 47.67           O  
+ATOM   5719  CB  ASN C 439      88.162  74.712  50.535  1.00 47.67           C  
+ATOM   5720  CG  ASN C 439      86.905  74.532  51.360  1.00 47.67           C  
+ATOM   5721  OD1 ASN C 439      86.474  73.410  51.619  1.00 47.67           O  
+ATOM   5722  ND2 ASN C 439      86.309  75.641  51.778  1.00 47.67           N  
+ATOM   5723  N   ASN C 440      87.416  74.190  47.333  1.00 53.06           N  
+ATOM   5724  CA  ASN C 440      86.340  74.255  46.350  1.00 53.06           C  
+ATOM   5725  C   ASN C 440      86.226  72.966  45.548  1.00 53.06           C  
+ATOM   5726  O   ASN C 440      85.122  72.586  45.143  1.00 53.06           O  
+ATOM   5727  CB  ASN C 440      86.555  75.444  45.414  1.00 53.06           C  
+ATOM   5728  CG  ASN C 440      87.801  75.299  44.563  1.00 53.06           C  
+ATOM   5729  OD1 ASN C 440      88.785  74.690  44.981  1.00 53.06           O  
+ATOM   5730  ND2 ASN C 440      87.763  75.858  43.360  1.00 53.06           N  
+ATOM   5731  N   LEU C 441      87.344  72.282  45.308  1.00 54.77           N  
+ATOM   5732  CA  LEU C 441      87.339  71.082  44.481  1.00 54.77           C  
+ATOM   5733  C   LEU C 441      87.242  69.802  45.299  1.00 54.77           C  
+ATOM   5734  O   LEU C 441      86.455  68.910  44.961  1.00 54.77           O  
+ATOM   5735  CB  LEU C 441      88.598  71.040  43.610  1.00 54.77           C  
+ATOM   5736  CG  LEU C 441      88.803  72.181  42.615  1.00 54.77           C  
+ATOM   5737  CD1 LEU C 441      89.770  71.760  41.520  1.00 54.77           C  
+ATOM   5738  CD2 LEU C 441      87.478  72.627  42.017  1.00 54.77           C  
+ATOM   5739  N   ASP C 442      88.024  69.690  46.370  1.00 52.79           N  
+ATOM   5740  CA  ASP C 442      88.116  68.461  47.144  1.00 52.79           C  
+ATOM   5741  C   ASP C 442      87.151  68.413  48.319  1.00 52.79           C  
+ATOM   5742  O   ASP C 442      87.234  67.487  49.130  1.00 52.79           O  
+ATOM   5743  CB  ASP C 442      89.546  68.266  47.651  1.00 52.79           C  
+ATOM   5744  CG  ASP C 442      90.500  67.861  46.551  1.00 52.79           C  
+ATOM   5745  OD1 ASP C 442      90.190  66.900  45.817  1.00 52.79           O  
+ATOM   5746  OD2 ASP C 442      91.558  68.508  46.418  1.00 52.79           O  
+ATOM   5747  N   SER C 443      86.245  69.377  48.436  1.00 49.69           N  
+ATOM   5748  CA  SER C 443      85.263  69.391  49.509  1.00 49.69           C  
+ATOM   5749  C   SER C 443      83.895  69.736  48.942  1.00 49.69           C  
+ATOM   5750  O   SER C 443      83.747  70.715  48.207  1.00 49.69           O  
+ATOM   5751  CB  SER C 443      85.641  70.389  50.604  1.00 49.69           C  
+ATOM   5752  OG  SER C 443      85.137  71.680  50.308  1.00 49.69           O  
+ATOM   5753  N   LYS C 444      82.900  68.925  49.292  1.00 51.23           N  
+ATOM   5754  CA  LYS C 444      81.529  69.151  48.865  1.00 51.23           C  
+ATOM   5755  C   LYS C 444      80.626  69.148  50.088  1.00 51.23           C  
+ATOM   5756  O   LYS C 444      81.041  68.781  51.190  1.00 51.23           O  
+ATOM   5757  CB  LYS C 444      81.067  68.092  47.855  1.00 51.23           C  
+ATOM   5758  CG  LYS C 444      80.936  66.696  48.438  1.00 51.23           C  
+ATOM   5759  CD  LYS C 444      80.282  65.746  47.449  1.00 51.23           C  
+ATOM   5760  CE  LYS C 444      80.048  64.380  48.071  1.00 51.23           C  
+ATOM   5761  NZ  LYS C 444      79.283  63.483  47.162  1.00 51.23           N  
+ATOM   5762  N   VAL C 445      79.376  69.567  49.880  1.00 53.45           N  
+ATOM   5763  CA  VAL C 445      78.426  69.645  50.981  1.00 53.45           C  
+ATOM   5764  C   VAL C 445      78.181  68.252  51.541  1.00 53.45           C  
+ATOM   5765  O   VAL C 445      77.839  67.318  50.807  1.00 53.45           O  
+ATOM   5766  CB  VAL C 445      77.119  70.302  50.515  1.00 53.45           C  
+ATOM   5767  CG1 VAL C 445      76.242  70.635  51.710  1.00 53.45           C  
+ATOM   5768  CG2 VAL C 445      77.416  71.550  49.698  1.00 53.45           C  
+ATOM   5769  N   GLY C 446      78.359  68.111  52.854  1.00 52.47           N  
+ATOM   5770  CA  GLY C 446      78.219  66.844  53.532  1.00 52.47           C  
+ATOM   5771  C   GLY C 446      79.529  66.181  53.905  1.00 52.47           C  
+ATOM   5772  O   GLY C 446      79.544  65.342  54.811  1.00 52.47           O  
+ATOM   5773  N   GLY C 447      80.622  66.537  53.235  1.00 51.94           N  
+ATOM   5774  CA  GLY C 447      81.917  65.964  53.544  1.00 51.94           C  
+ATOM   5775  C   GLY C 447      82.423  65.016  52.479  1.00 51.94           C  
+ATOM   5776  O   GLY C 447      81.723  64.076  52.093  1.00 51.94           O  
+ATOM   5777  N   ASN C 448      83.639  65.251  51.996  1.00 53.87           N  
+ATOM   5778  CA  ASN C 448      84.258  64.418  50.968  1.00 53.87           C  
+ATOM   5779  C   ASN C 448      85.203  63.441  51.660  1.00 53.87           C  
+ATOM   5780  O   ASN C 448      86.353  63.775  51.954  1.00 53.87           O  
+ATOM   5781  CB  ASN C 448      84.990  65.279  49.944  1.00 53.87           C  
+ATOM   5782  CG  ASN C 448      85.506  64.475  48.770  1.00 53.87           C  
+ATOM   5783  OD1 ASN C 448      85.039  63.367  48.508  1.00 53.87           O  
+ATOM   5784  ND2 ASN C 448      86.474  65.032  48.053  1.00 53.87           N  
+ATOM   5785  N   TYR C 449      84.715  62.228  51.913  1.00 51.91           N  
+ATOM   5786  CA  TYR C 449      85.458  61.226  52.663  1.00 51.91           C  
+ATOM   5787  C   TYR C 449      86.247  60.278  51.770  1.00 51.91           C  
+ATOM   5788  O   TYR C 449      86.641  59.201  52.226  1.00 51.91           O  
+ATOM   5789  CB  TYR C 449      84.507  60.422  53.553  1.00 51.91           C  
+ATOM   5790  CG  TYR C 449      83.629  61.273  54.440  1.00 51.91           C  
+ATOM   5791  CD1 TYR C 449      84.082  61.722  55.671  1.00 51.91           C  
+ATOM   5792  CD2 TYR C 449      82.344  61.620  54.050  1.00 51.91           C  
+ATOM   5793  CE1 TYR C 449      83.283  62.496  56.486  1.00 51.91           C  
+ATOM   5794  CE2 TYR C 449      81.538  62.394  54.860  1.00 51.91           C  
+ATOM   5795  CZ  TYR C 449      82.013  62.829  56.077  1.00 51.91           C  
+ATOM   5796  OH  TYR C 449      81.213  63.600  56.887  1.00 51.91           O  
+ATOM   5797  N   ASN C 450      86.488  60.650  50.513  1.00 58.34           N  
+ATOM   5798  CA  ASN C 450      87.233  59.782  49.609  1.00 58.34           C  
+ATOM   5799  C   ASN C 450      88.727  59.764  49.902  1.00 58.34           C  
+ATOM   5800  O   ASN C 450      89.445  58.951  49.310  1.00 58.34           O  
+ATOM   5801  CB  ASN C 450      86.994  60.206  48.160  1.00 58.34           C  
+ATOM   5802  CG  ASN C 450      85.652  59.746  47.633  1.00 58.34           C  
+ATOM   5803  OD1 ASN C 450      85.227  58.618  47.888  1.00 58.34           O  
+ATOM   5804  ND2 ASN C 450      84.974  60.617  46.897  1.00 58.34           N  
+ATOM   5805  N   TYR C 451      89.208  60.629  50.790  1.00 57.18           N  
+ATOM   5806  CA  TYR C 451      90.618  60.691  51.148  1.00 57.18           C  
+ATOM   5807  C   TYR C 451      90.799  60.115  52.546  1.00 57.18           C  
+ATOM   5808  O   TYR C 451      90.143  60.560  53.494  1.00 57.18           O  
+ATOM   5809  CB  TYR C 451      91.132  62.127  51.083  1.00 57.18           C  
+ATOM   5810  CG  TYR C 451      90.921  62.784  49.739  1.00 57.18           C  
+ATOM   5811  CD1 TYR C 451      91.832  62.607  48.708  1.00 57.18           C  
+ATOM   5812  CD2 TYR C 451      89.808  63.577  49.500  1.00 57.18           C  
+ATOM   5813  CE1 TYR C 451      91.642  63.203  47.478  1.00 57.18           C  
+ATOM   5814  CE2 TYR C 451      89.610  64.177  48.273  1.00 57.18           C  
+ATOM   5815  CZ  TYR C 451      90.530  63.987  47.266  1.00 57.18           C  
+ATOM   5816  OH  TYR C 451      90.337  64.583  46.042  1.00 57.18           O  
+ATOM   5817  N   LEU C 452      91.684  59.130  52.670  1.00 55.94           N  
+ATOM   5818  CA  LEU C 452      91.913  58.431  53.925  1.00 55.94           C  
+ATOM   5819  C   LEU C 452      93.369  58.576  54.347  1.00 55.94           C  
+ATOM   5820  O   LEU C 452      94.256  58.785  53.515  1.00 55.94           O  
+ATOM   5821  CB  LEU C 452      91.554  56.945  53.808  1.00 55.94           C  
+ATOM   5822  CG  LEU C 452      90.067  56.585  53.849  1.00 55.94           C  
+ATOM   5823  CD1 LEU C 452      89.438  56.718  52.473  1.00 55.94           C  
+ATOM   5824  CD2 LEU C 452      89.874  55.180  54.394  1.00 55.94           C  
+ATOM   5825  N   TYR C 453      93.605  58.459  55.653  1.00 52.68           N  
+ATOM   5826  CA  TYR C 453      94.945  58.520  56.215  1.00 52.68           C  
+ATOM   5827  C   TYR C 453      95.111  57.436  57.267  1.00 52.68           C  
+ATOM   5828  O   TYR C 453      94.186  57.136  58.026  1.00 52.68           O  
+ATOM   5829  CB  TYR C 453      95.243  59.898  56.834  1.00 52.68           C  
+ATOM   5830  CG  TYR C 453      94.374  60.270  58.014  1.00 52.68           C  
+ATOM   5831  CD1 TYR C 453      93.089  60.755  57.828  1.00 52.68           C  
+ATOM   5832  CD2 TYR C 453      94.848  60.158  59.313  1.00 52.68           C  
+ATOM   5833  CE1 TYR C 453      92.296  61.104  58.902  1.00 52.68           C  
+ATOM   5834  CE2 TYR C 453      94.062  60.505  60.392  1.00 52.68           C  
+ATOM   5835  CZ  TYR C 453      92.787  60.977  60.180  1.00 52.68           C  
+ATOM   5836  OH  TYR C 453      91.997  61.324  61.250  1.00 52.68           O  
+ATOM   5837  N   ARG C 454      96.305  56.850  57.305  1.00 60.00           N  
+ATOM   5838  CA  ARG C 454      96.625  55.830  58.295  1.00 60.00           C  
+ATOM   5839  C   ARG C 454      96.843  56.490  59.649  1.00 60.00           C  
+ATOM   5840  O   ARG C 454      97.671  57.398  59.777  1.00 60.00           O  
+ATOM   5841  CB  ARG C 454      97.863  55.044  57.870  1.00 60.00           C  
+ATOM   5842  CG  ARG C 454      98.282  53.972  58.856  1.00 60.00           C  
+ATOM   5843  CD  ARG C 454      99.387  53.106  58.280  1.00 60.00           C  
+ATOM   5844  NE  ARG C 454      99.158  52.806  56.871  1.00 60.00           N  
+ATOM   5845  CZ  ARG C 454      98.320  51.874  56.432  1.00 60.00           C  
+ATOM   5846  NH1 ARG C 454      97.628  51.142  57.295  1.00 60.00           N  
+ATOM   5847  NH2 ARG C 454      98.174  51.672  55.131  1.00 60.00           N  
+ATOM   5848  N   LEU C 455      96.103  56.035  60.658  1.00 54.92           N  
+ATOM   5849  CA  LEU C 455      96.160  56.660  61.972  1.00 54.92           C  
+ATOM   5850  C   LEU C 455      97.143  55.966  62.907  1.00 54.92           C  
+ATOM   5851  O   LEU C 455      97.900  56.639  63.614  1.00 54.92           O  
+ATOM   5852  CB  LEU C 455      94.767  56.681  62.604  1.00 54.92           C  
+ATOM   5853  CG  LEU C 455      94.598  57.631  63.790  1.00 54.92           C  
+ATOM   5854  CD1 LEU C 455      95.164  58.999  63.456  1.00 54.92           C  
+ATOM   5855  CD2 LEU C 455      93.138  57.738  64.189  1.00 54.92           C  
+ATOM   5856  N   PHE C 456      97.150  54.637  62.925  1.00 59.10           N  
+ATOM   5857  CA  PHE C 456      98.015  53.871  63.808  1.00 59.10           C  
+ATOM   5858  C   PHE C 456      98.861  52.892  63.005  1.00 59.10           C  
+ATOM   5859  O   PHE C 456      98.472  52.454  61.918  1.00 59.10           O  
+ATOM   5860  CB  PHE C 456      97.200  53.110  64.850  1.00 59.10           C  
+ATOM   5861  CG  PHE C 456      96.325  53.988  65.689  1.00 59.10           C  
+ATOM   5862  CD1 PHE C 456      96.843  54.664  66.776  1.00 59.10           C  
+ATOM   5863  CD2 PHE C 456      94.989  54.152  65.379  1.00 59.10           C  
+ATOM   5864  CE1 PHE C 456      96.039  55.475  67.548  1.00 59.10           C  
+ATOM   5865  CE2 PHE C 456      94.180  54.957  66.150  1.00 59.10           C  
+ATOM   5866  CZ  PHE C 456      94.706  55.622  67.232  1.00 59.10           C  
+ATOM   5867  N   ARG C 457     100.025  52.558  63.555  1.00 65.47           N  
+ATOM   5868  CA  ARG C 457     100.924  51.596  62.935  1.00 65.47           C  
+ATOM   5869  C   ARG C 457     101.868  51.049  63.995  1.00 65.47           C  
+ATOM   5870  O   ARG C 457     102.063  51.653  65.053  1.00 65.47           O  
+ATOM   5871  CB  ARG C 457     101.712  52.227  61.781  1.00 65.47           C  
+ATOM   5872  CG  ARG C 457     102.279  51.215  60.805  1.00 65.47           C  
+ATOM   5873  CD  ARG C 457     102.858  51.886  59.581  1.00 65.47           C  
+ATOM   5874  NE  ARG C 457     104.164  51.335  59.233  1.00 65.47           N  
+ATOM   5875  CZ  ARG C 457     104.344  50.199  58.570  1.00 65.47           C  
+ATOM   5876  NH1 ARG C 457     103.299  49.485  58.176  1.00 65.47           N  
+ATOM   5877  NH2 ARG C 457     105.571  49.776  58.300  1.00 65.47           N  
+ATOM   5878  N   LYS C 458     102.454  49.887  63.698  1.00 68.17           N  
+ATOM   5879  CA  LYS C 458     103.379  49.267  64.640  1.00 68.17           C  
+ATOM   5880  C   LYS C 458     104.700  50.023  64.712  1.00 68.17           C  
+ATOM   5881  O   LYS C 458     105.371  49.996  65.750  1.00 68.17           O  
+ATOM   5882  CB  LYS C 458     103.622  47.809  64.253  1.00 68.17           C  
+ATOM   5883  CG  LYS C 458     102.349  47.001  64.067  1.00 68.17           C  
+ATOM   5884  CD  LYS C 458     102.656  45.553  63.718  1.00 68.17           C  
+ATOM   5885  CE  LYS C 458     101.379  44.756  63.511  1.00 68.17           C  
+ATOM   5886  NZ  LYS C 458     100.508  44.776  64.718  1.00 68.17           N  
+ATOM   5887  N   SER C 459     105.088  50.696  63.633  1.00 65.32           N  
+ATOM   5888  CA  SER C 459     106.334  51.448  63.610  1.00 65.32           C  
+ATOM   5889  C   SER C 459     106.233  52.522  62.536  1.00 65.32           C  
+ATOM   5890  O   SER C 459     105.264  52.581  61.776  1.00 65.32           O  
+ATOM   5891  CB  SER C 459     107.536  50.532  63.360  1.00 65.32           C  
+ATOM   5892  OG  SER C 459     108.643  51.270  62.872  1.00 65.32           O  
+ATOM   5893  N   ASN C 460     107.254  53.373  62.486  1.00 68.00           N  
+ATOM   5894  CA  ASN C 460     107.296  54.453  61.512  1.00 68.00           C  
+ATOM   5895  C   ASN C 460     107.783  53.936  60.166  1.00 68.00           C  
+ATOM   5896  O   ASN C 460     108.511  52.942  60.092  1.00 68.00           O  
+ATOM   5897  CB  ASN C 460     108.209  55.578  62.000  1.00 68.00           C  
+ATOM   5898  CG  ASN C 460     107.798  56.117  63.356  1.00 68.00           C  
+ATOM   5899  OD1 ASN C 460     108.615  56.680  64.085  1.00 68.00           O  
+ATOM   5900  ND2 ASN C 460     106.526  55.951  63.701  1.00 68.00           N  
+ATOM   5901  N   LEU C 461     107.378  54.617  59.098  1.00 74.00           N  
+ATOM   5902  CA  LEU C 461     107.800  54.221  57.764  1.00 74.00           C  
+ATOM   5903  C   LEU C 461     109.214  54.707  57.471  1.00 74.00           C  
+ATOM   5904  O   LEU C 461     109.756  55.590  58.140  1.00 74.00           O  
+ATOM   5905  CB  LEU C 461     106.848  54.768  56.699  1.00 74.00           C  
+ATOM   5906  CG  LEU C 461     105.557  54.008  56.400  1.00 74.00           C  
+ATOM   5907  CD1 LEU C 461     104.556  54.178  57.516  1.00 74.00           C  
+ATOM   5908  CD2 LEU C 461     104.970  54.474  55.079  1.00 74.00           C  
+ATOM   5909  N   LYS C 462     109.811  54.106  56.447  1.00 83.75           N  
+ATOM   5910  CA  LYS C 462     111.084  54.571  55.938  1.00 83.75           C  
+ATOM   5911  C   LYS C 462     110.850  55.688  54.923  1.00 83.75           C  
+ATOM   5912  O   LYS C 462     109.721  55.902  54.476  1.00 83.75           O  
+ATOM   5913  CB  LYS C 462     111.850  53.413  55.299  1.00 83.75           C  
+ATOM   5914  CG  LYS C 462     111.987  52.187  56.193  1.00 83.75           C  
+ATOM   5915  CD  LYS C 462     112.886  52.459  57.391  1.00 83.75           C  
+ATOM   5916  CE  LYS C 462     114.189  53.127  56.981  1.00 83.75           C  
+ATOM   5917  NZ  LYS C 462     115.061  53.398  58.157  1.00 83.75           N  
+ATOM   5918  N   PRO C 463     111.894  56.437  54.567  1.00 87.09           N  
+ATOM   5919  CA  PRO C 463     111.738  57.451  53.518  1.00 87.09           C  
+ATOM   5920  C   PRO C 463     111.222  56.845  52.220  1.00 87.09           C  
+ATOM   5921  O   PRO C 463     111.705  55.808  51.760  1.00 87.09           O  
+ATOM   5922  CB  PRO C 463     113.156  58.007  53.355  1.00 87.09           C  
+ATOM   5923  CG  PRO C 463     113.767  57.831  54.695  1.00 87.09           C  
+ATOM   5924  CD  PRO C 463     113.194  56.556  55.253  1.00 87.09           C  
+ATOM   5925  N   PHE C 464     110.210  57.502  51.647  1.00 86.36           N  
+ATOM   5926  CA  PHE C 464     109.598  57.115  50.378  1.00 86.36           C  
+ATOM   5927  C   PHE C 464     108.932  55.745  50.448  1.00 86.36           C  
+ATOM   5928  O   PHE C 464     108.610  55.156  49.411  1.00 86.36           O  
+ATOM   5929  CB  PHE C 464     110.634  57.138  49.252  1.00 86.36           C  
+ATOM   5930  CG  PHE C 464     111.405  58.421  49.166  1.00 86.36           C  
+ATOM   5931  CD1 PHE C 464     110.785  59.590  48.761  1.00 86.36           C  
+ATOM   5932  CD2 PHE C 464     112.750  58.458  49.488  1.00 86.36           C  
+ATOM   5933  CE1 PHE C 464     111.492  60.773  48.680  1.00 86.36           C  
+ATOM   5934  CE2 PHE C 464     113.463  59.637  49.408  1.00 86.36           C  
+ATOM   5935  CZ  PHE C 464     112.834  60.796  49.004  1.00 86.36           C  
+ATOM   5936  N   GLU C 465     108.717  55.232  51.654  1.00 86.30           N  
+ATOM   5937  CA  GLU C 465     108.025  53.964  51.820  1.00 86.30           C  
+ATOM   5938  C   GLU C 465     106.516  54.178  51.799  1.00 86.30           C  
+ATOM   5939  O   GLU C 465     106.015  55.255  52.134  1.00 86.30           O  
+ATOM   5940  CB  GLU C 465     108.443  53.291  53.128  1.00 86.30           C  
+ATOM   5941  CG  GLU C 465     108.217  51.788  53.165  1.00 86.30           C  
+ATOM   5942  CD  GLU C 465     108.504  51.192  54.530  1.00 86.30           C  
+ATOM   5943  OE1 GLU C 465     107.846  51.603  55.509  1.00 86.30           O  
+ATOM   5944  OE2 GLU C 465     109.386  50.314  54.624  1.00 86.30           O  
+ATOM   5945  N   ARG C 466     105.791  53.138  51.394  1.00 76.74           N  
+ATOM   5946  CA  ARG C 466     104.338  53.187  51.294  1.00 76.74           C  
+ATOM   5947  C   ARG C 466     103.753  51.898  51.847  1.00 76.74           C  
+ATOM   5948  O   ARG C 466     104.223  50.806  51.512  1.00 76.74           O  
+ATOM   5949  CB  ARG C 466     103.890  53.393  49.843  1.00 76.74           C  
+ATOM   5950  CG  ARG C 466     102.391  53.583  49.673  1.00 76.74           C  
+ATOM   5951  CD  ARG C 466     101.983  53.506  48.209  1.00 76.74           C  
+ATOM   5952  NE  ARG C 466     102.651  54.520  47.396  1.00 76.74           N  
+ATOM   5953  CZ  ARG C 466     103.649  54.266  46.557  1.00 76.74           C  
+ATOM   5954  NH1 ARG C 466     104.101  53.026  46.417  1.00 76.74           N  
+ATOM   5955  NH2 ARG C 466     104.198  55.249  45.857  1.00 76.74           N  
+ATOM   5956  N   ASP C 467     102.732  52.026  52.690  1.00 74.06           N  
+ATOM   5957  CA  ASP C 467     102.043  50.887  53.283  1.00 74.06           C  
+ATOM   5958  C   ASP C 467     100.558  51.002  52.975  1.00 74.06           C  
+ATOM   5959  O   ASP C 467      99.892  51.930  53.447  1.00 74.06           O  
+ATOM   5960  CB  ASP C 467     102.276  50.825  54.794  1.00 74.06           C  
+ATOM   5961  CG  ASP C 467     101.626  49.613  55.435  1.00 74.06           C  
+ATOM   5962  OD1 ASP C 467     101.352  48.630  54.714  1.00 74.06           O  
+ATOM   5963  OD2 ASP C 467     101.388  49.642  56.660  1.00 74.06           O  
+ATOM   5964  N   ILE C 468     100.042  50.058  52.189  1.00 71.97           N  
+ATOM   5965  CA  ILE C 468      98.640  50.038  51.791  1.00 71.97           C  
+ATOM   5966  C   ILE C 468      97.855  48.960  52.523  1.00 71.97           C  
+ATOM   5967  O   ILE C 468      96.616  48.943  52.448  1.00 71.97           O  
+ATOM   5968  CB  ILE C 468      98.514  49.880  50.262  1.00 71.97           C  
+ATOM   5969  CG1 ILE C 468      99.332  50.968  49.565  1.00 71.97           C  
+ATOM   5970  CG2 ILE C 468      97.072  50.009  49.788  1.00 71.97           C  
+ATOM   5971  CD1 ILE C 468      99.016  51.139  48.094  1.00 71.97           C  
+ATOM   5972  N   SER C 469      98.534  48.091  53.273  1.00 77.19           N  
+ATOM   5973  CA  SER C 469      97.868  47.002  53.975  1.00 77.19           C  
+ATOM   5974  C   SER C 469      96.774  47.532  54.893  1.00 77.19           C  
+ATOM   5975  O   SER C 469      96.869  48.633  55.442  1.00 77.19           O  
+ATOM   5976  CB  SER C 469      98.883  46.197  54.788  1.00 77.19           C  
+ATOM   5977  OG  SER C 469      99.066  46.765  56.073  1.00 77.19           O  
+ATOM   5978  N   THR C 470      95.722  46.729  55.055  1.00 80.13           N  
+ATOM   5979  CA  THR C 470      94.558  47.105  55.847  1.00 80.13           C  
+ATOM   5980  C   THR C 470      94.342  46.169  57.031  1.00 80.13           C  
+ATOM   5981  O   THR C 470      93.225  46.081  57.550  1.00 80.13           O  
+ATOM   5982  CB  THR C 470      93.305  47.142  54.970  1.00 80.13           C  
+ATOM   5983  OG1 THR C 470      92.928  45.806  54.616  1.00 80.13           O  
+ATOM   5984  CG2 THR C 470      93.562  47.942  53.700  1.00 80.13           C  
+ATOM   5985  N   GLU C 471      95.385  45.465  57.464  1.00 82.11           N  
+ATOM   5986  CA  GLU C 471      95.255  44.550  58.589  1.00 82.11           C  
+ATOM   5987  C   GLU C 471      94.942  45.312  59.870  1.00 82.11           C  
+ATOM   5988  O   GLU C 471      95.489  46.389  60.120  1.00 82.11           O  
+ATOM   5989  CB  GLU C 471      96.536  43.732  58.761  1.00 82.11           C  
+ATOM   5990  CG  GLU C 471      96.516  42.729  59.916  1.00 82.11           C  
+ATOM   5991  CD  GLU C 471      95.447  41.652  59.783  1.00 82.11           C  
+ATOM   5992  OE1 GLU C 471      94.803  41.550  58.717  1.00 82.11           O  
+ATOM   5993  OE2 GLU C 471      95.250  40.898  60.759  1.00 82.11           O  
+ATOM   5994  N   ILE C 472      94.053  44.739  60.685  1.00 77.78           N  
+ATOM   5995  CA  ILE C 472      93.637  45.394  61.917  1.00 77.78           C  
+ATOM   5996  C   ILE C 472      94.829  45.569  62.847  1.00 77.78           C  
+ATOM   5997  O   ILE C 472      95.581  44.623  63.116  1.00 77.78           O  
+ATOM   5998  CB  ILE C 472      92.519  44.584  62.594  1.00 77.78           C  
+ATOM   5999  CG1 ILE C 472      91.338  44.407  61.639  1.00 77.78           C  
+ATOM   6000  CG2 ILE C 472      92.074  45.258  63.872  1.00 77.78           C  
+ATOM   6001  CD1 ILE C 472      90.681  45.704  61.234  1.00 77.78           C  
+ATOM   6002  N   TYR C 473      95.004  46.790  63.344  1.00 77.25           N  
+ATOM   6003  CA  TYR C 473      96.110  47.102  64.239  1.00 77.25           C  
+ATOM   6004  C   TYR C 473      95.790  46.631  65.651  1.00 77.25           C  
+ATOM   6005  O   TYR C 473      94.738  46.967  66.205  1.00 77.25           O  
+ATOM   6006  CB  TYR C 473      96.394  48.604  64.228  1.00 77.25           C  
+ATOM   6007  CG  TYR C 473      97.379  49.061  65.281  1.00 77.25           C  
+ATOM   6008  CD1 TYR C 473      98.746  48.904  65.098  1.00 77.25           C  
+ATOM   6009  CD2 TYR C 473      96.940  49.657  66.457  1.00 77.25           C  
+ATOM   6010  CE1 TYR C 473      99.648  49.323  66.058  1.00 77.25           C  
+ATOM   6011  CE2 TYR C 473      97.834  50.079  67.422  1.00 77.25           C  
+ATOM   6012  CZ  TYR C 473      99.186  49.910  67.217  1.00 77.25           C  
+ATOM   6013  OH  TYR C 473     100.078  50.329  68.177  1.00 77.25           O  
+ATOM   6014  N   GLN C 474      96.700  45.853  66.232  1.00 82.57           N  
+ATOM   6015  CA  GLN C 474      96.530  45.315  67.577  1.00 82.57           C  
+ATOM   6016  C   GLN C 474      97.195  46.260  68.572  1.00 82.57           C  
+ATOM   6017  O   GLN C 474      98.406  46.495  68.502  1.00 82.57           O  
+ATOM   6018  CB  GLN C 474      97.121  43.911  67.670  1.00 82.57           C  
+ATOM   6019  CG  GLN C 474      97.155  43.345  69.078  1.00 82.57           C  
+ATOM   6020  CD  GLN C 474      97.875  42.014  69.149  1.00 82.57           C  
+ATOM   6021  OE1 GLN C 474      98.184  41.520  70.232  1.00 82.57           O  
+ATOM   6022  NE2 GLN C 474      98.146  41.425  67.990  1.00 82.57           N  
+ATOM   6023  N   ALA C 475      96.405  46.797  69.500  1.00 78.88           N  
+ATOM   6024  CA  ALA C 475      96.920  47.743  70.482  1.00 78.88           C  
+ATOM   6025  C   ALA C 475      97.394  47.071  71.762  1.00 78.88           C  
+ATOM   6026  O   ALA C 475      98.322  47.573  72.407  1.00 78.88           O  
+ATOM   6027  CB  ALA C 475      95.853  48.788  70.819  1.00 78.88           C  
+ATOM   6028  N   GLY C 476      96.784  45.959  72.145  1.00 84.59           N  
+ATOM   6029  CA  GLY C 476      97.140  45.228  73.351  1.00 84.59           C  
+ATOM   6030  C   GLY C 476      98.048  44.053  73.059  1.00 84.59           C  
+ATOM   6031  O   GLY C 476      99.001  44.157  72.279  1.00 84.59           O  
+ATOM   6032  N   SER C 477      97.753  42.921  73.696  1.00 89.49           N  
+ATOM   6033  CA  SER C 477      98.513  41.694  73.493  1.00 89.49           C  
+ATOM   6034  C   SER C 477      97.661  40.513  73.060  1.00 89.49           C  
+ATOM   6035  O   SER C 477      98.197  39.562  72.488  1.00 89.49           O  
+ATOM   6036  CB  SER C 477      99.266  41.314  74.774  1.00 89.49           C  
+ATOM   6037  OG  SER C 477     100.059  40.156  74.574  1.00 89.49           O  
+ATOM   6038  N   THR C 478      96.357  40.549  73.314  1.00 96.32           N  
+ATOM   6039  CA  THR C 478      95.499  39.445  72.924  1.00 96.32           C  
+ATOM   6040  C   THR C 478      95.198  39.505  71.427  1.00 96.32           C  
+ATOM   6041  O   THR C 478      94.866  40.567  70.893  1.00 96.32           O  
+ATOM   6042  CB  THR C 478      94.191  39.477  73.710  1.00 96.32           C  
+ATOM   6043  OG1 THR C 478      93.310  40.447  73.131  1.00 96.32           O  
+ATOM   6044  CG2 THR C 478      94.454  39.843  75.162  1.00 96.32           C  
+ATOM   6045  N   PRO C 479      95.314  38.380  70.728  1.00100.70           N  
+ATOM   6046  CA  PRO C 479      94.919  38.340  69.317  1.00100.70           C  
+ATOM   6047  C   PRO C 479      93.414  38.498  69.162  1.00100.70           C  
+ATOM   6048  O   PRO C 479      92.622  38.156  70.042  1.00100.70           O  
+ATOM   6049  CB  PRO C 479      95.385  36.957  68.847  1.00100.70           C  
+ATOM   6050  CG  PRO C 479      96.379  36.509  69.870  1.00100.70           C  
+ATOM   6051  CD  PRO C 479      95.936  37.119  71.163  1.00100.70           C  
+ATOM   6052  N   CYS C 480      93.025  39.032  68.004  1.00104.29           N  
+ATOM   6053  CA  CYS C 480      91.621  39.224  67.663  1.00104.29           C  
+ATOM   6054  C   CYS C 480      91.261  38.786  66.251  1.00104.29           C  
+ATOM   6055  O   CYS C 480      90.085  38.848  65.886  1.00104.29           O  
+ATOM   6056  CB  CYS C 480      91.215  40.689  67.863  1.00104.29           C  
+ATOM   6057  SG  CYS C 480      92.308  41.907  67.117  1.00104.29           S  
+ATOM   6058  N   ASN C 481      92.242  38.365  65.447  1.00100.00           N  
+ATOM   6059  CA  ASN C 481      91.996  37.725  64.152  1.00100.00           C  
+ATOM   6060  C   ASN C 481      91.316  38.662  63.156  1.00100.00           C  
+ATOM   6061  O   ASN C 481      90.497  38.230  62.342  1.00100.00           O  
+ATOM   6062  CB  ASN C 481      91.171  36.443  64.314  1.00100.00           C  
+ATOM   6063  CG  ASN C 481      91.578  35.635  65.530  1.00100.00           C  
+ATOM   6064  OD1 ASN C 481      92.765  35.438  65.791  1.00100.00           O  
+ATOM   6065  ND2 ASN C 481      90.591  35.168  66.287  1.00100.00           N  
+ATOM   6066  N   GLY C 482      91.644  39.951  63.210  1.00 95.03           N  
+ATOM   6067  CA  GLY C 482      91.151  40.883  62.211  1.00 95.03           C  
+ATOM   6068  C   GLY C 482      89.674  41.195  62.304  1.00 95.03           C  
+ATOM   6069  O   GLY C 482      88.971  41.145  61.289  1.00 95.03           O  
+ATOM   6070  N   VAL C 483      89.182  41.523  63.495  1.00 93.86           N  
+ATOM   6071  CA  VAL C 483      87.789  41.898  63.697  1.00 93.86           C  
+ATOM   6072  C   VAL C 483      87.748  43.095  64.637  1.00 93.86           C  
+ATOM   6073  O   VAL C 483      88.658  43.288  65.451  1.00 93.86           O  
+ATOM   6074  CB  VAL C 483      86.957  40.722  64.256  1.00 93.86           C  
+ATOM   6075  CG1 VAL C 483      87.237  40.513  65.737  1.00 93.86           C  
+ATOM   6076  CG2 VAL C 483      85.473  40.944  64.004  1.00 93.86           C  
+ATOM   6077  N   GLU C 484      86.702  43.909  64.511  1.00 97.05           N  
+ATOM   6078  CA  GLU C 484      86.564  45.076  65.371  1.00 97.05           C  
+ATOM   6079  C   GLU C 484      86.245  44.646  66.796  1.00 97.05           C  
+ATOM   6080  O   GLU C 484      85.244  43.970  67.046  1.00 97.05           O  
+ATOM   6081  CB  GLU C 484      85.468  46.001  64.839  1.00 97.05           C  
+ATOM   6082  CG  GLU C 484      85.835  46.728  63.554  1.00 97.05           C  
+ATOM   6083  CD  GLU C 484      84.924  47.907  63.273  1.00 97.05           C  
+ATOM   6084  OE1 GLU C 484      85.330  49.053  63.556  1.00 97.05           O  
+ATOM   6085  OE2 GLU C 484      83.803  47.690  62.767  1.00 97.05           O  
+ATOM   6086  N   GLY C 485      87.100  45.044  67.729  1.00 91.02           N  
+ATOM   6087  CA  GLY C 485      86.909  44.687  69.115  1.00 91.02           C  
+ATOM   6088  C   GLY C 485      87.767  45.541  70.020  1.00 91.02           C  
+ATOM   6089  O   GLY C 485      88.197  46.636  69.651  1.00 91.02           O  
+ATOM   6090  N   PHE C 486      88.005  45.025  71.223  1.00 87.32           N  
+ATOM   6091  CA  PHE C 486      88.838  45.733  72.184  1.00 87.32           C  
+ATOM   6092  C   PHE C 486      90.279  45.779  71.695  1.00 87.32           C  
+ATOM   6093  O   PHE C 486      90.866  44.745  71.362  1.00 87.32           O  
+ATOM   6094  CB  PHE C 486      88.763  45.062  73.554  1.00 87.32           C  
+ATOM   6095  CG  PHE C 486      89.129  45.972  74.690  1.00 87.32           C  
+ATOM   6096  CD1 PHE C 486      88.210  46.879  75.190  1.00 87.32           C  
+ATOM   6097  CD2 PHE C 486      90.394  45.928  75.251  1.00 87.32           C  
+ATOM   6098  CE1 PHE C 486      88.542  47.720  76.234  1.00 87.32           C  
+ATOM   6099  CE2 PHE C 486      90.733  46.767  76.295  1.00 87.32           C  
+ATOM   6100  CZ  PHE C 486      89.806  47.666  76.787  1.00 87.32           C  
+ATOM   6101  N   ASN C 487      90.842  46.984  71.644  1.00 82.16           N  
+ATOM   6102  CA  ASN C 487      92.200  47.250  71.178  1.00 82.16           C  
+ATOM   6103  C   ASN C 487      92.437  46.797  69.740  1.00 82.16           C  
+ATOM   6104  O   ASN C 487      93.591  46.713  69.306  1.00 82.16           O  
+ATOM   6105  CB  ASN C 487      93.246  46.611  72.103  1.00 82.16           C  
+ATOM   6106  CG  ASN C 487      93.409  47.366  73.409  1.00 82.16           C  
+ATOM   6107  OD1 ASN C 487      93.204  48.578  73.469  1.00 82.16           O  
+ATOM   6108  ND2 ASN C 487      93.782  46.651  74.464  1.00 82.16           N  
+ATOM   6109  N   CYS C 488      91.376  46.507  68.987  1.00 87.54           N  
+ATOM   6110  CA  CYS C 488      91.473  46.163  67.571  1.00 87.54           C  
+ATOM   6111  C   CYS C 488      90.512  47.047  66.791  1.00 87.54           C  
+ATOM   6112  O   CYS C 488      89.326  47.132  67.127  1.00 87.54           O  
+ATOM   6113  CB  CYS C 488      91.170  44.686  67.322  1.00 87.54           C  
+ATOM   6114  SG  CYS C 488      92.102  43.524  68.331  1.00 87.54           S  
+ATOM   6115  N   TYR C 489      91.022  47.701  65.752  1.00 71.93           N  
+ATOM   6116  CA  TYR C 489      90.224  48.612  64.947  1.00 71.93           C  
+ATOM   6117  C   TYR C 489      90.935  48.886  63.630  1.00 71.93           C  
+ATOM   6118  O   TYR C 489      92.157  48.763  63.520  1.00 71.93           O  
+ATOM   6119  CB  TYR C 489      89.930  49.904  65.714  1.00 71.93           C  
+ATOM   6120  CG  TYR C 489      91.135  50.450  66.432  1.00 71.93           C  
+ATOM   6121  CD1 TYR C 489      91.336  50.184  67.780  1.00 71.93           C  
+ATOM   6122  CD2 TYR C 489      92.092  51.186  65.761  1.00 71.93           C  
+ATOM   6123  CE1 TYR C 489      92.436  50.666  68.445  1.00 71.93           C  
+ATOM   6124  CE2 TYR C 489      93.198  51.663  66.416  1.00 71.93           C  
+ATOM   6125  CZ  TYR C 489      93.367  51.404  67.758  1.00 71.93           C  
+ATOM   6126  OH  TYR C 489      94.472  51.884  68.414  1.00 71.93           O  
+ATOM   6127  N   PHE C 490      90.143  49.261  62.631  1.00 65.78           N  
+ATOM   6128  CA  PHE C 490      90.656  49.416  61.280  1.00 65.78           C  
+ATOM   6129  C   PHE C 490      91.632  50.591  61.221  1.00 65.78           C  
+ATOM   6130  O   PHE C 490      91.290  51.703  61.632  1.00 65.78           O  
+ATOM   6131  CB  PHE C 490      89.491  49.620  60.310  1.00 65.78           C  
+ATOM   6132  CG  PHE C 490      89.882  49.586  58.864  1.00 65.78           C  
+ATOM   6133  CD1 PHE C 490      90.263  48.397  58.269  1.00 65.78           C  
+ATOM   6134  CD2 PHE C 490      89.820  50.727  58.086  1.00 65.78           C  
+ATOM   6135  CE1 PHE C 490      90.610  48.354  56.935  1.00 65.78           C  
+ATOM   6136  CE2 PHE C 490      90.159  50.689  56.748  1.00 65.78           C  
+ATOM   6137  CZ  PHE C 490      90.558  49.502  56.173  1.00 65.78           C  
+ATOM   6138  N   PRO C 491      92.853  50.377  60.719  1.00 61.90           N  
+ATOM   6139  CA  PRO C 491      93.886  51.416  60.817  1.00 61.90           C  
+ATOM   6140  C   PRO C 491      93.842  52.437  59.691  1.00 61.90           C  
+ATOM   6141  O   PRO C 491      94.881  52.766  59.111  1.00 61.90           O  
+ATOM   6142  CB  PRO C 491      95.183  50.603  60.770  1.00 61.90           C  
+ATOM   6143  CG  PRO C 491      94.841  49.461  59.873  1.00 61.90           C  
+ATOM   6144  CD  PRO C 491      93.372  49.147  60.096  1.00 61.90           C  
+ATOM   6145  N   LEU C 492      92.656  52.954  59.381  1.00 56.13           N  
+ATOM   6146  CA  LEU C 492      92.508  53.964  58.339  1.00 56.13           C  
+ATOM   6147  C   LEU C 492      91.313  54.836  58.686  1.00 56.13           C  
+ATOM   6148  O   LEU C 492      90.220  54.319  58.933  1.00 56.13           O  
+ATOM   6149  CB  LEU C 492      92.325  53.326  56.961  1.00 56.13           C  
+ATOM   6150  CG  LEU C 492      93.574  52.852  56.214  1.00 56.13           C  
+ATOM   6151  CD1 LEU C 492      93.207  52.202  54.891  1.00 56.13           C  
+ATOM   6152  CD2 LEU C 492      94.513  54.014  55.986  1.00 56.13           C  
+ATOM   6153  N   GLN C 493      91.522  56.148  58.705  1.00 49.89           N  
+ATOM   6154  CA  GLN C 493      90.474  57.115  58.990  1.00 49.89           C  
+ATOM   6155  C   GLN C 493      90.268  57.999  57.771  1.00 49.89           C  
+ATOM   6156  O   GLN C 493      91.232  58.377  57.099  1.00 49.89           O  
+ATOM   6157  CB  GLN C 493      90.830  57.967  60.211  1.00 49.89           C  
+ATOM   6158  CG  GLN C 493      89.722  58.886  60.686  1.00 49.89           C  
+ATOM   6159  CD  GLN C 493      88.763  58.200  61.633  1.00 49.89           C  
+ATOM   6160  OE1 GLN C 493      88.904  57.014  61.930  1.00 49.89           O  
+ATOM   6161  NE2 GLN C 493      87.780  58.948  62.121  1.00 49.89           N  
+ATOM   6162  N   SER C 494      89.013  58.322  57.485  1.00 48.03           N  
+ATOM   6163  CA  SER C 494      88.662  59.128  56.327  1.00 48.03           C  
+ATOM   6164  C   SER C 494      88.633  60.603  56.705  1.00 48.03           C  
+ATOM   6165  O   SER C 494      88.116  60.975  57.763  1.00 48.03           O  
+ATOM   6166  CB  SER C 494      87.307  58.705  55.759  1.00 48.03           C  
+ATOM   6167  OG  SER C 494      86.323  58.657  56.777  1.00 48.03           O  
+ATOM   6168  N   TYR C 495      89.196  61.437  55.835  1.00 50.52           N  
+ATOM   6169  CA  TYR C 495      89.180  62.876  56.054  1.00 50.52           C  
+ATOM   6170  C   TYR C 495      87.785  63.430  55.796  1.00 50.52           C  
+ATOM   6171  O   TYR C 495      87.184  63.162  54.753  1.00 50.52           O  
+ATOM   6172  CB  TYR C 495      90.192  63.562  55.139  1.00 50.52           C  
+ATOM   6173  CG  TYR C 495      91.587  63.665  55.708  1.00 50.52           C  
+ATOM   6174  CD1 TYR C 495      91.811  64.251  56.945  1.00 50.52           C  
+ATOM   6175  CD2 TYR C 495      92.683  63.192  55.001  1.00 50.52           C  
+ATOM   6176  CE1 TYR C 495      93.086  64.352  57.466  1.00 50.52           C  
+ATOM   6177  CE2 TYR C 495      93.960  63.288  55.513  1.00 50.52           C  
+ATOM   6178  CZ  TYR C 495      94.156  63.868  56.745  1.00 50.52           C  
+ATOM   6179  OH  TYR C 495      95.428  63.967  57.258  1.00 50.52           O  
+ATOM   6180  N   GLY C 496      87.272  64.208  56.744  1.00 46.71           N  
+ATOM   6181  CA  GLY C 496      85.992  64.861  56.553  1.00 46.71           C  
+ATOM   6182  C   GLY C 496      86.155  66.284  56.064  1.00 46.71           C  
+ATOM   6183  O   GLY C 496      86.396  67.198  56.858  1.00 46.71           O  
+ATOM   6184  N   PHE C 497      86.012  66.487  54.757  1.00 46.32           N  
+ATOM   6185  CA  PHE C 497      86.285  67.770  54.123  1.00 46.32           C  
+ATOM   6186  C   PHE C 497      84.967  68.428  53.737  1.00 46.32           C  
+ATOM   6187  O   PHE C 497      84.323  68.023  52.764  1.00 46.32           O  
+ATOM   6188  CB  PHE C 497      87.181  67.589  52.901  1.00 46.32           C  
+ATOM   6189  CG  PHE C 497      88.606  67.276  53.236  1.00 46.32           C  
+ATOM   6190  CD1 PHE C 497      89.218  67.862  54.329  1.00 46.32           C  
+ATOM   6191  CD2 PHE C 497      89.335  66.395  52.458  1.00 46.32           C  
+ATOM   6192  CE1 PHE C 497      90.531  67.577  54.637  1.00 46.32           C  
+ATOM   6193  CE2 PHE C 497      90.647  66.106  52.761  1.00 46.32           C  
+ATOM   6194  CZ  PHE C 497      91.246  66.698  53.851  1.00 46.32           C  
+ATOM   6195  N   HIS C 498      84.574  69.438  54.491  1.00 46.10           N  
+ATOM   6196  CA  HIS C 498      83.388  70.222  54.206  1.00 46.10           C  
+ATOM   6197  C   HIS C 498      83.774  71.549  53.568  1.00 46.10           C  
+ATOM   6198  O   HIS C 498      84.905  72.019  53.724  1.00 46.10           O  
+ATOM   6199  CB  HIS C 498      82.595  70.469  55.494  1.00 46.10           C  
+ATOM   6200  CG  HIS C 498      82.059  69.219  56.119  1.00 46.10           C  
+ATOM   6201  ND1 HIS C 498      82.874  68.231  56.624  1.00 46.10           N  
+ATOM   6202  CD2 HIS C 498      80.788  68.800  56.324  1.00 46.10           C  
+ATOM   6203  CE1 HIS C 498      82.129  67.255  57.111  1.00 46.10           C  
+ATOM   6204  NE2 HIS C 498      80.860  67.576  56.941  1.00 46.10           N  
+ATOM   6205  N   PRO C 499      82.862  72.181  52.824  1.00 45.20           N  
+ATOM   6206  CA  PRO C 499      83.194  73.484  52.225  1.00 45.20           C  
+ATOM   6207  C   PRO C 499      83.311  74.602  53.241  1.00 45.20           C  
+ATOM   6208  O   PRO C 499      83.953  75.618  52.949  1.00 45.20           O  
+ATOM   6209  CB  PRO C 499      82.032  73.731  51.257  1.00 45.20           C  
+ATOM   6210  CG  PRO C 499      80.900  72.968  51.843  1.00 45.20           C  
+ATOM   6211  CD  PRO C 499      81.508  71.737  52.454  1.00 45.20           C  
+ATOM   6212  N   THR C 500      82.716  74.449  54.420  1.00 38.39           N  
+ATOM   6213  CA  THR C 500      82.764  75.458  55.466  1.00 38.39           C  
+ATOM   6214  C   THR C 500      83.748  75.114  56.577  1.00 38.39           C  
+ATOM   6215  O   THR C 500      83.578  75.583  57.707  1.00 38.39           O  
+ATOM   6216  CB  THR C 500      81.365  75.671  56.050  1.00 38.39           C  
+ATOM   6217  OG1 THR C 500      81.410  76.689  57.057  1.00 38.39           O  
+ATOM   6218  CG2 THR C 500      80.823  74.383  56.641  1.00 38.39           C  
+ATOM   6219  N   ASN C 501      84.769  74.315  56.283  1.00 43.43           N  
+ATOM   6220  CA  ASN C 501      85.774  73.983  57.282  1.00 43.43           C  
+ATOM   6221  C   ASN C 501      86.785  75.112  57.426  1.00 43.43           C  
+ATOM   6222  O   ASN C 501      86.912  75.981  56.559  1.00 43.43           O  
+ATOM   6223  CB  ASN C 501      86.494  72.690  56.907  1.00 43.43           C  
+ATOM   6224  CG  ASN C 501      85.918  71.480  57.606  1.00 43.43           C  
+ATOM   6225  OD1 ASN C 501      85.257  71.602  58.637  1.00 43.43           O  
+ATOM   6226  ND2 ASN C 501      86.169  70.301  57.052  1.00 43.43           N  
+ATOM   6227  N   GLY C 502      87.511  75.093  58.538  1.00 40.35           N  
+ATOM   6228  CA  GLY C 502      88.540  76.082  58.773  1.00 40.35           C  
+ATOM   6229  C   GLY C 502      89.723  75.910  57.842  1.00 40.35           C  
+ATOM   6230  O   GLY C 502      89.883  74.901  57.157  1.00 40.35           O  
+ATOM   6231  N   VAL C 503      90.577  76.937  57.825  1.00 42.06           N  
+ATOM   6232  CA  VAL C 503      91.748  76.916  56.953  1.00 42.06           C  
+ATOM   6233  C   VAL C 503      92.684  75.779  57.336  1.00 42.06           C  
+ATOM   6234  O   VAL C 503      93.346  75.189  56.474  1.00 42.06           O  
+ATOM   6235  CB  VAL C 503      92.461  78.282  56.994  1.00 42.06           C  
+ATOM   6236  CG1 VAL C 503      93.707  78.267  56.120  1.00 42.06           C  
+ATOM   6237  CG2 VAL C 503      91.511  79.385  56.558  1.00 42.06           C  
+ATOM   6238  N   GLY C 504      92.746  75.442  58.623  1.00 41.83           N  
+ATOM   6239  CA  GLY C 504      93.546  74.316  59.060  1.00 41.83           C  
+ATOM   6240  C   GLY C 504      92.919  72.961  58.833  1.00 41.83           C  
+ATOM   6241  O   GLY C 504      93.566  71.942  59.087  1.00 41.83           O  
+ATOM   6242  N   TYR C 505      91.674  72.925  58.360  1.00 42.99           N  
+ATOM   6243  CA  TYR C 505      90.969  71.680  58.091  1.00 42.99           C  
+ATOM   6244  C   TYR C 505      90.448  71.600  56.663  1.00 42.99           C  
+ATOM   6245  O   TYR C 505      89.627  70.728  56.360  1.00 42.99           O  
+ATOM   6246  CB  TYR C 505      89.817  71.502  59.079  1.00 42.99           C  
+ATOM   6247  CG  TYR C 505      90.265  71.130  60.472  1.00 42.99           C  
+ATOM   6248  CD1 TYR C 505      90.722  72.096  61.356  1.00 42.99           C  
+ATOM   6249  CD2 TYR C 505      90.231  69.812  60.902  1.00 42.99           C  
+ATOM   6250  CE1 TYR C 505      91.129  71.760  62.629  1.00 42.99           C  
+ATOM   6251  CE2 TYR C 505      90.639  69.467  62.172  1.00 42.99           C  
+ATOM   6252  CZ  TYR C 505      91.086  70.445  63.032  1.00 42.99           C  
+ATOM   6253  OH  TYR C 505      91.493  70.105  64.300  1.00 42.99           O  
+ATOM   6254  N   GLN C 506      90.892  72.486  55.789  1.00 42.37           N  
+ATOM   6255  CA  GLN C 506      90.487  72.404  54.397  1.00 42.37           C  
+ATOM   6256  C   GLN C 506      91.455  71.522  53.616  1.00 42.37           C  
+ATOM   6257  O   GLN C 506      92.651  71.481  53.921  1.00 42.37           O  
+ATOM   6258  CB  GLN C 506      90.440  73.794  53.773  1.00 42.37           C  
+ATOM   6259  CG  GLN C 506      89.175  74.569  54.095  1.00 42.37           C  
+ATOM   6260  CD  GLN C 506      89.395  76.066  54.094  1.00 42.37           C  
+ATOM   6261  OE1 GLN C 506      90.410  76.556  53.600  1.00 42.37           O  
+ATOM   6262  NE2 GLN C 506      88.444  76.803  54.656  1.00 42.37           N  
+ATOM   6263  N   PRO C 507      90.963  70.799  52.611  1.00 43.14           N  
+ATOM   6264  CA  PRO C 507      91.833  69.886  51.850  1.00 43.14           C  
+ATOM   6265  C   PRO C 507      92.905  70.655  51.092  1.00 43.14           C  
+ATOM   6266  O   PRO C 507      92.606  71.430  50.181  1.00 43.14           O  
+ATOM   6267  CB  PRO C 507      90.861  69.180  50.898  1.00 43.14           C  
+ATOM   6268  CG  PRO C 507      89.674  70.081  50.823  1.00 43.14           C  
+ATOM   6269  CD  PRO C 507      89.563  70.733  52.161  1.00 43.14           C  
+ATOM   6270  N   TYR C 508      94.159  70.431  51.471  1.00 47.27           N  
+ATOM   6271  CA  TYR C 508      95.310  71.080  50.853  1.00 47.27           C  
+ATOM   6272  C   TYR C 508      96.030  70.056  49.985  1.00 47.27           C  
+ATOM   6273  O   TYR C 508      96.699  69.157  50.504  1.00 47.27           O  
+ATOM   6274  CB  TYR C 508      96.250  71.648  51.914  1.00 47.27           C  
+ATOM   6275  CG  TYR C 508      95.982  73.088  52.280  1.00 47.27           C  
+ATOM   6276  CD1 TYR C 508      94.964  73.422  53.160  1.00 47.27           C  
+ATOM   6277  CD2 TYR C 508      96.754  74.112  51.752  1.00 47.27           C  
+ATOM   6278  CE1 TYR C 508      94.718  74.736  53.500  1.00 47.27           C  
+ATOM   6279  CE2 TYR C 508      96.515  75.430  52.086  1.00 47.27           C  
+ATOM   6280  CZ  TYR C 508      95.496  75.736  52.961  1.00 47.27           C  
+ATOM   6281  OH  TYR C 508      95.254  77.047  53.297  1.00 47.27           O  
+ATOM   6282  N   ARG C 509      95.894  70.194  48.669  1.00 58.50           N  
+ATOM   6283  CA  ARG C 509      96.594  69.305  47.751  1.00 58.50           C  
+ATOM   6284  C   ARG C 509      98.090  69.587  47.788  1.00 58.50           C  
+ATOM   6285  O   ARG C 509      98.527  70.712  47.531  1.00 58.50           O  
+ATOM   6286  CB  ARG C 509      96.058  69.478  46.332  1.00 58.50           C  
+ATOM   6287  CG  ARG C 509      94.731  68.792  46.078  1.00 58.50           C  
+ATOM   6288  CD  ARG C 509      94.246  69.050  44.663  1.00 58.50           C  
+ATOM   6289  NE  ARG C 509      93.066  68.258  44.335  1.00 58.50           N  
+ATOM   6290  CZ  ARG C 509      92.409  68.342  43.183  1.00 58.50           C  
+ATOM   6291  NH1 ARG C 509      92.816  69.187  42.247  1.00 58.50           N  
+ATOM   6292  NH2 ARG C 509      91.345  67.582  42.967  1.00 58.50           N  
+ATOM   6293  N   VAL C 510      98.876  68.562  48.106  1.00 62.21           N  
+ATOM   6294  CA  VAL C 510     100.323  68.684  48.229  1.00 62.21           C  
+ATOM   6295  C   VAL C 510     100.973  67.892  47.107  1.00 62.21           C  
+ATOM   6296  O   VAL C 510     100.680  66.705  46.927  1.00 62.21           O  
+ATOM   6297  CB  VAL C 510     100.821  68.194  49.600  1.00 62.21           C  
+ATOM   6298  CG1 VAL C 510     102.284  68.555  49.789  1.00 62.21           C  
+ATOM   6299  CG2 VAL C 510      99.975  68.783  50.713  1.00 62.21           C  
+ATOM   6300  N   VAL C 511     101.851  68.550  46.354  1.00 72.48           N  
+ATOM   6301  CA  VAL C 511     102.653  67.904  45.322  1.00 72.48           C  
+ATOM   6302  C   VAL C 511     104.107  67.965  45.769  1.00 72.48           C  
+ATOM   6303  O   VAL C 511     104.659  69.053  45.966  1.00 72.48           O  
+ATOM   6304  CB  VAL C 511     102.465  68.570  43.951  1.00 72.48           C  
+ATOM   6305  CG1 VAL C 511     103.297  67.853  42.901  1.00 72.48           C  
+ATOM   6306  CG2 VAL C 511     100.998  68.570  43.559  1.00 72.48           C  
+ATOM   6307  N   VAL C 512     104.724  66.799  45.929  1.00 80.47           N  
+ATOM   6308  CA  VAL C 512     106.084  66.686  46.442  1.00 80.47           C  
+ATOM   6309  C   VAL C 512     107.003  66.333  45.282  1.00 80.47           C  
+ATOM   6310  O   VAL C 512     106.829  65.291  44.637  1.00 80.47           O  
+ATOM   6311  CB  VAL C 512     106.181  65.636  47.559  1.00 80.47           C  
+ATOM   6312  CG1 VAL C 512     107.619  65.487  48.020  1.00 80.47           C  
+ATOM   6313  CG2 VAL C 512     105.274  66.011  48.720  1.00 80.47           C  
+ATOM   6314  N   LEU C 513     107.979  67.197  45.020  1.00 93.95           N  
+ATOM   6315  CA  LEU C 513     108.963  66.977  43.967  1.00 93.95           C  
+ATOM   6316  C   LEU C 513     110.276  66.534  44.599  1.00 93.95           C  
+ATOM   6317  O   LEU C 513     110.876  67.279  45.382  1.00 93.95           O  
+ATOM   6318  CB  LEU C 513     109.167  68.242  43.134  1.00 93.95           C  
+ATOM   6319  CG  LEU C 513     108.404  68.335  41.810  1.00 93.95           C  
+ATOM   6320  CD1 LEU C 513     108.889  67.270  40.840  1.00 93.95           C  
+ATOM   6321  CD2 LEU C 513     106.905  68.219  42.031  1.00 93.95           C  
+ATOM   6322  N   SER C 514     110.719  65.329  44.257  1.00107.32           N  
+ATOM   6323  CA  SER C 514     111.959  64.764  44.770  1.00107.32           C  
+ATOM   6324  C   SER C 514     112.952  64.611  43.628  1.00107.32           C  
+ATOM   6325  O   SER C 514     112.582  64.174  42.533  1.00107.32           O  
+ATOM   6326  CB  SER C 514     111.711  63.415  45.445  1.00107.32           C  
+ATOM   6327  OG  SER C 514     110.838  62.612  44.669  1.00107.32           O  
+ATOM   6328  N   PHE C 515     114.205  64.969  43.885  1.00113.72           N  
+ATOM   6329  CA  PHE C 515     115.260  64.921  42.884  1.00113.72           C  
+ATOM   6330  C   PHE C 515     116.428  64.109  43.423  1.00113.72           C  
+ATOM   6331  O   PHE C 515     116.734  64.174  44.618  1.00113.72           O  
+ATOM   6332  CB  PHE C 515     115.715  66.332  42.509  1.00113.72           C  
+ATOM   6333  CG  PHE C 515     114.580  67.297  42.296  1.00113.72           C  
+ATOM   6334  CD1 PHE C 515     113.816  67.249  41.142  1.00113.72           C  
+ATOM   6335  CD2 PHE C 515     114.282  68.256  43.250  1.00113.72           C  
+ATOM   6336  CE1 PHE C 515     112.776  68.136  40.944  1.00113.72           C  
+ATOM   6337  CE2 PHE C 515     113.242  69.145  43.058  1.00113.72           C  
+ATOM   6338  CZ  PHE C 515     112.488  69.086  41.903  1.00113.72           C  
+ATOM   6339  N   GLU C 516     117.075  63.347  42.544  1.00123.71           N  
+ATOM   6340  CA  GLU C 516     118.172  62.472  42.930  1.00123.71           C  
+ATOM   6341  C   GLU C 516     119.222  62.443  41.829  1.00123.71           C  
+ATOM   6342  O   GLU C 516     118.952  62.800  40.680  1.00123.71           O  
+ATOM   6343  CB  GLU C 516     117.672  61.049  43.215  1.00123.71           C  
+ATOM   6344  CG  GLU C 516     117.338  60.255  41.966  1.00123.71           C  
+ATOM   6345  CD  GLU C 516     115.943  60.531  41.440  1.00123.71           C  
+ATOM   6346  OE1 GLU C 516     115.476  59.769  40.570  1.00123.71           O  
+ATOM   6347  OE2 GLU C 516     115.313  61.510  41.895  1.00123.71           O  
+ATOM   6348  N   LEU C 517     120.425  62.002  42.193  1.00128.91           N  
+ATOM   6349  CA  LEU C 517     121.564  61.951  41.285  1.00128.91           C  
+ATOM   6350  C   LEU C 517     122.116  60.534  41.238  1.00128.91           C  
+ATOM   6351  O   LEU C 517     122.384  59.933  42.284  1.00128.91           O  
+ATOM   6352  CB  LEU C 517     122.664  62.925  41.722  1.00128.91           C  
+ATOM   6353  CG  LEU C 517     122.351  64.421  41.807  1.00128.91           C  
+ATOM   6354  CD1 LEU C 517     123.637  65.230  41.759  1.00128.91           C  
+ATOM   6355  CD2 LEU C 517     121.420  64.850  40.688  1.00128.91           C  
+ATOM   6356  N   LEU C 518     122.285  60.004  40.028  1.00130.76           N  
+ATOM   6357  CA  LEU C 518     122.919  58.706  39.818  1.00130.76           C  
+ATOM   6358  C   LEU C 518     123.877  58.835  38.638  1.00130.76           C  
+ATOM   6359  O   LEU C 518     124.105  59.927  38.111  1.00130.76           O  
+ATOM   6360  CB  LEU C 518     121.880  57.600  39.592  1.00130.76           C  
+ATOM   6361  CG  LEU C 518     120.711  57.466  40.571  1.00130.76           C  
+ATOM   6362  CD1 LEU C 518     119.490  58.194  40.044  1.00130.76           C  
+ATOM   6363  CD2 LEU C 518     120.393  56.002  40.836  1.00130.76           C  
+ATOM   6364  N   ASN C 519     124.443  57.702  38.218  1.00131.68           N  
+ATOM   6365  CA  ASN C 519     125.364  57.681  37.089  1.00131.68           C  
+ATOM   6366  C   ASN C 519     124.656  57.707  35.741  1.00131.68           C  
+ATOM   6367  O   ASN C 519     125.333  57.722  34.707  1.00131.68           O  
+ATOM   6368  CB  ASN C 519     126.266  56.447  37.168  1.00131.68           C  
+ATOM   6369  CG  ASN C 519     125.500  55.188  37.529  1.00131.68           C  
+ATOM   6370  OD1 ASN C 519     124.272  55.195  37.607  1.00131.68           O  
+ATOM   6371  ND2 ASN C 519     126.225  54.097  37.749  1.00131.68           N  
+ATOM   6372  N   ALA C 520     123.325  57.711  35.724  1.00129.58           N  
+ATOM   6373  CA  ALA C 520     122.589  57.761  34.475  1.00129.58           C  
+ATOM   6374  C   ALA C 520     122.754  59.129  33.814  1.00129.58           C  
+ATOM   6375  O   ALA C 520     122.906  60.145  34.496  1.00129.58           O  
+ATOM   6376  CB  ALA C 520     121.111  57.466  34.718  1.00129.58           C  
+ATOM   6377  N   PRO C 521     122.733  59.178  32.482  1.00128.66           N  
+ATOM   6378  CA  PRO C 521     122.892  60.463  31.793  1.00128.66           C  
+ATOM   6379  C   PRO C 521     121.693  61.373  32.018  1.00128.66           C  
+ATOM   6380  O   PRO C 521     120.578  60.918  32.286  1.00128.66           O  
+ATOM   6381  CB  PRO C 521     123.024  60.064  30.318  1.00128.66           C  
+ATOM   6382  CG  PRO C 521     122.368  58.725  30.228  1.00128.66           C  
+ATOM   6383  CD  PRO C 521     122.641  58.050  31.538  1.00128.66           C  
+ATOM   6384  N   ALA C 522     121.938  62.677  31.905  1.00126.08           N  
+ATOM   6385  CA  ALA C 522     120.898  63.681  32.109  1.00126.08           C  
+ATOM   6386  C   ALA C 522     119.889  63.609  30.970  1.00126.08           C  
+ATOM   6387  O   ALA C 522     120.268  63.592  29.794  1.00126.08           O  
+ATOM   6388  CB  ALA C 522     121.518  65.073  32.201  1.00126.08           C  
+ATOM   6389  N   THR C 523     118.603  63.562  31.314  1.00128.11           N  
+ATOM   6390  CA  THR C 523     117.555  63.404  30.315  1.00128.11           C  
+ATOM   6391  C   THR C 523     116.630  64.609  30.200  1.00128.11           C  
+ATOM   6392  O   THR C 523     116.120  64.868  29.105  1.00128.11           O  
+ATOM   6393  CB  THR C 523     116.717  62.159  30.626  1.00128.11           C  
+ATOM   6394  OG1 THR C 523     116.463  62.093  32.035  1.00128.11           O  
+ATOM   6395  CG2 THR C 523     117.449  60.898  30.188  1.00128.11           C  
+ATOM   6396  N   VAL C 524     116.401  65.356  31.281  1.00127.76           N  
+ATOM   6397  CA  VAL C 524     115.383  66.401  31.300  1.00127.76           C  
+ATOM   6398  C   VAL C 524     115.994  67.743  31.696  1.00127.76           C  
+ATOM   6399  O   VAL C 524     115.959  68.133  32.868  1.00127.76           O  
+ATOM   6400  CB  VAL C 524     114.198  66.022  32.216  1.00127.76           C  
+ATOM   6401  CG1 VAL C 524     113.467  64.834  31.635  1.00127.76           C  
+ATOM   6402  CG2 VAL C 524     114.675  65.639  33.616  1.00127.76           C  
+ATOM   6403  N   CYS C 525     116.522  68.465  30.708  1.00125.17           N  
+ATOM   6404  CA  CYS C 525     116.823  69.880  30.855  1.00125.17           C  
+ATOM   6405  C   CYS C 525     116.844  70.534  29.481  1.00125.17           C  
+ATOM   6406  O   CYS C 525     117.137  69.897  28.466  1.00125.17           O  
+ATOM   6407  CB  CYS C 525     118.145  70.126  31.598  1.00125.17           C  
+ATOM   6408  SG  CYS C 525     119.555  69.073  31.168  1.00125.17           S  
+ATOM   6409  N   GLY C 526     116.523  71.824  29.463  1.00114.78           N  
+ATOM   6410  CA  GLY C 526     116.517  72.597  28.235  1.00114.78           C  
+ATOM   6411  C   GLY C 526     116.778  74.078  28.459  1.00114.78           C  
+ATOM   6412  O   GLY C 526     116.847  74.544  29.598  1.00114.78           O  
+TER    6413      GLY C 526                                                      
+HETATM 6414 ZN    ZN A 901      78.696  84.715  76.442  1.00 70.96          ZN  
+HETATM 6415  C1  NAG A 902      95.723 103.020  69.355  1.00 60.56           C  
+HETATM 6416  C2  NAG A 902      94.524 103.965  69.414  1.00 60.56           C  
+HETATM 6417  C3  NAG A 902      94.257 104.567  68.039  1.00 60.56           C  
+HETATM 6418  C4  NAG A 902      95.517 105.230  67.498  1.00 60.56           C  
+HETATM 6419  C5  NAG A 902      96.677 104.239  67.509  1.00 60.56           C  
+HETATM 6420  C6  NAG A 902      97.990 104.861  67.095  1.00 60.56           C  
+HETATM 6421  C7  NAG A 902      93.012 103.231  71.204  1.00 60.56           C  
+HETATM 6422  C8  NAG A 902      91.757 102.481  71.534  1.00 60.56           C  
+HETATM 6423  N2  NAG A 902      93.341 103.278  69.909  1.00 60.56           N  
+HETATM 6424  O3  NAG A 902      93.207 105.522  68.133  1.00 60.56           O  
+HETATM 6425  O4  NAG A 902      95.297 105.686  66.168  1.00 60.56           O  
+HETATM 6426  O5  NAG A 902      96.863 103.721  68.834  1.00 60.56           O  
+HETATM 6427  O6  NAG A 902      98.646 105.474  68.197  1.00 60.56           O  
+HETATM 6428  O7  NAG A 902      93.697 103.766  72.069  1.00 60.56           O  
+HETATM 6429  C1  NAG A 903     101.697  62.986  77.835  1.00 68.43           C  
+HETATM 6430  C2  NAG A 903     103.127  63.412  78.166  1.00 68.43           C  
+HETATM 6431  C3  NAG A 903     103.572  64.535  77.233  1.00 68.43           C  
+HETATM 6432  C4  NAG A 903     103.388  64.123  75.780  1.00 68.43           C  
+HETATM 6433  C5  NAG A 903     101.951  63.670  75.540  1.00 68.43           C  
+HETATM 6434  C6  NAG A 903     101.729  63.132  74.146  1.00 68.43           C  
+HETATM 6435  C7  NAG A 903     103.866  63.097  80.484  1.00 68.43           C  
+HETATM 6436  C8  NAG A 903     103.890  63.676  81.866  1.00 68.43           C  
+HETATM 6437  N2  NAG A 903     103.242  63.826  79.554  1.00 68.43           N  
+HETATM 6438  O3  NAG A 903     104.939  64.844  77.483  1.00 68.43           O  
+HETATM 6439  O4  NAG A 903     103.684  65.216  74.920  1.00 68.43           O  
+HETATM 6440  O5  NAG A 903     101.612  62.614  76.451  1.00 68.43           O  
+HETATM 6441  O6  NAG A 903     102.702  63.629  73.238  1.00 68.43           O  
+HETATM 6442  O7  NAG A 903     104.388  62.019  80.222  1.00 68.43           O  
+HETATM 6443  C1  NAG A 904      65.330  76.467  54.170  1.00 84.98           C  
+HETATM 6444  C2  NAG A 904      66.033  76.557  52.817  1.00 84.98           C  
+HETATM 6445  C3  NAG A 904      65.051  76.254  51.691  1.00 84.98           C  
+HETATM 6446  C4  NAG A 904      64.371  74.912  51.927  1.00 84.98           C  
+HETATM 6447  C5  NAG A 904      63.737  74.879  53.315  1.00 84.98           C  
+HETATM 6448  C6  NAG A 904      63.159  73.528  53.665  1.00 84.98           C  
+HETATM 6449  C7  NAG A 904      67.782  78.047  51.955  1.00 84.98           C  
+HETATM 6450  C8  NAG A 904      68.268  79.461  51.857  1.00 84.98           C  
+HETATM 6451  N2  NAG A 904      66.642  77.863  52.629  1.00 84.98           N  
+HETATM 6452  O3  NAG A 904      65.744  76.234  50.448  1.00 84.98           O  
+HETATM 6453  O4  NAG A 904      63.365  74.696  50.944  1.00 84.98           O  
+HETATM 6454  O5  NAG A 904      64.724  75.175  54.313  1.00 84.98           O  
+HETATM 6455  O6  NAG A 904      64.079  72.751  54.419  1.00 84.98           O  
+HETATM 6456  O7  NAG A 904      68.393  77.112  51.446  1.00 84.98           O  
+HETATM 6457  C1  NAG C 601      96.587  73.836  35.245  1.00 98.46           C  
+HETATM 6458  C2  NAG C 601      97.949  74.275  34.708  1.00 98.46           C  
+HETATM 6459  C3  NAG C 601      98.122  75.784  34.869  1.00 98.46           C  
+HETATM 6460  C4  NAG C 601      96.949  76.525  34.243  1.00 98.46           C  
+HETATM 6461  C5  NAG C 601      95.633  75.996  34.805  1.00 98.46           C  
+HETATM 6462  C6  NAG C 601      94.419  76.608  34.146  1.00 98.46           C  
+HETATM 6463  C7  NAG C 601     100.196  73.289  34.791  1.00 98.46           C  
+HETATM 6464  C8  NAG C 601     101.193  72.547  35.629  1.00 98.46           C  
+HETATM 6465  N2  NAG C 601      99.026  73.563  35.377  1.00 98.46           N  
+HETATM 6466  O3  NAG C 601      99.339  76.190  34.253  1.00 98.46           O  
+HETATM 6467  O4  NAG C 601      97.049  77.917  34.517  1.00 98.46           O  
+HETATM 6468  O5  NAG C 601      95.550  74.579  34.593  1.00 98.46           O  
+HETATM 6469  O6  NAG C 601      94.382  76.320  32.755  1.00 98.46           O  
+HETATM 6470  O7  NAG C 601     100.438  73.624  33.636  1.00 98.46           O  
+CONECT  293 6443                                                                
+CONECT  592 6429                                                                
+CONECT  919  981                                                                
+CONECT  981  919                                                                
+CONECT 2660 2796                                                                
+CONECT 2796 2660                                                                
+CONECT 2901 6414                                                                
+CONECT 2932 6414                                                                
+CONECT 3125 6414                                                                
+CONECT 4193 4284                                                                
+CONECT 4284 4193                                                                
+CONECT 4314 6415                                                                
+CONECT 4907 5110                                                                
+CONECT 4964 6457                                                                
+CONECT 5110 4907                                                                
+CONECT 5252 5666                                                                
+CONECT 5342 6408                                                                
+CONECT 5666 5252                                                                
+CONECT 6057 6114                                                                
+CONECT 6114 6057                                                                
+CONECT 6408 5342                                                                
+CONECT 6414 2901 2932 3125                                                      
+CONECT 6415 4314 6416 6426                                                      
+CONECT 6416 6415 6417 6423                                                      
+CONECT 6417 6416 6418 6424                                                      
+CONECT 6418 6417 6419 6425                                                      
+CONECT 6419 6418 6420 6426                                                      
+CONECT 6420 6419 6427                                                           
+CONECT 6421 6422 6423 6428                                                      
+CONECT 6422 6421                                                                
+CONECT 6423 6416 6421                                                           
+CONECT 6424 6417                                                                
+CONECT 6425 6418                                                                
+CONECT 6426 6415 6419                                                           
+CONECT 6427 6420                                                                
+CONECT 6428 6421                                                                
+CONECT 6429  592 6430 6440                                                      
+CONECT 6430 6429 6431 6437                                                      
+CONECT 6431 6430 6432 6438                                                      
+CONECT 6432 6431 6433 6439                                                      
+CONECT 6433 6432 6434 6440                                                      
+CONECT 6434 6433 6441                                                           
+CONECT 6435 6436 6437 6442                                                      
+CONECT 6436 6435                                                                
+CONECT 6437 6430 6435                                                           
+CONECT 6438 6431                                                                
+CONECT 6439 6432                                                                
+CONECT 6440 6429 6433                                                           
+CONECT 6441 6434                                                                
+CONECT 6442 6435                                                                
+CONECT 6443  293 6444 6454                                                      
+CONECT 6444 6443 6445 6451                                                      
+CONECT 6445 6444 6446 6452                                                      
+CONECT 6446 6445 6447 6453                                                      
+CONECT 6447 6446 6448 6454                                                      
+CONECT 6448 6447 6455                                                           
+CONECT 6449 6450 6451 6456                                                      
+CONECT 6450 6449                                                                
+CONECT 6451 6444 6449                                                           
+CONECT 6452 6445                                                                
+CONECT 6453 6446                                                                
+CONECT 6454 6443 6447                                                           
+CONECT 6455 6448                                                                
+CONECT 6456 6449                                                                
+CONECT 6457 4964 6458 6468                                                      
+CONECT 6458 6457 6459 6465                                                      
+CONECT 6459 6458 6460 6466                                                      
+CONECT 6460 6459 6461 6467                                                      
+CONECT 6461 6460 6462 6468                                                      
+CONECT 6462 6461 6469                                                           
+CONECT 6463 6464 6465 6470                                                      
+CONECT 6464 6463                                                                
+CONECT 6465 6458 6463                                                           
+CONECT 6466 6459                                                                
+CONECT 6467 6460                                                                
+CONECT 6468 6457 6461                                                           
+CONECT 6469 6462                                                                
+CONECT 6470 6463                                                                
+MASTER      167    0    5   35   13    0    0    6 6461    2   78   63          
+END                                                                             

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -5536,6 +5536,38 @@ class TestSeqIO(SeqIOTestBaseClass):
             messages,
         )
 
+    def test_pdb_seqres3(self):
+        sequences = [
+            "STIEEQAKTFLDKFNHEAEDLFYQSSLASWNYNTNITEEN...DWSPYAD",
+            "RVQPTESIVRFPNITNLCPFGEVFNATTFASVYAWNRKRI...PATVCGP",
+        ]
+        ids = ["7DDO:A", "7DDO:C"]
+        names = ["7DDO:A", "7DDO:C"]
+        lengths = [597, 209]
+        alignment = None
+        messages = {
+            "fastq": "No suitable quality scores found in letter_annotations of SeqRecord (id=7DDO:C).",
+            "fastq-illumina": "No suitable quality scores found in letter_annotations of SeqRecord (id=7DDO:C).",
+            "fastq-solexa": "No suitable quality scores found in letter_annotations of SeqRecord (id=7DDO:C).",
+            "nib": "Sequence should contain A,C,G,T,N,a,c,g,t,n only",
+            "phd": "No suitable quality scores found in letter_annotations of SeqRecord (id=7DDO:C).",
+            "qual": "No suitable quality scores found in letter_annotations of SeqRecord (id=7DDO:C).",
+            "sff": "Missing SFF flow information",
+            "xdna": "More than one sequence found",
+        }
+        self.perform_test(
+            "pdb-seqres",
+            False,
+            "PDB/7DDO.pdb",
+            2,
+            ids,
+            names,
+            sequences,
+            lengths,
+            alignment,
+            messages,
+        )
+
     def test_cif_atom1(self):
         sequences = ["MDIRQGPKEPFRDYVDRFYKTLRAEQASQEVKNWMTETLL...MMTACQG"]
         ids = ["1A8O:A"]


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #3887. For those PDB chains where cross-reference links to sequence databases are too long for `DBREF` records, `DBREF1` and `DBREF2` are used. This PR implements reading of `DBREF1` and `DBREF2` PDB records.