### PR TITLE
In Bio.Align, use metadata consistently

### DIFF
--- a/Bio/Align/emboss.py
+++ b/Bio/Align/emboss.py
@@ -50,7 +50,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
         # assume srspair format (default) if not specified explicitly in
         # the output file
-        self.align_format = "srspair"
+        self.metadata = {}
+        self.metadata["Align_format"] = "srspair"
         commandline = None
         for line in stream:
             if line.rstrip() == "########################################":
@@ -61,17 +62,17 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 if line.startswith("#    "):
                     commandline += " " + line[1:].strip()
                     continue
-                self.commandline = commandline
+                self.metadata["Command line"] = commandline
                 commandline = None
             key, value = line[2:].split(":", 1)
             if key == "Program":
-                self.program = value.strip()
+                self.metadata["Program"] = value.strip()
             elif key == "Rundate":
-                self.rundate = value.strip()
+                self.metadata["Rundate"] = value.strip()
             elif key == "Report_file":
-                self.report_file = value.strip()
+                self.metadata["Report_file"] = value.strip()
             elif key == "Align_format":
-                self.align_format = value.strip()
+                self.metadata["Align_format"] = value.strip()
             elif key == "Commandline":
                 commandline = value.strip()
 
@@ -220,7 +221,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                         # Record the start
                         starts[index] = start
                     else:
-                        if self.align_format == "srspair" and len(sequence) == 0:
+                        if self.metadata["Align_format"] == "srspair" and len(sequence) == 0:
                             start += 1
                         assert start == starts[index] + length
                     assert end == start + len(sequence)

--- a/Bio/Align/exonerate.py
+++ b/Bio/Align/exonerate.py
@@ -71,14 +71,8 @@ class AlignmentWriter(interfaces.AlignmentWriter):
 
     def write_header(self, alignments):
         """Write the header."""
-        try:
-            commandline = alignments.commandline
-        except AttributeError:
-            commandline = ""
-        try:
-            hostname = alignments.hostname
-        except AttributeError:
-            hostname = ""
+        commandline = alignments.metadata.get("Command line", "")
+        hostname = alignments.metadata.get("Hostname", "")
         self.stream.write(f"Command line: [{commandline}]\n")
         self.stream.write(f"Hostname: [{hostname}]\n")
 
@@ -440,21 +434,22 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         """
         super().__init__(source, mode="t", fmt="Exonerate")
         stream = self.stream
-        self.program = "exonerate"
+        self.metadata = {}
+        self.metadata["Program"] = "exonerate"
         line = next(stream)
         prefix = "Command line: "
         assert line.startswith(prefix)
         commandline = line[len(prefix) :].strip()
         assert commandline.startswith("[")
         assert commandline.endswith("]")
-        self.commandline = commandline[1:-1]
+        self.metadata["Command line"] = commandline[1:-1]
         line = next(stream)
         prefix = "Hostname: "
         assert line.startswith(prefix)
         hostname = line[len(prefix) :].strip()
         assert hostname.startswith("[")
         assert hostname.endswith("]")
-        self.hostname = hostname[1:-1]
+        self.metadata["Hostname"] = hostname[1:-1]
 
     @staticmethod
     def _parse_cigar(words):

--- a/Bio/Align/hhr.py
+++ b/Bio/Align/hhr.py
@@ -64,9 +64,9 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             elif key == "Searched_HMMs":
                 metadata[key] = int(value)
             elif key == "Date":
-                metadata[key] = value
+                metadata["Rundate"] = value
             elif key == "Command":
-                self.commandline = value
+                metadata["Command line"] = value
             else:
                 raise ValueError("Unknown key '%s'" % key)
         self.metadata = metadata

--- a/Bio/Align/maf.py
+++ b/Bio/Align/maf.py
@@ -98,15 +98,21 @@ class AlignmentWriter(interfaces.AlignmentWriter):
         for key, value in metadata.items():
             if key in track_keys:
                 continue
-            if key == "comments":
+            if key == "Comments":
                 continue
-            if key not in ("version", "scoring", "program"):
+            if key == "MAF Version":
+                if value != "1":
+                    raise ValueError("MAF version must be 1")
+                key = "version"
+            elif key == "Scoring":
+                key = "scoring"
+            elif key == "Program":
+                key = "program"
+            else:
                 raise ValueError("Unexpected key '%s' for header" % key)
-            if key == "version" and value != "1":
-                raise ValueError("MAF version must be 1")
             stream.write(f" {key}={value}")
         stream.write("\n")
-        comments = metadata.get("comments")
+        comments = metadata.get("Comments")
         if comments is not None:
             for comment in comments:
                 stream.write(f"# {comment}\n")
@@ -303,10 +309,16 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             raise ValueError("header line does not start with ##maf")
         for word in words[1:]:
             key, value = word.split("=")
-            if key not in ("version", "scoring", "program"):
+            if key == "version":
+                key = "MAF Version"
+            elif key == "scoring":
+                key = "Scoring"
+            elif key == "program":
+                key = "Porgram"
+            else:
                 raise ValueError("Unexpected variable '%s' in header line" % key)
             metadata[key] = value
-        if metadata.get("version") != "1":
+        if metadata.get("MAF Version") != "1":
             raise ValueError("MAF version must be 1")
         comments = []
         for line in stream:
@@ -320,7 +332,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             self.stream = None
             self.line = None
         if comments:
-            metadata["comments"] = comments
+            metadata["Comments"] = comments
         self.metadata = metadata
 
     @staticmethod

--- a/Bio/Align/mauve.py
+++ b/Bio/Align/mauve.py
@@ -58,7 +58,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
                 stream.write(line)
                 line = f"#Sequence{number}Format\tFastA\n"
                 stream.write(line)
-        backbone_file = metadata.get("BackboneFile", None)
+        backbone_file = metadata.get("BackboneFile")
         if backbone_file is not None:
             line = f"#BackboneFile\t{backbone_file}\n"
             stream.write(line)

--- a/Bio/Align/psl.py
+++ b/Bio/Align/psl.py
@@ -91,7 +91,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
         except AttributeError:
             version = "3"
         else:
-            version = metadata.get("version", "3")
+            version = metadata.get("psLayout version", "3")
         # fmt: off
         self.stream.write(
             f"""\
@@ -322,7 +322,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             words = line.split()
             if words[1] != "version":
                 raise ValueError("Unexpected word '%s' in header line" % words[1])
-            self.metadata = {"version": words[2]}
+            self.metadata = {"psLayout version": words[2]}
             line = next(stream)
             line = next(stream)
             line = next(stream)

--- a/Tests/test_Align_clustal.py
+++ b/Tests/test_Align_clustal.py
@@ -27,8 +27,7 @@ class TestClustalReadingWriting(unittest.TestCase):
         alignment = next(alignments)
         stream.seek(0)
         saved_alignments = AlignmentIterator(stream)
-        self.assertEqual(saved_alignments.program, alignments.program)
-        self.assertEqual(saved_alignments.version, alignments.version)
+        self.assertEqual(saved_alignments.metadata, alignments.metadata)
         saved_alignment = next(saved_alignments)
         with self.assertRaises(StopIteration):
             next(saved_alignments)
@@ -45,8 +44,8 @@ class TestClustalReadingWriting(unittest.TestCase):
         # includes the sequence length on the right hand side of each line
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "CLUSTAL")
-            self.assertEqual(alignments.version, "1.81")
+            self.assertEqual(alignments.metadata["Program"], "CLUSTAL")
+            self.assertEqual(alignments.metadata["Version"], "1.81")
             alignment = next(alignments)
             with self.assertRaises(StopIteration):
                 next(alignments)
@@ -82,8 +81,8 @@ class TestClustalReadingWriting(unittest.TestCase):
         # http://virgil.ruc.dk/kurser/Sekvens/Treedraw.htm
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "MSAPROBS")
-            self.assertEqual(alignments.version, "0.9.7")
+            self.assertEqual(alignments.metadata["Program"], "MSAPROBS")
+            self.assertEqual(alignments.metadata["Version"], "0.9.7")
             alignment = next(alignments)
             with self.assertRaises(StopIteration):
                 next(alignments)
@@ -177,8 +176,8 @@ class TestClustalReadingWriting(unittest.TestCase):
         # includes the sequence length on the right hand side of each line
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "MUSCLE")
-            self.assertEqual(alignments.version, "3.8")
+            self.assertEqual(alignments.metadata["Program"], "MUSCLE")
+            self.assertEqual(alignments.metadata["Version"], "3.8")
             alignment = next(alignments)
             with self.assertRaises(StopIteration):
                 next(alignments)
@@ -226,8 +225,8 @@ class TestClustalReadingWriting(unittest.TestCase):
         path = "Clustalw/kalign.aln"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "Kalign")
