### PR TITLE
Expose Alignment namedtuple to allow pickling

### DIFF
--- a/Bio/pairwise2.py
+++ b/Bio/pairwise2.py
@@ -286,6 +286,8 @@ warnings.warn(
 
 MAX_ALIGNMENTS = 1000  # maximum alignments recovered in traceback
 
+Alignment = namedtuple("Alignment", ("seqA, seqB, score, start, end"))
+
 
 class align:
     """Provide functions that do alignments.
@@ -1152,7 +1154,6 @@ def _clean_alignments(alignments):
     Remove duplicates, make sure begin and end are set correctly, remove
     empty alignments.
     """
-    Alignment = namedtuple("Alignment", ("seqA, seqB, score, start, end"))
     unique_alignments = []
     for align in alignments:
         if align not in unique_alignments:

--- a/Tests/pairwise2_testCases.py
+++ b/Tests/pairwise2_testCases.py
@@ -11,7 +11,7 @@ as TestCases in ``test_pairwise2.py`` and ``test_pairwise2_no_C.py``
 with or without complementing C extensions.
 
 """
-
+import pickle
 import unittest
 import warnings
 
@@ -857,6 +857,12 @@ class TestOtherFunctions(unittest.TestCase):
         ]
         expected = [("ACCGT", "AC-G-", 3.0, 0, 4), ("ACCGT", "A-CG-", 3.0, 0, 4)]
         result = pairwise2._clean_alignments(alns)
+        self.assertEqual(expected, result)
+
+    def test_alignments_can_be_pickled(self):
+        alns = [("ACCGT", "AC-G-", 3.0, 0, 4)]
+        expected = [("ACCGT", "AC-G-", 3.0, 0, 4)]
+        result = pickle.loads(pickle.dumps(pairwise2._clean_alignments(alns)))
         self.assertEqual(expected, result)
 
     def test_print_matrix(self):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3908

Expose the Alignment namedtuple in pairwise2. It was previous within a function which prevented pickling from working correctly.
