### PR TITLE
Extracts information about the relative orientation of chains in oligomeric structures

### DIFF
--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -226,7 +226,7 @@ def _parse_pdb_header_list(header):
         "source": {"1": {"misc": ""}},
         "has_missing_residues": False,
         "missing_residues": [],
-        "chain_orientations":{},
+        "chain_orientations":None,
     }
 
     pdbh_dict["structure_reference"] = _get_references(header)

--- a/Bio/PDB/parse_pdb_header.py
+++ b/Bio/PDB/parse_pdb_header.py
@@ -15,6 +15,7 @@ Kristian Rother.
 
 
 import re
+import numpy
 
 from Bio import File
 
@@ -39,8 +40,8 @@ def _get_chain_orientations(inl):
                 structure_orientations[counter][chain]=[]
             next_index+=1
             while "BIOMT" in inl[next_index+index]:
-                rotation_matrix=np.zeros((3,3))
-                translation_matrix=np.zeros(3)
+                rotation_matrix=numpy.zeros((3,3))
+                translation_matrix=numpy.zeros(3)
                 for i in range(3):
                     relevant_elems=' '.join(inl[next_index+index+i].split()).split(' ')
                     for j in range(4,7):

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -302,6 +302,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Uri Laserson <https://github.com/laserson>
 - Uwe Schmitt <https://github.com/uweschmitt>
 - Valentin Vareškić <https://github.com/valentin994>
+- Vedant Sachdeva <https://github.com/sachdved>
 - Veronika Berman <https://github.com/NikiB>
 - Victor Lin <https://github.com/victorlin>
 - Vini Salazar <https://github.com/vinisalazar>


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x ] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Currently, no functionality in the PDB parser extracts information from REMARK 350 about the orientations of the chains in their oligomeric state. I have written an additional function to extract the information accordingly and save it into the dictionary belonging to the header attribute of a structure.
