### PR TITLE
Adds support for downloading biological assemblies to Bio.PDB.PDBList

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -584,9 +584,7 @@ class PDBList:
             urlcleanup()
             urlretrieve(url, assembly_gz_file)
         except OSError as err:
-            print(
-                f"Download failed! Maybe the desired assembly does not exist: {err}"
-            )
+            print(f"Download failed! Maybe the desired assembly does not exist: {err}")
         else:
             with gzip.open(assembly_gz_file, "rb") as gz:
                 with open(assembly_final_file, "wb") as out:

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -241,7 +241,6 @@ class PDBList:
             * "xml" (PDBML/XML format),
             * "mmtf" (highly compressed),
             * "bundle" (PDB formatted archive for large structure)
-            * "biounit" (Biological assembly in PDBx/mmCif format)
 
         :type file_format: string
 
@@ -276,15 +275,14 @@ class PDBList:
             "mmCif": "%s.cif.gz",
             "xml": "%s.xml.gz",
             "mmtf": "%s",
-            "bundle": "%s-pdb-bundle.tar.gz",
-            "biounit": "%s-assembly1.cif.gz" # The example files currently aren't shown as compressed, some cases have multiple assemblies
+            "bundle": "%s-pdb-bundle.tar.gz"
         }
         archive_fn = archive[file_format] % code
 
         if file_format not in archive.keys():
             raise (
                 "Specified file_format %s doesn't exists or is not supported. Maybe a "
-                "typo. Please, use one of the following: mmCif, pdb, xml, mmtf, bundle, biounit"
+                "typo. Please, use one of the following: mmCif, pdb, xml, mmtf, bundle"
                 % file_format
             )
 
@@ -308,13 +306,7 @@ class PDBList:
                 code[1:3],
                 code,
                 archive_fn,
-            )
-        elif file_format == "biounit":
-            url = self.pdb_server + "/pub/pdb/data/assemblies/mmCIF/%s/%s/%s" % (
-                code[1:3],
-                code,
-                archive_fn  # This will currently just pull biological assembly 1
-            )              
+            )             
         else:
             url = f"http://mmtf.rcsb.org/v1.0/full/{code}"
 
@@ -333,8 +325,7 @@ class PDBList:
             "mmCif": "%s.cif",
             "xml": "%s.xml",
             "mmtf": "%s.mmtf",
-            "bundle": "%s-pdb-bundle.tar",
-            "biounit": "%s-assembly1.cif" # Again just pulling assembly 1
+            "bundle": "%s-pdb-bundle.tar"
         }
         final_file = os.path.join(path, final[file_format] % code)
 
@@ -461,7 +452,6 @@ class PDBList:
             * "xml" (PMDML/XML format),
             * "mmtf" (highly compressed),
             * "bundle" (PDB formatted archive for large structure)
-            * "biounit" (Biological assembly in PDBx/mmCif format)
 
         :param overwrite: if set to True, existing structure files will be overwritten. Default: False
         :type overwrite: bool
@@ -506,7 +496,6 @@ class PDBList:
             * "xml" (PMDML/XML format),
             * "mmtf" (highly compressed),
             * "bundle" (PDB formatted archive for large structure)
-            * "biounit" (Biological assembly in PDBx/mmCif format)
 
         NOTE. The default download format has changed from PDB to PDBx/mmCif
         """

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -454,9 +454,8 @@ class PDBList:
         """
         assemblies_to_fetch = []
 
-        print(f"Fetching assemblies associated with PDB ID(s) '{pdb_codes}'")
-
         if isinstance(pdb_codes, str):
+            print(f"Fetching assemblies associated with PDB ID(s) '{pdb_codes}'...")
             ftp = ftplib.FTP("ftp.wwpdb.org")
             ftp.login()  # anonymous
             division = pdb_codes[1:3]
@@ -465,14 +464,15 @@ class PDBList:
             else:
                 ftp.cwd(f"pub/pdb/data/biounit/mmCIF/divided/{division}")
             # else:
-            #     ftp.cwd("pub/pdb/data/assemblies/mmCIF/all/")
+            #     ftp.cwd("pub/pdb/data/assemblies/mmCIF/divided/{division}") # For May
             entries = []
             ftp.retrlines("NLST", callback=entries.append)
             assemblies_to_fetch += [e for e in entries if pdb_codes in e]
             if len(assemblies_to_fetch) == 0 and file_format.lower() == 'mmcif':
-                print(f"The desired assembly doesn't exist in mmCIF format.")
+                print(f"The assembly for '{code}' doesn't exist in mmCIF format.")
 
         else:
+            print(f"Fetching assemblies associated with PDB ID(s) '{', '.join(pdb_codes)}'")
             for code in pdb_codes:
                 ftp = ftplib.FTP("ftp.wwpdb.org")
                 ftp.login()  # anonymous
@@ -482,12 +482,12 @@ class PDBList:
                 else:
                     ftp.cwd(f"pub/pdb/data/biounit/mmCIF/divided/{division}")
                 # else:
-                #     ftp.cwd("pub/pdb/data/assemblies/mmCIF/all/")
+                #     ftp.cwd("pub/pdb/data/assemblies/mmCIF/divided/{division}") # For May
                 entries = []
                 ftp.retrlines("NLST", callback=entries.append)
                 assemblies_tmp = [e for e in entries if code in e]
                 if len(assemblies_tmp) == 0 and file_format.lower() == 'mmcif':
-                    print(f"The desired assembly doesn't exist in mmCIF format.")
+                    print(f"The assembly for '{code}' doesn't exist in mmCIF format.")
                 else:
                     assemblies_to_fetch += [e for e in entries if code in e]
 

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -37,18 +37,16 @@
 
 
 import contextlib
+import ftplib
 import gzip
 import os
-import shutil
 import re
+import shutil
 import sys
-import ftplib
 
 from urllib.request import urlopen
 from urllib.request import urlretrieve
 from urllib.request import urlcleanup
-
-from requests import codes
 
 
 class PDBList:
@@ -272,7 +270,7 @@ class PDBList:
             "mmCif": "%s.cif.gz",
             "xml": "%s.xml.gz",
             "mmtf": "%s",
-            "bundle": "%s-pdb-bundle.tar.gz"
+            "bundle": "%s-pdb-bundle.tar.gz",
         }
         archive_fn = archive[file_format] % code
 
@@ -303,7 +301,7 @@ class PDBList:
                 code[1:3],
                 code,
                 archive_fn,
-            )             
+            )
         else:
             url = f"http://mmtf.rcsb.org/v1.0/full/{code}"
 
@@ -322,7 +320,7 @@ class PDBList:
             "mmCif": "%s.cif",
             "xml": "%s.xml",
             "mmtf": "%s.mmtf",
-            "bundle": "%s-pdb-bundle.tar"
+            "bundle": "%s-pdb-bundle.tar",
         }
         final_file = os.path.join(path, final[file_format] % code)
 
@@ -348,7 +346,7 @@ class PDBList:
             os.remove(filename)
         return final_file
 
-    def update_pdb(self, file_format=None):
+    def update_pdb(self, file_format=None, with_assemblies=False):
         """Update your local copy of the PDB files.
 
         I guess this is the 'most wanted' function from this module.
@@ -367,12 +365,27 @@ class PDBList:
         for pdb_code in new + modified:
             try:
                 self.retrieve_pdb_file(pdb_code, file_format=file_format)
-            except Exception:
-                print(f"error {pdb_code}\n")
+                if with_assemblies:
+                    assemblies = self.get_all_assemblies(file_format)
+                    for a_pdb_code, assembly_num in assemblies:
+                        if a_pdb_code == pdb_code:
+                            pl.retrieve_assembly_file(
+                                pdb_code,
+                                assembly_num,
+                                file_format=file_format,
+                                overwrite=True,
+                            )
+
+            except Exception as err:
+                print(f"error {pdb_code}: {err}\n")
                 # you can insert here some more log notes that
                 # something has gone wrong.
 
         # Move the obsolete files to a special folder
+        # NOTE: This should be updated to handle multiple file types and
+        # assemblies. As of now, it only looks for PDB-formatted files.
+        # Using pathlib will be probably the best approach here, to build
+        # and index of which files we have efficiently (or glob them).
         for pdb_code in obsolete:
             if self.flat_tree:
                 old_file = os.path.join(self.local_pdb, f"pdb{pdb_code}.ent")
@@ -445,90 +458,161 @@ class PDBList:
                 file_format=file_format,
                 overwrite=overwrite,
             )
-    
-    def fetch_assembly_list(
-        self, pdb_codes, file_format=None,
+
+    def get_all_assemblies(self, file_format="mmCif"):
+        """Retrieve the list of PDB entries with an associated bio assembly.
+
+        The requested list will be cached to avoid multiple calls to the FTP
+        server.
+
+        :type  file_format: str, optional
+        :param file_format: format in which to download the entries. Available
+            options are "mmCif" or "pdb". Defaults to mmCif.
+        """
+        if hasattr(self, "assemblies") and self.assemblies:
+            if self._verbose:
+                print("Retrieving cached list of assemblies.")
+            return self.assemblies  # cache
+
+        if self._verbose:
+            print("Retrieving list of assemblies. This might take a while.")
+
+        # FTPLib is much faster than urlopen
+        idx = self.pdb_server.find("://")
+        if idx >= 0:
+            ftp = ftplib.FTP(self.pdb_server[idx + 3 :])
+        else:
+            ftp = ftplib.FTP(self.pdb_server)
+        ftp.login()  # anonymous
+
+        if file_format.lower() == "mmcif":
+            ftp.cwd("/pub/pdb/data/assemblies/mmCIF/all/")
+            re_name = re.compile(r"(\d[0-9a-z]{3})-assembly(\d+).cif.gz")
+        elif file_format.lower() == "pdb":
+            ftp.cwd("/pub/pdb/data/biounit/PDB/all/")
+            re_name = re.compile(r"(\d[0-9a-z]{3}).pdb(\d+).gz")
+        else:
+            msg = "file_format for assemblies must be 'pdb' or 'mmCif'"
+            raise ValueError(msg)
+
+        response = []
+        ftp.retrlines("NLST", callback=response.append)
+        # PDB entries can have more than one assembly:
+        #  e.g.
+        #    104l-assembly1.cif.gz           2022-01-15 19:38   36K
+        #    104l-assembly2.cif.gz           2022-01-15 19:38   36K
+        #    ...
+        #    104l.pdb1.gz               2010-01-15 08:00   28K
+        #    104l.pdb2.gz               2010-01-15 08:00   28K
+        all_assemblies = []
+        for line in response:
+            if line.endswith(".gz"):
+                match = re_name.findall(line)
+                try:
+                    if len(match):
+                        entry, assembly = match[0]
+                except ValueError:
+                    pass
+                else:
+                    all_assemblies.append((entry, assembly))
+        self.assemblies = all_assemblies  # cache
+        return all_assemblies
+
+    def retrieve_assembly_file(
+        self, pdb_code, assembly_num, pdir=None, file_format=None, overwrite=False
     ):
-        """
-        Fetch list of assemblies to download
-        """
-        assemblies_to_fetch = []
+        """Fetch one or more assembly structures associated with a PDB entry.
 
