### PR TITLE
SeqUtils cleanup

### DIFF
--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -344,9 +344,7 @@ def molecular_weight(
     249.29
 
     """
-    # Rewritten by Markus Piotrowski, 2014
-
-    seq = "".join(str(seq).split()).upper()  # Do the minimum formatting
+    seq = seq.upper()  # Do the minimum formatting
 
     if seq_type == "DNA":
         if monoisotopic:
@@ -377,7 +375,7 @@ def molecular_weight(
             weight -= water
     except KeyError as e:
         raise ValueError(
-            f"{e} is not a valid unambiguous letter for {seq_type}"
+            f"'{e}' is not a valid unambiguous letter for {seq_type}"
         ) from None
 
     if double_stranded:

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -322,7 +322,7 @@ def molecular_weight(
     have a 5' phosphate.
 
     Arguments:
-     - seq: String or Biopython sequence object.
+     - seq: string, Seq, or SeqRecord object.
      - seq_type: The default is to assume DNA; override this with a string
        "DNA", "RNA", or "protein".
      - double_stranded: Calculate the mass for the double stranded molecule?
@@ -344,7 +344,11 @@ def molecular_weight(
     249.29
 
     """
-    seq = seq.upper()  # Do the minimum formatting
+    try:
+        seq = seq.seq
+    except AttributeError:  # not a  SeqRecord object
+        pass
+    seq = "".join(str(seq).split()).upper()  # Do the minimum formatting
 
     if seq_type == "DNA":
         if monoisotopic:

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -171,7 +171,7 @@ def xGC_skew(seq, window=1000, zoom=100, r=300, px=100, py=100):
 
 
 def nt_search(seq, subseq):
-    """Search for a DNA subseq in sequence, return list of [subseq, positions].
+    """Search for a DNA subseq in seq, return list of [subseq, positions].
 
     Use ambiguous values (like N = A or T or C or G, R = A or G etc.),
     searches only on forward strand.

--- a/Tests/test_ProtParam.py
+++ b/Tests/test_ProtParam.py
@@ -9,6 +9,7 @@
 
 import unittest
 from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
 from Bio.SeqUtils import ProtParam, ProtParamData
 from Bio.SeqUtils import molecular_weight
 
@@ -18,51 +19,59 @@ class ProtParamTest(unittest.TestCase):
 
     def setUp(self):
         """Initialise objects."""
-        self.seq_text = "MAEGEITTFTALTEKFNLPPGNYKKPKLLYCSNGGHFLRILPDGTVDGTRDRSDQHIQLQLSAESVGEVYIKSTETGQYLAMDTSGLLYGSQTPSEECLFLERLEENHYNTYTSKKHAEKNWFVGLKKNGSCKRGPRTHYGQKAILFLPLPV"
-        self.analysis = ProtParam.ProteinAnalysis(self.seq_text)
+        text = "MAEGEITTFTALTEKFNLPPGNYKKPKLLYCSNGGHFLRILPDGTVDGTRDRSDQHIQLQLSAESVGEVYIKSTETGQYLAMDTSGLLYGSQTPSEECLFLERLEENHYNTYTSKKHAEKNWFVGLKKNGSCKRGPRTHYGQKAILFLPLPV"
+        seq = Seq(text)
+        record = SeqRecord(seq)
+        analysis_text = ProtParam.ProteinAnalysis(text)
+        analysis_seq = ProtParam.ProteinAnalysis(seq)
+        analysis_record = ProtParam.ProteinAnalysis(record)
+        self.text = text
+        self.sequences = (text, seq, record)
+        self.analyses = (analysis_text, analysis_seq, analysis_record)
+        self.analysis = ProtParam.ProteinAnalysis(text)
 
     def test_count_amino_acids(self):
         """Calculate amino acid counts."""
         count_dict = self.analysis.count_amino_acids()
-        for i in sorted(count_dict):
-            self.assertEqual(count_dict[i], self.seq_text.count(i))
+        for i in count_dict:
+            self.assertEqual(count_dict[i], self.text.count(i))
 
     def test_get_amino_acids_percent(self):
         """Calculate amino acid percentages."""
         percent_dict = self.analysis.get_amino_acids_percent()
-        seq_len = len(self.seq_text)
-        for i in sorted(percent_dict):
-            self.assertAlmostEqual(
-                percent_dict[i], self.seq_text.count(i) / float(seq_len)
-            )
+        seq_len = len(self.text)
+        for i in percent_dict:
+            self.assertAlmostEqual(percent_dict[i], self.text.count(i) / float(seq_len))
 
     def test_get_molecular_weight(self):
         """Calculate protein molecular weight."""
-        self.assertAlmostEqual(self.analysis.molecular_weight(), 17103.16, 2)
+        for analysis in self.analyses:
+            self.assertAlmostEqual(analysis.molecular_weight(), 17103.16, 2)
 
     def test_get_monoisotopic_molecular_weight(self):
         """Calculate monoisotopic molecular weight."""
-        self.analysis = ProtParam.ProteinAnalysis(self.seq_text, monoisotopic=True)
-        self.assertAlmostEqual(self.analysis.molecular_weight(), 17092.61, 2)
+        for sequence in self.sequences:
+            analysis = ProtParam.ProteinAnalysis(sequence, monoisotopic=True)
+            self.assertAlmostEqual(analysis.molecular_weight(), 17092.61, 2)
 
     def test_get_molecular_weight_identical(self):
         """Confirm protein molecular weight agrees with calculation from Bio.SeqUtils."""
         # This test is somehow useless, since ProteinAnalysis.molecular_weight
         # is internally calling SeqUtils.molecular_weight.
-        mw_1 = self.analysis.molecular_weight()
-        mw_2 = molecular_weight(Seq(self.seq_text), seq_type="protein")
-        self.assertAlmostEqual(mw_1, mw_2)
+        mw_2 = molecular_weight(self.text, seq_type="protein")
+        for analysis in self.analyses:
+            mw_1 = analysis.molecular_weight()
+            self.assertAlmostEqual(mw_1, mw_2)
 
     def test_get_monoisotopic_molecular_weight_identical(self):
         """Confirm protein molecular weight agrees with calculation from Bio.SeqUtils."""
         # This test is somehow useless, since ProteinAnalysis.molecular_weight
         # is internally calling SeqUtils.molecular_weight.
-        self.analysis = ProtParam.ProteinAnalysis(self.seq_text, monoisotopic=True)
-        mw_1 = self.analysis.molecular_weight()
-        mw_2 = molecular_weight(
-            Seq(self.seq_text), seq_type="protein", monoisotopic=True
-        )
-        self.assertAlmostEqual(mw_1, mw_2)
+        mw_2 = molecular_weight(self.text, seq_type="protein", monoisotopic=True)
+        for sequence in self.sequences:
+            analysis = ProtParam.ProteinAnalysis(sequence, monoisotopic=True)
+            mw_1 = analysis.molecular_weight()
+            self.assertAlmostEqual(mw_1, mw_2)
 
     def test_aromaticity(self):
         """Calculate protein aromaticity."""
@@ -71,12 +80,12 @@ class ProtParamTest(unittest.TestCase):
 
     def test_instability_index(self):
         """Calculate protein instability index."""
-        # Old test used a number rounded to two digits, so use the same
-        self.assertAlmostEqual(self.analysis.instability_index(), 41.98, 2)
+        for analysis in self.analyses:
+            # Old test used a number rounded to two digits, so use the same
+            self.assertAlmostEqual(analysis.instability_index(), 41.98, 2)
 
     def test_flexibility(self):
         """Calculate protein flexibility."""
-        flexibility = self.analysis.flexibility()
         # Turn black code style off
         # fmt: off
         expected_flexibility = [
@@ -130,11 +139,13 @@ class ProtParamTest(unittest.TestCase):
         # Turn black code style on
         # fmt: on
 
-        self.assertEqual(
-            len(flexibility), len(expected_flexibility), "Output length differs"
-        )
-        for f, e in zip(flexibility, expected_flexibility):
-            self.assertAlmostEqual(f, e)
+        for analysis in self.analyses:
+            flexibility = analysis.flexibility()
+            self.assertEqual(
+                len(flexibility), len(expected_flexibility), "Output length differs"
+            )
+            for f, e in zip(flexibility, expected_flexibility):
+                self.assertAlmostEqual(f, e)
 
     def test_isoelectric_point(self):
         """Calculate the isoelectric point."""
@@ -177,11 +188,10 @@ class ProtParamTest(unittest.TestCase):
                     -1.4742, -0.8083, -0.2100, +0.8067, +1.3092, +1.8367, +2.0283, +2.3558]
         # Turn black code style on
         # fmt: on
-        for i, e in zip(
-            self.analysis.protein_scale(ProtParamData.kd, 9, 0.4), expected
-        ):
-            # Expected values have 4 decimal places, so restrict to that exactness
-            self.assertAlmostEqual(i, e, places=4)
+        for analysis in self.analyses:
+            for i, e in zip(analysis.protein_scale(ProtParamData.kd, 9, 0.4), expected):
+                # Expected values have 4 decimal places, so restrict to that exactness
+                self.assertAlmostEqual(i, e, places=4)
 
     def test_gravy(self):
         """Calculate gravy. Tests all pre-defined scales."""
@@ -216,12 +226,13 @@ class ProtParamTest(unittest.TestCase):
             "Zimmerman": 1.2841,
         }
 