-            self.assertEqual(alignments.version, "2.0")
+            self.assertEqual(alignments.metadata["Program"], "Kalign")
+            self.assertEqual(alignments.metadata["Version"], "2.0")
             alignment = next(alignments)
             with self.assertRaises(StopIteration):
                 next(alignments)
@@ -250,8 +249,8 @@ class TestClustalReadingWriting(unittest.TestCase):
         # example taken from the PROBCONS documentation
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "PROBCONS")
-            self.assertEqual(alignments.version, "1.12")
+            self.assertEqual(alignments.metadata["Program"], "PROBCONS")
+            self.assertEqual(alignments.metadata["Version"], "1.12")
             alignment = next(alignments)
             with self.assertRaises(StopIteration):
                 next(alignments)

--- a/Tests/test_Align_emboss.py
+++ b/Tests/test_Align_emboss.py
@@ -33,9 +33,9 @@ class TestEmboss(unittest.TestCase):
         path = "Emboss/water.txt"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "water")
-            self.assertEqual(alignments.rundate, "Wed Jan 16 17:23:19 2002")
-            self.assertEqual(alignments.report_file, "stdout")
+            self.assertEqual(alignments.metadata["Program"], "water")
+            self.assertEqual(alignments.metadata["Rundate"], "Wed Jan 16 17:23:19 2002")
+            self.assertEqual(alignments.metadata["Report_file"], "stdout")
             alignments = list(alignments)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -82,14 +82,14 @@ class TestEmboss(unittest.TestCase):
         path = "Emboss/water2.txt"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "water")
-            self.assertEqual(alignments.rundate, "Sat Apr 04 2009 22:08:44")
+            self.assertEqual(alignments.metadata["Program"], "water")
+            self.assertEqual(alignments.metadata["Rundate"], "Sat Apr 04 2009 22:08:44")
             self.assertEqual(
-                alignments.commandline,
+                alignments.metadata["Command line"],
                 "water -asequence asis:ACACACTCACACACACTTGGTCAGAGATGCTGTGCTTCTTGGAAGCAAGGNCTCAAAGGCAAGGTGCACGCAGAGGGACGTTTGAGTCTGGGATGAAGCATGTNCGTATTATTTATATGATGGAATTTCACGTTTTTATG -bsequence asis:CGTTTGAGTACTGGGATG -gapopen 10 -gapextend 0.5 -filter",
             )
-            self.assertEqual(alignments.align_format, "srspair")
-            self.assertEqual(alignments.report_file, "stdout")
+            self.assertEqual(alignments.metadata["Align_format"], "srspair")
+            self.assertEqual(alignments.metadata["Report_file"], "stdout")
             alignments = list(alignments)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -125,14 +125,14 @@ class TestEmboss(unittest.TestCase):
         path = "Emboss/matcher_simple.txt"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "matcher")
-            self.assertEqual(alignments.rundate, "Tue  8 Dec 2009 11:48:35")
+            self.assertEqual(alignments.metadata["Program"], "matcher")
+            self.assertEqual(alignments.metadata["Rundate"], "Tue  8 Dec 2009 11:48:35")
             self.assertEqual(
-                alignments.commandline,
+                alignments.metadata["Command line"],
                 "matcher [-asequence] rose.pro [-bsequence] rosemary.pro [-outfile] matcher_simple.txt -auto -sprotein -aformat simple",
             )
-            self.assertEqual(alignments.align_format, "simple")
-            self.assertEqual(alignments.report_file, "matcher_simple.txt")
+            self.assertEqual(alignments.metadata["Align_format"], "simple")
+            self.assertEqual(alignments.metadata["Report_file"], "matcher_simple.txt")
             alignments = list(alignments)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -170,14 +170,14 @@ class TestEmboss(unittest.TestCase):
         path = "Emboss/matcher_pair.txt"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "matcher")
-            self.assertEqual(alignments.rundate, "Tue  8 Dec 2009 12:01:34")
+            self.assertEqual(alignments.metadata["Program"], "matcher")
+            self.assertEqual(alignments.metadata["Rundate"], "Tue  8 Dec 2009 12:01:34")
             self.assertEqual(
-                alignments.commandline,
+                alignments.metadata["Command line"],
                 "matcher [-asequence] hba_human.fasta [-bsequence] hbb_human.fasta [-outfile] matcher_pair.txt -alternatives 5 -aformat pair -sprotein",
             )
-            self.assertEqual(alignments.align_format, "pair")
-            self.assertEqual(alignments.report_file, "matcher_pair.txt")
+            self.assertEqual(alignments.metadata["Align_format"], "pair")
+            self.assertEqual(alignments.metadata["Report_file"], "matcher_pair.txt")
             alignments = list(alignments)
         self.assertEqual(len(alignments), 5)
         alignment = alignments[0]
@@ -358,14 +358,14 @@ class TestEmboss(unittest.TestCase):
         path = "Emboss/needle_nobrief_multiple.pair"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "needle")
-            self.assertEqual(alignments.rundate, "Fri 23 Jul 2021 22:45:41")
+            self.assertEqual(alignments.metadata["Program"], "needle")
+            self.assertEqual(alignments.metadata["Rundate"], "Fri 23 Jul 2021 22:45:41")
             self.assertEqual(
-                alignments.commandline,
+                alignments.metadata["Command line"],
                 "needle -asequence seqa.fa -bsequence seqb.fa -datafile EBLOSUM62 -gapopen 10 -gapextend 0.5 -nobrief -outfile stdout",
             )
-            self.assertEqual(alignments.align_format, "srspair")
-            self.assertEqual(alignments.report_file, "stdout")
+            self.assertEqual(alignments.metadata["Align_format"], "srspair")
+            self.assertEqual(alignments.metadata["Report_file"], "stdout")
             alignments = list(alignments)
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
@@ -500,14 +500,14 @@ class TestEmboss(unittest.TestCase):
     def test_pair_example2(self):
         with open("Emboss/needle.txt") as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "needle")
-            self.assertEqual(alignments.rundate, "Sun 27 Apr 2007 17:20:35")
+            self.assertEqual(alignments.metadata["Program"], "needle")
+            self.assertEqual(alignments.metadata["Rundate"], "Sun 27 Apr 2007 17:20:35")
             self.assertEqual(
-                alignments.commandline,
+                alignments.metadata["Command line"],
                 "needle [-asequence] Spo0F.faa [-bsequence] paired_r.faa -sformat2 pearson",
             )
-            self.assertEqual(alignments.align_format, "srspair")
-            self.assertEqual(alignments.report_file, "ref_rec .needle")
+            self.assertEqual(alignments.metadata["Align_format"], "srspair")
+            self.assertEqual(alignments.metadata["Report_file"], "ref_rec .needle")
             alignments = list(alignments)
         self.assertEqual(len(alignments), 5)
         alignment = alignments[0]
@@ -717,14 +717,14 @@ class TestEmboss(unittest.TestCase):
     def test_pair_example3(self):
         with open("Emboss/needle_overhang.txt") as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "needle")
-            self.assertEqual(alignments.rundate, "Mon 14 Jul 2008 11:45:42")
+            self.assertEqual(alignments.metadata["Program"], "needle")
+            self.assertEqual(alignments.metadata["Rundate"], "Mon 14 Jul 2008 11:45:42")
             self.assertEqual(
-                alignments.commandline,
+                alignments.metadata["Command line"],
                 "needle [-asequence] asis:TGTGGTTAGGTTTGGTTTTATTGGGGGCTTGGTTTGGGCCCACCCCAAATAGGGAGTGGGGGTATGACCTCAGATAGACGAGCTTATTTTAGGGCGGCGACTATAATTATTTCGTTTCCTACAAGGATTAAAGTTTTTTCTTTTACTGTGGGAGGGGGTTTGGTATTAAGAAACGCTAGTCCGGATGTGGCTCTCCATGATACTTATTGTGTAGTAGCTCATTTTCATTATGTTCTTCGAATGGGAGCAGTCATTGGTATTTTTTTGGTTTTTTTTTGAAATTTTTAGGTTATTTAGACCATTTTTTTTTGTTTCGCTAATTAGAATTTTATTAGCCTTTGGTTTTTTTTTATTTTTTGGGGTTAAGACAAGGTGTCGTTGAATTAGTTTAGCAAAATACTGCTTAAGGTAGGCTATAGGATCTACCTTTTATCTTTCTAATCTTTTGTTTTAGTATAATTGGTCTTCGATTCAACAATTTTTAGTCTTCAGTCTTTTTTTTTATTTTGAAAAGGTTTTAACACTCTTGGTTTTGGAGGCTTTGGCTTTCTTCTTACTCTTAGGAGGATGGGCGCTAGAAAGAGTTTTAAGAGGGTGTGAAAGGGGGTTAATAGC [-bsequence] asis:TTATTAATCTTATGGTTTTGCCGTAAAATTTCTTTCTTTATTTTTTATTGTTAGGATTTTGTTGATTTTATTTTTCTCAAGAATTTTTAGGTCAATTAGACCGGCTTATTTTTTTGTCAGTGTTTAAAGTTTTATTAATTTTTGGGGGGGGGGGGAGACGGGGTGTTATCTGAATTAGTTTTTGGGAGTCTCTAGACATCTCATGGGTTGGCCGGGGGCCTGCCGTCTATAGTTCTTATTCCTTTTAAGGGAGTAAGAATTTCGATTCAGCAACTTTAGTTCACAGTCTTTTTTTTTATTAAGAAAGGTTT -filter",
             )
