### PR TITLE
KEGG.Compound.parse not returning mass

### DIFF
--- a/Bio/KEGG/Compound/__init__.py
+++ b/Bio/KEGG/Compound/__init__.py
@@ -153,7 +153,7 @@ def parse(handle):
             record.pathway.append(pathway)
         elif keyword == "FORMULA     ":
             record.formula = data
-        elif keyword == "EXACT_MASS  ":
+        elif keyword in ("MASS        ", "EXACT_MASS  "):
             record.mass = data
         elif keyword == "DBLINKS     ":
             if ":" in data:

--- a/Bio/KEGG/Compound/__init__.py
+++ b/Bio/KEGG/Compound/__init__.py
@@ -153,7 +153,7 @@ def parse(handle):
             record.pathway.append(pathway)
         elif keyword == "FORMULA     ":
             record.formula = data
-        elif keyword == "MASS        ":
+        elif keyword == "EXACT_MASS  ":
             record.mass = data
         elif keyword == "DBLINKS     ":
             if ":" in data:

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -131,6 +131,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Hector Martinez <https://github.com/hmarlo>
 - Hielke Walinga <https://github.com/hwalinga>
 - Hongbo Zhu <https://github.com/hongbo-zhu-cn>
+- Hussein Faara <https://github.com/hfaara18>
 - Hye-Shik Chang <perky at domain fallin.lv>
 - Iddo Friedberg <https://github.com/idoerg>
 - Ilya Flyamer <https://github.com/Phlya>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -61,6 +61,7 @@ possible, especially the following contributors:
 - Damien Goutte-Gattat
 - Erik  Whiting
 - Fabian Egli
+- Hussein Faara (first contribution)
 - Manuel Lera Ramirez
 - João Rodrigues
 - Markus Piotrowski

--- a/Tests/test_KEGG.py
+++ b/Tests/test_KEGG.py
@@ -145,12 +145,13 @@ class CompoundTests(unittest.TestCase):
         self.assertEqual(records[1].structures, [])
         self.assertEqual(records[1].dblinks[0], ("PubChem", ["3319"]))
         self.assertEqual(
-            str(records[-1]).replace(" ", "").split("\n")[:10],
+            str(records[-1]).replace(" ", "").split("\n")[:11],
             [
                 "ENTRYC01386",
                 "NAMENH2Mec",
                 "7-Amino-4-methylcoumarin",
                 "FORMULAC10H9NO2",
+                "MASS175.0633",
                 "DBLINKSCAS:26093-31-2",
                 "PubChem:4580",
                 "ChEBI:51771",

--- a/Tests/test_KEGG.py
+++ b/Tests/test_KEGG.py
@@ -134,7 +134,7 @@ class CompoundTests(unittest.TestCase):
             records = list(Compound.parse(handle))
         self.assertEqual(len(records), 8)
         self.assertEqual(records[1].entry, "C00017")
-        self.assertEqual(records[1].mass, "")  # Why?
+        self.assertEqual(records[1].mass, "55.9349")
         self.assertEqual(records[1].formula, "C2H4NO2R(C2H2NOR)n")
         self.assertEqual(records[1].name, ["Protein"])
         self.assertEqual(

--- a/Tests/test_KEGG.py
+++ b/Tests/test_KEGG.py
@@ -134,7 +134,7 @@ class CompoundTests(unittest.TestCase):
             records = list(Compound.parse(handle))
         self.assertEqual(len(records), 8)
         self.assertEqual(records[1].entry, "C00017")
-        self.assertEqual(records[1].mass, "55.9349")
+        self.assertEqual(records[1].mass, "")
         self.assertEqual(records[1].formula, "C2H4NO2R(C2H2NOR)n")
         self.assertEqual(records[1].name, ["Protein"])
         self.assertEqual(
@@ -166,6 +166,17 @@ class CompoundTests(unittest.TestCase):
             records = list(Compound.parse(handle))
         self.assertEqual(len(records), 2)
         self.assertEqual(records[0].entry, "C01454")
+
+    def test_mass(self):
+        """record.mass tests."""
+        with open("KEGG/compound.sample") as handle:
+            records = list(Compound.parse(handle))
+        self.assertEqual(records[0].entry, "C00023")
+        self.assertEqual(records[0].mass, "55.9349")
+        self.assertEqual(records[2].entry, "C00099")
+        self.assertEqual(records[2].mass, "89.0477")
+        self.assertEqual(records[3].entry, "C00294")
+        self.assertEqual(records[3].mass, "268.0808")
 
 
 class MapTests(unittest.TestCase):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3914. Updated parse to reflect the KEGG record replacing the MASS field with EXACT_MASS