-        if isinstance(pdb_codes, str):
-            pdb_codes = [pdb_codes.lower()]
-        
-        print(f"Fetching assemblies associated with PDB ID(s) '{', '.join(pdb_codes).lower()}'...")
-        for code in pdb_codes:
-            code = code.lower()
-            ftp = ftplib.FTP("ftp.wwpdb.org")
-            ftp.login()  # anonymous
-            division = code[1:3]
-            if file_format.lower() == 'pdb':
-                ftp.cwd(f"pub/pdb/data/biounit/PDB/divided/{division}")
-            else:
-                ftp.cwd(f"pub/pdb/data/biounit/mmCIF/divided/{division}")
-            # else:
-            #     ftp.cwd("pub/pdb/data/assemblies/mmCIF/divided/{division}") # For May
-            entries = []
-            ftp.retrlines("NLST", callback=entries.append)
-            assemblies_tmp = [e for e in entries if code in e]
-            if len(assemblies_tmp) == 0:
-                raise OSError(f"No assembly for '{code}' in the desired format")
-            else:
-                assemblies_to_fetch += assemblies_tmp
-            
-        return assemblies_to_fetch
+        Unless noted below, parameters are described in ``retrieve_pdb_file``.
 
-    def retrieve_assembly(
-        self, assembly_in, pdir=None, file_format=None, overwrite=False
-    ):
+        :type  assembly_num: int
+        :param assembly_num: assembly number to download.
+
+        :rtype : str
+        :return: file name of the downloaded assembly file.
         """
-        Fetch assembly for specified PDB code.
+        archive = {
+            "pdb": "%s-pdb%s.gz",
+            "mmcif": "%s-assembly%s.cif.gz",
+        }
 
-        Rest of docstring todo.
-        """
-        code = assembly_in[:4]
+        file_format = self._print_default_format_warning(file_format)
+        file_format = file_format.lower()  # we should standardize this.
+        if file_format not in archive:
+            raise (
+                "Specified file_format '%s' is not supported. Use one of the "
+                "following: 'mmcif' or 'pdb'." % file_format
+            )
 
+        # Get the compressed assembly structure name
+        archive_fn = archive[file_format] % (pdb_code.lower(), int(assembly_num))
+
+        if file_format == "mmcif":
+            url = self.pdb_server + "/pub/pdb/data/assemblies/mmCIF/all/%s" % archive_fn
+        elif file_format == "pdb":
+            url = self.pdb_server + "/pub/pdb/data/biounit/PDB/all/%s" % archive_fn
+        else:  # better safe than sorry
+            raise ValueError("file_format '%s' not supported: %s" % file_format)
+
+        # Where will the file be saved?
         if pdir is None:
             path = self.local_pdb
             if not self.flat_tree:  # Put in PDB-style directory tree