-            self.assertEqual(alignments.align_format, "srspair")
-            self.assertEqual(alignments.report_file, "stdout")
+            self.assertEqual(alignments.metadata["Align_format"], "srspair")
+            self.assertEqual(alignments.metadata["Report_file"], "stdout")
             alignments = list(alignments)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -876,14 +876,14 @@ class TestEmboss(unittest.TestCase):
     def test_needle_asis(self):
         with open("Emboss/needle_asis.txt") as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "needle")
-            self.assertEqual(alignments.rundate, "Mon 14 Jul 2008 11:37:15")
+            self.assertEqual(alignments.metadata["Program"], "needle")
+            self.assertEqual(alignments.metadata["Rundate"], "Mon 14 Jul 2008 11:37:15")
             self.assertEqual(
-                alignments.commandline,
+                alignments.metadata["Command line"],
                 "needle [-asequence] asis:TATTTTTTGGATTTTTTTCTAGATTTTCTAGGTTATTTAAACCGTTTTTTTTTAATTTAGTGTTTGAGTTTTGACAGGTCTCCACTTTGGGGGCTCCATCGCAAGGAAATTAGAATTCTTATACTTGGTTCTCTTTCCCAGGGACTCCAAGGATCTTTTCATTAGTTTGGATTTTGGTGTTTTCTTTAATTTTGTTAAGAAACAAATCCTTTCTAGAGTTTTTTCTAGCATTATGTTTTTTTTTCTCCTTATCTAAGGGGGTTTGTCGAGGTTTCTTAAATCTTTTTTTCTCTGGGTTTTAAAATTGTTTAAATTTTTTTGACCGAGGGGTTGGGGTGGTTTTCTCATGATAACAGGGGCTGGTGCTTTAGATCCTACCTCTACTGACCCGGGGTCTGCTACTGTGGCTTCTGATGAAGATCCACAGTATGCGCCTACGGAARCTCGGCAGTTTGGTGTTCGAAATCCAGCCCCTCGAATTAATACTCTTGTGCAGGTGGTTGACGAGCGCGGTATCGAATTGCAAAATTTGGGGCGGGACCCCGCTGTTCCGCCTGTTGCTCCGGGGGGGGCAGGTTAATCCTCCAGTCGTCTCCTTTTGGGGGCGTCTTTGACGGGGGTTTAAATCTTTCTTTGGTTGTGGATAGGATTTTTTTTCTAATATCGATCCTACCTGTTTTGGCGGGGCTATTACTTTGTTACTTTTGACCGAAATTTTAATGGAAATTTCTTTGATTCAAATGAATCCCTTAGTTTTCCAACACTTTTTTTTGGTTTTTTTAGGGATAGTCTACGCTGTGGTTAGGTTTGGTTTTATTGGGGGCTTGGTTTGGGCCCACCCCAAATAGGGAGTGGGGGTATGACCTCAGATAGACGAGCTTATTTTAGGGCGGCGACTATAATTATTTCGTTTCCTACAAGGATTAAAGTTTTTTCTTTTACTGTGGGAGGGGGTTTGGTATTAAGAAACGCTAGTCCGGATGTGGCTCTCCATGATACTTATTGTGTAGTAGCTCATTTTCATTATGTTCTTCGAATGGGAGCAGTCATTGGTATTTTTTTGGTTTTTTTTTGAAATTTTTAGGTTATTTAGACCATTTTTTTTTGTTTCGCTAATTAGAATTTTATTAGCCTTTGGTTTTTTTTTATTTTTTGGGGTTAAGACAAGGTGTCGTTGAATTAGTTTAGCAAAATACTGCTTAAGGTAGGCTATAGGATCTACCTTTTATCTTTCTAATCTTTTGTTTTAGTATAATTGGTCTTCGATTCAACAATTTTTAGTCTTCAGTCTTTTTTTTTATTTTGAAAAGGTTTTAACACTCTTGGTTTTGGAGGCTTTGGCTTTCTTCTTACTCTTAGGAGGATGGGCGCTAGAAAGAGTTTTAAGAGGGTGTGAAAGGGGGTTAATAGCAGGATTTGCTTTTTTAACTTATACTGGTTCGTAACGCATTAGCTCAACTCTCTCTTGTAGTTCTAGCAGCCGCCTTTTCTTTGTTGGGGGAGGGTTTAGGAGGAGTCTTTTTTTTCCTAACCCAAGGTGTTTCTTTCTTTTTTTCTTTAAAGTTCTTGACTGTTGGCACTTGTCTCCATAAATTTTCTTTCTTGTAAAGGGCTCCTAAGGCTTCTTGTTTCTGAATTCCTCTTTTCTTTTATTCTGTTTTGAGCTTATTTTTCTTGTTAGCTATTACGTAGGCATAGGGCAAATAATTTTTTTTTCTGCTCTCATTATTCCTTCTCCCTGCTTGTTTCACCCTGTGGGCTCTTTGAGCCCCACTAAGTGAGCGGGGCTCCTGCTTCCGCTCAATTAAATTTTGGTGGGTATTGAGTCTCAGAGGGACTATGATATAGGTTCAGATTGATGGACCTAATCAATCAATTGTATCGCTATACAATCTAGTACCCCTACCAGGGTACCAAGAGAGAGATAACTAGGGTGAATACTACGACTTAGATGTAGTGTTTAAGTTTCTACGGGCTACAGAGAAGCTACCCGCAGGGTAYATATTTGTTCATTACATATTTGTTGACTTTTCTATCTCTGCTTTTACTTTTTTATTTATTTTTAAATCTTTTTAACTTCAGCTGTTTTTCCTTATCTATTTGACGTAGGCATAGGAAAGTTAACGAATTTTGTAATATTTTTAATTATTTTGTATAGTATACAGGGTAGTGGTATGTAATAGGTAAATTCCATAAGTTCATTATAGTTTATCAGTTGAGAGGAATTTAGTATAAGAAGGCCCATTGGGGCTCTTGTCTTATCCAAGAACTGGTAAGATTTAATTCTACCGGGACGGTAGAAATCGGGCAGAGCATGATCTATTTCTTCGGGTATGGCTATAGGGACTAGGTGCTAGGGAGGTATTAGGGCACCGCTCTTTATACAATCTCCATAGATACAACCAGGTCAACTAGGACAACGGAGGACGTTGACAGAGCATAAATAGCGATAGCGTACAAGATAWAATAGGGGCAGTGGTAGCGAAGCGTAGAAGAAAAAATAAGAGTATTGTTTGTAAATAATTCTTTTTTTAGTTTTTAAATATTCTTTTTTTAGGTGGTGTGTGGTTAGGTATGGGGTTAAGGGTGTGGCAAAGAGAAATGTTTATTAAACATTCTTATGGCCGTAGATAGCATATCGATTATACGAGACCTTCGTAAGATCAATCCCCACTAGCATTGCTCATACAGGTTAACTCAATAGGAGGAGCTGGGGTAGAACGTTTCTAGTTCGGGGGTAACCGCAGTTCAATGAAAGTGACGACGTCGGATGGAACAAACTTAATACCACCAGTTGTGCTAACGATTGTTATCTCAATCTATCCCAACAGGCCCCCAGGTAGTGATGAGTGGTGGAATGGTACAGGGTACCAGTGGGTGAAGAGCGTCACGAACCAGGGAATACGGAGTACAGAGTTGAGCGCCCGGGGCTCCGCCCCCGGCTTTTATAGCGCGAGACGTGGTCAGTCGATTCAGCGTTAGGTTTAAACTCCTTTGGCAAAGATTGACTCTAGCGATCCAGAGACCCTGCCTGGCATAAAAGTCTTTATWAACACCAGTAGGTTCAATAAGGTAGTAATCCAATAGAATGGAAAACTCAAGATCTAATCTCTCGAYTTCCTAGTGTCATGGAAATCAGCCAGGTTCTCTTCATCTGCAACAGTAGAAGAAGAAGAGAGACTAGCGAGAGAGTCTTATGGCGGAGACGCTAAGGCTTAAATGTAATGTAGATAACCCCTTACGGAACACTAGAGTGCGACGTAGACTACATAATCCCTCAGGGATATTAGCTCTGCTCGATTAACAATAGCATACTTTGTTACACGGAGTGTATCTAGGGGGAATAATACTAACTTACTTAGCACTATCGCGATGCTACGCATTCGCTCTTTCGCTAAATAAGATACGACGATGAGTGGTTGGTGGAGAGAATAACCGATTCTAACTTGATAATTCGCATGAAATAATTTTTTTATTTTGTTTTTTTTTTGCTCTTAATTTTAGWGGGRGTGTTTATTTTTATTCTAATAAAAAGGATCCGTTGAA [-bsequence] asis:TTATTAATCTTATGGTTTTGCCGTAAAATTTCTTTCTTTATTTTTTATTGTTAGGATTTTGTTGATTTTATTTTTCTCAAGAATTTTTAGGTCAATTAGACCGGCTTATTTTTTTGTCAGTGTTTAAAGTTTTATTAATTTTTGGGGGGGGGGGGAGACGGGGTGTTATCTGAATTAGTTTTTGGGAGTCTCTAGACATCTCATGGGTTGGCCGGGGGCCTGCCGTCTATAGTTCTTATTCCTTTTAAGGGAGTAAGAATTTCGATTCAGCAACTTTAGTTCACAGTCTTTTTTTTTATTAAGAAAGGTTTTAATATTCTTGTGGTTTTGAACCTTTAGGTTTCTTTCTTTACCTTCGAGGGATTGGGCACTAGAATGAGTTTTAAGAGTGTGTGAAAGGGGGCTTGATAGCAGGGGAATGCTTTTTTAACTTATACTGGCTCGTAACGCATCAGTTCAACTCTCTCTTGCAGTTCTAGCAGCCGCCTTTTTTTTGTTGGGGGGGGGTTAAGAGAGTGTTTTTTTTCTAATCCAAGGGTCTTACTTTCTTTCTTTCTTTAAAAATTCTTTGGCTGTCGACACCTTTCTCTCCCGTCAGTCTCATGGTTTCTGGCTCTCTTGGGCTTTTTTTGTTTGTGAATGCCTCTTTTTTTTATTCTGTTTTGAGCTTATTTTTCTTGTTTACTATTACGTAGGTATAGGGCAAATAATTTTTTTTTCGCGTCTCTTGGCATGCCCATTACTCTAGTTTTATTCCCGGGCTTCTTCTCTCACCCTAGAGGGCTCTTTGAGCCCACACTCAAGTGAGCGGGGCTCCCGCTTCCGCTCAATTAAATTTGGTGGGTATTGAGTCTCAGAGGGACTATGATATAGGTTCAGATTGATGGACCTAGTCAATCAATTGTATCGCTATACAATCTAGTACCCCTACCAGGGTACCAGGAGAGAGATAACTAGGGTGAATACTACGACTTAGATGTACTGTTTAAGTTTCTACGGGCTACAGAGAAGCTACCCGCAGGGTATATATTTGCTCATTACATATTTGTTGATTTTTCTATGTCCGCTTTACTTTTTATATTTTTTTAACTTCAGCTGTTTTTCCTTATCTATTTGACGTAGGCATAGGAAAGTTAACGAATTTTGTAATATTTTTAATTATTTTGTATAGTATACAGGGTAGTGGTATGTAATAGGTAAATTCCATAAGTTCATTATAGTCTATCAGTTGAGAGGAATTTAGTATAAGAAAGCCTGTCAGGGCTCTTGCCTTATCCAAGAACTGGTAAGGATTTCTTGACAGAGGGACTCTGTCAAATCGGGCAGAGCATGATCTATTTCTTCGGGTATGGTTATAAGGCTTAGGTGCTTGGAGGGTATTAGGGCACCGCTCTTAATACAGTCTCCATAGGTGTAACCAGGTCAACTAGGACAACGGAGGACGTTGACAAAGCATGGATAGCGATAGCGTAGAAGATAAAATGGGGCAGTGGTAGCGAAGCGTAGAAGAAAAAATAAGAGTATTGTTTGTAAATAATTCTTTTTTTAGTTTTTAAATATTCTTTTTTTAGGTGGTGTGTGGTTAGGTATGGGGTTAGGGGAGTGGCAAAGAGAAGTGTTTATTAAACATTCTTATGGCCGTAGATAGCATATCGATTATACGAGACCTTCGTAAGATCAATCCCCACTAGCATTGCTCATACAGGTTAACTCAATAGGAGGAGCTGGGGTAGAACGTATCTAGTTCGGGGGTAACCGCAGTTCAATGAAAGTGACGACGTCGGATGGAACAAACTTAATACCACCAGTTGTGCTAACGATTGTTATCTCAATCTATCCCAACAGGCCCCCAGGTAGTGATGAGTGGTGGAATGGTACAGGGTACCAGTGGGTGAAGAGCGTCACGAACCAGGGAATACGGAGTACAGAGTTGAGCGCCCGGGGCTCCGCCCCCGGCTTTTATAGCGCGAGACGTGGTCAGTCGATTCAGCGTTAGGTTTTAAACTCCTTTGGCAAAGATTGATTCTAGCGATCCAGAGACCCTGCCTGGCATAAAAGTCTTTATTAGCACCAGTAGGTTCAATAAGGTAGTAGTCCAATAGAATGGAAAACTCGAGATCTAATCTCTCGATTTCCTAGTGTCATGGAAATCAGCCAGGTTCTCTTCATCTGCAACAGTAGAAGAAGAAGAGAGGCTAGCGAGAGAGTCTTATGGCGGAGACGCTAAGGCTTAAATGTAATGTAGATAACCCCTTACGGAACACTTGAGTGCGACGTAGACTACATAATCCCTCAGGGATATTAGCTCTGCTCGATTAACAATAGCATACTTTGTTACACGGAGTGTATCTGGGGGGAATAATACTAACTTACTTAGCACTATCGCGATGCTACGCATTCGCTCTTTCGCTAAATAAGATACGACGATGAGTGGTTGGTGGAGAGAATAACCGATTCTAACTTGATAATTCGCATGAAATAATTTTTTATTTGTTTTTTTTTTTGCTCTTAATTTTAGAGGATGTTTATTTTTATTCTAATAAAAAGGATCCGTTGAA -filter",
             )
