### PR TITLE
Drop pre-commit.ci badge & configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,13 +67,3 @@ repos:
         entry: '(?i)(doi:|dx\.doi\.org|http://doi\.org)'
         language: pygrep
         files: \.(rst|tex)$
-ci:
-    # Settings for the https://pre-commit.ci/ continuous integration service
-    autofix_prs: false
-    # Default message is more verbose
-    autoupdate_commit_msg: '[pre-commit.ci] autoupdate'
-    # Default is weekly
-    autoupdate_schedule: quarterly
-    # Currently pre-commit.ci checks all files, and flake8 takes too long
-    # and causes a timeout - so as a short-term workaround, skip it:
-    skip: [flake8]

--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,6 @@
 .. image:: https://img.shields.io/conda/vn/conda-forge/biopython.svg?logo=conda-forge
    :alt: Biopython on the Conda package conda-forge channel
    :target: https://anaconda.org/conda-forge/biopython
-.. image:: https://results.pre-commit.ci/badge/github/biopython/biopython/master.svg
-   :target: https://results.pre-commit.ci/latest/github/biopython/biopython/master
-   :alt: pre-commit.ci status
 .. image:: https://img.shields.io/circleci/build/github/biopython/biopython.svg?logo=circleci
    :alt: Linux testing with CircleCI
    :target: https://app.circleci.com/pipelines/github/biopython/biopython


### PR DESCRIPTION
Separately we will disable the https://pre-commit.ci/ integration with GitHub.

As per discussion on #3958, this was redundant with the pre-commit tool checks already being run via GitHub Actions (and that was faster thanks to only checking recently changed files).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3958