-                path = os.path.join(path, code[1:3])
+                path = os.path.join(path, pdb_code[1:3])
         else:  # Put in specified directory
             path = pdir
         if not os.access(path, os.F_OK):
             os.makedirs(path)
 
-        final_assembly_file = os.path.join(path, assembly_in[:-3])
+        assembly_gz_file = os.path.join(path, archive_fn)
+        assembly_final_file = os.path.join(path, archive_fn[:-3])  # no .gz
+
         # Skip download if the file already exists
         if not overwrite:
-            if os.path.exists(final_assembly_file):
+            if os.path.exists(assembly_final_file):
                 if self._verbose:
-                    print(f"Assembly exists: '{final_assembly_file}' ")
-                return final_assembly_file
+                    print(f"Structure exists: '{assembly_final_file}' ")
+                return assembly_final_file
 
-        if file_format=='pdb':
-            number = assembly_in[8]
-            assembly_url = f"http://ftp.wwpdb.org/pub/pdb/data/biounit/PDB/all/{assembly_in}"
-            assembly_filename = os.path.join(path, assembly_in)
-        else:
-            number = assembly_in[-8]
-            assembly_url = f"http://ftp.wwpdb.org/pub/pdb/data/biounit/mmCIF/all/{assembly_in}"
-            assembly_filename = os.path.join(path, assembly_in)
-        # try:
+        # Otherwise,retrieve the file(s)
         if self._verbose:
-            print(f"Downloading '{code}' assembly {number}...")
+            print(
+                f"Downloading assembly ({assembly_num}) for PDB entry "
+                f"'{pdb_code}'..."
+            )
+        try:
+            urlcleanup()
+            urlretrieve(url, assembly_gz_file)
+        except OSError as err:
+            print(
+                f"Download failed! Maybe the desired assembly does not exist: {err}"
+            )
+        else:
+            with gzip.open(assembly_gz_file, "rb") as gz:
+                with open(assembly_final_file, "wb") as out:
+                    out.writelines(gz)
+            os.remove(assembly_gz_file)
+        return assembly_final_file
 
