### PR TITLE
Add a BiopythonDeprecationWarning to deprecated code

### DIFF
--- a/Bio/SearchIO/_legacy/NCBIStandalone.py
+++ b/Bio/SearchIO/_legacy/NCBIStandalone.py
@@ -22,9 +22,9 @@ preferred. Furthermore, the NCBI themselves regard these command line tools as
 wrappers for these under Bio.Blast.Applications (see the tutorial).
 """
 
+from io import StringIO
 import re
 
-from io import StringIO
 from Bio.SearchIO._legacy.ParserSupport import (
     UndoHandle,
     AbstractParser,
@@ -39,8 +39,6 @@ from Bio.SearchIO._legacy.ParserSupport import (
 )
 from Bio.Blast import Record
 
-from Bio import BiopythonWarning
-import warnings
 
 _score_e_re = re.compile(r"Score +E")
 
@@ -83,15 +81,6 @@ class _Scanner:
      - feed     Feed data into the scanner.
 
     """
-
-    def __init__(self):
-        """Raise warning that this module is outdated."""
-        warnings.warn(
-            "Parsing BLAST plain text output file is not a well supported"
-            " functionality anymore. Consider generating your BLAST output for parsing"
-            " as XML or tabular format instead.",
-            BiopythonWarning,
-        )
 
     def feed(self, handle, consumer):
         """Feed in a BLAST report for scanning.

--- a/Bio/SearchIO/_legacy/__init__.py
+++ b/Bio/SearchIO/_legacy/__init__.py
@@ -2,4 +2,17 @@
 # choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
 # Please see the LICENSE file that should have been included as part of this
 # package.
-"""Legacy functionalities from other parts of Biopython used by SearchIO."""
+"""Legacy functionalities from other parts of Biopython used by SearchIO (DEPRECATED)."""
+
+
+import warnings
+from Bio import BiopythonDeprecationWarning
+
+
+warnings.warn(
+    "The 'Bio.SearchIO._legacy' module for parsing BLAST plain text output is "
+    "deprecated and will be removed in a future release of Biopython. "
+    "Consider generating your BLAST output for parsing as XML or tabular "
+    "format instead.",
+    BiopythonDeprecationWarning,
+)

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -392,13 +392,13 @@ the BLAST+ wrappers in Bio.Blast.Applications instead.
 
 The remainder of this module is a parser for the plain text BLAST output,
 which was declared obsolete in Release 1.54, and deprecated in Release 1.63.
+The module was removed in Release 1.72 from the public API. It lives now
+in maintenance mode in Bio.SearchIO._legacy to preserve existing functionality.
+A BiopythonDeprecationWarning was added to this module in Release 1.80.
 
 For some time now, both the NCBI and Biopython have encouraged people to
 parse the XML output instead, however Bio.SearchIO will initially attempt
 to support plain text BLAST output.
-
-The module was removed in Release 1.72 from the public API. It lives now
-in maintenance mode in Bio.SearchIO._legacy to preserve existing functionality.
 
 Bio.Blast.Applications
 ----------------------

--- a/Tests/test_SearchIO_legacy.py
+++ b/Tests/test_SearchIO_legacy.py
@@ -13,10 +13,10 @@ from io import StringIO
 
 
 import warnings
-from Bio import BiopythonWarning
+from Bio import BiopythonDeprecationWarning
 
 with warnings.catch_warnings():
-    warnings.simplefilter("ignore", BiopythonWarning)
+    warnings.simplefilter("ignore", BiopythonDeprecationWarning)
     from Bio.SearchIO._legacy import ParserSupport
 
 


### PR DESCRIPTION
The predecessor to `Bio.SearchIO._legacy` was deprecated in release 1.63. However, instead of a `BiopythonDeprecationWarning`, a generic `BiopythonWarning` was used. This PR replaces the `BiopythonWarning` by a `BiopythonDeprecationWarning`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
