### PR TITLE
Bio.Restriction minor update

### DIFF
--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -86,6 +86,7 @@ Notes about the diverses class of the restriction enzyme implementation::
 import warnings
 
 import re
+import string
 import itertools
 
 from Bio.Seq import Seq, MutableSeq
@@ -94,33 +95,6 @@ from Bio.Restriction.Restriction_Dictionary import typedict
 from Bio.Restriction.Restriction_Dictionary import suppliers as suppliers_dict
 from Bio.Restriction.PrintFormat import PrintFormat
 from Bio import BiopythonWarning
-
-
-# Used to use Bio.Restriction.DNAUtils.check_bases (and expose it under this
-# namespace), but have deprecated that module.
-
-
-def _check_bases(seq_string):
-    """Check characters in a string (PRIVATE).
-
-    Remove digits and white space present in string. Allows any valid ambiguous
-    IUPAC DNA single letters codes (ABCDGHKMNRSTVWY, lower case are converted).
-
-    Other characters (e.g. symbols) trigger a TypeError.
-
-    Returns the string WITH A LEADING SPACE (!). This is for backwards
-    compatibility, and may in part be explained by the fact that
-    ``Bio.Restriction`` doesn't use zero based counting.
-    """
-    # Remove white space and make upper case:
-    seq_string = "".join(seq_string.split()).upper()
-    # Remove digits
-    for c in "0123456789":
-        seq_string = seq_string.replace(c, "")
-    # Check only allowed IUPAC letters
-    if not set(seq_string).issubset(set("ABCDGHKMNRSTVWY")):
-        raise TypeError(f"Invalid character found in {seq_string!r}")
-    return " " + seq_string
 
 
 matching = {
@@ -157,6 +131,15 @@ class FormattedSeq:
     circular. Restriction sites are search over the edges of circular sequence.
     """
 
+    _remove_chars = string.whitespace.encode() + string.digits.encode()
+    _table = bytearray(256)
+    upper_to_lower = ord("A") - ord("a")
+    for c in b"ABCDGHKMNRSTVWY":  # Only allow IUPAC letters
+        _table[c] = c  # map uppercase to uppercase
+        _table[c - upper_to_lower] = c  # map lowercase to uppercase
+    del upper_to_lower
+    _table = bytes(_table)
+
     def __init__(self, seq, linear=True):
         """Initialize ``FormattedSeq`` with sequence and topology (optional).
 
@@ -165,10 +148,13 @@ class FormattedSeq:
         will have no effect on the shape of the sequence.
         """
         if isinstance(seq, (Seq, MutableSeq)):
-            stringy = str(seq)
-            self.lower = stringy.islower()
+            self.lower = seq.islower()
+            data = bytes(seq)
+            self.data = data.translate(self._table, delete=self._remove_chars)
+            if 0 in self.data:  # Check if all letters were IUPAC
+                raise TypeError(f"Invalid character found in {data.decode()}")
             # Note this adds a leading space to the sequence (!)
-            self.data = _check_bases(stringy)
+            self.data = " " + self.data.decode("ASCII")
             self.linear = linear
             self.klass = seq.__class__
         elif isinstance(seq, FormattedSeq):


### PR DESCRIPTION
Removing whitespace and digits, and changing to upper case can be done in one step by `.translate`; checking for invalid characters is also easier this way, as `set` is not needed. This is about 2 - 10 times faster, depending on string contents.
Note that calling `bytes` on a `Seq` object returns a reference, not a copy, of the `bytes` object stored in `Seq`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

