### PR TITLE
Deprecate SeqFeature position objects' .position & .extension

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1599,6 +1599,30 @@ class AbstractPosition:
         """Represent the AbstractPosition object as a string for debugging."""
         return f"{self.__class__.__name__}(...)"
 
+    @property
+    def position(self):
+        """Legacy attribute to get (left-most) position as an integer (DEPRECATED)."""
+        warnings.warn(
+            "Alias location.position is deprecated and will be removed in a future "
+            "release. Use location directly, or int(location). However, that will "
+            "fail for UnknownPosition, and for OneOfPosition and WithinPosition "
+            "will give the default rather than left-most value.",
+            BiopythonDeprecationWarning,
+        )
+        return int(self)
+
+    @property
+    def extension(self):
+        """Legacy attribute to get the position's 'width' as an integer, tyically zero (DEPRECATED)."""
+        warnings.warn(
+            "Alias location.extension is deprecated and will be removed in a "
+            "future release. It was undefined or zero except for OneOfPosition, "
+            "WithinPosition and WithinPosition which must now be handled "
+            "explicitly instead.",
+            BiopythonDeprecationWarning,
+        )
+        return 0
+
 
 class ExactPosition(int, AbstractPosition):
     """Specify the specific position of a boundary.
@@ -1650,16 +1674,6 @@ class ExactPosition(int, AbstractPosition):
         """Represent the ExactPosition object as a string for debugging."""
         return "%s(%i)" % (self.__class__.__name__, int(self))
 
-    @property
-    def position(self):
-        """Legacy attribute to get position as integer (OBSOLETE)."""
-        return int(self)
-
-    @property
-    def extension(self):
-        """Not present in this object, return zero (OBSOLETE)."""
-        return 0
-
     def _shift(self, offset):
         """Return a copy of the position object with its location shifted (PRIVATE)."""
         # By default preserve any subclass
@@ -1697,13 +1711,26 @@ class UnknownPosition(AbstractPosition):
 
     @property
     def position(self):
-        """Legacy attribute to get location (None) (OBSOLETE)."""
-        return None
+        """Legacy attribute to get location (None) (DEPRECATED).
 
-    @property
-    def extension(self):  # noqa: D402
-        """Legacy attribute to get extension (zero) as integer (OBSOLETE)."""  # noqa: D402
-        return 0
+        In general you can use the location directly as with the exception of
+        UnknownPosition it subclasses int, or use int(location), rather than
+        this location.position legacy attribute.
+
+        However, the UnknownPosition cannot be cast to an integer, and thus
+        does not subclass int, and int(...) will fail. The legacy attribute
+        would return None instead.
+
+        Note that while None == None, UnknownPosition() != UnknownPosition()
+        which is like the behavour for NaN.
+        """
+        warnings.warn(
+            "Alias location.position is deprecated and will be removed in a future release. "
+            "In general use position directly, but not note for UnknownPosition "
+            "int(location) will fail. Use try/except or isinstance(location, UnknownPosition).",
+            BiopythonDeprecationWarning,
+        )
+        return None
 
     def _shift(self, offset):
         """Return a copy of the position object with its location shifted (PRIVATE)."""
@@ -1722,10 +1749,10 @@ class WithinPosition(int, AbstractPosition):
     - left - The start (left) position of the boundary
     - right - The end (right) position of the boundary
 
-    This allows dealing with a location like ((1.4)..100). This
-    indicates that the start of the sequence is somewhere between 1
-    and 4. Since this is a start coordinate, it should acts like
-    it is at position 1 (or in Python counting, 0).
+    This allows dealing with a location like ((11.14)..100). This
+    indicates that the start of the sequence is somewhere between 11
+    and 14. Since this is a start coordinate, it should act like
+    it is at position 11 (or in Python counting, 10).
 
     >>> p = WithinPosition(10, 10, 13)
     >>> p
@@ -1766,7 +1793,8 @@ class WithinPosition(int, AbstractPosition):
     >>> p == AfterPosition(10)
     True
 
-    If this were an end point, you would want the position to be 13:
+    If this were an end point, you would want the position to be 13
+    (the right/larger value, not the left/smaller value as above):
 
     >>> p2 = WithinPosition(13, 10, 13)
     >>> p2
@@ -1778,23 +1806,6 @@ class WithinPosition(int, AbstractPosition):
     >>> p2 == 13
     True
     >>> p2 == ExactPosition(13)
-    True
-
-    The old legacy properties of position and extension give the
-    starting/lower/left position as an integer, and the distance
-    to the ending/higher/right position as an integer. Note that
-    the position object will act like either the left or the right
-    end-point depending on how it was created:
-
-    >>> p.position == p2.position == 10
-    True
-    >>> p.extension == p2.extension == 3
-    True
-    >>> int(p) == int(p2)
-    False
-    >>> p == 10
-    True
-    >>> p2 == 13
     True
 
     """
