### PR TITLE
Added quiet/verbose option to Bio.PDB.PSEA and updated tests

### DIFF
--- a/Bio/PDB/PSEA.py
+++ b/Bio/PDB/PSEA.py
@@ -17,7 +17,7 @@ ftp://ftp.lmcp.jussieu.fr/pub/sincris/software/protein/p-sea/
 """
 
 import subprocess
-from os.path import exists
+import os
 
 from Bio.PDB.Polypeptide import is_aa
 
@@ -38,12 +38,12 @@ def run_psea(fname, verbose=False):
     base = last.split(".")[0]
     cmd = ["psea", fname]
 
-    p = subprocess.run(cmd, capture_output=True)
+    p = subprocess.run(cmd, capture_output=True, universal_newlines=True)
 
     if verbose:
-        print(p.stdout.decode("utf-8"))
+        print(p.stdout)
 
-    if not p.stderr.decode("utf-8") and exists(base + ".sea"):
+    if not p.stderr.strip() and os.path.exists(base + ".sea"):
         return base + ".sea"
     else:
         raise RuntimeError("stderr not empty")

--- a/Bio/PDB/PSEA.py
+++ b/Bio/PDB/PSEA.py
@@ -46,7 +46,7 @@ def run_psea(fname, verbose=False):
     if not p.stderr.strip() and os.path.exists(base + ".sea"):
         return base + ".sea"
     else:
-        raise RuntimeError("stderr not empty")
+        raise RuntimeError(f"Error running p-sea: {p.stderr}")
 
 
 def psea(pname):

--- a/Bio/PDB/PSEA.py
+++ b/Bio/PDB/PSEA.py
@@ -36,8 +36,8 @@ def run_psea(fname, verbose=False):
     """
     last = fname.split("/")[-1]
     base = last.split(".")[0]
-
     cmd = ["psea", fname]
+
     p = subprocess.run(cmd, capture_output=True)
 
     if verbose:

--- a/Bio/PDB/PSEA.py
+++ b/Bio/PDB/PSEA.py
@@ -17,11 +17,12 @@ ftp://ftp.lmcp.jussieu.fr/pub/sincris/software/protein/p-sea/
 """
 
 import subprocess
+from os.path import exists
 
 from Bio.PDB.Polypeptide import is_aa
 
 
-def run_psea(fname):
+def run_psea(fname, verbose=False):
     """Run PSEA and return output filename.
 
     Note that this assumes the P-SEA binary is called "psea" and that it is
@@ -30,12 +31,22 @@ def run_psea(fname):
     Note that P-SEA will write an output file in the current directory using
     the input filename with extension ".sea".
 
-    Note that P-SEA will write output to the terminal while run.
+    Note that P-SEA will not write output to the terminal while run unless
+     verbose is set to True.
     """
-    subprocess.call(["psea", fname])
     last = fname.split("/")[-1]
     base = last.split(".")[0]
-    return base + ".sea"
+
+    cmd = ["psea", fname]
+    p = subprocess.run(cmd, capture_output=True)
+
+    if verbose:
+        print(p.stdout.decode("utf-8"))
+
+    if not p.stderr.decode("utf-8") and exists(base + ".sea"):
+        return base + ".sea"
+    else:
+        raise RuntimeError("stderr not empty")
 
 
 def psea(pname):

--- a/Tests/test_PDB_PSEA.py
+++ b/Tests/test_PDB_PSEA.py
@@ -5,9 +5,11 @@
 
 """Tests for PDB PSEA."""
 
+import io
 import os
 import unittest
 from subprocess import getoutput
+import sys
 
 from Bio import MissingExternalDependencyError
 from Bio.PDB import PDBParser
@@ -36,9 +38,21 @@ class TestPDBPSEA(unittest.TestCase):
     def tearDown(self):
         remove_sea_files()
 
-    def test_run_psea(self):
-        psae_run = run_psea("PDB/1A8O.pdb")
+    def test_run_psea_verbose(self):
+        captured_ouput = io.StringIO()
+        sys.stdout = captured_ouput
+        psae_run = run_psea("PDB/1A8O.pdb", verbose=True)
+        sys.stdout = sys.__stdout__
         self.assertEqual(psae_run, "1A8O.sea")
+        self.assertTrue(captured_ouput.getvalue())
+
+    def test_run_psea_quiet(self):
+        captured_ouput = io.StringIO()
+        sys.stdout = captured_ouput
+        psae_run = run_psea("PDB/1A8O.pdb", verbose=False)
+        sys.stdout = sys.__stdout__
+        self.assertEqual(psae_run, "1A8O.sea")
+        self.assertFalse(captured_ouput.getvalue())
 
     def test_psea(self):
         psae_run = psea("PDB/2BEG.pdb")


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3999 

I've added a verbose option to the `psea_run()` function in `Bio.PDB.PSEA` and set the default to False since I don't think most people would actually want the stdout to be printed. If you think that this might interfere with the existing code of some users I can switch the default.

We aren't able to use the try/except pattern for error handling originally suggested by @JoaoRodrigues in the issue because p-sea is coded to give an exit-status of 1 even when the program runs and outputs the `.sea` file correctly. Instead the function now checks that the stderr is empty and that the correct `.sea` output exists. I'm not sure if the `raise RuntimeError` is correct here, definitely looking for feedback on that.

The tests have been updated to capture the stderr and check whether or not it is empty with verbose set to True or False. This gets the job done and the tests work as expected, but I'm wondering if there is a cleaner approach to capturing the stdout.