### PR TITLE
test_seq.py catch deprecation warnings

### DIFF
--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -1004,7 +1004,9 @@ class TestComplement(unittest.TestCase):
 
     def test_complement_of_mixed_dna_rna(self):
         seq = "AUGAAACTG"  # U and T
-        self.assertRaises(ValueError, Seq.complement, seq)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=BiopythonDeprecationWarning)
+            self.assertRaises(ValueError, Seq.complement, seq)
 
     def test_complement_of_rna(self):
         seq = "AUGAAACUG"
@@ -1081,7 +1083,9 @@ class TestReverseComplement(unittest.TestCase):
 
     def test_reverse_complement_of_mixed_dna_rna(self):
         seq = "AUGAAACTG"  # U and T
-        self.assertRaises(ValueError, Seq.reverse_complement, seq)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=BiopythonDeprecationWarning)
+            self.assertRaises(ValueError, Seq.reverse_complement, seq)
 
     def test_reverse_complement_of_rna(self):
         # old approach
@@ -1463,13 +1467,15 @@ class TestAttributes(unittest.TestCase):
 
 class TestSeqDefined(unittest.TestCase):
     def test_zero_length(self):
-        zero_length_seqs = [
-            Seq.Seq(""),
-            Seq.Seq(None, length=0),
-            Seq.Seq({}, length=0),
-            Seq.UnknownSeq(length=0),
-            Seq.MutableSeq(""),
-        ]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=BiopythonDeprecationWarning)
+            zero_length_seqs = [
+                Seq.Seq(""),
+                Seq.Seq(None, length=0),
+                Seq.Seq({}, length=0),
+                Seq.UnknownSeq(length=0),
+                Seq.MutableSeq(""),
+            ]
 
         for seq in zero_length_seqs:
             self.assertTrue(seq.defined, msg=repr(seq))
@@ -1482,7 +1488,9 @@ class TestSeqDefined(unittest.TestCase):
         seq = Seq.Seq({3: "ACGT"}, length=10)
         self.assertFalse(seq.defined)
         self.assertEqual(seq.defined_ranges, ((3, 7),))
-        seq = Seq.UnknownSeq(length=1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=BiopythonDeprecationWarning)
+            seq = Seq.UnknownSeq(length=1)
         self.assertFalse(seq.defined)
         self.assertEqual(seq.defined_ranges, ())
 


### PR DESCRIPTION
In `test_seq.py`, catch deprecation warnings so they don't pollute the output.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

