### PR TITLE
Fix flake8 C417 failure in codonseq

### DIFF
--- a/Bio/codonalign/codonseq.py
+++ b/Bio/codonalign/codonseq.py
@@ -779,9 +779,7 @@ def _yn00(seq1, seq2, k, codon_table):
             S_sites + N_sites
         )
         w = dSdN[1] / dSdN[0]
-        if all(
-            map(lambda x: x < tolerance, (abs(i - j) for i, j in zip(dSdN, dSdN_pre)))
-        ):
+        if all(abs(i - j) < tolerance for i, j in zip(dSdN, dSdN_pre)):
             return dSdN[1], dSdN[0]  # dN, dS
         dSdN_pre = dSdN
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Fix flake8 [C417](https://github.com/adamchainz/flake8-comprehensions/blob/404158c012f2200e33ae53f91c9063ff4e2b229f/README.rst#c417-unnecessary-map-usage---rewrite-using-a-generator-expressionlistsetdict-comprehension) failure in codonseq
Failure was: 
```
Bio/codonalign/codonseq.py:783:13: C417 Unnecessary use of map - use a generator expression instead.
```