### PR TITLE
KEGG moved to HTTPS

### DIFF
--- a/Bio/KEGG/REST.py
+++ b/Bio/KEGG/REST.py
@@ -10,7 +10,7 @@
 """Provides code to access the REST-style KEGG online API.
 
 This module aims to make the KEGG online REST-style API easier to use. See:
-http://www.kegg.jp/kegg/rest/keggapi.html
+https://www.kegg.jp/kegg/rest/keggapi.html
 
 The KEGG REST-style API provides simple access to a range of KEGG databases.
 This works using simple URLs (which this module will construct for you),
@@ -34,7 +34,7 @@ from urllib.request import urlopen
 
 
 def _q(op, arg1, arg2=None, arg3=None):
-    URL = "http://rest.kegg.jp/%s"
+    URL = "https://rest.kegg.jp/%s"
     if arg2 and arg3:
         args = f"{op}/{arg1}/{arg2}/{arg3}"
     elif arg2:
@@ -51,7 +51,7 @@ def _q(op, arg1, arg2=None, arg3=None):
     return handle
 
 
-# http://www.kegg.jp/kegg/rest/keggapi.html
+# https://www.kegg.jp/kegg/rest/keggapi.html
 def kegg_info(database):
     """KEGG info - Displays the current statistics of a given database.
 
@@ -62,14 +62,14 @@ def kegg_info(database):
     (e.g. 'hsa' or 'T01001' for human).
 
     A valid list of organism codes and their T numbers can be obtained
-    via kegg_info('organism') or http://rest.kegg.jp/list/organism
+    via kegg_info('organism') or https://rest.kegg.jp/list/organism
 
     """
     # TODO - return a string (rather than the handle?)
     # TODO - cache and validate the organism code / T numbers?
     # TODO - can we parse the somewhat formatted output?
     #
-    # http://rest.kegg.jp/info/<database>
+    # https://rest.kegg.jp/info/<database>
     #
     # <database> = pathway | brite | module | disease | drug | environ |
     #              ko | genome |<org> | compound | glycan | reaction |
@@ -90,7 +90,7 @@ def kegg_list(database, org=None):
     """
     # TODO - split into two functions (dbentries seems separate)?
     #
-    #  http://rest.kegg.jp/list/<database>/<org>
+    #  https://rest.kegg.jp/list/<database>/<org>
     #
     #  <database> = pathway | module
     #  <org> = KEGG organism code
@@ -99,7 +99,7 @@ def kegg_list(database, org=None):
     elif isinstance(database, str) and database and org:
         raise ValueError("Invalid database arg for kegg list request.")
 
-    # http://rest.kegg.jp/list/<database>
+    # https://rest.kegg.jp/list/<database>
     #
     # <database> = pathway | brite | module | disease | drug | environ |
     #              ko | genome | <org> | compound | glycan | reaction |
@@ -107,7 +107,7 @@ def kegg_list(database, org=None):
     # <org> = KEGG organism code or T number
     #
     #
-    # http://rest.kegg.jp/list/<dbentries>
+    # https://rest.kegg.jp/list/<dbentries>
     #
     # <dbentries> = KEGG database entries involving the following <database>
     # <database> = pathway | brite | module | disease | drug | environ |
@@ -146,7 +146,7 @@ def kegg_find(database, query, option=None):
     """
     # TODO - return list of tuples?
     #
-    # http://rest.kegg.jp/find/<database>/<query>/<option>
+    # https://rest.kegg.jp/find/<database>/<query>/<option>
     #
     # <database> = compound | drug
     # <option> = formula | exact_mass | mol_weight
@@ -159,7 +159,7 @@ def kegg_find(database, query, option=None):
     elif option:
         raise ValueError("Invalid option arg for kegg find request.")
 
-    # http://rest.kegg.jp/find/<database>/<query>
+    # https://rest.kegg.jp/find/<database>/<query>
     #
     # <database> = pathway | module | disease | drug | environ | ko |
     #              genome | <org> | compound | glycan | reaction | rpair |
@@ -190,7 +190,7 @@ def kegg_get(dbentries, option=None):
     elif isinstance(dbentries, list) and len(dbentries) > 10:
         raise ValueError("Maximum number of dbentries is 10 for kegg get query")
 
-    # http://rest.kegg.jp/get/<dbentries>[/<option>]
+    # https://rest.kegg.jp/get/<dbentries>[/<option>]
     #
     # <dbentries> = KEGG database entries involving the following <database>
     # <database> = pathway | brite | module | disease | drug | environ |
@@ -219,7 +219,7 @@ def kegg_conv(target_db, source_db, option=None):
      - option - Can be "turtle" or "n-triple" (string).
 
     """
