### PR TITLE
Bio.SeqUtils.lcc bug fix

### DIFF
--- a/Bio/SeqUtils/lcc.py
+++ b/Bio/SeqUtils/lcc.py
@@ -24,8 +24,8 @@ def lcc_mult(seq, wsize):
     value of previous window as a base to compute the next one.
     """
     l4 = math.log(4)
+    seq = seq.upper()
     tamseq = len(seq)
-    upper = str(seq).upper()
     compone = [0]
     lccsal = []
     for i in range(wsize):
@@ -44,7 +44,7 @@ def lcc_mult(seq, wsize):
     lccsal.append(-(term_a + term_c + term_t + term_g))
     tail = seq[0]
     for x in range(tamseq - wsize):
-        window = upper[x + 1 : wsize + x + 1]
+        window = seq[x + 1 : wsize + x + 1]
         if tail == window[-1]:
             lccsal.append(lccsal[-1])
         elif tail == "A":
@@ -132,31 +132,31 @@ def lcc_simp(seq):
     https://doi.org/10.1038/npg.els.0005260
     """
     wsize = len(seq)
-    upper = str(seq).upper()
+    seq = seq.upper()
     l4 = math.log(4)
     # Check to avoid calculating the log of 0.
     if "A" not in seq:
         term_a = 0
     else:
-        term_a = ((upper.count("A")) / float(wsize)) * (
-            (math.log((upper.count("A")) / float(wsize))) / l4
+        term_a = ((seq.count("A")) / float(wsize)) * (
+            (math.log((seq.count("A")) / float(wsize))) / l4
         )
     if "C" not in seq:
         term_c = 0
     else:
-        term_c = ((upper.count("C")) / float(wsize)) * (
-            (math.log((upper.count("C")) / float(wsize))) / l4
+        term_c = ((seq.count("C")) / float(wsize)) * (
+            (math.log((seq.count("C")) / float(wsize))) / l4
         )
     if "T" not in seq:
         term_t = 0
     else:
-        term_t = ((upper.count("T")) / float(wsize)) * (
-            (math.log((upper.count("T")) / float(wsize))) / l4
+        term_t = ((seq.count("T")) / float(wsize)) * (
+            (math.log((seq.count("T")) / float(wsize))) / l4
         )
     if "G" not in seq:
         term_g = 0
     else:
-        term_g = ((upper.count("G")) / float(wsize)) * (
-            (math.log((upper.count("G")) / float(wsize))) / l4
+        term_g = ((seq.count("G")) / float(wsize)) * (
+            (math.log((seq.count("G")) / float(wsize))) / l4
         )
     return -(term_a + term_c + term_t + term_g)


### PR DESCRIPTION
This fixes a bug that crept in in commit 91471531548cb80ece1e2ab6b3ce3891dc47eb98 : `upper` is defined but not used consistently.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