-            self.assertEqual(alignments.align_format, "srspair")
-            self.assertEqual(alignments.report_file, "stdout")
+            self.assertEqual(alignments.metadata["Align_format"], "srspair")
+            self.assertEqual(alignments.metadata["Report_file"], "stdout")
             alignments = list(alignments)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -1197,14 +1197,14 @@ class TestEmboss(unittest.TestCase):
     def test_pair_aln_full_blank_line(self):
         with open("Emboss/emboss_pair_aln_full_blank_line.txt") as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "stretcher")
-            self.assertEqual(alignments.rundate, "Tue 15 May 2018 17:01:31")
+            self.assertEqual(alignments.metadata["Program"], "stretcher")
+            self.assertEqual(alignments.metadata["Rundate"], "Tue 15 May 2018 17:01:31")
             self.assertEqual(
-                alignments.commandline,
+                alignments.metadata["Command line"],
                 "stretcher -auto -stdout -asequence emboss_stretcher-I20180515-170128-0371-22292969-p1m.aupfile -bsequence emboss_stretcher-I20180515-170128-0371-22292969-p1m.bupfile -datafile EDNAFULL -gapopen 16 -gapextend 4 -aformat3 pair -snucleotide1 -snucleotide2",
             )
-            self.assertEqual(alignments.align_format, "pair")
-            self.assertEqual(alignments.report_file, "stdout")
+            self.assertEqual(alignments.metadata["Align_format"], "pair")
+            self.assertEqual(alignments.metadata["Report_file"], "stdout")
             alignments = list(alignments)
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]

