### PR TITLE
SearchIO spelling and grammar fixes.

### DIFF
--- a/Bio/SearchIO/BlatIO.py
+++ b/Bio/SearchIO/BlatIO.py
@@ -82,7 +82,7 @@ BlatIO provides the following attribute-column mapping:
 +----------------+-------------------------+-----------------------------------+
 | Object         | Attribute               | Column Name, Value                |
 +================+=========================+===================================+
-| QueryResutl    | id                      | Q name, query sequence ID         |
+| QueryResult    | id                      | Q name, query sequence ID         |
 |                +-------------------------+-----------------------------------+
 |                | seq_len                 | Q size, query sequence full       |
 |                |                         | length                            |

--- a/Bio/SearchIO/__init__.py
+++ b/Bio/SearchIO/__init__.py
@@ -24,7 +24,7 @@ the search output file:
 In addition to the four objects above, SearchIO is also tightly integrated with
 the SeqRecord objects (see SeqIO) and MultipleSeqAlignment objects (see
 AlignIO). SeqRecord objects are used to store the actual matching hit and query
-sequences, while MultipleSeqAlignment objects stores the alignment between them.
+sequences, while MultipleSeqAlignment objects store the alignment between them.
 
 A detailed description of these objects' features and their example usages are
 available in their respective documentations.
@@ -50,7 +50,7 @@ that yields one QueryResult object per iteration.
 SearchIO also provides the Bio.SearchIO.read(...) function, which is intended
 for use on search output files containing only one query. ``read`` returns one
 QueryResult object and will raise an exception if the source file contains more
-than one queries:
+than one query:
 
     >>> qresult = SearchIO.read('Blast/xml_2226_blastp_004.xml', 'blast-xml')
     >>> print("%s %s" % (qresult.id, qresult.description))
@@ -70,7 +70,7 @@ of optional, format-specific keyword arguments.
 
 Output
 ======
-SearchIO has writing support for several formats, accessible from the
+SearchIO has write support for several formats, accessible from the
 Bio.SearchIO.write(...) function. This function returns a tuple of four
 numbers: the number of QueryResult, Hit, HSP, and HSPFragment written::
 
@@ -94,7 +94,7 @@ SearchIO provides a shortcut function Bio.SearchIO.convert(...) to convert a
 given file into another format. Under the hood, ``convert`` simply parses a given
 output file and writes it to another using the ``parse`` and ``write`` functions.
 
-Note that the same restrictions found in Bio.SearchIO.write(...) applies to the
+Note that the same restrictions found in Bio.SearchIO.write(...) apply to the
 convert function as well.
 
 
@@ -131,7 +131,7 @@ and 28 again.
 Sequence coordinate order
 -------------------------
 
-Some search output format reverses the start and end coordinate sequences
+Some search output formats reverse the start and end coordinate sequences
 according to the sequence's strand. For example, in BLAST plain text
 format if the matching strand lies in the minus orientation, then the
 start coordinate will always be bigger than the end coordinate.
@@ -329,14 +329,14 @@ def read(handle, format=None, **kwargs):
     ...
     ValueError: No query results found in handle
 
-    Similarly, if the given handle has more than one results, an exception will
-    also be raised:
+    Similarly, if the given handle has more than one result, an exception will
+    be raised:
 
     >>> from Bio import SearchIO
     >>> qresult = SearchIO.read('Blast/tab_2226_tblastn_001.txt', 'blast-tab')
     Traceback (most recent call last):
     ...
-    ValueError: More than one query results found in handle
+    ValueError: More than one query result found in handle
 
     Like ``parse``, ``read`` may also accept keyword argument(s) depending on the
     search output file format.
@@ -350,7 +350,7 @@ def read(handle, format=None, **kwargs):
         raise ValueError("No query results found in handle") from None
     try:
         next(query_results)
-        raise ValueError("More than one query results found in handle")
+        raise ValueError("More than one query result found in handle")
     except StopIteration:
         pass
 
@@ -433,7 +433,7 @@ def index(filename, format=None, key_function=None, **kwargs):
     given QueryResult object much faster than using parse or read.
 
     Index works by storing in-memory the start locations of all queries in a
-    file. When a user requested access to the query, this function will jump
+    file. When a user requests access to the query, this function will jump
     to its start position, parse the whole query, and return it as a
     QueryResult object:
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -57,6 +57,7 @@ possible, especially the following contributors:
 - Aziz Khan
 - Alex Morehead
 - Chenghao Zhu
+- Christian Brueffer
 - Damien Goutte-Gattat
 - Erik  Whiting
 - Fabian Egli


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Fixes some language issues in the SearchIO documentation, mainly spelling and grammar.