@@ -1833,12 +1844,23 @@ class WithinPosition(int, AbstractPosition):
 
     @property
     def position(self):
-        """Legacy attribute to get (left) position as integer (OBSOLETE)."""
+        """Legacy attribute to get (left) position as integer (DEPRECATED)."""
+        warnings.warn(
+            "Alias location.position is deprecated and will be removed in a future release. "
+            "Use location directly, or int(location) which will return the preferred location "
+            "defined for WithinPosition (which may not be the left-most position).",
+            BiopythonDeprecationWarning,
+        )
         return self._left
 
     @property
-    def extension(self):  # noqa: D402
-        """Legacy attribute to get extension (from left to right) as an integer (OBSOLETE)."""  # noqa: D402
+    def extension(self):
+        """Legacy attribute to get the within-position's 'width' as an integer (DEPRECATED)."""
+        warnings.warn(
+            "Alias location.extension is deprecated and will be removed in a future release. "
+            "This is usually zero, but there is no neat replacement for the WithinPosition object.",
+            BiopythonDeprecationWarning,
+        )
         return self._right - self._left
 
     def _shift(self, offset):
@@ -1892,14 +1914,6 @@ class BetweenPosition(int, AbstractPosition):
     end-point depending on how it was created:
 
     >>> p2 = BetweenPosition(123, left=123, right=456)
-    >>> p.position == p2.position == 123
-    True
-    >>> p.extension
-    333
-    >>> p2.extension
-    333
-    >>> p.extension == p2.extension == 333
-    True
     >>> int(p) == int(p2)
     False
     >>> p == 456
@@ -1924,6 +1938,7 @@ class BetweenPosition(int, AbstractPosition):
     def __new__(cls, position, left, right):
         """Create a new instance in BetweenPosition object."""
         assert position == left or position == right
+        # TODO - public API for getting left/right, especially the unknown one
         obj = int.__new__(cls, position)
         obj._left = left
         obj._right = right
@@ -1951,12 +1966,23 @@ class BetweenPosition(int, AbstractPosition):
 
     @property
     def position(self):
-        """Legacy attribute to get (left) position as integer (OBSOLETE)."""
+        """Legacy attribute to get (left) position as integer (DEPRECATED)."""
+        warnings.warn(
+            "Alias location.position is deprecated and will be removed in a future release. "
+            "Use location directly, or int(location) which will return the preferred location "
+            "defined for a BetweenPosition (which may not be the left-most position).",
+            BiopythonDeprecationWarning,
+        )
         return self._left
 
     @property
-    def extension(self):  # noqa: D402
-        """Legacy attribute to get extension (from left to right) as an integer (OBSOLETE)."""  # noqa: D402
+    def extension(self):
+        """Legacy attribute to get the between-position's 'width' as an integer (DEPRECATED)."""
+        warnings.warn(
+            "Alias location.extension is deprecated and will be removed in a future release. "
+            "This is usually zero, but there is no neat replacement for the BetweenPosition object.",
+            BiopythonDeprecationWarning,
+        )
         return self._right - self._left
 
     def _shift(self, offset):
@@ -2012,23 +2038,13 @@ class BeforePosition(int, AbstractPosition):
             raise AttributeError(f"Non-zero extension {extension} for exact position.")
         return int.__new__(cls, position)
 
-    @property
-    def position(self):
-        """Legacy attribute to get position as integer (OBSOLETE)."""
-        return int(self)
-
-    @property
-    def extension(self):  # noqa: D402
-        """Legacy attribute to get extension (zero) as integer (OBSOLETE)."""  # noqa: D402
-        return 0
-
     def __repr__(self):
         """Represent the location as a string for debugging."""
         return "%s(%i)" % (self.__class__.__name__, int(self))
 
     def __str__(self):
         """Return a representation of the BeforePosition object (with python counting)."""
-        return f"<{self.position}"
+        return f"<{int(self)}"
 
     def _shift(self, offset):
         """Return a copy of the position object with its location shifted (PRIVATE)."""
@@ -2086,23 +2102,13 @@ class AfterPosition(int, AbstractPosition):
             raise AttributeError(f"Non-zero extension {extension} for exact position.")
         return int.__new__(cls, position)
 
