### PR TITLE
Skip pre-commit debug-statements check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
     -   id: check-executables-have-shebangs
         files: \.(py|sh)$
     -   id: check-json
-    -   id: debug-statements
     -   id: end-of-file-fixer
         files: \.py$
     -   id: mixed-line-ending


### PR DESCRIPTION
This checks for debugger imports and py37+ breakpoint() calls in python source.

We've never had those to my knowledge, and this check seems to add a couple of seconds to the run.

Dropping this might help with the 3 minute time out (mostly due to running black).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Should help with #3958 