### PR TITLE
Improve PDB server interoperability

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -61,9 +61,13 @@ from Bio.PDB.PDBExceptions import PDBException
 
 @dataclasses.dataclass
 class PDBServer:
-    """Protein Data Server class.
+    """Dataclass to store parameters for connecting to PDB server.
 
-    In charge of the interactions with the server.
+    param domain: server domain name.
+    type domain: string
+
+    :param pdb_directory: path to the PDB data directory.
+    :type domain: string
     """
 
     domain: str
@@ -532,11 +536,12 @@ class PDBList:
             ftp = ftplib.FTP(pdb_server.split("/", 1)[0])
         ftp.login()  # anonymous
         pdb_directory = pdb_server.split("/", 1)[1]
+        ftp.cwd(pdb_directory)
         if file_format.lower() == "mmcif":
-            ftp.cwd(f"{pdb_directory}/data/assemblies/mmCIF/all/")
+            ftp.cwd("data/assemblies/mmCIF/all/")
             re_name = re.compile(r"(\d[0-9a-z]{3})-assembly(\d+).cif.gz")
         elif file_format.lower() == "pdb":
-            ftp.cwd(f"{pdb_directory}/data/biounit/PDB/all/")
+            ftp.cwd("data/biounit/PDB/all/")
             re_name = re.compile(r"(\d[0-9a-z]{3}).pdb(\d+).gz")
         else:
             msg = "file_format for assemblies must be 'pdb' or 'mmCif'"

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -66,12 +66,12 @@ class PDBServer:
     param domain: server domain name.
     type domain: string
 
-    :param pdb_directory: path to the PDB data directory.
+    :param pdb_dir_path: path to the PDB data directory.
     :type domain: string
     """
 
     domain: str
