### PR TITLE
IsoelectricPoint: remove str conversion

### DIFF
--- a/Bio/SeqUtils/IsoelectricPoint.py
+++ b/Bio/SeqUtils/IsoelectricPoint.py
@@ -81,7 +81,7 @@ class IsoelectricPoint:
 
     def __init__(self, protein_sequence, aa_content=None):
         """Initialize the class."""
-        self.sequence = str(protein_sequence).upper()
+        self.sequence = protein_sequence.upper()
         if not aa_content:
             from Bio.SeqUtils.ProtParam import ProteinAnalysis as _PA
 


### PR DESCRIPTION
Using `str` to get a plain string is not needed here, and may result in an incorrect answer if a user mistakenly passes a `SeqRecord` object instead of a `Seq` object.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