-    @property
-    def position(self):
-        """Legacy attribute to get position as integer (OBSOLETE)."""
-        return int(self)
-
-    @property
-    def extension(self):  # noqa: D402
-        """Legacy attribute to get extension (zero) as integer (OBSOLETE)."""  # noqa: D402
-        return 0
-
     def __repr__(self):
         """Represent the location as a string for debugging."""
         return "%s(%i)" % (self.__class__.__name__, int(self))
 
     def __str__(self):
         """Return a representation of the AfterPosition object (with python counting)."""
-        return f">{self.position}"
+        return f">{int(self)}"
 
     def _shift(self, offset):
         """Return a copy of the position object with its location shifted (PRIVATE)."""
@@ -2144,24 +2150,6 @@ class OneOfPosition(int, AbstractPosition):
     >>> isinstance(p, int)
     True
 
-    The old legacy properties of position and extension give the
-    starting/lowest/left-most position as an integer, and the
-    distance to the ending/highest/right-most position as an integer.
-    Note that the position object will act like one of the list of
-    possible locations depending on how it was created:
-
-    >>> p2 = OneOfPosition(1901, [ExactPosition(1888), ExactPosition(1901)])
-    >>> p.position == p2.position == 1888
-    True
-    >>> p.extension == p2.extension == 13
-    True
-    >>> int(p) == int(p2)
-    False
-    >>> p == 1888
-    True
-    >>> p2 == 1901
-    True
-
     """
 
     def __new__(cls, position, choices):
@@ -2189,12 +2177,25 @@ class OneOfPosition(int, AbstractPosition):
 
     @property
     def position(self):
-        """Legacy attribute to get (left) position as integer (OBSOLETE)."""
+        """Legacy attribute to get (left) position as integer (DEPRECATED)."""
+        warnings.warn(
+            "Alias location.position is deprecated and will be removed in a future release. "
+            "Use location directly, or int(location) which will return the preferred location "
+            "defined for a OneOfPosition (which may not be the left-most position), or "
+            "min(location.position_choices) instead.",
+            BiopythonDeprecationWarning,
+        )
         return min(int(pos) for pos in self.position_choices)
 
     @property
     def extension(self):
-        """Legacy attribute to get extension as integer (OBSOLETE)."""
+        """Legacy attribute to get the one-of-position's 'width' as an integer (DEPRECATED)."""
+        warnings.warn(
+            "Alias location.extension is deprecated and will be removed in a future release. "
+            "This is usually zero, but for a OneOfPosition you can use "
+            "max(position.position_choices) - min(position.position_choices)",
+            BiopythonDeprecationWarning,
+        )
         positions = [int(pos) for pos in self.position_choices]
         return max(positions) - min(positions)
 

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1613,7 +1613,7 @@ class AbstractPosition:
 
     @property
     def extension(self):