-        urlcleanup()
-        urlretrieve(assembly_url, assembly_filename)
-        # except OSError:
-        #     print("Desired assembly doesn't exist")  # I don't think we need this try/except since I take care of that in the fetch
-        # else:
+    def download_all_assemblies(self, listfile=None, file_format=None):
+        """Retrieve all biological assemblies not in the local PDB copy.
 
-        with gzip.open(assembly_filename, "rb") as gz:
-            with open(final_assembly_file, "wb") as out:
-                out.writelines(gz)
-        os.remove(assembly_filename)
-        return final_assembly_file
+        :type  listfile: str, optional
+        :param listfile: file name to which all assembly codes will be written
+
+        :type  file_format: str, optional
+        :param file_format: format in which to download the entries. Available
+            options are "mmCif" or "pdb". Defaults to mmCif.
+        """
+        # Deprecation warning
+        file_format = self._print_default_format_warning(file_format)
+        assemblies = self.get_all_assemblies(file_format)
+        for pdb_code, assembly_num in assemblies:
+            self.retrieve_assembly_file(pdb_code, assembly_num, file_format=file_format)
+        # Write the list
+        if listfile:
+            with open(listfile, "w") as outfile:
+                outfile.writelines(f"{pdb_code}.{assembly_num}\n" for x in assemblies)
 
     def download_entire_pdb(self, listfile=None, file_format=None):
         """Retrieve all PDB entries not present in the local PDB copy.
@@ -601,6 +685,8 @@ if __name__ == "__main__":
                                                    local pdb tree.
         PDBList.py obsol  <pdb_path> [options]   - write all obsolete PDB
                                                    entries to local pdb tree.
+        PDBList.py assemb <pdb_path> [options]   - write all assemblies for each
+                                                   PDB entry to local pdb tree.
         PDBList.py <PDB-ID> <pdb_path> [options] - retrieve single structure
         PDBList.py (<PDB-ID1>,<PDB-ID2>,...) <pdb_path> [options] - retrieve a set
                                                    of structures
@@ -611,6 +697,7 @@ if __name__ == "__main__":
      -pdb     Downloads structures in PDB format
      -xml     Downloads structures in PDBML (XML) format
      -mmtf    Downloads structures in mmtf format
+     -with-assemblies    Downloads assemblies along with regular entries.
 
     Maximum one format can be specified simultaneously (if more selected, only
     the last will be considered). By default (no format specified) structures are
@@ -620,8 +707,7 @@ if __name__ == "__main__":
 
     file_format = "mmCif"
     overwrite = False
-    assemblies = False
-    assemblies_only = False
+    with_assemblies = False
 
     if len(sys.argv) > 2:
         pdb_path = sys.argv[2]
@@ -635,12 +721,8 @@ if __name__ == "__main__":
                 elif option in ("-pdb", "-xml", "-mmtf"):
                     file_format = option[1:]
                 # Allow for download of assemblies alongside ASU
-                elif option == "-assemblies":
-                    assemblies = True
-                # Allow for download of assemblies alone
-                elif option == "-assemblies-only":
-                    assemblies_only = True
-
+                elif option == "-with-assemblies":
+                    with_assemblies = True
 
     else:
         pdb_path = os.getcwd()
@@ -656,45 +738,53 @@ if __name__ == "__main__":
         elif sys.argv[1] == "all":
             # get the entire PDB
             pl.download_entire_pdb(file_format=file_format)
+            if with_assemblies:
+                # get all assembly structures
+                pl.download_all_assemblies(file_format=file_format)
 
         elif sys.argv[1] == "obsol":
             # get all obsolete entries
             pl.download_obsolete_entries(pdb_path, file_format=file_format)
 
+        elif sys.argv[1] == "assemb":
+            # get all assembly structures
+            pl.download_all_assemblies(file_format=file_format)
+
         elif len(sys.argv[1]) == 4 and sys.argv[1][0].isdigit():
+            pdb_code = sys.argv[1]
             # get single PDB entry
-            if assemblies or assemblies_only:
-                fetch_output = pl.fetch_assembly_list(sys.argv[1], file_format=file_format
+            pl.retrieve_pdb_file(
+                pdb_code, pdir=pdb_path, file_format=file_format, overwrite=overwrite
             )
-            if assemblies_only:
-                for assembly in fetch_output:
-                        pl.retrieve_assembly(assembly, pdir=pdb_path, file_format=file_format, overwrite=overwrite
-            )
-            else:
-                if assemblies:
-                    for assembly in fetch_output:
-                        pl.retrieve_assembly(assembly, pdir=pdb_path, file_format=file_format, overwrite=overwrite
-            )
-                pl.retrieve_pdb_file(
-                    sys.argv[1], pdir=pdb_path, file_format=file_format, overwrite=overwrite
-            )
+            if with_assemblies:
+                # PDB Code might have more than one assembly.
+                assemblies = pl.get_all_assemblies(file_format)
+                for a_pdb_code, assembly_num in assemblies:
+                    if a_pdb_code == pdb_code:
+                        pl.retrieve_assembly_file(
+                            pdb_code,
+                            assembly_num,
+                            pdir=pdb_path,
+                            file_format=file_format,
+                            overwrite=overwrite,
+                        )
 
         elif sys.argv[1][0] == "(":
             # get a set of PDB entries
             pdb_ids = re.findall("[0-9A-Za-z]{4}", sys.argv[1])
-            if assemblies or assemblies_only:
-                    fetch_output = pl.fetch_assembly_list(pdb_ids, file_format=file_format
-            )
-            if assemblies_only:
-                for assembly in fetch_output:
-                    pl.retrieve_assembly(assembly, pdir=pdb_path, file_format=file_format, overwrite=overwrite
-            )
-            else:
-                if assemblies:
-                    for assembly in fetch_output:
-                        pl.retrieve_assembly(assembly, pdir=pdb_path, file_format=file_format, overwrite=overwrite
-            )
-                for pdb_id in pdb_ids:
-                    pl.retrieve_pdb_file(
-                        pdb_id, pdir=pdb_path, file_format=file_format, overwrite=overwrite
-            )
+            for pdb_id in pdb_ids:
+                pl.retrieve_pdb_file(
+                    pdb_id, pdir=pdb_path, file_format=file_format, overwrite=overwrite
+                )
+                if with_assemblies:
+                    # PDB Code might have more than one assembly.
+                    assemblies = pl.get_all_assemblies(file_format)
+                    for a_pdb_code, assembly_num in assemblies:
+                        if a_pdb_code == pdb_id:
+                            pl.retrieve_assembly_file(
+                                pdb_id,
+                                assembly_num,
+                                pdir=pdb_path,
+                                file_format=file_format,
+                                overwrite=overwrite,
+                            )

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -497,6 +497,15 @@ class PDBList:
             path = pdir
         if not os.access(path, os.F_OK):
             os.makedirs(path)
+
+        final_assembly_file = os.path.join(path, assembly_in[:-3])
+        # Skip download if the file already exists
+        if not overwrite:
+            if os.path.exists(final_assembly_file):
+                if self._verbose:
+                    print(f"Assembly exists: '{final_assembly_file}' ")
+                return final_assembly_file
+
         if file_format=='pdb':
             number = assembly_in[8]
             assembly_url = f"http://ftp.wwpdb.org/pub/pdb/data/biounit/PDB/all/{assembly_in}"
@@ -506,22 +515,14 @@ class PDBList:
             assembly_url = f"http://ftp.wwpdb.org/pub/pdb/data/biounit/mmCIF/all/{assembly_in}"
             assembly_filename = os.path.join(path, assembly_in)
         # try:
+        if self._verbose:
+            print(f"Downloading '{code}' assembly {number}...")
+
         urlcleanup()
         urlretrieve(assembly_url, assembly_filename)
         # except OSError:
         #     print("Desired assembly doesn't exist")  # I don't think we need this try/except since I take care of that in the fetch
         # else:
-        final_assembly_file = os.path.join(path, assembly_in[:-3])
-
-        # Skip download if the file already exists
-        if not overwrite:
-            if os.path.exists(final_assembly_file):
-                if self._verbose:
-                    print(f"Assembly exists: '{final_assembly_file}' ")
-                return final_assembly_file
-
-        if self._verbose:
-            print(f"Downloading '{code}' assembly {number}...")
 
         with gzip.open(assembly_filename, "rb") as gz:
             with open(final_assembly_file, "wb") as out:
@@ -693,7 +694,7 @@ if __name__ == "__main__":
                     for assembly in fetch_output:
                         pl.retrieve_assembly(assembly, pdir=pdb_path, file_format=file_format, overwrite=overwrite
             )
-                    for pdb_id in pdb_ids:
-                        pl.retrieve_pdb_file(
-                            pdb_id, pdir=pdb_path, file_format=file_format, overwrite=overwrite
+                for pdb_id in pdb_ids:
+                    pl.retrieve_pdb_file(
+                        pdb_id, pdir=pdb_path, file_format=file_format, overwrite=overwrite
             )

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -505,7 +505,8 @@ class PDBList:
             * "pdb" (format PDB),
             * "xml" (PMDML/XML format),
             * "mmtf" (highly compressed),
-            * "bundle" (PDB formatted archive for large structure}
+            * "bundle" (PDB formatted archive for large structure)
+            * "biounit" (Biological assembly in PDBx/mmCif format)
 
         NOTE. The default download format has changed from PDB to PDBx/mmCif
         """

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -240,7 +240,8 @@ class PDBList:
             * "pdb" (format PDB),
             * "xml" (PDBML/XML format),
             * "mmtf" (highly compressed),
