### PR TITLE
silence the deprecation warning

### DIFF
--- a/Tests/test_NCBITextParser.py
+++ b/Tests/test_NCBITextParser.py
@@ -10,13 +10,12 @@ import os
 import unittest
 
 import warnings
-from Bio import BiopythonWarning
-from Bio.SearchIO._legacy import NCBIStandalone
+from Bio import BiopythonDeprecationWarning
 
-# This prevents the NCBIStandalone usage warning from
-# printing to screen when running the test suite
-warnings.filterwarnings("ignore", r"Parsing BLAST plain text output "
-                        "file is not a well supported.*", BiopythonWarning)
+# Hide the deprecation warning
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonDeprecationWarning)
+    from Bio.SearchIO._legacy import NCBIStandalone
 
 
 class TestBlastRecord(unittest.TestCase):

--- a/Tests/test_SearchIO_blast_text.py
+++ b/Tests/test_SearchIO_blast_text.py
@@ -10,19 +10,17 @@ import unittest
 import warnings
 
 from Bio.SearchIO import parse
-from Bio import BiopythonWarning
+from Bio import BiopythonDeprecationWarning
+
+# Hide the deprecation warning
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", BiopythonDeprecationWarning)
+    from Bio.SearchIO import _legacy
+
 
 # test case files are in the Blast directory
 TEST_DIR = "Blast"
 FMT = "blast-text"
-
-# This prevents the NCBIStandalone usage warning from
-# printing to screen when running the test suite
-warnings.filterwarnings(
-    "ignore",
-    r"Parsing BLAST plain text output file is not a well supported.*",
-    BiopythonWarning,
-)
 
 
 def get_file(filename):


### PR DESCRIPTION
Slice the deprecation warnings when running `test_NCBITextParser.py` and `test_SearchIO_blast_text.py`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
