### PR TITLE
Clean up Bio.Align.interfaces

### DIFF
--- a/Bio/Align/a2m.py
+++ b/Bio/Align/a2m.py
@@ -76,8 +76,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         """
         super().__init__(source, mode="t", fmt="A2M")
 
-    def parse(self, stream):
-        """Parse the next alignment from the stream."""
+    def _read_next_alignment(self, stream):
         names = []
         descriptions = []
         lines = []
@@ -127,4 +126,5 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         alignment = Alignment(records, coordinates)
         alignment.column_annotations = {}
         alignment.column_annotations["state"] = state
-        yield alignment
+        self._close()  # a2m files contain only one alignment
+        return alignment

--- a/Bio/Align/clustal.py
+++ b/Bio/Align/clustal.py
@@ -111,7 +111,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
         """
         super().__init__(source, mode="t", fmt="Clustal")
-        stream = self.stream
+
+    def _read_header(self, stream):
         try:
             line = next(stream)
         except StopIteration:
@@ -144,11 +145,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 self.metadata["Version"] = word
                 break
 
-    def parse(self, stream):
-        """Parse the next alignment from the stream."""
-        if stream is None:
-            raise StopIteration
-
+    def _read_next_alignment(self, stream):
         # If the alignment contains entries with the same sequence
         # identifier (not a good idea - but seems possible), then this
         # dictionary based parser will merge their sequences.  Fix this?
@@ -262,8 +259,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         ]
         coordinates = Alignment.infer_coordinates(aligned_seqs)
         alignment = Alignment(records, coordinates)
-        # TODO - Handle alignment annotation better, for now
-        # mimic the old parser in Bio.Clustalw
         if consensus:
             rows, columns = alignment.shape
             if len(consensus) != columns:
@@ -275,4 +270,5 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 )
             alignment.column_annotations = {}
             alignment.column_annotations["clustal_consensus"] = consensus
-        yield alignment
+        self._close()
+        return alignment

--- a/Bio/Align/emboss.py
+++ b/Bio/Align/emboss.py
@@ -40,7 +40,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
         """
         super().__init__(source, mode="t", fmt="EMBOSS")
-        stream = self.stream
+
+    def _read_header(self, stream):
         try:
             line = next(stream)
         except StopIteration:
@@ -76,11 +77,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             elif key == "Commandline":
                 commandline = value.strip()
 
-    def parse(self, stream):
-        """Parse the next alignment from the stream."""
-        if stream is None:
-            raise StopIteration
-
+    def _read_next_alignment(self, stream):
         identifiers = None
         number_of_sequences = None
         annotations = {}
@@ -201,9 +198,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                                 alignment.column_annotations = {
                                     "emboss_consensus": consensus
                                 }
-                            yield alignment
-                            identifiers = None
-                            annotations = {}
+                            return alignment
                     continue
                 prefix = line[:21].strip()
                 if prefix == "":

--- a/Bio/Align/fasta.py
+++ b/Bio/Align/fasta.py
@@ -65,8 +65,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         """
         super().__init__(source, mode="t", fmt="FASTA")
 
-    def parse(self, stream):
-        """Parse the next alignment from the stream."""
+    def _read_next_alignment(self, stream):
         names = []
         descriptions = []
         lines = []
@@ -96,4 +95,5 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 record = SeqRecord(sequence, name, description=description)
             records.append(record)
         alignment = Alignment(records, coordinates)
-        yield alignment
+        self._close()
+        return alignment

--- a/Bio/Align/hhr.py
+++ b/Bio/Align/hhr.py
@@ -115,15 +115,24 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             query = SeqRecord(query_seq, id=self.query_name)
             sequence = {target_start: target_sequence.replace("-", "")}
             target_seq = Seq(sequence, length=target_length)
-            target_annotations = {"hmm_name": hmm_name, "hmm_description": hmm_description}
-            target = SeqRecord(target_seq, id=target_name, annotations=target_annotations)
+            target_annotations = {
+                "hmm_name": hmm_name,
+                "hmm_description": hmm_description,
+            }
+            target = SeqRecord(
+                target_seq, id=target_name, annotations=target_annotations
+            )
             fmt = f"{' ' * target_start}%-{target_length - target_start}s"
-            target.letter_annotations["Consensus"] = fmt % target_consensus.replace("-", "")
+            target.letter_annotations["Consensus"] = fmt % target_consensus.replace(
+                "-", ""
+            )
             target.letter_annotations["ss_pred"] = fmt % target_ss_pred.replace("-", "")
             target.letter_annotations["ss_dssp"] = fmt % target_ss_dssp.replace("-", "")
             target.letter_annotations["Confidence"] = fmt % confidence.replace(" ", "")
             fmt = f"{' ' * query_start}%-{query_length - query_start}s"