-    # http://rest.kegg.jp/conv/<target_db>/<source_db>[/<option>]
+    # https://rest.kegg.jp/conv/<target_db>/<source_db>[/<option>]
     #
     # (<target_db> <source_db>) = (<kegg_db> <outside_db>) |
     #                             (<outside_db> <kegg_db>)
@@ -235,7 +235,7 @@ def kegg_conv(target_db, source_db, option=None):
     #
     # <option> = turtle | n-triple
     #
-    # http://rest.kegg.jp/conv/<target_db>/<dbentries>[/<option>]
+    # https://rest.kegg.jp/conv/<target_db>/<dbentries>[/<option>]
     #
     # For gene identifiers:
     # <dbentries> = database entries involving the following <database>
@@ -283,7 +283,7 @@ def kegg_link(target_db, source_db, option=None):
     source_db_or_dbentries - source database
     option - Can be "turtle" or "n-triple" (string).
     """
-    # http://rest.kegg.jp/link/<target_db>/<source_db>[/<option>]
+    # https://rest.kegg.jp/link/<target_db>/<source_db>[/<option>]
     #
     # <target_db> = <database>
     # <source_db> = <database>
@@ -293,7 +293,7 @@ def kegg_link(target_db, source_db, option=None):
     #              drug | dgroup | environ
     #
     # <option> = turtle | n-triple
-    # http://rest.kegg.jp/link/<target_db>/<dbentries>[/<option>]
+    # https://rest.kegg.jp/link/<target_db>/<dbentries>[/<option>]
     #
     # <dbentries> = KEGG database entries involving the following <database>
     # <database> = pathway | brite | module | ko | genome | <org> | compound |

--- a/Tests/test_KEGG_online.py
+++ b/Tests/test_KEGG_online.py
@@ -28,145 +28,145 @@ class KEGGTests(unittest.TestCase):
     def test_info_kegg(self):
         with kegg_info("kegg") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/info/kegg")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/info/kegg")
 
     def test_info_pathway(self):
         with kegg_info("pathway") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/info/pathway")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/info/pathway")
 
     def test_list_pathway(self):
         with kegg_list("pathway") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/list/pathway")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/list/pathway")
 
     def test_pathway_hsa(self):
         with kegg_list("pathway", "hsa") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/list/pathway/hsa")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/list/pathway/hsa")
 
     def test_list_organism(self):
         with kegg_list("organism") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/list/organism")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/list/organism")
 
     def test_list_hsa(self):
         with kegg_list("hsa") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/list/hsa")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/list/hsa")
 
     def test_list_T01001(self):
         with kegg_list("T01001") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/list/T01001")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/list/T01001")
 
     def test_list_hsa_10458_plus_ece_Z5100(self):
         with kegg_list("hsa:10458+ece:Z5100") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/list/hsa:10458+ece:Z5100")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/list/hsa:10458+ece:Z5100")
 
     def test_list_hsa_10458_list_ece_Z5100(self):
         with kegg_list(["hsa:10458", "ece:Z5100"]) as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/list/hsa:10458+ece:Z5100")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/list/hsa:10458+ece:Z5100")
 
     def test_list_cpd_C01290_plus_gl_G0009(self):
         with kegg_list("cpd:C01290+gl:G00092") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/list/cpd:C01290+gl:G00092")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/list/cpd:C01290+gl:G00092")
 
     def test_list_cpd_C01290_list_gl_G0009(self):
         with kegg_list(["cpd:C01290", "gl:G00092"]) as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/list/cpd:C01290+gl:G00092")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/list/cpd:C01290+gl:G00092")
 
     def test_list_C01290_plus_G00092(self):
         with kegg_list("C01290+G00092") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/list/C01290+G00092")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/list/C01290+G00092")
 
     def test_list_C01290_list_G00092(self):
         with kegg_list(["C01290", "G00092"]) as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/list/C01290+G00092")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/list/C01290+G00092")
 
     def test_find_genes_shiga_plus_toxin(self):
         with kegg_find("genes", "shiga+toxin") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/find/genes/shiga+toxin")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/find/genes/shiga+toxin")
 
     def test_find_genes_shiga_list_toxin(self):
         with kegg_find("genes", ["shiga", "toxin"]) as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/find/genes/shiga+toxin")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/find/genes/shiga+toxin")
 
     def test_find_compound_C7H10O5_formula(self):
         with kegg_find("compound", "C7H10O5", "formula") as handle:
             handle.read()
         self.assertEqual(
-            handle.url, "http://rest.kegg.jp/find/compound/C7H10O5/formula"
+            handle.url, "https://rest.kegg.jp/find/compound/C7H10O5/formula"
         )
 
     def test_find_compound_O5C7_formula(self):
         with kegg_find("compound", "O5C7", "formula") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/find/compound/O5C7/formula")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/find/compound/O5C7/formula")
 
     def test_find_compound_exact_mass(self):
         with kegg_find("compound", "174.05", "exact_mass") as handle:
             handle.read()
         self.assertEqual(
-            handle.url, "http://rest.kegg.jp/find/compound/174.05/exact_mass"
+            handle.url, "https://rest.kegg.jp/find/compound/174.05/exact_mass"
         )
 
     def test_find_compound_weight(self):
         with kegg_find("compound", "300-310", "mol_weight") as handle:
             handle.read()
         self.assertEqual(
-            handle.url, "http://rest.kegg.jp/find/compound/300-310/mol_weight"
+            handle.url, "https://rest.kegg.jp/find/compound/300-310/mol_weight"
         )
 
     def test_get_br_ko00002(self):
         with kegg_get("br:ko00002", "json") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/get/br:ko00002/json")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/get/br:ko00002/json")
 
     def test_get_cpd_C01290_plus_gl_G00092(self):
         with kegg_get("cpd:C01290+gl:G00092") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/get/cpd:C01290+gl:G00092")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/get/cpd:C01290+gl:G00092")
 
     def test_get_cpd_C01290_list_gl_G00092(self):
         with kegg_get(["cpd:C01290", "gl:G00092"]) as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/get/cpd:C01290+gl:G00092")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/get/cpd:C01290+gl:G00092")
 
     def test_get_C01290_plus_G00092(self):
         with kegg_get(["C01290+G00092"]) as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/get/C01290+G00092")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/get/C01290+G00092")
 
     def test_get_C01290_list_G00092(self):
         with kegg_get(["C01290", "G00092"]) as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/get/C01290+G00092")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/get/C01290+G00092")
 
     def test_get_hsa_10458_plus_ece_Z5100(self):
         with kegg_get("hsa:10458+ece:Z5100") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/get/hsa:10458+ece:Z5100")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/get/hsa:10458+ece:Z5100")
 
     def test_get_hsa_10458_list_ece_Z5100(self):
         with kegg_get(["hsa:10458", "ece:Z5100"]) as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/get/hsa:10458+ece:Z5100")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/get/hsa:10458+ece:Z5100")
 
     def test_get_hsa_10458_plus_ece_Z5100_as_aaseq(self):
         with kegg_get("hsa:10458+ece:Z5100", "aaseq") as handle:
             data = SeqIO.parse(handle, "fasta")
             self.assertEqual(len(list(data)), 2)
         self.assertEqual(
-            handle.url, "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq"
+            handle.url, "https://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq"
         )
 
     def test_get_hsa_10458_list_ece_Z5100_as_aaseq(self):
@@ -174,7 +174,7 @@ class KEGGTests(unittest.TestCase):
             data = SeqIO.parse(handle, "fasta")
             self.assertEqual(len(list(data)), 2)
         self.assertEqual(
-            handle.url, "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq"
+            handle.url, "https://rest.kegg.jp/get/hsa:10458+ece:Z5100/aaseq"
         )
 
     def test_get_hsa_10458_plus_ece_Z5100_as_ntseq(self):
@@ -182,7 +182,7 @@ class KEGGTests(unittest.TestCase):
             data = SeqIO.parse(handle, "fasta")
             self.assertEqual(len(list(data)), 2)
         self.assertEqual(
-            handle.url, "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq"
+            handle.url, "https://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq"
         )
 
     def test_get_hsa_10458_list_ece_Z5100_as_ntseq(self):
@@ -190,61 +190,61 @@ class KEGGTests(unittest.TestCase):
             data = SeqIO.parse(handle, "fasta")
             self.assertEqual(len(list(data)), 2)
         self.assertEqual(
-            handle.url, "http://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq"
+            handle.url, "https://rest.kegg.jp/get/hsa:10458+ece:Z5100/ntseq"
         )
 
     def test_get_hsa05130_image(self):
         with kegg_get("hsa05130", "image") as handle:
             data = handle.read()
         self.assertEqual(data[:4], b"\x89PNG")
-        self.assertEqual(handle.url, "http://rest.kegg.jp/get/hsa05130/image")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/get/hsa05130/image")
 
     def test_conv_eco_ncbi_geneid(self):
         with kegg_conv("eco", "ncbi-geneid") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/conv/eco/ncbi-geneid")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/conv/eco/ncbi-geneid")
 
     def test_conv_ncbi_geneid_eco(self):
         with kegg_conv("ncbi-geneid", "eco") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/conv/ncbi-geneid/eco")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/conv/ncbi-geneid/eco")
 
     def test_conv_ncbi_gi_hsa_10458_plus_ece_Z5100(self):
         with kegg_conv("ncbi-gi", "hsa:10458+ece:Z5100") as handle:
             handle.read()
         self.assertEqual(
-            handle.url, "http://rest.kegg.jp/conv/ncbi-gi/hsa:10458+ece:Z5100"
+            handle.url, "https://rest.kegg.jp/conv/ncbi-gi/hsa:10458+ece:Z5100"
         )
 
     def test_conv_ncbi_gi_hsa_10458_list_ece_Z5100(self):
         with kegg_conv("ncbi-gi", ["hsa:10458", "ece:Z5100"]) as handle:
             handle.read()
         self.assertEqual(
-            handle.url, "http://rest.kegg.jp/conv/ncbi-gi/hsa:10458+ece:Z5100"
+            handle.url, "https://rest.kegg.jp/conv/ncbi-gi/hsa:10458+ece:Z5100"
         )
 
     def test_link_pathway_hsa(self):
         with kegg_link("pathway", "hsa") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/link/pathway/hsa")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/link/pathway/hsa")
 
     def test_link_hsa_pathway(self):
         with kegg_link("hsa", "pathway") as handle:
             handle.read()
-        self.assertEqual(handle.url, "http://rest.kegg.jp/link/hsa/pathway")
+        self.assertEqual(handle.url, "https://rest.kegg.jp/link/hsa/pathway")
 
     def test_pathway_hsa_10458_plus_ece_Z5100(self):
         with kegg_link("pathway", "hsa:10458+ece:Z5100") as handle:
             handle.read()
         self.assertEqual(
-            handle.url, "http://rest.kegg.jp/link/pathway/hsa:10458+ece:Z5100"
+            handle.url, "https://rest.kegg.jp/link/pathway/hsa:10458+ece:Z5100"
         )
 
     def test_pathway_hsa_10458_list_ece_Z5100(self):
         with kegg_link("pathway", ["hsa:10458", "ece:Z5100"]) as handle:
             handle.read()
         self.assertEqual(
-            handle.url, "http://rest.kegg.jp/link/pathway/hsa:10458+ece:Z5100"
+            handle.url, "https://rest.kegg.jp/link/pathway/hsa:10458+ece:Z5100"
         )
 
 


### PR DESCRIPTION
KEGG now redirects all HTTP access to HTTPS. This works perfectly fine, however, calling HTTPS in the first place spares the KEGG servers from sending one HTTP 304 redirect per request.

See update history at https://www.kegg.jp/kegg/rest/
"June 1, 2022 Moved from HTTP to HTTPS"

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