-        """Legacy attribute to get the position's 'width' as an integer, tyically zero (DEPRECATED)."""
+        """Legacy attribute to get the position's 'width' as an integer, typically zero (DEPRECATED)."""
         warnings.warn(
             "Alias location.extension is deprecated and will be removed in a "
             "future release. It was undefined or zero except for OneOfPosition, "

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -222,21 +222,23 @@ def _insdc_feature_position_string(pos, offset=0):
     Use offset=1 to add one to convert a start position from python counting.
     """
     if isinstance(pos, SeqFeature.ExactPosition):
-        return "%i" % (pos.position + offset)
+        return "%i" % (pos + offset)
     elif isinstance(pos, SeqFeature.WithinPosition):
+        # TODO - avoid private variables
         return "(%i.%i)" % (
-            pos.position + offset,
-            pos.position + pos.extension + offset,
+            pos._left + offset,
+            pos._right + offset,
         )
     elif isinstance(pos, SeqFeature.BetweenPosition):
+        # TODO - avoid private variables
         return "(%i^%i)" % (
-            pos.position + offset,
-            pos.position + pos.extension + offset,
+            pos._left + offset,
+            pos._right + offset,
         )
     elif isinstance(pos, SeqFeature.BeforePosition):
-        return "<%i" % (pos.position + offset)
+        return "<%i" % (pos + offset)
     elif isinstance(pos, SeqFeature.AfterPosition):
-        return ">%i" % (pos.position + offset)
+        return ">%i" % (pos + offset)
     elif isinstance(pos, SeqFeature.OneOfPosition):
         return "one-of(%s)" % ",".join(
             _insdc_feature_position_string(p, offset) for p in pos.position_choices
@@ -256,25 +258,25 @@ def _insdc_location_string_ignoring_strand_and_subfeatures(location, rec_length)
     if (
         isinstance(location.start, SeqFeature.ExactPosition)
         and isinstance(location.end, SeqFeature.ExactPosition)
-        and location.start.position == location.end.position
+        and location.start == location.end
     ):
         # Special case, for 12:12 return 12^13
         # (a zero length slice, meaning the point between two letters)
-        if location.end.position == rec_length:
+        if location.end == rec_length:
             # Very special case, for a between position at the end of a
             # sequence (used on some circular genomes, Bug 3098) we have
             # N:N so return N^1
             return "%s%i^1" % (ref, rec_length)
         else:
-            return "%s%i^%i" % (ref, location.end.position, location.end.position + 1)
+            return "%s%i^%i" % (ref, location.end, location.end + 1)
     if (
         isinstance(location.start, SeqFeature.ExactPosition)
         and isinstance(location.end, SeqFeature.ExactPosition)
-        and location.start.position + 1 == location.end.position
+        and location.start + 1 == location.end
     ):
         # Special case, for 11:12 return 12 rather than 12..12
         # (a length one slice, meaning a single letter)
-        return "%s%i" % (ref, location.end.position)
+        return "%s%i" % (ref, location.end)
     elif isinstance(location.start, SeqFeature.UnknownPosition) or isinstance(
         location.end, SeqFeature.UnknownPosition
     ):

--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -338,8 +338,8 @@ class XdnaWriter(SequenceWriter):
 
             self._write_pstring(feature.type)
 
-            start = feature.location.start.position + 1  # 1-based coordinates
-            end = feature.location.end.position
+            start = int(feature.location.start) + 1  # 1-based coordinates
+            end = int(feature.location.end)
             strand = 1
             if feature.location.strand == -1:
                 start, end = end, start

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -275,10 +275,18 @@ There were multiple deprecations in Release 1.80:
 * Arguments ``strand``, ``ref`` and ``ref_db`` to the ``SeqFeature``
   class - set them via the location object
 * Unused class ``PositionGap`` - originally for very old GenBank files.
-* Attributes ``location.nofuzzy_start`` and ``location..nofuzzy_end`` -
+* Location attributes ``location.nofuzzy_start`` and ``location.nofuzzy_end`` -
   use the location directly or if required ``int(location.start)`` and
   ``int(location.end)``. This will fail for the ``UnknownPosition``
   where the nofuzzy aliases returned ``None``.
+* Position attribute ``.position`` returned the (left) position as an
+  integer - use the location directly or if required ``int(position)``,
+  however for ``OneOfPosition``, ``BetweenPosition``, and
+  ``WithinPosition`` that will give the default position rather than
+  the left-most (minimum) value.
+* Position attribute ``.extension`` returned the "width", typically
+  zero except for ``OneOfPosition``, ``BetweenPosition``, and
+  ``WithinPosition`` where this must be handled explicitly now.
 
 Bio.Motif
 ---------

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -387,13 +387,7 @@ of fuzzy positions, so we have five classes do deal with them:
   this class models a position which occurs somewhere between two
   specified nucleotides. In GenBank/EMBL notation, this would be
   represented as `(1.5)', to represent that the position is somewhere
-  within the range 1 to 5. To get the information in this class you
-  have to look at two attributes. The \verb|position| attribute
-  specifies the lower boundary of the range we are looking at, so in
-  our example case this would be one. The \verb|extension| attribute
-  specifies the range to the higher boundary, so in this case it
-  would be 4. So \verb|object.position| is the lower boundary and
-  \verb|object.position + object.extension| is the upper boundary.
+  within the range 1 to 5.
 
   \item[OneOfPosition] -- Occasionally used for GenBank/EMBL locations,
   this class deals with a position where several possible values exist,

--- a/Tests/test_GenomeDiagram.py
+++ b/Tests/test_GenomeDiagram.py
@@ -829,10 +829,11 @@ class DiagramTest(unittest.TestCase):
             if feature.type != "CDS":
                 # We're going to ignore these.
                 continue
-            if feature.location.end.position < start:
+            # These may miss fuzzy locations where the integer sorting is a simplification
+            if feature.location.end < start:
                 # Out of frame (too far left)
                 continue
-            if feature.location.start.position > end:
+            if feature.location.start > end:
                 # Out of frame (too far right)
                 continue
 

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -58,8 +58,8 @@ class SeqUtilsTests(unittest.TestCase):
         records = []
         for feature in record.features:
             if feature.type == "CDS" and len(feature.location.parts) == 1:
-                start = feature.location.start.position
-                end = feature.location.end.position
+                start = feature.location.start
+                end = feature.location.end
                 table = int(feature.qualifiers["transl_table"][0])
                 if feature.strand == -1:
                     seq = record.seq[start:end].reverse_complement()


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Deprecate ``Bio.SeqFeature`` position objects' ``.position`` & ``.extension`` attributes.

Also includes a slight refactoring to define default methods on the base class as discussed on #3961..

Closes #3961.