--- a/Tests/test_Align_exonerate.py
+++ b/Tests/test_Align_exonerate.py
@@ -50,12 +50,12 @@ class Exonerate_est2genome(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m est2genome ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar yes --showvulgar no",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -155,12 +155,12 @@ class Exonerate_est2genome(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m est2genome ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar no --showvulgar yes",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -278,12 +278,12 @@ class Exonerate_affine_local(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m affine:local ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar yes --showvulgar no",
         )
-        self.assertEqual(alignments.hostname, "Michiels-MacBook-Pro.local")
+        self.assertEqual(alignments.metadata["Hostname"], "Michiels-MacBook-Pro.local")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -385,12 +385,12 @@ class Exonerate_affine_local(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m affine:local ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar no --showvulgar yes",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -510,12 +510,12 @@ class Exonerate_cdna2genome(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m cdna2genome ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar yes --showvulgar no",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -610,12 +610,12 @@ class Exonerate_cdna2genome(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m cdna2genome ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar no --showvulgar yes",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -727,12 +727,12 @@ class Exonerate_coding2coding(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m coding2coding ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar yes --showvulgar no",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -797,12 +797,12 @@ class Exonerate_coding2coding(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m coding2coding ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar no --showvulgar yes",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -875,12 +875,12 @@ class Exonerate_coding2genome(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m coding2genome ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar yes --showvulgar no",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -948,12 +948,12 @@ class Exonerate_coding2genome(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m coding2genome ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar no --showvulgar yes",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -1029,12 +1029,12 @@ class Exonerate_dna2protein(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate --showcigar yes --showvulgar no --showalignment no nuc2.fa pro.fa",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "dna")
         self.assertEqual(alignment.target.id, "protein")
@@ -1071,12 +1071,12 @@ class Exonerate_dna2protein(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate --showcigar no --showvulgar yes --showalignment no nuc2.fa pro.fa",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "dna")
         self.assertEqual(alignment.target.id, "protein")
@@ -1116,12 +1116,12 @@ class Exonerate_genome2genome(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m genome2genome ../intron.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showvulgar yes --showcigar yes",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "sacCer3_dna")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -1366,12 +1366,12 @@ class Exonerate_genome2genome(unittest.TestCase):
         self.check_vulgar(alignments)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m genome2genome ../intron.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showvulgar yes --showcigar no",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "sacCer3_dna")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -1520,12 +1520,12 @@ class Exonerate_ungapped(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m ungapped ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar yes --showvulgar no",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -1585,12 +1585,12 @@ class Exonerate_ungapped(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m ungapped ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar no --showvulgar yes",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -1658,12 +1658,12 @@ class Exonerate_ungapped_trans(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m ungapped:trans ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar yes --showvulgar no",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -1723,12 +1723,12 @@ class Exonerate_ungapped_trans(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m ungapped:trans ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar no --showvulgar yes",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -1796,12 +1796,12 @@ class Exonerate_ner(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m ner ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar yes --showvulgar no",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -1959,12 +1959,12 @@ class Exonerate_ner(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m ner ../scer_cad1.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar no --showvulgar yes",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -2124,12 +2124,12 @@ class Exonerate_multiple(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m est2genome comb.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar yes --showvulgar no",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296142823|ref|NM_001178508.1|")
         self.assertEqual(alignment.target.id, "gi|330443482|ref|NC_001134.8|")
@@ -2318,12 +2318,12 @@ class Exonerate_multiple(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m est2genome comb.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showvulgar yes",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296142823|ref|NM_001178508.1|")
         self.assertEqual(alignment.target.id, "gi|330443482|ref|NC_001134.8|")
@@ -2548,12 +2548,12 @@ class Exonerate_coding2coding_fshifts(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m coding2coding c2c_frameshift2.fa scer_cad1.fa --showcigar yes --showvulgar no --showalignment no --bestn 3",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|296143771|ref|NM_001180731.1|")
@@ -2612,12 +2612,12 @@ class Exonerate_coding2coding_fshifts(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m coding2coding c2c_frameshift2.fa scer_cad1.fa --showvulgar yes --showalignment no --bestn 3",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "gi|296143771|ref|NM_001180731.1|")
         self.assertEqual(alignment.target.id, "gi|296143771|ref|NM_001180731.1|")
@@ -2682,12 +2682,12 @@ class Exonerate_protein2dna(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m protein2dna ../scer_cad1_prot.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar yes --showvulgar no",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "sp|P24813|YAP2_YEAST")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -2749,12 +2749,12 @@ class Exonerate_protein2dna(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m protein2dna ../scer_cad1_prot.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar no --showvulgar yes",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "sp|P24813|YAP2_YEAST")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -2832,12 +2832,12 @@ class Exonerate_protein2dna_fshifts(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m protein2dna scer_cad1_prot.fa scer_cad1frameshift.fa --showcigar yes --showvulgar no --showalignment no --bestn 3",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "sp|P24813|YAP2_YEAST")
         self.assertEqual(alignment.target.id, "gi|296143771|ref|NM_001180731.1|")
@@ -2885,12 +2885,12 @@ class Exonerate_protein2dna_fshifts(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m protein2dna scer_cad1_prot.fa scer_cad1frameshift.fa --showvulgar yes --showalignment no --bestn 3",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "sp|P24813|YAP2_YEAST")
         self.assertEqual(alignment.target.id, "gi|296143771|ref|NM_001180731.1|")
@@ -2944,12 +2944,12 @@ class Exonerate_protein2genome(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m protein2genome ../scer_cad1_prot.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar yes --showvulgar no",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "sp|P24813|YAP2_YEAST")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -3015,12 +3015,12 @@ class Exonerate_protein2genome(unittest.TestCase):
         # does not regenerate all information provided in the vulgar file.
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m protein2genome ../scer_cad1_prot.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showalignment no --showcigar no --showvulgar yes",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "sp|P24813|YAP2_YEAST")
         self.assertEqual(alignment.target.id, "gi|330443520|ref|NC_001136.10|")
@@ -3102,12 +3102,12 @@ class Exonerate_protein2genome_revcomp_fshifts(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m protein2genome gene026_baits.fasta gene026_contigs.fasta --showalignment no --showcigar yes --showvulgar no --bestn 2 --refine full",
         )
-        self.assertEqual(alignments.hostname, "Michiels-MacBook-Pro.local")
+        self.assertEqual(alignments.metadata["Hostname"], "Michiels-MacBook-Pro.local")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "Morus-gene026")
         self.assertEqual(alignment.target.id, "NODE_2_length_1708_cov_48.590765")
@@ -3154,12 +3154,12 @@ class Exonerate_protein2genome_revcomp_fshifts(unittest.TestCase):
         self.check_vulgar(alignments, check_operations=False)
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m protein2genome gene026_baits.fasta gene026_contigs.fasta --showalignment no --showcigar no --showvulgar yes --bestn 2 --refine full",
         )
-        self.assertEqual(alignments.hostname, "Michiels-MacBook-Pro.local")
+        self.assertEqual(alignments.metadata["Hostname"], "Michiels-MacBook-Pro.local")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "Morus-gene026")
         self.assertEqual(alignment.target.id, "NODE_2_length_1708_cov_48.590765")
@@ -3210,12 +3210,12 @@ class Exonerate_protein2genome_met_intron(unittest.TestCase):
         self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m protein2genome gene001_baits.fasta gene001_contigs.fasta --showalignment no --showcigar yes --showvulgar no --bestn 1 --refine full",
         )
-        self.assertEqual(alignments.hostname, "Michiels-MacBook-Pro.local")
+        self.assertEqual(alignments.metadata["Hostname"], "Michiels-MacBook-Pro.local")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "Morus-gene001")
         self.assertEqual(alignment.target.id, "NODE_1_length_2817_cov_100.387732")
@@ -3258,12 +3258,12 @@ class Exonerate_protein2genome_met_intron(unittest.TestCase):
         # information provided in the vulgar file.
 
     def check_vulgar(self, alignments, check_operations=True):
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m protein2genome gene001_baits.fasta gene001_contigs.fasta --showalignment no --showcigar no --showvulgar yes --bestn 1 --refine full",
         )
-        self.assertEqual(alignments.hostname, "Michiels-MacBook-Pro.local")
+        self.assertEqual(alignments.metadata["Hostname"], "Michiels-MacBook-Pro.local")
         alignment = next(alignments)
         self.assertEqual(alignment.query.id, "Morus-gene001")
         self.assertEqual(alignment.target.id, "NODE_1_length_2817_cov_100.387732")
@@ -3297,12 +3297,12 @@ class Exonerate_none(unittest.TestCase):
         """Test parsing exonerate output (exn_22_q_none.exn)."""
         exn_file = os.path.join("Exonerate", "exn_22_q_none.exn")
         alignments = exonerate.AlignmentIterator(exn_file)
-        self.assertEqual(alignments.program, "exonerate")
+        self.assertEqual(alignments.metadata["Program"], "exonerate")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "exonerate -m est2genome none.fa /media/Waterloo/Downloads/genomes/scer_s288c/scer_s288c.fa --bestn 3 --showcigar yes --showvulgar yes",
         )
-        self.assertEqual(alignments.hostname, "blackbriar")
+        self.assertEqual(alignments.metadata["Hostname"], "blackbriar")
         self.assertRaises(StopIteration, next, alignments)
 
 

--- a/Tests/test_Align_hhr.py
+++ b/Tests/test_Align_hhr.py
@@ -31,8 +31,8 @@ class Align_hhr_2uvo_hhblits(unittest.TestCase):
         self.assertEqual(alignments.metadata["No_of_seqs"], (1560, 4005))
         self.assertAlmostEqual(alignments.metadata["Neff"], 8.3)
         self.assertEqual(alignments.metadata["Searched_HMMs"], 34)
-        self.assertEqual(alignments.metadata["Date"], "Fri Feb 15 16:34:13 2019")
-        self.assertEqual(alignments.commandline, "hhblits -i 2uvoAh.fasta -d /pdb70")
+        self.assertEqual(alignments.metadata["Rundate"], "Fri Feb 15 16:34:13 2019")
+        self.assertEqual(alignments.metadata["Command line"], "hhblits -i 2uvoAh.fasta -d /pdb70")
         alignment = next(alignments)
         self.assertAlmostEqual(alignment.annotations["Probab"], 99.95)
         self.assertAlmostEqual(alignment.annotations["E-value"], 3.7e-34)
@@ -1764,9 +1764,9 @@ class Align_hhr_2uvo_hhsearch(unittest.TestCase):
         self.assertEqual(alignments.metadata["No_of_seqs"], (1, 4))
         self.assertAlmostEqual(alignments.metadata["Neff"], 1.0)
         self.assertEqual(alignments.metadata["Searched_HMMs"], 38388)
-        self.assertEqual(alignments.metadata["Date"], "Fri Feb  1 13:49:32 2019")
+        self.assertEqual(alignments.metadata["Rundate"], "Fri Feb  1 13:49:32 2019")
         self.assertEqual(
-            alignments.commandline, "hhsearch -i 2uvo.fasta -d /pdb70_hhm_db"
+            alignments.metadata["Command line"], "hhsearch -i 2uvo.fasta -d /pdb70_hhm_db"
         )
         alignment = next(alignments)
         self.assertAlmostEqual(alignment.annotations["Probab"], 100.00)
@@ -3513,9 +3513,9 @@ class Align_hhr_allx(unittest.TestCase):
         self.assertEqual(alignments.metadata["No_of_seqs"], (1, 1))
         self.assertAlmostEqual(alignments.metadata["Neff"], 1.0)
         self.assertEqual(alignments.metadata["Searched_HMMs"], 38388)
-        self.assertEqual(alignments.metadata["Date"], "Fri Feb 15 16:24:19 2019")
+        self.assertEqual(alignments.metadata["Rundate"], "Fri Feb 15 16:24:19 2019")
         self.assertEqual(
-            alignments.commandline, "hhsearch -i allx.fasta -d /pdb70_hhm_db"
+            alignments.metadata["Command line"], "hhsearch -i allx.fasta -d /pdb70_hhm_db"
         )
         alignment = next(alignments)
         self.assertAlmostEqual(alignment.annotations["Probab"], 0.04)
@@ -3966,9 +3966,9 @@ class Align_hhr_4p79_hhsearch_server_NOssm(unittest.TestCase):
         self.assertEqual(alignments.metadata["No_of_seqs"], (110, 1051))
         self.assertAlmostEqual(alignments.metadata["Neff"], 10.453)
         self.assertEqual(alignments.metadata["Searched_HMMs"], 46616)
-        self.assertEqual(alignments.metadata["Date"], "Thu Nov 29 16:33:45 2018")
+        self.assertEqual(alignments.metadata["Rundate"], "Thu Nov 29 16:33:45 2018")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "hhsearch -cpu 8 -i ../results/full.a3m -d /cluster/toolkit/production/databases/hh-suite/mmcif70/pdb70 -o ../results/4P79_1.hhr -oa3m ../results/4P79_1.a3m -p 50 -Z 250 -loc -z 1 -b 1 -B 250 -ssm 0 -sc 1 -seq 1 -dbstrlen 10000 -norealign -maxres 32000 -contxt /cluster/toolkit/production/bioprogs/tools/hh-suite-build/data/context_data.crf",
         )
         alignment = next(alignments)
@@ -4460,9 +4460,9 @@ class Align_hhr_4y9h_hhsearch_server_NOssm(unittest.TestCase):
         self.assertEqual(alignments.metadata["No_of_seqs"], (141, 1242))
         self.assertAlmostEqual(alignments.metadata["Neff"], 8.55177)
         self.assertEqual(alignments.metadata["Searched_HMMs"], 46616)
-        self.assertEqual(alignments.metadata["Date"], "Thu Nov 29 16:28:55 2018")
+        self.assertEqual(alignments.metadata["Rundate"], "Thu Nov 29 16:28:55 2018")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "hhsearch -cpu 8 -i ../results/full.a3m -d /cluster/toolkit/production/databases/hh-suite/mmcif70/pdb70 -o ../results/4Y9H_1.hhr -oa3m ../results/4Y9H_1.a3m -p 50 -Z 250 -loc -z 1 -b 1 -B 250 -ssm 0 -sc 1 -seq 1 -dbstrlen 10000 -norealign -maxres 32000 -contxt /cluster/toolkit/production/bioprogs/tools/hh-suite-build/data/context_data.crf",
         )
         alignment = next(alignments)
@@ -6257,9 +6257,9 @@ class Align_hhr_hhpred_9590198(unittest.TestCase):
         self.assertEqual(alignments.metadata["No_of_seqs"], (157, 584))
         self.assertAlmostEqual(alignments.metadata["Neff"], 6.82639)
         self.assertEqual(alignments.metadata["Searched_HMMs"], 64707)
-        self.assertEqual(alignments.metadata["Date"], "Fri Feb  1 15:48:30 2019")
+        self.assertEqual(alignments.metadata["Rundate"], "Fri Feb  1 15:48:30 2019")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "hhsearch -cpu 8 -i ../results/full.a3m -d /cluster/toolkit/production/databases/hh-suite/mmcif70/pdb70 -d /cluster/toolkit/production/databases/hh-suite/pfama/pfama -o ../results/9590198.hhr -oa3m ../results/9590198.a3m -p 20 -Z 250 -loc -z 1 -b 1 -B 250 -ssm 2 -sc 1 -seq 1 -dbstrlen 10000 -norealign -maxres 32000 -contxt /cluster/toolkit/production/bioprogs/tools/hh-suite-build/data/context_data.crf",
         )
         alignment = next(alignments)
@@ -8162,9 +8162,9 @@ class Align_hhr_hhsearch_q9bsu1_uniclust_w_ss_pfamA_30(unittest.TestCase):
         self.assertEqual(alignments.metadata["No_of_seqs"], (149, 573))
         self.assertAlmostEqual(alignments.metadata["Neff"], 6.62119)
         self.assertEqual(alignments.metadata["Searched_HMMs"], 16712)
-        self.assertEqual(alignments.metadata["Date"], "Wed Feb 13 09:26:07 2019")
+        self.assertEqual(alignments.metadata["Rundate"], "Wed Feb 13 09:26:07 2019")
         self.assertEqual(
-            alignments.commandline,
+            alignments.metadata["Command line"],
             "/home/shah/hh-suite/build/bin/hhsearch -i /home/shah/seq/q9bsu1/hhblits/q9bsu1_uniclust_w_ss.a3m -d /home/shah/db/pfamA_30/pfam -o /home/shah/seq/q9bsu1/hhsearch_q9bsu1_uniclust_w_ss_pfamA_30.hhr -p 20 -Z 250 -loc -z 1 -b 1 -B 250 -ssm 2 -sc 1 -seq 1 -dbstrlen 10000 -norealign -maxres 32000",
         )
         alignment = next(alignments)
@@ -9032,7 +9032,7 @@ class Align_hhr_2uvo_hhblits_emptytable(unittest.TestCase):
         self.assertEqual(alignments.metadata["No_of_seqs"], (1560, 4005))
         self.assertAlmostEqual(alignments.metadata["Neff"], 8.3)
         self.assertEqual(alignments.metadata["Searched_HMMs"], 34)
-        self.assertEqual(alignments.metadata["Date"], "Fri Feb 15 16:34:13 2019")
+        self.assertEqual(alignments.metadata["Rundate"], "Fri Feb 15 16:34:13 2019")
         with self.assertRaises(StopIteration):
             next(alignments)
 

--- a/Tests/test_Align_maf.py
+++ b/Tests/test_Align_maf.py
@@ -30,8 +30,8 @@ class TestAlign_reading(unittest.TestCase):
         """Test parsing bundle_without_target.maf."""
         path = "MAF/bundle_without_target.maf"
         alignments = maf.AlignmentIterator(path)
-        self.assertEqual(alignments.metadata["version"], "1")
-        self.assertEqual(alignments.metadata["scoring"], "autoMZ.v1")
+        self.assertEqual(alignments.metadata["MAF Version"], "1")
+        self.assertEqual(alignments.metadata["Scoring"], "autoMZ.v1")
         alignment = next(alignments)
         self.assertRaises(StopIteration, next, alignments)
         self.assertEqual(alignment.score, 6441)
@@ -80,8 +80,8 @@ class TestAlign_reading(unittest.TestCase):
         """Test parsing MAF file ucsc_mm9_chr10.maf."""
         path = "MAF/ucsc_mm9_chr10.maf"
         alignments = maf.AlignmentIterator(path)
-        self.assertEqual(alignments.metadata["version"], "1")
-        self.assertEqual(alignments.metadata["scoring"], "autoMZ.v1")
+        self.assertEqual(alignments.metadata["MAF Version"], "1")
+        self.assertEqual(alignments.metadata["Scoring"], "autoMZ.v1")
         alignment = next(alignments)
         self.assertEqual(alignment.score, 6441)
         self.assertEqual(alignment.sequences[0].id, "mm9.chr10")
@@ -6940,8 +6940,8 @@ class TestAlign_reading(unittest.TestCase):
         """Test parsing MAF file ucsc_mm9_chr10_bad.maf with incorrect sequence size."""
         path = "MAF/ucsc_mm9_chr10_bad.maf"
         alignments = maf.AlignmentIterator(path)
-        self.assertEqual(alignments.metadata["version"], "1")
-        self.assertEqual(alignments.metadata["scoring"], "autoMZ.v1")
+        self.assertEqual(alignments.metadata["MAF Version"], "1")
+        self.assertEqual(alignments.metadata["Scoring"], "autoMZ.v1")
         next(alignments)
         next(alignments)
         next(alignments)
@@ -6958,8 +6958,8 @@ class TestAlign_reading(unittest.TestCase):
         """Test parsing inconsistent MAF file length_coords_mismatch.maf."""
         path = "MAF/length_coords_mismatch.maf"
         alignments = maf.AlignmentIterator(path)
-        self.assertEqual(alignments.metadata["version"], "1")
-        self.assertEqual(alignments.metadata["scoring"], "autoMZ.v1")
+        self.assertEqual(alignments.metadata["MAF Version"], "1")
+        self.assertEqual(alignments.metadata["Scoring"], "autoMZ.v1")
         alignment = next(alignments)
         self.assertEqual(alignment.score, 6441)
         self.assertEqual(len(alignment.sequences), 2)
@@ -7021,10 +7021,10 @@ class TestAlign_reading(unittest.TestCase):
         self.check_ucsc_test(alignments)
 
     def check_ucsc_test(self, alignments):
-        self.assertEqual(alignments.metadata["version"], "1")
-        self.assertEqual(alignments.metadata["scoring"], "tba.v8")
+        self.assertEqual(alignments.metadata["MAF Version"], "1")
+        self.assertEqual(alignments.metadata["Scoring"], "tba.v8")
         self.assertEqual(
-            alignments.metadata["comments"],
+            alignments.metadata["Comments"],
             [
                 "tba.v8 (((human chimp) baboon) (mouse rat))",
                 "multiz.v7",

--- a/Tests/test_Align_psl.py
+++ b/Tests/test_Align_psl.py
@@ -55,7 +55,7 @@ class TestAlign_dna_rna(unittest.TestCase):
         """Test parsing dna_rna.psl."""
         path = "Blat/dna_rna.psl"
         alignments = psl.AlignmentIterator(path)
-        self.assertEqual(alignments.metadata["version"], "3")
+        self.assertEqual(alignments.metadata["psLayout version"], "3")
         alignment = next(alignments)
         self.assertEqual(alignment.matches, 165)
         self.assertEqual(alignment.misMatches, 0)
@@ -338,7 +338,7 @@ class TestAlign_dna(unittest.TestCase):
         """Check parsing psl_34_001.psl or pslx_34_001.pslx."""
         path = "Blat/%s_34_001.%s" % (fmt, fmt)
         alignments = psl.AlignmentIterator(path)
-        self.assertEqual(alignments.metadata["version"], "3")
+        self.assertEqual(alignments.metadata["psLayout version"], "3")
         alignment = next(alignments)
         self.assertEqual(alignment.matches, 16)
         self.assertEqual(alignment.misMatches, 0)
@@ -1095,7 +1095,7 @@ class TestAlign_dna(unittest.TestCase):
     def check_reading_psl_34_002(self, path):
         """Check parsing psl_34_002.psl or pslx_34_002.pslx."""
         alignments = psl.AlignmentIterator(path)
-        self.assertEqual(alignments.metadata["version"], "3")
+        self.assertEqual(alignments.metadata["psLayout version"], "3")
         self.assertRaises(StopIteration, next, alignments)
 
     def test_writing_psl_34_002(self):
@@ -1122,7 +1122,7 @@ class TestAlign_dna(unittest.TestCase):
         """Check parsing psl_34_003.psl or pslx_34_003.pslx."""
         path = "Blat/%s_34_003.%s" % (fmt, fmt)
         alignments = psl.AlignmentIterator(path)
-        self.assertEqual(alignments.metadata["version"], "3")
+        self.assertEqual(alignments.metadata["psLayout version"], "3")
         alignment = next(alignments)
         self.assertEqual(alignment.matches, 16)
         self.assertEqual(alignment.misMatches, 0)
@@ -1244,7 +1244,7 @@ class TestAlign_dna(unittest.TestCase):
         """Check parsing psl_34_004.psl or pslx_34_004.pslx."""
         path = "Blat/%s_34_004.%s" % (fmt, fmt)
         alignments = psl.AlignmentIterator(path)
-        self.assertEqual(alignments.metadata["version"], "3")
+        self.assertEqual(alignments.metadata["psLayout version"], "3")
         alignment = next(alignments)
         self.assertEqual(alignment.matches, 38)
         self.assertEqual(alignment.misMatches, 3)
@@ -2661,7 +2661,7 @@ class TestAlign_dnax_prot(unittest.TestCase):
         """Check parsing psl_35_001.psl or pslx_35_001.pslx."""
         path = "Blat/%s_35_001.%s" % (fmt, fmt)
         alignments = psl.AlignmentIterator(path)
-        self.assertEqual(alignments.metadata["version"], "3")
+        self.assertEqual(alignments.metadata["psLayout version"], "3")
         alignment = next(alignments)
         self.assertEqual(alignment.matches, 52)
         self.assertEqual(alignment.misMatches, 0)
@@ -3222,7 +3222,7 @@ QFLKQLGLHPNWQFVDVYGMDPELLSMVPRPVCAVLLLFPITDEKVDLHFIALVHVDGHLYEL
         """Check parsing psl_35_002.psl or pslx_35_002.pslx."""
         path = "Blat/%s_35_002.%s" % (fmt, fmt)
         alignments = psl.AlignmentIterator(path)
-        self.assertEqual(alignments.metadata["version"], "3")
+        self.assertEqual(alignments.metadata["psLayout version"], "3")
         alignment = next(alignments)
         self.assertEqual(alignment.matches, 210)
         self.assertEqual(alignment.misMatches, 3)

--- a/Tests/test_Align_tabular.py
+++ b/Tests/test_Align_tabular.py
@@ -45,12 +45,12 @@ class TestFastaProtein(unittest.TestCase):
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
             self.assertEqual(
-                alignments.commandline,
+                alignments.metadata["Command line"],
                 "fasta36 -q -m 8CB seq/mgstm1.aa seq/prot_test.lseg",
             )
-            self.assertEqual(alignments.program, "FASTA")
-            self.assertEqual(alignments.metadata["version"], "36.3.8h May, 2020")
-            self.assertEqual(alignments.metadata["database"], "seq/prot_test.lseg")
+            self.assertEqual(alignments.metadata["Program"], "FASTA")
+            self.assertEqual(alignments.metadata["Version"], "36.3.8h May, 2020")
+            self.assertEqual(alignments.metadata["Database"], "seq/prot_test.lseg")
             alignments = list(alignments)
         self.assertEqual(len(alignments), 12)
         # sp|P10649|GSTM1_MOUSE   sp|P09488|GSTM1_HUMAN
@@ -472,12 +472,12 @@ class TestFastaProtein(unittest.TestCase):
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
             self.assertEqual(
-                alignments.commandline,
+                alignments.metadata["Command line"],
                 "fasta36 -q -m 8CC seq/mgstm1.aa seq/prot_test.lseg",
             )
-            self.assertEqual(alignments.program, "FASTA")
-            self.assertEqual(alignments.metadata["version"], "36.3.8h May, 2020")
-            self.assertEqual(alignments.metadata["database"], "seq/prot_test.lseg")
+            self.assertEqual(alignments.metadata["Program"], "FASTA")
+            self.assertEqual(alignments.metadata["Version"], "36.3.8h May, 2020")
+            self.assertEqual(alignments.metadata["Database"], "seq/prot_test.lseg")
             alignments = list(alignments)
         self.assertEqual(len(alignments), 12)
         # sp|P10649|GSTM1_MOUSE   sp|P09488|GSTM1_HUMAN
@@ -913,12 +913,12 @@ class TestFastaNucleotide(unittest.TestCase):
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
             self.assertEqual(
-                alignments.commandline,
+                alignments.metadata["Command line"],
                 "fasta36 -m 8CB seq/mgstm1.nt seq/gst.nlib",
             )
-            self.assertEqual(alignments.program, "FASTA")
-            self.assertEqual(alignments.metadata["version"], "36.3.8h May, 2020")
-            self.assertEqual(alignments.metadata["database"], "seq/gst.nlib")
+            self.assertEqual(alignments.metadata["Program"], "FASTA")
+            self.assertEqual(alignments.metadata["Version"], "36.3.8h May, 2020")
+            self.assertEqual(alignments.metadata["Database"], "seq/gst.nlib")
             alignments = list(alignments)
         self.assertEqual(len(alignments), 12)
         # pGT875   pGT875
@@ -1326,12 +1326,12 @@ class TestFastaNucleotide(unittest.TestCase):
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
             self.assertEqual(
-                alignments.commandline,
+                alignments.metadata["Command line"],
                 "fasta36 -m 8CC seq/mgstm1.nt seq/gst.nlib",
             )
-            self.assertEqual(alignments.program, "FASTA")
-            self.assertEqual(alignments.metadata["version"], "36.3.8h May, 2020")
-            self.assertEqual(alignments.metadata["database"], "seq/gst.nlib")
+            self.assertEqual(alignments.metadata["Program"], "FASTA")
+            self.assertEqual(alignments.metadata["Version"], "36.3.8h May, 2020")
+            self.assertEqual(alignments.metadata["Database"], "seq/gst.nlib")
             alignments = list(alignments)
         self.assertEqual(len(alignments), 12)
         # pGT875   pGT875
@@ -1770,9 +1770,9 @@ class TestBlast(unittest.TestCase):
         path = "Blast/tab_2226_tblastn_005.txt"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "TBLASTN")
-            self.assertEqual(alignments.metadata["version"], "2.2.26+")
-            self.assertEqual(alignments.metadata["database"], "db/minirefseq_mrna")
+            self.assertEqual(alignments.metadata["Program"], "TBLASTN")
+            self.assertEqual(alignments.metadata["Version"], "2.2.26+")
+            self.assertEqual(alignments.metadata["Database"], "db/minirefseq_mrna")
             alignment = next(alignments)
             self.assertEqual(alignment.query.id, "gi|16080617|ref|NP_391444.1|")
             self.assertEqual(alignment.target.id, "gi|145479850|ref|XM_001425911.1|")
@@ -1945,9 +1945,9 @@ class TestBlast(unittest.TestCase):
         path = "Blast/tab_2226_tblastn_007.txt"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "TBLASTN")
-            self.assertEqual(alignments.metadata["version"], "2.2.26+")
-            self.assertEqual(alignments.metadata["database"], "db/minirefseq_mrna")
+            self.assertEqual(alignments.metadata["Program"], "TBLASTN")
+            self.assertEqual(alignments.metadata["Version"], "2.2.26+")
+            self.assertEqual(alignments.metadata["Database"], "db/minirefseq_mrna")
             alignment = next(alignments)
             self.assertEqual(alignment.query.id, "gi|16080617|ref|NP_391444.1|")
             self.assertEqual(alignment.target.id, "gi|145479850|ref|XM_001425911.1|")
@@ -2006,9 +2006,9 @@ class TestBlast(unittest.TestCase):
         path = "Blast/tab_2226_tblastn_008.txt"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "TBLASTN")
-            self.assertEqual(alignments.metadata["version"], "2.2.26+")
-            self.assertEqual(alignments.metadata["database"], "db/minirefseq_mrna")
+            self.assertEqual(alignments.metadata["Program"], "TBLASTN")
+            self.assertEqual(alignments.metadata["Version"], "2.2.26+")
+            self.assertEqual(alignments.metadata["Database"], "db/minirefseq_mrna")
 
             alignment = next(alignments)
             self.assertEqual(alignment.query.id, "gi|11464971:4-101")
@@ -2149,9 +2149,9 @@ class TestBlast(unittest.TestCase):
         path = "Blast/tab_2226_tblastn_010.txt"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "TBLASTN")
-            self.assertEqual(alignments.metadata["version"], "2.2.26+")
-            self.assertEqual(alignments.metadata["database"], "db/minirefseq_mrna")
+            self.assertEqual(alignments.metadata["Program"], "TBLASTN")
+            self.assertEqual(alignments.metadata["Version"], "2.2.26+")
+            self.assertEqual(alignments.metadata["Database"], "db/minirefseq_mrna")
 
             alignment = next(alignments)
             self.assertEqual(alignment.query.id, "gi|16080617|ref|NP_391444.1|")
@@ -2220,9 +2220,9 @@ class TestBlast(unittest.TestCase):
         path = "Blast/tab_2226_tblastn_011.txt"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "TBLASTN")
