### PR TITLE
Changed parse_pdb_header to extract information on the orientation of the chains in oligomeric structures

### DIFF
--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -226,7 +226,7 @@ def _parse_pdb_header_list(header):
         "source": {"1": {"misc": ""}},
         "has_missing_residues": False,
         "missing_residues": [],
-        "chain_orientations":{},
+        "chain_orientations":None,
     }
 
     pdbh_dict["structure_reference"] = _get_references(header)

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -15,6 +15,7 @@ Kristian Rother.
 
 
 import re
+import numpy
 
 from Bio import File
 
@@ -39,8 +40,8 @@ def _get_chain_orientations(inl):
                 structure_orientations[counter][chain]=[]
             next_index+=1
             while "BIOMT" in inl[next_index+index]:
-                rotation_matrix=np.zeros((3,3))
-                translation_matrix=np.zeros(3)
+                rotation_matrix=numpy.zeros((3,3))
+                translation_matrix=numpy.zeros(3)
                 for i in range(3):
                     relevant_elems=' '.join(inl[next_index+index+i].split()).split(' ')
                     for j in range(4,7):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x ] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Many pdb files, at remark 350, have information on the relative orientation of each chain, giving rise to the full oligomeric structure. I did not see a way of accessing this in Biopython as is so I wrote up a simple method that extracts the info and places it in the header attribute of a structure.
