### PR TITLE
Bio.SeqUtils.ProtParam Seq handling

### DIFF
--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -58,9 +58,7 @@ class ProteinAnalysis:
     """Class containing methods for protein analysis.
 
     The constructor takes two arguments.
-    The first is the protein sequence as a string, which is then converted to a
-    sequence object using the Bio.Seq module. This is done just to make sure
-    the sequence is a protein sequence and not anything else.
+    The first is the protein sequence as a string or a Seq object.
 
     The second argument is optional. If set to True, the weight of the amino
     acids will be calculated using their monoisotopic mass (the weight of the
@@ -73,10 +71,7 @@ class ProteinAnalysis:
 
     def __init__(self, prot_sequence, monoisotopic=False):
         """Initialize the class."""
-        if prot_sequence.islower():
-            self.sequence = Seq(prot_sequence.upper())
-        else:
-            self.sequence = Seq(prot_sequence)
+        self.sequence = prot_sequence.upper()
         self.amino_acids_content = None
         self.amino_acids_percent = None
         self.length = len(self.sequence)


### PR DESCRIPTION
- Now that alphabets are gone, converting a string to a `Seq` object won't check if the sequence is a protein (it didn't really check that when we still had alphabets either).
- The test for `islower` will fail to detect a string that contains both upper and lower characters. This could be changed to `not isupper`, but we may as well just call `upper` and keep the code simple.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