-            self.assertEqual(alignments.metadata["version"], "2.2.26+")
-            self.assertEqual(alignments.metadata["database"], "db/minirefseq_mrna")
+            self.assertEqual(alignments.metadata["Program"], "TBLASTN")
+            self.assertEqual(alignments.metadata["Version"], "2.2.26+")
+            self.assertEqual(alignments.metadata["Database"], "db/minirefseq_mrna")
             alignment = next(alignments)
             self.assertEqual(alignment.query.id, "gi|16080617|ref|NP_391444.1|")
             self.assertEqual(
@@ -2906,10 +2906,10 @@ class TestBlast(unittest.TestCase):
         path = "Blast/tab_2226_tblastn_012.txt"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "TBLASTN")
-            self.assertEqual(alignments.metadata["version"], "2.2.26+")
+            self.assertEqual(alignments.metadata["Program"], "TBLASTN")
+            self.assertEqual(alignments.metadata["Version"], "2.2.26+")
             self.assertEqual(alignments.metadata["RID"], "X76FDCG9016")
-            self.assertEqual(alignments.metadata["database"], "refseq_rna")
+            self.assertEqual(alignments.metadata["Database"], "refseq_rna")
 
             alignment = next(alignments)
             self.assertEqual(alignment.query.id, "gi|16080617|ref|NP_391444.1|")
