### PR TITLE
Fix bug in rotation matrix transpose when using QCP methods

### DIFF
--- a/Bio/PDB/QCPSuperimposer/__init__.py
+++ b/Bio/PDB/QCPSuperimposer/__init__.py
@@ -103,7 +103,7 @@ class QCPSuperimposer:
             -1.0,
         )
         rot = array([r0, r1, r2, r3, r4, r5, r6, r7, r8]).reshape(3, 3)
-        return (rmsd, rot.T, [q1, q2, q3, q4])
+        return (rmsd, rot, [q1, q2, q3, q4])
 
     # Public methods
     def set(self, reference_coords, coords):

--- a/Bio/PDB/cealign.py
+++ b/Bio/PDB/cealign.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from Bio.PDB.ccealign import run_cealign
 from Bio.PDB.PDBExceptions import PDBException
-from Bio.PDB.QCPSuperimposer import QCPSuperimposer
+from Bio.PDB.qcprot import QCPSuperimposer
 
 
 _RESID_SORTER = lambda r: r.id[1]  # noqa: E731

--- a/Bio/PDB/qcprot.py
+++ b/Bio/PDB/qcprot.py
@@ -28,7 +28,7 @@ from Bio.PDB.PDBExceptions import PDBException
 
 
 def qcp(coords1, coords2, natoms):
-    """Implementats of the QCP code in Python.
+    """Implement the QCP code in Python.
 
     Input coordinate arrays must be centered at the origin and have
     shape Nx3.
@@ -200,15 +200,15 @@ def qcp(coords1, coords2, natoms):
     ax = q1 * q2
 
     rot = np.zeros((3, 3))
-    # Transposed rotation matrix.
+
     rot[0][0] = a2 + x2 - y2 - z2
-    rot[1][0] = 2 * (xy + az)
-    rot[2][0] = 2 * (zx - ay)
-    rot[0][1] = 2 * (xy - az)
+    rot[0][1] = 2 * (xy + az)
+    rot[0][2] = 2 * (zx - ay)
+    rot[1][0] = 2 * (xy - az)
     rot[1][1] = a2 - x2 + y2 - z2
-    rot[2][1] = 2 * (yz + ax)
-    rot[0][2] = 2 * (zx + ay)
-    rot[1][2] = 2 * (yz - ax)
+    rot[1][2] = 2 * (yz + ax)
+    rot[2][0] = 2 * (zx + ay)
+    rot[2][1] = 2 * (yz - ax)
     rot[2][2] = a2 - x2 - y2 + z2
 
     return rmsd, rot, (q1, q2, q3, q4)
@@ -318,7 +318,7 @@ class QCPSuperimposer:
         coords -= com1
         coords_ref -= com2
 
-        (self.rms, self.rot, self.lquart) = qcp(coords_ref, coords, self._natoms)
+        (self.rms, self.rot, _) = qcp(coords_ref, coords, self._natoms)
         self.tran = com2 - np.dot(com1, self.rot)
 
     # Getters

--- a/Tests/test_PDB_QCSuperimposer.py
+++ b/Tests/test_PDB_QCSuperimposer.py
@@ -70,12 +70,12 @@ class QCPSuperimposerTest(unittest.TestCase):
         self.assertEqual(self._arr_to_list(self.sup.coords), self._arr_to_list(self.y))
         self.assertIsNone(self.sup.transformed_coords)
         calc_rot = [
-            [0.683, -0.523, -0.510],
-            [0.537, 0.833, -0.135],
-            [0.495, -0.181, 0.849],
+            [0.683, 0.537, 0.495],
+            [-0.523, 0.833, -0.181],
+            [-0.510, -0.135, 0.849],
         ]
         self.assertEqual(self._arr_to_list(self.sup.rot), calc_rot)
-        calc_tran = [-7.439, 36.515, 36.811]
+        calc_tran = [38.786, -20.655, -15.422]
         self.assertEqual(self._arr_to_list(self.sup.tran), calc_tran)
         # We can reduce precision here since we do a similar calculation
         # for a full structure down below.
@@ -86,10 +86,10 @@ class QCPSuperimposerTest(unittest.TestCase):
         """Test transformation of coordinates after QCP."""
         self.sup.run()
         transformed_coords = [
-            [49.055, -1.239, 50.584],
-            [50.022, -0.394, 51.425],
-            [51.477, -0.573, 51.068],
-            [52.396, -0.984, 52.033],
+            [51.652, -1.900, 50.071],
+            [50.398, -1.229, 50.649],
+            [50.680, -0.042, 51.537],
+            [50.220, -0.019, 52.853],
         ]
 
         self.assertEqual(


### PR DESCRIPTION
- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

Closes #3950. In addition, replaces the QCP method in use by CEAligner by the pure python version, as the C version will be deprecated sooner or later.
