### PR TITLE
deprecating one_to_three, three_to_one

### DIFF
--- a/Bio/PDB/DSSP.py
+++ b/Bio/PDB/DSSP.py
@@ -98,8 +98,8 @@ import warnings
 from Bio.PDB.AbstractPropertyMap import AbstractResiduePropertyMap
 from Bio.PDB.PDBExceptions import PDBException
 from Bio.PDB.PDBParser import PDBParser
-from Bio.PDB.Polypeptide import three_to_one
 from Bio.PDB.MMCIF2Dict import MMCIF2Dict
+from Bio.SeqUtils import seq1
 
 # Match C in DSSP
 _dssp_cys = re.compile("[a-z]")
@@ -582,10 +582,7 @@ class DSSP(AbstractResiduePropertyMap):
             # Verify if AA in DSSP == AA in Structure
             # Something went wrong if this is not true!
             # NB: DSSP uses X often
-            try:
-                resname = three_to_one(resname)
-            except KeyError:
-                resname = "X"
+            resname = seq1(resname)
             if resname == "C":
                 # DSSP renames C in C-bridges to a,b,c,d,...
                 # - we rename it back to 'C'

--- a/Bio/PDB/PICIO.py
+++ b/Bio/PDB/PICIO.py
@@ -24,8 +24,6 @@ from Bio.PDB.StructureBuilder import StructureBuilder
 from Bio.PDB.parse_pdb_header import _parse_pdb_header_list
 from Bio.PDB.PDBExceptions import PDBException
 
-from Bio.PDB.Polypeptide import one_to_three
-
 from Bio.PDB.internal_coords import (
     IC_Residue,
     IC_Chain,
@@ -48,6 +46,7 @@ from typing import TextIO, Set, List, Tuple, Union, Optional
 from Bio.PDB.Structure import Structure
 from Bio.PDB.Residue import Residue
 from Bio import SeqIO
+from Bio.SeqUtils import seq3
 
 
 # @profile
@@ -831,8 +830,8 @@ def read_PIC_seq(
     output += f"TITLE     {title.upper():69}\n"
 
     ndx = 1
-    for r in seqRec.seq:
-        output += f"('{pdbid}', 0, '{chain}', (' ', {ndx}, ' ')) {one_to_three(r)}\n"
+    for r in seqRec:
+        output += f"('{pdbid}', 0, '{chain}', (' ', {ndx}, ' ')) {seq3(r).upper()}\n"
         ndx += 1
 
     sp = StringIO()

--- a/Bio/PDB/Polypeptide.py
+++ b/Bio/PDB/Polypeptide.py
@@ -57,6 +57,8 @@ from Bio.Seq import Seq
 from Bio.PDB.PDBExceptions import PDBException
 from Bio.PDB.vectors import calc_dihedral, calc_angle
 
+from Bio import BiopythonDeprecationWarning
+
 
 standard_aa_names = [
     "ALA",
@@ -159,6 +161,12 @@ def three_to_one(s):
        ...
     KeyError: 'MSE'
     """
+    warnings.warn(
+        "The function one_to_three in Bio.PDB.Polypeptide is deprecated and "
+        "will be removed in a future release of Biopython. Please use the "
+        "function seq1 in Bio.SeqUtils instead.",
+        BiopythonDeprecationWarning,
+    )
     i = d3_to_index[s]
     return dindex_to_1[i]
 
@@ -171,6 +179,12 @@ def one_to_three(s):
     >>> one_to_three('Y')
     'TYR'
     """
+    warnings.warn(
+        "The function one_to_three in Bio.PDB.Polypeptide is deprecated and "
+        "will be removed in a future release of Biopython. Please use the "
+        "function seq1 in Bio.SeqUtils instead.",
+        BiopythonDeprecationWarning,
+    )
     i = d1_to_index[s]
     return dindex_to_3[i]
 

--- a/Bio/PDB/internal_coords.py
+++ b/Bio/PDB/internal_coords.py
@@ -129,7 +129,6 @@ except ImportError:
     )
 
 from Bio.PDB.Atom import Atom, DisorderedAtom
-from Bio.PDB.Polypeptide import three_to_one
 
 from Bio.PDB.vectors import multi_coord_space, multi_rot_Z
 from Bio.PDB.vectors import coord_space
@@ -138,6 +137,8 @@ from Bio.PDB.ic_data import ic_data_backbone, ic_data_sidechains
 from Bio.PDB.ic_data import primary_angles
 from Bio.PDB.ic_data import ic_data_sidechain_extras, residue_atom_bond_state
 from Bio.PDB.ic_data import dihedra_primary_defaults, hedra_defaults
+
+from Bio.SeqUtils import seq1
 
 # for type checking only
 from typing import (
@@ -2391,12 +2392,13 @@ class IC_Residue:
         # rbase = position, insert code or none, resname (1 letter if in 20)
         rid = parent.id
         rbase = [rid[1], rid[2] if " " != rid[2] else None, parent.resname]
-        try:
-            rbase[2] = three_to_one(rbase[2]).upper()
-        except KeyError:
+        resname = seq1(rbase[2])
+        if resname == "X":
             self.is20AA = False
             if rbase[2] not in self.accept_resnames:
                 self.isAccept = False
+        else:
+            rbase[2] = resname
 
         self.rbase = tuple(rbase)
         self.lc = rbase[2]

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -252,6 +252,12 @@ This was removed in Release 1.62, when MMCIF2Dict was updated to use shlex
 from the standard library instead. This had required manual intervention to
 include when installing Biopython from source due to a dependency on flex.
 
+Bio.PDB.Polypeptide
+-------------------
+The ``one_to_three`` and ``three_to_one`` functions in Bio.PDB.Polypeptide were
+deprecated in Release 1.80. Please use the `seq3` and `seq` functions in
+Bio.SeqUtils instead.
+
 Bio.PDB.Residue
 ---------------
 The ``sort`` and ``get_atom`` methods of the ``Residue`` class were removed in

--- a/Scripts/PDB/generate_three_to_one_dict.py
+++ b/Scripts/PDB/generate_three_to_one_dict.py
@@ -40,7 +40,7 @@ with open(gzname, "wb") as gzh:
 if os.path.getsize(gzname) < 29944258:
     warnings.warn("ERROR: Downloaded file is too small", RuntimeWarning)
 
-fh = gzip.open(gzname, "rb")
+fh = gzip.open(gzname, "rt")
 
 # write extracted file to disk (not necessary)
 # with open(cifname, 'wb') as cifh:


### PR DESCRIPTION
This PR deprecates the `one_to_three` and `three_to_one` functions in `Bio.PDB.Polypeptide`, as the `seq1` and `seq3` functions in `Bio.SeqUtils` provide the same functionality while being more general.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