-            * "bundle" (PDB formatted archive for large structure}
+            * "bundle" (PDB formatted archive for large structure)
+            * "biounit" (Biological assembly in PDBx/mmCif format)
 
         :type file_format: string
 
@@ -276,13 +277,14 @@ class PDBList:
             "xml": "%s.xml.gz",
             "mmtf": "%s",
             "bundle": "%s-pdb-bundle.tar.gz",
+            "biounit": "%s-assembly1.cif.gz" # The example files currently aren't shown as compressed, some cases have multiple assemblies
         }
         archive_fn = archive[file_format] % code
 
         if file_format not in archive.keys():
             raise (
                 "Specified file_format %s doesn't exists or is not supported. Maybe a "
-                "typo. Please, use one of the following: mmCif, pdb, xml, mmtf, bundle"
+                "typo. Please, use one of the following: mmCif, pdb, xml, mmtf, bundle, biounit"
                 % file_format
             )
 
@@ -307,6 +309,12 @@ class PDBList:
                 code,
                 archive_fn,
             )
+        elif file_format == "biounit":
+            url = self.pdb_server + "/pub/pdb/data/assemblies/mmCIF/%s/%s/%s" % (
+                code[1:3],
+                code,
+                archive_fn  # This will currently just pull biological assembly 1
+            )              
         else:
             url = f"http://mmtf.rcsb.org/v1.0/full/{code}"
 
@@ -326,6 +334,7 @@ class PDBList:
             "xml": "%s.xml",
             "mmtf": "%s.mmtf",
             "bundle": "%s-pdb-bundle.tar",
+            "biounit": "%s-assembly1.cif" # Again just pulling assembly 1
         }
         final_file = os.path.join(path, final[file_format] % code)
 
@@ -451,7 +460,8 @@ class PDBList:
             * "pdb" (format PDB),
             * "xml" (PMDML/XML format),
             * "mmtf" (highly compressed),
-            * "bundle" (PDB formatted archive for large structure}
+            * "bundle" (PDB formatted archive for large structure)
+            * "biounit" (Biological assembly in PDBx/mmCif format)
 
         :param overwrite: if set to True, existing structure files will be overwritten. Default: False
         :type overwrite: bool

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -733,7 +733,7 @@ if __name__ == "__main__":
         if sys.argv[1] == "update":
             # update PDB
             print("updating local PDB at " + pdb_path)