-    pdb_directory: str
+    pdb_dir_path: str
 
 
 SERVERS = [
@@ -159,7 +159,7 @@ class PDBList:
 
         if pdb_server:
             return urlunsplit(
-                ("ftp", pdb_server.domain, pdb_server.pdb_directory, None, None)
+                ("ftp", pdb_server.domain, pdb_server.pdb_dir_path, None, None)
             )
 
         raise TypeError(f"Unexpected server (server: {server}).")
@@ -535,8 +535,8 @@ class PDBList:
         else:
             ftp = ftplib.FTP(pdb_server.split("/", 1)[0])
         ftp.login()  # anonymous
-        pdb_directory = pdb_server.split("/", 1)[1]
-        ftp.cwd(pdb_directory)
+        pdb_dir_path = pdb_server.split("/", 1)[1]
+        ftp.cwd(pdb_dir_path)
         if file_format.lower() == "mmcif":
             ftp.cwd("data/assemblies/mmCIF/all/")
             re_name = re.compile(r"(\d[0-9a-z]{3})-assembly(\d+).cif.gz")

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import collections
 import contextlib
+import dataclasses
 import ftplib
 import functools
 import gzip
@@ -53,16 +54,26 @@ from urllib.request import urlopen
 from urllib.request import urlretrieve
 from urllib.request import urlcleanup
 from urllib.parse import urljoin
+from urllib.parse import urlunsplit
 
 from Bio.PDB.PDBExceptions import PDBException
 
 
-PDBServer = collections.namedtuple("PDBServer", ["domain", "pdb_directory"])
+@dataclasses.dataclass
+class PDBServer:
+    """Protein Data Server class.
+
+    In charge of the interactions with the server.
+    """
+
+    domain: str
+    pdb_directory: str
+
 
 SERVERS = [
-    PDBServer("ftp.rcsb.org", "/pub/pdb"),
-    PDBServer("ftp.ebi.ac.uk", "/pub/databases/pdb"),
-    PDBServer("ftp.pdbj.org", "/pub/pdb"),
+    PDBServer("ftp.rcsb.org", "/pub/pdb/"),
+    PDBServer("ftp.ebi.ac.uk", "/pub/databases/pdb/"),
+    PDBServer("ftp.pdbj.org", "/pub/pdb/"),
 ]
 
 
@@ -138,12 +149,14 @@ class PDBList:
         if server is None:
             pdb_server = get_fastest_server()
         elif isinstance(server, str):
-            return f"{server}/pub/pdb"
+            return urljoin(server, "pub/pdb/")
         elif isinstance(server, PDBServer):
             pdb_server = server
 
         if pdb_server:
-            return f"ftp://{pdb_server.domain}{pdb_server.pdb_directory}/"
+            return urlunsplit(
+                ("ftp", pdb_server.domain, pdb_server.pdb_directory, None, None)
+            )
 
         raise TypeError(f"Unexpected server (server: {server}).")
 

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -52,6 +52,7 @@ import time
 from urllib.request import urlopen
 from urllib.request import urlretrieve
 from urllib.request import urlcleanup
+from urllib.parse import urljoin
 
 from Bio.PDB.PDBExceptions import PDBException
 
@@ -142,7 +143,7 @@ class PDBList:
             pdb_server = server
 
         if pdb_server:
-            return f"ftp://{pdb_server.domain}{pdb_server.pdb_directory}"
+            return f"ftp://{pdb_server.domain}{pdb_server.pdb_directory}/"
 
         raise TypeError(f"Unexpected server (server: {server}).")
 
@@ -191,7 +192,7 @@ class PDBList:
             -rw-r--r--   1 1002     sysadmin    1327 Mar 12  2001 README
 
         """
-        url = f"{self.pdb_server}/data/status/latest"
+        url = urljoin(self.pdb_server, "data/status/latest")
 
         # Retrieve the lists
         added = self.get_status_list(f"{url}/added.pdb")
@@ -204,7 +205,7 @@ class PDBList:
 
         Returns a list of PDB codes in the index file.
         """
-        url = f"{self.pdb_server}/derived_data/index/entries.idx"
+        url = urljoin(self.pdb_server, "derived_data/index/entries.idx")
         if self._verbose:
             print("Retrieving index file. Takes about 27 MB.")
         with contextlib.closing(urlopen(url)) as handle:
@@ -236,7 +237,7 @@ class PDBList:
             ...
 
         """
-        url = f"{self.pdb_server}/data/status/obsolete.dat"
+        url = urljoin(self.pdb_server, "data/status/obsolete.dat")
         with contextlib.closing(urlopen(url)) as handle:
             # Extract pdb codes. Could use a list comprehension, but I want
             # to include an assert to check for mis-reading the data.
@@ -324,14 +325,14 @@ class PDBList:
                 if file_format == "mmCif"
                 else "XML"
             )
-            url = (
-                f"{self.pdb_server}/data/structures/"
-                f"{pdb_dir}/{file_type}/{code[1:3]}/{archive_fn}"
+            url = urljoin(
+                self.pdb_server,
+                f"data/structures/{pdb_dir}/{file_type}/{code[1:3]}/{archive_fn}",
             )
         elif file_format == "bundle":
-            url = (
-                f"{self.pdb_server}/compatible/pdb_bundle/"
-                f"{code[1:3]}/{code}/{archive_fn}"
+            url = urljoin(
+                self.pdb_server,
+                f"compatible/pdb_bundle/{code[1:3]}/{code}/{archive_fn}",
             )
         else:
             url = f"http://mmtf.rcsb.org/v1.0/full/{code}"
@@ -581,9 +582,9 @@ class PDBList:
         archive_fn = archive[file_format] % (pdb_code.lower(), int(assembly_num))
 
         if file_format == "mmcif":
-            url = self.pdb_server + "/data/assemblies/mmCIF/all/%s" % archive_fn
+            url = urljoin(self.pdb_server, f"data/assemblies/mmCIF/all/{archive_fn}")
         elif file_format == "pdb":
-            url = self.pdb_server + "/data/biounit/PDB/all/%s" % archive_fn
+            url = urljoin(self.pdb_server, f"data/biounit/PDB/all/{archive_fn}")
         else:  # better safe than sorry
             raise ValueError("file_format '%s' not supported: %s" % file_format)
 
@@ -698,7 +699,7 @@ class PDBList:
         """Retrieve and save a (big) file containing all the sequences of PDB entries."""
         if self._verbose:
             print("Retrieving sequence file (takes over 110 MB).")
-        url = f"{self.pdb_server}/derived_data/pdb_seqres.txt"
+        url = urljoin(self.pdb_server, "derived_data/pdb_seqres.txt")
         urlretrieve(url, savefile)
 
 

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -162,7 +162,7 @@ class PDBList:
                 ("ftp", pdb_server.domain, pdb_server.pdb_dir_path, None, None)
             )
 
-        raise TypeError(f"Unexpected server (server: {server}).")
+        raise TypeError(f"Unsupported server option: {server}")
 
     @staticmethod
     def _print_default_format_warning(file_format):

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -56,6 +56,15 @@ from urllib.request import urlcleanup
 from Bio.PDB.PDBExceptions import PDBException
 
 
+PDBServer = collections.namedtuple("PDBServer", ["domain", "pdb_directory"])
+
+SERVERS = [
+    PDBServer("ftp.rcsb.org", "/pub/pdb"),
+    PDBServer("ftp.ebi.ac.uk", "/pub/databases/pdb"),
+    PDBServer("ftp.pdbj.org", "/pub/pdb"),
+]
+
+
 class PDBList:
     """Quick access to the structure lists on the PDB or its mirrors.
 
@@ -125,12 +134,12 @@ class PDBList:
         If no server specified, chose the fastest one.
         """
         pdb_server = None
-        if isinstance(server, str):
-            return "{server}/pub/pdb"
+        if server is None:
+            pdb_server = get_fastest_server()
+        elif isinstance(server, str):
+            return f"{server}/pub/pdb"
         elif isinstance(server, PDBServer):
             pdb_server = server
-        elif server is None:
-            pdb_server = get_fastest_server()
 
         if pdb_server:
             return f"ftp://{pdb_server.domain}{pdb_server.pdb_directory}"
@@ -691,15 +700,6 @@ class PDBList:
             print("Retrieving sequence file (takes over 110 MB).")
         url = f"{self.pdb_server}/derived_data/pdb_seqres.txt"
         urlretrieve(url, savefile)
-
-
-PDBServer = collections.namedtuple("PDBServer", ["domain", "pdb_directory"])
-
-SERVERS = [
-    PDBServer("ftp.rcsb.org", "/pub/pdb"),
-    PDBServer("ftp.ebi.ac.uk", "/pub/databases/pdb"),
-    PDBServer("ftp.pdbj.org", "/pub/pdb"),
-]
 
 
 @functools.lru_cache(maxsize=None)

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -27,7 +27,7 @@ class TestPBDListGetList(unittest.TestCase):
         """Tests the Bio.PDB.PDBList.get_recent_changes method."""
         # obsolete_pdb declared to prevent from creating the "obsolete" directory
         pdblist = PDBList(obsolete_pdb="unimportant")
-        url = pdblist.pdb_server + "/pub/pdb/data/status/latest/added.pdb"
+        url = f"{pdblist.pdb_server}/data/status/latest/added.pdb"
         entries = pdblist.get_status_list(url)
         self.assertIsNotNone(entries)
 

--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from urllib.parse import urljoin
 
 # We want to test this module:
 from Bio.PDB.PDBList import PDBList
@@ -27,7 +28,7 @@ class TestPBDListGetList(unittest.TestCase):
         """Tests the Bio.PDB.PDBList.get_recent_changes method."""
         # obsolete_pdb declared to prevent from creating the "obsolete" directory
         pdblist = PDBList(obsolete_pdb="unimportant")
-        url = f"{pdblist.pdb_server}/data/status/latest/added.pdb"
+        url = urljoin(pdblist.pdb_server, "data/status/latest/added.pdb")
         entries = pdblist.get_status_list(url)
         self.assertIsNotNone(entries)
 


### PR DESCRIPTION
Hello :wave: 

This RP is intended to resolve issue #3987.

I'm not a PDB server specialist but I found information [here](https://www.wwpdb.org/ftp/pdb-ftp-sites) and [here](https://www.rcsb.org/docs/programmatic-access/file-download-services).

Introducing a new module `PDBServer` containing the eponymous class to organize server-related data and processing.
I think this implementation will allow us to evolve the `PDBList` module in a good direction.

It is fully backwards compatible. and thanks to lru cache we will avoid duplicated network queries.

### Protocols

As the introduction of the `PDBServer` module has greatly facilitated the implementation of this feature, I went a little further than the need expressed in the issue by implementing the ability to download files using the HTTPS protocol.

This need seemed to me necessary in view of the recommendations of the RCSB ([source](https://www.rcsb.org/docs/programmatic-access/file-download-services)):

> The HTTPS protocol offers more flexibility and less overhead and is strongly recommended for usage in scripts and third party software. HTTPS links for this service are described below. The FTP protocol will be gradually phased out.


______

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

______

Closes #3987