-            query.letter_annotations["Consensus"] = fmt % query_consensus.replace("-", "")
+            query.letter_annotations["Consensus"] = fmt % query_consensus.replace(
+                "-", ""
+            )
             query.letter_annotations["ss_pred"] = fmt % query_ss_pred.replace("-", "")
             records = [target, query]
             alignment = Alignment(records, coordinates=coordinates)
@@ -178,7 +187,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 assert int(value) == self._counter
                 if self._counter > self._number:
                     raise ValueError(
-                        "Expected %d alignments, found %d" % (self._number, self._counter)
+                        "Expected %d alignments, found %d"
+                        % (self._number, self._counter)
                     )
                 if counter > 0:
                     return create_alignment()
@@ -244,7 +254,5 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             del self._number
             del self._counter
         if alignment is None and number > 0:
-            raise ValueError(
-                "Expected %d alignments, found %d" % (number, counter)
-            )
+            raise ValueError("Expected %d alignments, found %d" % (number, counter))
         return alignment

--- a/Bio/Align/maf.py
+++ b/Bio/Align/maf.py
@@ -30,8 +30,6 @@ zero-based end position. We can therefore manipulate ``start`` and
 """
 import shlex
 
-from itertools import chain
-
 
 from Bio.Align import Alignment
 from Bio.Align import interfaces

--- a/Bio/Align/maf.py
+++ b/Bio/Align/maf.py
@@ -352,9 +352,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             elif key == "pass":
                 value = int(value)
                 if value <= 0:
-                    raise ValueError(
-                        "pass value must be positive (found %d)" % value
-                    )
+                    raise ValueError("pass value must be positive (found %d)" % value)
                 annotations["pass"] = value
             else:
                 raise ValueError("Unknown annotation variable '%s'" % key)

--- a/Bio/Align/maf.py
+++ b/Bio/Align/maf.py
@@ -277,7 +277,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
         """
         super().__init__(source, mode="t", fmt="MAF")
-        stream = self.stream
+
+    def _read_header(self, stream):
         metadata = {}
         line = next(stream)
         if line.startswith("track "):
@@ -324,76 +325,44 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         for line in stream:
             if line.strip():
                 if not line.startswith("#"):
-                    self.line = line
+                    self._line = line
                     break
                 comment = line[1:].strip()
                 comments.append(comment)
         else:
-            self.stream = None
-            self.line = None
+            self._close()
         if comments:
             metadata["Comments"] = comments
         self.metadata = metadata
 
-    @staticmethod
-    def create_alignment(
-        records,
-        aligned_sequences,
-        strands,
-        annotations,
-        column_annotations,
-        score,
-    ):
-        """Create the Alignment object from the collected alignment data."""
-        coordinates = Alignment.infer_coordinates(aligned_sequences)
-        for record, strand, row in zip(records, strands, coordinates):
-            if strand == "-":
-                row[:] = row[-1] - row[0] - row
-            start = record.seq.defined_ranges[0][0]
-            row += start
-        alignment = Alignment(records, coordinates)
-        if annotations is not None:
-            alignment.annotations = annotations
-        if column_annotations is not None:
-            alignment.column_annotations = column_annotations
-        if score is not None:
-            alignment.score = score
-        return alignment
+    def _read_next_alignment(self, stream):
+        records = []
+        strands = []
+        column_annotations = {}
+        aligned_sequences = []
+        annotations = {}
 
-    def parse(self, stream):
-        """Parse the next alignment from the stream."""
-        if stream is None:
-            raise StopIteration
+        line = self._line
+        assert line.startswith("a")
+        words = line[1:].split()
+        for word in words:
+            key, value = word.split("=")
+            if key == "score":
+                score = float(value)
+            elif key == "pass":
+                value = int(value)
+                if value <= 0:
+                    raise ValueError(
+                        "pass value must be positive (found %d)" % value
+                    )
+                annotations["pass"] = value
+            else:
+                raise ValueError("Unknown annotation variable '%s'" % key)
 
-        line = self.line
-        self.line = None
-        if line is not None:
-            lines = chain([line], stream)
-        else:
-            lines = stream
-        records = None
-        for line in lines:
+        for line in stream:
             if line.startswith("a"):