-            pl.update_pdb(file_format=file_format)
+            pl.update_pdb(file_format=file_format, with_assemblies=with_assemblies)
 
         elif sys.argv[1] == "all":
             # get the entire PDB

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -532,7 +532,7 @@ class PDBList:
         :return: file name of the downloaded assembly file.
         """
         archive = {
-            "pdb": "%s-pdb%s.gz",
+            "pdb": "%s.pdb%s.gz",
             "mmcif": "%s-assembly%s.cif.gz",
         }
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -267,6 +267,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Saket Choudhary <https://github.com/saketkc>
 - Sean Aubin <https://github.com/seanny123>
 - Sean Davis <https://github.com/seandavi>
+- Sean Workman <https://github.com/sean-workman>
 - Sebastian Bassi <https://about.me/bassi>
 - Sergei Lebedev <https://github.com/superbobry>
 - Sergio Valqui <https://github.com/svalqui>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -79,6 +79,7 @@ possible, especially the following contributors:
 - Robert Sawicki (first contribution)
 - Sebastian Bassi
 - Sean Aubin
+- Sean Workman (first contribution)
 - Tim Burke
 - Valentin Vareškić (first contribution)
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -48,6 +48,9 @@ performance improvement and to much better maintainability. The refactored
 ``qcprot.QCPSuperimposer`` class has small changes to its API, to better mirror
 that of ``Bio.PDB.Superimposer``.
 
+The ``Bio.PDB.PDBList`` module now allows downloading biological assemblies,
+for one or more entries of the wwPDB.
+
 In the ``Bio.Restriction`` module, each restriction enzyme now includes an `id`
 property giving the numerical identifier for the REBASE database identifier
 from which the enzyme object was created, and a `uri` property with a canonical

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -173,7 +173,7 @@ class TestPDBListGetAssembly(unittest.TestCase):
             self.assertTrue(os.path.isfile(path))
             os.remove(path)
 
-    def test_retrieve_assembly_file_small_mmcif(self):
+    def test_retrieve_assembly_file_mmcif(self):
         """Tests retrieving a small assembly in mmCif format."""
         structure = "127d"
         assembly_num = "1"
@@ -184,7 +184,7 @@ class TestPDBListGetAssembly(unittest.TestCase):
             "mmCif",
         )
 
-    def test_retrieve_assembly_file_small_pdb(self):
+    def test_retrieve_assembly_file_pdb(self):
         """Tests retrieving a small assembly in pdb format."""
         structure = "127d"
         assembly_num = "1"
@@ -193,17 +193,6 @@ class TestPDBListGetAssembly(unittest.TestCase):
             assembly_num,
             os.path.join(structure[1:3], f"{structure}.pdb{assembly_num}"),
             "pdb",
-        )
-
-    def test_retrieve_assembly_file_large_mmcif(self):
-        """Tests retrieving a large assembly in mmCif format."""
-        structure = "3k1q"
-        assembly_num = "1"
-        self.check(
-            structure,
-            assembly_num,
-            os.path.join(structure[1:3], f"{structure}-assembly{assembly_num}.cif"),
-            "mmCif",
         )
 
     def test_double_retrieve_assembly(self):

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -72,7 +72,7 @@ class TestPDBListGetStructure(unittest.TestCase):
 
     def check(self, structure, filename, file_format, obsolete=False, pdir=None):
         with self.make_temp_directory(os.getcwd()) as tmp:
-            pdblist = PDBList(pdb=tmp, obsolete_pdb=os.path.join(tmp, "obsolete"))
+            pdblist = PDBList(pdb=tmp)
             path = os.path.join(tmp, filename)
             if pdir:
                 pdir = os.path.join(tmp, pdir)
@@ -80,7 +80,6 @@ class TestPDBListGetStructure(unittest.TestCase):
                 structure, obsolete=obsolete, pdir=pdir, file_format=file_format
             )
             self.assertTrue(os.path.isfile(path))
-            os.remove(path)
 
     def test_retrieve_pdb_file_small_pdb(self):
         """Tests retrieving the small molecule in pdb format."""
@@ -163,7 +162,7 @@ class TestPDBListGetAssembly(unittest.TestCase):
 
     def check(self, structure, assembly_num, filename, file_format, pdir=None):
         with self.make_temp_directory(os.getcwd()) as tmp:
-            pdblist = PDBList(pdb=tmp, obsolete_pdb=os.path.join(tmp, "obsolete"))
+            pdblist = PDBList(pdb=tmp)
             path = os.path.join(tmp, filename)
             if pdir:
                 pdir = os.path.join(tmp, pdir)
@@ -171,7 +170,6 @@ class TestPDBListGetAssembly(unittest.TestCase):
                 structure, assembly_num, pdir=pdir, file_format=file_format
             )
             self.assertTrue(os.path.isfile(path))
-            os.remove(path)
 
     def test_retrieve_assembly_file_mmcif(self):
         """Tests retrieving a small assembly in mmCif format."""

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -49,6 +49,15 @@ class TestPBDListGetList(unittest.TestCase):
         # was exceeded
         self.assertGreater(len(entries), 3000)
 
+    def test_get_all_assemblies(self):
+        """Tests the Bio.PDB.PDBList.get_all_assemblies method."""
+        # obsolete_pdb declared to prevent from creating the "obsolete" directory
+        pdblist = PDBList(obsolete_pdb="unimportant")
+        entries = pdblist.get_all_assemblies()
+        # As number of obsolete entries constantly grow, test checks if a certain number
+        # was exceeded
+        self.assertGreater(len(entries), 100000)
+
 
 class TestPDBListGetStructure(unittest.TestCase):
     """Test methods responsible for getting structures."""
@@ -134,11 +143,87 @@ class TestPDBListGetStructure(unittest.TestCase):
         structure = "127d"
         self.check(structure, os.path.join(structure[1:3], f"{structure}.mmtf"), "mmtf")
 
-    def test_double_retrieve(self):
+    def test_double_retrieve_structure(self):
         """Tests retrieving the same file to different directories."""
         structure = "127d"
         self.check(structure, os.path.join("a", f"{structure}.cif"), "mmCif", pdir="a")
         self.check(structure, os.path.join("b", f"{structure}.cif"), "mmCif", pdir="b")
+
+
+class TestPDBListGetAssembly(unittest.TestCase):
+    """Test methods responsible for getting assemblies."""
+
+    @contextlib.contextmanager
+    def make_temp_directory(self, directory):
+        temp_dir = tempfile.mkdtemp(dir=directory)
+        try:
+            yield temp_dir
+        finally:
+            shutil.rmtree(temp_dir)
+
+    def check(self, structure, assembly_num, filename, file_format, pdir=None):
+        with self.make_temp_directory(os.getcwd()) as tmp:
+            pdblist = PDBList(pdb=tmp, obsolete_pdb=os.path.join(tmp, "obsolete"))
+            path = os.path.join(tmp, filename)
+            if pdir:
+                pdir = os.path.join(tmp, pdir)
+            pdblist.retrieve_assembly_file(
+                structure, assembly_num, pdir=pdir, file_format=file_format
+            )
+            self.assertTrue(os.path.isfile(path))
+            os.remove(path)
+
+    def test_retrieve_assembly_file_small_mmcif(self):
+        """Tests retrieving a small assembly in mmCif format."""
+        structure = "127d"
+        assembly_num = "1"
+        self.check(
+            structure,
+            assembly_num,
+            os.path.join(structure[1:3], f"{structure}-assembly{assembly_num}.cif"),
+            "mmCif",
+        )
+
+    def test_retrieve_assembly_file_small_pdb(self):
+        """Tests retrieving a small assembly in pdb format."""
+        structure = "127d"
+        assembly_num = "1"
+        self.check(
+            structure,
+            assembly_num,
+            os.path.join(structure[1:3], f"{structure}.pdb{assembly_num}"),
+            "pdb",
+        )
+
+    def test_retrieve_assembly_file_large_mmcif(self):
+        """Tests retrieving a large assembly in mmCif format."""
+        structure = "3k1q"
+        assembly_num = "1"
+        self.check(
+            structure,
+            assembly_num,
+            os.path.join(structure[1:3], f"{structure}-assembly{assembly_num}.cif"),
+            "mmCif",
+        )
+
+    def test_double_retrieve_assembly(self):
+        """Tests retrieving the same file to different directories."""
+        structure = "127d"
+        assembly_num = "1"
+        self.check(
+            structure,
+            assembly_num,
+            os.path.join("a", f"{structure}-assembly{assembly_num}.cif"),
+            "mmCif",
+            pdir="a",
+        )
+        self.check(
+            structure,
+            assembly_num,
+            os.path.join("b", f"{structure}-assembly{assembly_num}.cif"),
+            "mmCif",
+            pdir="b",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #1875 

This PR adds the ability to request assemblies for download along with regular entries. It requests the assemblies from the newly available directory (as of May 2022) that provides assemblies in mmCIF format for all PDB entries. I am working on putting together a couple of unit tests now. This is my first contribution and I am grateful to @JoaoRodrigues for providing some help and guidance through the process.
