### PR TITLE
resolve Seqfeature inconsistency

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1156,12 +1156,6 @@ class FeatureLocation:
                     " not found in references"
                 )
             parent_sequence = references[self.ref]
-            try:
-                # If was a SeqRecord, just take the sequence
-                # (should focus on the annotation of the feature)
-                parent_sequence = parent_sequence.seq
-            except AttributeError:
-                pass
         f_seq = parent_sequence[int(self.start) : int(self.end)]
         if isinstance(f_seq, MutableSeq):
             f_seq = Seq(f_seq)

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -101,7 +101,7 @@ class SeqFeature:
         ref=None,
         ref_db=None,
     ):
-        """Initialize a SeqFeature on a Sequence.
+        """Initialize a SeqFeature on a sequence.
 
         location can either be a FeatureLocation (with strand argument also
         given if required), or None.

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -280,7 +280,9 @@ class TestExtract(unittest.TestCase):
         ):
             location.extract(parent_record, references={"SOMEOTHER.2": another_record})
         self.assertEqual(
-            location.extract(parent_record, references={"ANOTHER.7": another_record}),
+            location.extract(
+                parent_record, references={"ANOTHER.7": another_record}
+            ).seq,
             "cta",
         )
 

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -235,7 +235,7 @@ class TestLocations(unittest.TestCase):
 
 class TestPositions(unittest.TestCase):
     def test_pickle(self):
-        """Test pickle behaviour of position instances."""
+        """Test pickle behavior of position instances."""
         # setup
         import pickle
 
@@ -249,7 +249,7 @@ class TestPositions(unittest.TestCase):
             oneof_pos.__getnewargs__(),
             (1888, [ExactPosition(1888), ExactPosition(1901)]),
         )
-        # test pickle behaviour
+        # test pickle behavior
         within_pos2 = pickle.loads(pickle.dumps(within_pos))
         between_pos2 = pickle.loads(pickle.dumps(between_pos))
         oneof_pos2 = pickle.loads(pickle.dumps(oneof_pos))

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -279,24 +279,22 @@ class TestExtract(unittest.TestCase):
             r"Feature references another sequence \(ANOTHER\.7\), not found in references",
         ):
             location.extract(parent_record, references={"SOMEOTHER.2": another_record})
-        self.assertEqual(
-            location.extract(
-                parent_record, references={"ANOTHER.7": another_record}
-            ).seq,
-            "cta",
+        record = location.extract(
+            parent_record, references={"ANOTHER.7": another_record}
         )
+        self.assertEqual(type(record), SeqRecord.SeqRecord)
+        self.assertEqual(record.seq, "cta")
 
     def test_reference_in_location_sequence(self):
         """Test location with reference to another sequence."""
         parent_sequence = Seq.Seq("actg")
         another_sequence = Seq.Seq("gtcagctac")
         location = FeatureLocation(5, 8, ref="ANOTHER.7")
-        self.assertEqual(
-            location.extract(
-                parent_sequence, references={"ANOTHER.7": another_sequence}
-            ),
-            "cta",
+        sequence = location.extract(
+            parent_sequence, references={"ANOTHER.7": another_sequence}
         )
+        self.assertEqual(type(sequence), Seq.Seq)
+        self.assertEqual(sequence, "cta")
 
     def test_reference_in_compound_location_record(self):
         """Test compound location with reference to another record."""
@@ -313,24 +311,22 @@ class TestExtract(unittest.TestCase):
             r"Feature references another sequence \(ANOTHER\.7\), not found in references",
         ):
             location.extract(parent_record, references={"SOMEOTHER.2": another_record})
-        self.assertEqual(
-            location.extract(
-                parent_record, references={"ANOTHER.7": another_record}
-            ).seq,
-            "ccaatgg",
+        record = location.extract(
+            parent_record, references={"ANOTHER.7": another_record}
         )
+        self.assertEqual(type(record), SeqRecord.SeqRecord)
+        self.assertEqual(record.seq, "ccaatgg")
 
     def test_reference_in_compound_location_sequence(self):
         """Test compound location with reference to another sequence."""
         parent_sequence = Seq.Seq("aaccaaccaaccaaccaa")
         another_sequence = Seq.Seq("ttggttggttggttggtt")
         location = FeatureLocation(2, 6) + FeatureLocation(5, 8, ref="ANOTHER.7")
-        self.assertEqual(
-            location.extract(
-                parent_sequence, references={"ANOTHER.7": another_sequence}
-            ),
-            "ccaatgg",
+        sequence = location.extract(
+            parent_sequence, references={"ANOTHER.7": another_sequence}
         )
+        self.assertEqual(type(sequence), Seq.Seq)
+        self.assertEqual(sequence, "ccaatgg")
 
 
 if __name__ == "__main__":

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -235,7 +235,7 @@ class TestLocations(unittest.TestCase):
 
 class TestPositions(unittest.TestCase):
     def test_pickle(self):
-        """Test pickle behavior of position instances."""
+        """Test pickle behaviour of position instances."""
         # setup
         import pickle
 
@@ -249,7 +249,7 @@ class TestPositions(unittest.TestCase):
             oneof_pos.__getnewargs__(),
             (1888, [ExactPosition(1888), ExactPosition(1901)]),
         )
-        # test pickle behavior
+        # test pickle behaviour
         within_pos2 = pickle.loads(pickle.dumps(within_pos))
         between_pos2 = pickle.loads(pickle.dumps(between_pos))
         oneof_pos2 = pickle.loads(pickle.dumps(oneof_pos))


### PR DESCRIPTION
The docstring for the `extract` method of `FeatureLocation` in `Bio.SeqFeature` says
```
        The parent_sequence can be a Seq like object or a string, and will
        generally return an object of the same type. The exception to this is
        a MutableSeq as the parent sequence will return a Seq object.
```

If the `parent_sequence` is a `SeqRecord` object, and if `self.ref` and `self.ref_db` are both `None`, then `extract` will indeed return a `SeqRecord` object. However, if `self.ref` and `self.ref_db` are not `None`, then `extract` will return a `Seq` object.

This PR changes the `extract` method such that it always returns a `SeqRecord` if `parent_sequence` is a `SeqRecord`. The behavior of the `extract` method is then consistent with its docstring.



- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