-        for scale, exp_v in expected_values.items():
-            self.assertAlmostEqual(self.analysis.gravy(scale=scale), exp_v, places=4)
+        for analysis in self.analyses:
+            for scale, exp_v in expected_values.items():
+                self.assertAlmostEqual(analysis.gravy(scale=scale), exp_v, places=4)
 
-        with self.assertRaises(ValueError) as cm:
-            self.analysis.gravy("Wrong Scale")
-        self.assertEqual("scale: Wrong Scale not known", str(cm.exception))
+            with self.assertRaises(ValueError) as cm:
+                analysis.gravy("Wrong Scale")
+            self.assertEqual("scale: Wrong Scale not known", str(cm.exception))
 
     def test_molar_extinction_coefficient(self):
         """Molar extinction coefficient."""


### PR DESCRIPTION
Whitespace is removed from `seq` by calling `"".join(str(seq).split())`. But it's not necessary to do this, as any whitespace in `seq` will be caught as a `KeyError` anyway. With this PR, `molecular_weight` can be applied to `SeqRecord` objects (in addition to `Seq` objects and plain strings). I have expanded the tests in `test_ProtParam.py` to cover plain strings, `Seq`, and `SeqRecord` where possible (the remaining ones will need a `.count` method on `SeqRecord`).

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