@@ -3083,10 +3083,10 @@ class TestBlast(unittest.TestCase):
         path = "Blast/tab_2228_tblastn_001.txt"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "TBLASTN")
-            self.assertEqual(alignments.metadata["version"], "2.2.28+")
+            self.assertEqual(alignments.metadata["Program"], "TBLASTN")
+            self.assertEqual(alignments.metadata["Version"], "2.2.28+")
             self.assertEqual(alignments.metadata["RID"], "M6BMVNA2015")
-            self.assertEqual(alignments.metadata["database"], "nr")
+            self.assertEqual(alignments.metadata["Database"], "nr")
 
             alignment = next(alignments)
             self.assertEqual(alignment.query.id, "gi|148227874|ref|NP_001088636.1|")
@@ -3166,10 +3166,10 @@ class TestBlast(unittest.TestCase):
         path = "Blast/tab_2228_tblastx_001.txt"
         with open(path) as stream:
             alignments = AlignmentIterator(stream)
-            self.assertEqual(alignments.program, "TBLASTX")
-            self.assertEqual(alignments.metadata["version"], "2.2.28+")
+            self.assertEqual(alignments.metadata["Program"], "TBLASTX")
+            self.assertEqual(alignments.metadata["Version"], "2.2.28+")
             self.assertEqual(alignments.metadata["RID"], "P06P5RN0015")
-            self.assertEqual(alignments.metadata["database"], "refseq_rna")
+            self.assertEqual(alignments.metadata["Database"], "refseq_rna")
             alignment = next(alignments)
             self.assertTrue(
                 numpy.array_equal(


### PR DESCRIPTION
Use the `.metadata` dictionary consistently to store metadata in the `AlignmentIterator` object, instead of saving some metadata in this dictionary and others as attributes of `AlignmentIterator`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