-                strands = []
-                annotations = {}
-                column_annotations = {}
-                records = []
-                aligned_sequences = []
-                score = None
-                words = line[1:].split()
-                for word in words:
-                    key, value = word.split("=")
-                    if key == "score":
-                        score = float(value)
-                    elif key == "pass":
-                        value = int(value)
-                        if value <= 0:
-                            raise ValueError(
-                                "pass value must be positive (found %d)" % value
-                            )
-                        annotations["pass"] = value
-                    else:
-                        raise ValueError("Unknown annotation variable '%s'" % key)
+                self._line = line
+                break
             elif line.startswith("s "):
                 words = line.strip().split()
                 if len(words) != 7:
@@ -466,25 +435,24 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 value = words[2].replace("-", "")
                 record.annotations["quality"] = value
             elif not line.strip():
-                # reached the end of this alignment
-                yield AlignmentIterator.create_alignment(
-                    records,
-                    aligned_sequences,
-                    strands,
-                    annotations,
-                    column_annotations,
-                    score,
-                )
-                records = None
+                # reached the end of the alignment, but keep reading until we
+                # find the next alignment
+                continue
             else:
                 raise ValueError(f"Error parsing alignment - unexpected line:\n{line}")
-        if records is None:
-            return
-        yield AlignmentIterator.create_alignment(
-            records,
-            aligned_sequences,
-            strands,
-            annotations,
-            column_annotations,
-            score,
-        )
+        else:
+            self._close()
+        coordinates = Alignment.infer_coordinates(aligned_sequences)
+        for record, strand, row in zip(records, strands, coordinates):
+            if strand == "-":
+                row[:] = row[-1] - row[0] - row
+            start = record.seq.defined_ranges[0][0]
+            row += start
+        alignment = Alignment(records, coordinates)
+        if annotations is not None:
+            alignment.annotations = annotations
+        if column_annotations is not None:
+            alignment.column_annotations = column_annotations
+        if score is not None:
+            alignment.score = score
+        return alignment

--- a/Bio/Align/msf.py
+++ b/Bio/Align/msf.py
@@ -41,13 +41,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
         """
         super().__init__(source, mode="t", fmt="MSF")
-        stream = self.stream
 
-    def parse(self, stream):
-        """Parse the next alignment from the stream."""
-        if stream is None:
-            raise StopIteration
-
+    def _read_next_alignment(self, stream):
         try:
             line = next(stream)
         except StopIteration:
@@ -256,4 +251,5 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 "GCG MSF headers said alignment length %i, but found %i"
                 % (aln_length, columns)
             )
-        yield alignment
+        self._close()
+        return alignment

--- a/Bio/Align/nexus.py
+++ b/Bio/Align/nexus.py
@@ -127,7 +127,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
         """
         super().__init__(source, mode="t", fmt="Nexus")
-        stream = self.stream
+
+    def _read_header(self, stream):
         try:
             line = next(stream)
         except StopIteration:
@@ -136,17 +137,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         if line.strip() != "#NEXUS":
             raise ValueError("File does not start with NEXUS header.")
 
-    def parse(self, stream):
-        """Parse the next alignment from the stream.
-
-        This uses the Bio.Nexus module to do the hard work.
-
-        You are expected to call this function via Bio.Align
-        (and not use it directly).
-
-        NOTE - We only expect ONE alignment matrix per Nexus file,
-        meaning this iterator will only yield one Alignment.
-        """
+    def _read_next_alignment(self, stream):
+        # NOTE - We only expect ONE alignment matrix per Nexus file.
         n = Nexus.Nexus(stream)
         if not n.matrix:
             # No alignment found
@@ -176,4 +168,5 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         ]
         coordinates = Alignment.infer_coordinates(aligned_seqs)
         alignment = Alignment(records, coordinates)
-        yield alignment
+        self._close()
+        return alignment

--- a/Bio/Align/stockholm.py
+++ b/Bio/Align/stockholm.py
@@ -301,11 +301,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                     letter_annotation = letter_annotation.replace(".", "")
                 record.letter_annotations[feature] = letter_annotation
 
-    def parse(self, stream):
-        """Parse the next alignment from the stream."""
-        if stream is None:
-            raise StopIteration
-
+    def _read_next_alignment(self, stream):
         for line in stream:
             line = line.strip()
             if not line:
@@ -353,7 +349,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 AlignmentIterator._store_per_sequence_and_per_column_annotations(
                     alignment, gr
                 )
-                yield alignment
+                return alignment
             elif not line.startswith("#"):
                 # Sequence
                 # Format: "<seqname> <sequence>"


### PR DESCRIPTION
Clean up `Bio.Align.interfaces` to get rid of the double iterator.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

