### PR TITLE
Take the other object's class into consideration when comparing objec…

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -288,7 +288,8 @@ class SeqFeature:
     def __eq__(self, other):
         """Check if two SeqFeature objects should be considered equal."""
         return (
-            self.id == other.id
+            isinstance(other, SeqFeature)
+            and self.id == other.id
             and self.type == other.type
             and self.location == other.location
             and self.qualifiers == other.qualifiers

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -259,6 +259,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Richard Neher <https://github.com/rneher>
 - Rob Miller <https://github.com/rob-miller>
 - Robert Ernst <https://github.com/rernst>
+- Robert Sawicki <https://github.com/Battlesheepu>
 - Rodrigo Dorantes-Gilardi <https://github.com/rodogi>
 - Rona Costello <https://github.com/RonaCostello>
 - Ryan Stecher <https://github.com/rystecher>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -76,6 +76,7 @@ possible, especially the following contributors:
 - Michiel de Hoon
 - Neil P. (first contribution)
 - Peter Cock
+- Robert Sawicki (first contribution)
 - Sebastian Bassi
 - Sean Aubin
 - Tim Burke


### PR DESCRIPTION
…ts using the __eq__ method

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [ X ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ X ] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ X ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #3978

Fixes an AttributeError raised whenever SeqFeature objects are compared to objects of any other type. 
