### PR TITLE
Blastn, megablast, blastp as scoring options for the pairwise aligner

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -2825,12 +2825,39 @@ class PairwiseAligner(_aligners.PairwiseAligner):
 
     """
 
-    def __init__(self, **kwargs):
-        """Initialize a new PairwiseAligner with the keyword arguments as attributes.
+    def __init__(self, scoring=None, **kwargs):
+        """Initialize a new PairwiseAligner as specified by the keyword arguments.
 
-        Loops over the keyword arguments and sets them as attributes on the object.
+        If scoring is None, use the default scoring scheme match = 1.0,
+        mismatch = 0.0, gap score = 0.0
+        If scoring is "blastn", "megablast", or "blastp", use the default
+        substitution matrix and gap scores for BLASTN, MEGABLAST, or BLASTP,
+        respectively.
+
+        Loops over the remaining keyword arguments and sets them as attributes
+        on the object.
         """
         super().__init__()
+        if scoring is None:
+            # use default values:
+            # match = 1.0
+            # mismatch = 0.0
+            # gap_score = 0.0
+            pass
+        elif scoring == "blastn":
+            self.substitution_matrix = substitution_matrices.load("BLASTN")
+            self.open_gap_score = -7.0
+            self.extend_gap_score = -2.0
+        elif scoring == "megablast":
+            self.substitution_matrix = substitution_matrices.load("MEGABLAST")
+            self.open_gap_score = -2.5
+            self.extend_gap_score = -2.5
+        elif scoring == "blastp":
+            self.substitution_matrix = substitution_matrices.load("BLASTP")
+            self.open_gap_score = -12.0
+            self.extend_gap_score = -1.0
+        else:
+            raise ValueError("Unknown scoring scheme '%s'" % scoring)
         for name, value in kwargs.items():
             setattr(self, name, value)
 

--- a/Bio/Align/substitution_matrices/data/BLASTN
+++ b/Bio/Align/substitution_matrices/data/BLASTN
@@ -1,0 +1,29 @@
+# BLASTN default substitution scores.
+# For the default gap scores, as used for BLASTN on NCBI Web
+# BLAST, The BLAST documentation shows gap costs a = 5 for opening
+# a gap, and b = 2 for each letter in the gap, and defines the
+# total score of a gap of k residues as -(a + b*k). In contrast,
+# Biopython follows the definition given in "Biological Sequence
+# Analysis" (Durbin et al., 1998), for which the total score of a
+# gap of k residues is -d - e * (k - 1), where d is the gap-open
+# penalty and e is the gap-extend penalty. Biopython uses -d as
+# the gap open score and -e as the gap extend penalty:
+# gap open score: -7
+# gap extend score: -2
+# with the substitution matrix below, as the BLASTN score parameters.
+    A   T   G   C   S   W   R   Y   K   M   B   V   H   D   N
+A   2  -3  -3  -3  -3  -1  -1  -3  -3  -1  -3  -1  -1  -1  -2
+T  -3   2  -3  -3  -3  -1  -3  -1  -1  -3  -1  -3  -1  -1  -2
+G  -3  -3   2  -3  -1  -3  -1  -3  -1  -3  -1  -1  -3  -1  -2
+C  -3  -3  -3   2  -1  -3  -3  -1  -3  -1  -1  -1  -1  -3  -2
+S  -3  -3  -1  -1  -1  -3  -1  -1  -1  -1  -1  -1  -1  -1  -2
+W  -1  -1  -3  -3  -3  -1  -1  -1  -1  -1  -1  -1  -1  -1  -2
+R  -1  -3  -1  -3  -1  -1  -1  -3  -1  -1  -1  -1  -1  -1  -2
+Y  -3  -1  -3  -1  -1  -1  -3  -1  -1  -1  -1  -1  -1  -1  -2
+K  -3  -1  -1  -3  -1  -1  -1  -1  -1  -3  -1  -1  -1  -1  -2
+M  -1  -3  -3  -1  -1  -1  -1  -1  -3  -1  -1  -1  -1  -1  -2
+B  -3  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -2
+V  -1  -3  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -2
+H  -1  -1  -3  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -2
+D  -1  -1  -1  -3  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -2
+N  -2  -2  -2  -2  -2  -2  -2  -2  -2  -2  -2  -2  -2  -2  -2

--- a/Bio/Align/substitution_matrices/data/BLASTP
+++ b/Bio/Align/substitution_matrices/data/BLASTP
@@ -1,0 +1,44 @@
+# BLASTP default substitution scores.
+# For the default gap scores, as used for BLASTP on NCBI Web
+# BLAST, The BLAST documentation shows gap costs a = 11 for opening
+# a gap, and b = 1 for each letter in the gap, and defines the
+# total score of a gap of k residues as -(a + b*k). In contrast,
+# Biopython follows the definition given in "Biological Sequence
+# Analysis" (Durbin et al., 1998), for which the total score of a
+# gap of k residues is -d - e * (k - 1), where d is the gap-open
+# penalty and e is the gap-extend penalty. Biopython uses -d as
+# the gap open score and -e as the gap extend penalty:
+# gap open score: -12
+# gap extend score: -1
+# with the substitution matrix below, as the BLASTP score parameters.
+# The substitution matrix is identical to BLOSUM62, except for some
+# values of the ambiguous amino acids B, Z, and X; the values for
+# the ambiguous amino acids U, O, and J are not included in BLOSUM62.
+    A   B   C   D   E   F   G   H   I   J   K   L   M   N   O   P   Q   R   S   T   U   V   W   X   Y   Z   *
+A   4  -2   0  -2  -1  -2   0  -2  -1  -1  -1  -1  -1  -2  -1  -1  -1  -1   1   0   0   0  -3  -1  -2  -1  -4
+B  -2   4  -3   4   1  -3  -1   0  -3  -3   0  -4  -3   4  -1  -2   0  -1   0  -1  -3  -3  -4  -1  -3   0  -4
+C   0  -3   9  -3  -4  -2  -3  -3  -1  -1  -3  -1  -1  -3  -1  -3  -3  -3  -1  -1   9  -1  -2  -1  -2  -3  -4
+D  -2   4  -3   6   2  -3  -1  -1  -3  -3  -1  -4  -3   1  -1  -1   0  -2   0  -1  -3  -3  -4  -1  -3   1  -4
+E  -1   1  -4   2   5  -3  -2   0  -3  -3   1  -3  -2   0  -1  -1   2   0   0  -1  -4  -2  -3  -1  -2   4  -4
+F  -2  -3  -2  -3  -3   6  -3  -1   0   0  -3   0   0  -3  -1  -4  -3  -3  -2  -2  -2  -1   1  -1   3  -3  -4
+G   0  -1  -3  -1  -2  -3   6  -2  -4  -4  -2  -4  -3   0  -1  -2  -2  -2   0  -2  -3  -3  -2  -1  -3  -2  -4
+H  -2   0  -3  -1   0  -1  -2   8  -3  -3  -1  -3  -2   1  -1  -2   0   0  -1  -2  -3  -3  -2  -1   2   0  -4
+I  -1  -3  -1  -3  -3   0  -4  -3   4   3  -3   2   1  -3  -1  -3  -3  -3  -2  -1  -1   3  -3  -1  -1  -3  -4
+J  -1  -3  -1  -3  -3   0  -4  -3   3   3  -3   3   2  -3  -1  -3  -2  -2  -2  -1  -1   2  -2  -1  -1  -3  -4
+K  -1   0  -3  -1   1  -3  -2  -1  -3  -3   5  -2  -1   0  -1  -1   1   2   0  -1  -3  -2  -3  -1  -2   1  -4
+L  -1  -4  -1  -4  -3   0  -4  -3   2   3  -2   4   2  -3  -1  -3  -2  -2  -2  -1  -1   1  -2  -1  -1  -3  -4
+M  -1  -3  -1  -3  -2   0  -3  -2   1   2  -1   2   5  -2  -1  -2   0  -1  -1  -1  -1   1  -1  -1  -1  -1  -4
+N  -2   4  -3   1   0  -3   0   1  -3  -3   0  -3  -2   6  -1  -2   0   0   1   0  -3  -3  -4  -1  -2   0  -4
+O  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -4
+P  -1  -2  -3  -1  -1  -4  -2  -2  -3  -3  -1  -3  -2  -2  -1   7  -1  -2  -1  -1  -3  -2  -4  -1  -3  -1  -4
+Q  -1   0  -3   0   2  -3  -2   0  -3  -2   1  -2   0   0  -1  -1   5   1   0  -1  -3  -2  -2  -1  -1   4  -4
+R  -1  -1  -3  -2   0  -3  -2   0  -3  -2   2  -2  -1   0  -1  -2   1   5  -1  -1  -3  -3  -3  -1  -2   0  -4
+S   1   0  -1   0   0  -2   0  -1  -2  -2   0  -2  -1   1  -1  -1   0  -1   4   1  -1  -2  -3  -1  -2   0  -4
+T   0  -1  -1  -1  -1  -2  -2  -2  -1  -1  -1  -1  -1   0  -1  -1  -1  -1   1   5  -1   0  -2  -1  -2  -1  -4
+U   0  -3   9  -3  -4  -2  -3  -3  -1  -1  -3  -1  -1  -3  -1  -3  -3  -3  -1  -1   9  -1  -2  -1  -2  -3  -4
+V   0  -3  -1  -3  -2  -1  -3  -3   3   2  -2   1   1  -3  -1  -2  -2  -3  -2   0  -1   4  -3  -1  -1  -2  -4
+W  -3  -4  -2  -4  -3   1  -2  -2  -3  -2  -3  -2  -1  -4  -1  -4  -2  -3  -3  -2  -2  -3  11  -1   2  -2  -4
+X  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -4
+Y  -2  -3  -2  -3  -2   3  -3   2  -1  -1  -2  -1  -1  -2  -1  -3  -1  -2  -2  -2  -2  -1   2  -1   7  -2  -4
+Z  -1   0  -3   1   4  -3  -2   0  -3  -3   1  -3  -1   0  -1  -1   4   0   0  -1  -3  -2  -2  -1  -2   4  -4
+*  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4  -4   1

--- a/Bio/Align/substitution_matrices/data/MEGABLAST
+++ b/Bio/Align/substitution_matrices/data/MEGABLAST
@@ -1,0 +1,29 @@
+# MEGABLAST default substitution scores.
+# For the default gap scores, as used for MEGABLAST on NCBI Web
+# BLAST, The BLAST documentation shows gap costs a = 0 for opening
+# a gap, and b = 2.5 for each letter in the gap, and defines the
+# total score of a gap of k residues as -(a + b*k). In contrast,
+# Biopython follows the definition given in "Biological Sequence
+# Analysis" (Durbin et al., 1998), for which the total score of a
+# gap of k residues is -d - e * (k - 1), where d is the gap-open
+# penalty and e is the gap-extend penalty. Biopython uses -d as
+# the gap open score and -e as the gap extend penalty:
+# gap open score: -2.5
+# gap extend score: -2.5
+# with the substitution matrix below, as the MEGABLAST score parameters.
+    A   T   G   C   S   W   R   Y   K   M   B   V   H   D   N
+A   1  -2  -2  -2  -2  -1  -1  -2  -2  -1  -2  -1  -1  -1  -1
+T  -2   1  -2  -2  -2  -1  -2  -1  -1  -2  -1  -2  -1  -1  -1
+G  -2  -2   1  -2  -1  -2  -1  -2  -1  -2  -1  -1  -2  -1  -1
+C  -2  -2  -2   1  -1  -2  -2  -1  -2  -1  -1  -1  -1  -2  -1
+S  -2  -2  -1  -1  -1  -2  -1  -1  -1  -1  -1  -1  -1  -1  -1
+W  -1  -1  -2  -2  -2  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1
+R  -1  -2  -1  -2  -1  -1  -1  -2  -1  -1  -1  -1  -1  -1  -1
+Y  -2  -1  -2  -1  -1  -1  -2  -1  -1  -1  -1  -1  -1  -1  -1
+K  -2  -1  -1  -2  -1  -1  -1  -1  -1  -2  -1  -1  -1  -1  -1
+M  -1  -2  -2  -1  -1  -1  -1  -1  -2  -1  -1  -1  -1  -1  -1
+B  -2  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1
+V  -1  -2  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1
+H  -1  -1  -2  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1
+D  -1  -1  -1  -2  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1
+N  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1  -1

--- a/Bio/Align/substitution_matrices/data/README.txt
+++ b/Bio/Align/substitution_matrices/data/README.txt
@@ -1,5 +1,7 @@
 The BLOSUM and PAM matrices in this directory were obtained from NCBI
 (ftp://ftp.ncbi.nih.gov/blast/matrices/).
 
+The BLASTN, MEGABLAST, and BLASTP matrices were derived by running BLAST.
+
 All other matrices were obtained from the primary literature, as indicated in
 the header of each file.

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1856,6 +1856,52 @@ AATT-
 <BLANKLINE>
 \end{minted}
 
+\subsection{Using a pre-defined substitution matrix and gap scores}
+\label{sec:pairwise-predefined-scoring}
+
+By default, a \verb+PairwiseAligner+ object is initialized with a match score of +1.0, a mismatch score of 0.0, and all gap scores equal to 0.0, While this has the benefit of being a simple scoring scheme, in general it does not give the best performance. Instead, you can use the argument \verb+scoring+ to select a predefined scoring scheme when initializing a \verb+PairwiseAligner+ object. Currently, the provided scoring schemes are \verb+blastn+ and \verb+megablast+, which are suitable for nucleotide alignments, and \verb+blastp+, which is suitable for protein alignments. Selecting these scoring schemes will initialize the \verb+PairwiseAligner+ object to the default scoring parameters used by BLASTN, MegaBLAST, and BLASTP, respectively.
+
+%doctest
+\begin{minted}{pycon}
+>>> from Bio import Align
+>>> aligner = Align.PairwiseAligner(scoring="blastn")
+>>> print(aligner)
+Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at 0x114bbf7b0>
+  target_internal_open_gap_score: -7.000000
+  target_internal_extend_gap_score: -2.000000
+  target_left_open_gap_score: -7.000000
+  target_left_extend_gap_score: -2.000000
+  target_right_open_gap_score: -7.000000
+  target_right_extend_gap_score: -2.000000
+  query_internal_open_gap_score: -7.000000
+  query_internal_extend_gap_score: -2.000000
+  query_left_open_gap_score: -7.000000
+  query_left_extend_gap_score: -2.000000
+  query_right_open_gap_score: -7.000000
+  query_right_extend_gap_score: -2.000000
+  mode: global
+<BLANKLINE>
+>>> print(aligner.substitution_matrix[:, :])
+     A    T    G    C    S    W    R    Y    K    M    B    V    H    D    N
+A  2.0 -3.0 -3.0 -3.0 -3.0 -1.0 -1.0 -3.0 -3.0 -1.0 -3.0 -1.0 -1.0 -1.0 -2.0
+T -3.0  2.0 -3.0 -3.0 -3.0 -1.0 -3.0 -1.0 -1.0 -3.0 -1.0 -3.0 -1.0 -1.0 -2.0
+G -3.0 -3.0  2.0 -3.0 -1.0 -3.0 -1.0 -3.0 -1.0 -3.0 -1.0 -1.0 -3.0 -1.0 -2.0
+C -3.0 -3.0 -3.0  2.0 -1.0 -3.0 -3.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -3.0 -2.0
+S -3.0 -3.0 -1.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+W -1.0 -1.0 -3.0 -3.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+R -1.0 -3.0 -1.0 -3.0 -1.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+Y -3.0 -1.0 -3.0 -1.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+K -3.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -2.0
+M -1.0 -3.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+B -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+V -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+H -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+D -1.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
+<BLANKLINE>
+\end{minted}
+
 \subsection{Iterating over alignments}
 
 The \verb+alignments+ returned by \verb+aligner.align+ are a kind of immutable iterable objects (similar to \verb+range+). While they appear similar to a \verb+tuple+ or \verb+list+ of \verb+Alignment+ objects, they are different in the sense that each \verb+Alignment+ object is created dynamically when it is needed. This approach was chosen because the number of alignments can be extremely large, in particular for poor alignments (see Section~\ref{sec:pairwise-examples} for an example).

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1865,9 +1865,9 @@ By default, a \verb+PairwiseAligner+ object is initialized with a match score of
 \begin{minted}{pycon}
 >>> from Bio import Align
 >>> aligner = Align.PairwiseAligner(scoring="blastn")
->>> print(aligner)
+>>> print(aligner)  # doctest:+ELLIPSIS
 Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at 0x114bbf7b0>
+  substitution_matrix: <Array object at 0x...>
   target_internal_open_gap_score: -7.000000
   target_internal_extend_gap_score: -2.000000
   target_left_open_gap_score: -7.000000

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1867,7 +1867,7 @@ By default, a \verb+PairwiseAligner+ object is initialized with a match score of
 >>> aligner = Align.PairwiseAligner(scoring="blastn")
 >>> print(aligner)  # doctest:+ELLIPSIS
 Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at 0x...>
+  substitution_matrix: <Array object at ...>
   target_internal_open_gap_score: -7.000000
   target_internal_extend_gap_score: -2.000000
   target_left_open_gap_score: -7.000000
@@ -2005,8 +2005,8 @@ The \verb+aligner.align+ method returns \verb+Alignment+ objects, each represent
 >>> query = "GAT"
 >>> alignments = aligner.align(target, query)
 >>> alignment = alignments[0]
->>> alignment  # doctest: +SKIP
-<Alignment object (2 rows x 5 columns) at 0x10204d250>
+>>> alignment  # doctest: +ELLIPSIS
+<Alignment object (2 rows x 5 columns) at ...>
 \end{minted}
 
 Each alignment stores the alignment score:

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1670,7 +1670,7 @@ Alternatively, you can use the \verb+substitution_matrix+ attribute of the \verb
 \begin{minted}{pycon}
 >>> from Bio.Align import substitution_matrices
 >>> substitution_matrices.load()  # doctest: +ELLIPSIS
-['BENNER22', 'BENNER6', 'BENNER74', 'BLOSUM45', 'BLOSUM50', 'BLOSUM62', ..., 'TRANS']
+['BENNER22', 'BENNER6', 'BENNER74', 'BLASTN', 'BLASTP', 'BLOSUM45', 'BLOSUM50', 'BLOSUM62', ..., 'TRANS']
 >>> matrix = substitution_matrices.load("BLOSUM62")
 >>> print(matrix)  # doctest: +ELLIPSIS
 #  Matrix made by matblas from blosum62.iij
@@ -3302,7 +3302,7 @@ To get a full list of available substitution matrices, use \verb+load+ without a
 %cont-doctest
 \begin{minted}{pycon}
 >>> substitution_matrices.load()  # doctest: +ELLIPSIS
-['BENNER22', 'BENNER6', 'BENNER74', 'BLOSUM45', 'BLOSUM50', ..., 'TRANS']
+['BENNER22', 'BENNER6', 'BENNER74', 'BLASTN', 'BLASTP', 'BLOSUM45', 'BLOSUM50', ..., 'TRANS']
 \end{minted}
 
 \hypertarget{codonmatrix}{

--- a/Doc/Tutorial/chapter_seqio.tex
+++ b/Doc/Tutorial/chapter_seqio.tex
@@ -1,4 +1,4 @@
-def get_accession(record):def get_accession(record):\chapter{Sequence Input/Output}
+\chapter{Sequence Input/Output}
 \label{chapter:seqio}
 
 In this chapter we'll discuss in more detail the \verb|Bio.SeqIO| module, which was briefly introduced in Chapter~\ref{chapter:quick_start} and also used in Chapter~\ref{chapter:seq_annot}. This aims to provide a simple interface for working with assorted sequence file formats in a uniform way.

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -1764,12 +1764,11 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
         lines = str(aligner).splitlines()
         self.assertEqual(len(lines), 15)
         self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        line = lines[1]
-        prefix = "  substitution_matrix: <Array object at "
-        suffix = ">"
-        self.assertTrue(line.startswith(prefix))
-        self.assertTrue(line.endswith(suffix))
-        address = int(line[len(prefix) : -len(suffix)], 16)
+        self.assertEqual(
+            lines[1],
+            "  substitution_matrix: <Array object at %s>"
+            % hex(id(aligner.substitution_matrix)),
+        )
         self.assertEqual(lines[2], "  target_internal_open_gap_score: -0.500000")
         self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -0.500000")
@@ -1868,12 +1867,11 @@ AT-T
         lines = str(aligner).splitlines()
         self.assertEqual(len(lines), 15)
         self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        line = lines[1]
-        prefix = "  substitution_matrix: <Array object at "
-        suffix = ">"
-        self.assertTrue(line.startswith(prefix))
-        self.assertTrue(line.endswith(suffix))
-        address = int(line[len(prefix) : -len(suffix)], 16)
+        self.assertEqual(
+            lines[1],
+            "  substitution_matrix: <Array object at %s>"
+            % hex(id(aligner.substitution_matrix)),
+        )
         self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
         self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
@@ -1940,12 +1938,11 @@ ATT
         lines = str(aligner).splitlines()
         self.assertEqual(len(lines), 15)
         self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        line = lines[1]
-        prefix = "  substitution_matrix: <Array object at "
-        suffix = ">"
-        self.assertTrue(line.startswith(prefix))
-        self.assertTrue(line.endswith(suffix))
-        address = int(line[len(prefix) : -len(suffix)], 16)
+        self.assertEqual(
+            lines[1],
+            "  substitution_matrix: <Array object at %s>"
+            % hex(id(aligner.substitution_matrix)),
+        )
         self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
         self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
@@ -2015,12 +2012,11 @@ ATAT
         lines = str(aligner).splitlines()
         self.assertEqual(len(lines), 15)
         self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        line = lines[1]
-        prefix = "  substitution_matrix: <Array object at "
-        suffix = ">"
-        self.assertTrue(line.startswith(prefix))
-        self.assertTrue(line.endswith(suffix))
-        address = int(line[len(prefix) : -len(suffix)], 16)
+        self.assertEqual(
+            lines[1],
+            "  substitution_matrix: <Array object at %s>"
+            % hex(id(aligner.substitution_matrix)),
+        )
         self.assertEqual(lines[2], "  target_internal_open_gap_score: -0.500000")
         self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -0.500000")
@@ -2121,12 +2117,11 @@ AT-T
         lines = str(aligner).splitlines()
         self.assertEqual(len(lines), 15)
         self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        line = lines[1]
-        prefix = "  substitution_matrix: <Array object at "
-        suffix = ">"
-        self.assertTrue(line.startswith(prefix))
-        self.assertTrue(line.endswith(suffix))
-        address = int(line[len(prefix) : -len(suffix)], 16)
+        self.assertEqual(
+            lines[1],
+            "  substitution_matrix: <Array object at %s>"
+            % hex(id(aligner.substitution_matrix)),
+        )
         self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
         self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
@@ -2195,12 +2190,11 @@ ATT
         lines = str(aligner).splitlines()
         self.assertEqual(len(lines), 15)
         self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        line = lines[1]
-        prefix = "  substitution_matrix: <Array object at "
-        suffix = ">"
-        self.assertTrue(line.startswith(prefix))
-        self.assertTrue(line.endswith(suffix))
-        address = int(line[len(prefix) : -len(suffix)], 16)
+        self.assertEqual(
+            lines[1],
+            "  substitution_matrix: <Array object at %s>"
+            % hex(id(aligner.substitution_matrix)),
+        )
         self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
         self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
@@ -3591,6 +3585,155 @@ Pairwise sequence aligner with parameters
   query_right_open_gap_score: -0.300000
   query_right_extend_gap_score: -0.100000
   mode: local
+""",
+        )
+
+
+class TestPredefinedScoringSchemes(unittest.TestCase):
+    def test_blastn(self):
+        aligner = Align.PairwiseAligner(scoring="blastn")
+        self.assertEqual(
+            str(aligner),
+            """\
+Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at %s>
+  target_internal_open_gap_score: -7.000000
+  target_internal_extend_gap_score: -2.000000
+  target_left_open_gap_score: -7.000000
+  target_left_extend_gap_score: -2.000000
+  target_right_open_gap_score: -7.000000
+  target_right_extend_gap_score: -2.000000
+  query_internal_open_gap_score: -7.000000
+  query_internal_extend_gap_score: -2.000000
+  query_left_open_gap_score: -7.000000
+  query_left_extend_gap_score: -2.000000
+  query_right_open_gap_score: -7.000000
+  query_right_extend_gap_score: -2.000000
+  mode: global
+"""
+            % hex(id(aligner.substitution_matrix)),
+        )
+        self.assertEqual(
+            str(aligner.substitution_matrix[:, :]),
+            """\
+     A    T    G    C    S    W    R    Y    K    M    B    V    H    D    N
+A  2.0 -3.0 -3.0 -3.0 -3.0 -1.0 -1.0 -3.0 -3.0 -1.0 -3.0 -1.0 -1.0 -1.0 -2.0
+T -3.0  2.0 -3.0 -3.0 -3.0 -1.0 -3.0 -1.0 -1.0 -3.0 -1.0 -3.0 -1.0 -1.0 -2.0
+G -3.0 -3.0  2.0 -3.0 -1.0 -3.0 -1.0 -3.0 -1.0 -3.0 -1.0 -1.0 -3.0 -1.0 -2.0
+C -3.0 -3.0 -3.0  2.0 -1.0 -3.0 -3.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -3.0 -2.0
+S -3.0 -3.0 -1.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+W -1.0 -1.0 -3.0 -3.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+R -1.0 -3.0 -1.0 -3.0 -1.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+Y -3.0 -1.0 -3.0 -1.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+K -3.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -2.0
+M -1.0 -3.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+B -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+V -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+H -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+D -1.0 -1.0 -1.0 -3.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0
+N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
+""",
+        )
+
+    def test_megablast(self):
+        aligner = Align.PairwiseAligner(scoring="megablast")
+        self.assertEqual(
+            str(aligner),
+            """\
+Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at %s>
+  target_internal_open_gap_score: -2.500000
+  target_internal_extend_gap_score: -2.500000
+  target_left_open_gap_score: -2.500000
+  target_left_extend_gap_score: -2.500000
+  target_right_open_gap_score: -2.500000
+  target_right_extend_gap_score: -2.500000
+  query_internal_open_gap_score: -2.500000
+  query_internal_extend_gap_score: -2.500000
+  query_left_open_gap_score: -2.500000
+  query_left_extend_gap_score: -2.500000
+  query_right_open_gap_score: -2.500000
+  query_right_extend_gap_score: -2.500000
+  mode: global
+"""
+            % hex(id(aligner.substitution_matrix)),
+        )
+        self.assertEqual(
+            str(aligner.substitution_matrix[:, :]),
+            """\
+     A    T    G    C    S    W    R    Y    K    M    B    V    H    D    N
+A  1.0 -2.0 -2.0 -2.0 -2.0 -1.0 -1.0 -2.0 -2.0 -1.0 -2.0 -1.0 -1.0 -1.0 -1.0
+T -2.0  1.0 -2.0 -2.0 -2.0 -1.0 -2.0 -1.0 -1.0 -2.0 -1.0 -2.0 -1.0 -1.0 -1.0
+G -2.0 -2.0  1.0 -2.0 -1.0 -2.0 -1.0 -2.0 -1.0 -2.0 -1.0 -1.0 -2.0 -1.0 -1.0
+C -2.0 -2.0 -2.0  1.0 -1.0 -2.0 -2.0 -1.0 -2.0 -1.0 -1.0 -1.0 -1.0 -2.0 -1.0
+S -2.0 -2.0 -1.0 -1.0 -1.0 -2.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
+W -1.0 -1.0 -2.0 -2.0 -2.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
+R -1.0 -2.0 -1.0 -2.0 -1.0 -1.0 -1.0 -2.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
+Y -2.0 -1.0 -2.0 -1.0 -1.0 -1.0 -2.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
+K -2.0 -1.0 -1.0 -2.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0 -1.0 -1.0 -1.0 -1.0 -1.0
+M -1.0 -2.0 -2.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
+B -2.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
+V -1.0 -2.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
+H -1.0 -1.0 -2.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
+D -1.0 -1.0 -1.0 -2.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
+N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
+""",
+        )
+
+    def test_blastp(self):
+        aligner = Align.PairwiseAligner(scoring="blastp")
+        self.assertEqual(
+            str(aligner),
+            """\
+Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at %s>
+  target_internal_open_gap_score: -12.000000
+  target_internal_extend_gap_score: -1.000000
+  target_left_open_gap_score: -12.000000
+  target_left_extend_gap_score: -1.000000
+  target_right_open_gap_score: -12.000000
+  target_right_extend_gap_score: -1.000000
+  query_internal_open_gap_score: -12.000000
+  query_internal_extend_gap_score: -1.000000
+  query_left_open_gap_score: -12.000000
+  query_left_extend_gap_score: -1.000000
+  query_right_open_gap_score: -12.000000
+  query_right_extend_gap_score: -1.000000
+  mode: global
+"""
+            % hex(id(aligner.substitution_matrix)),
+        )
+        self.assertEqual(
+            str(aligner.substitution_matrix[:, :]),
+            """\
+     A    B    C    D    E    F    G    H    I    J    K    L    M    N    O    P    Q    R    S    T    U    V    W    X    Y    Z    *
+A  4.0 -2.0  0.0 -2.0 -1.0 -2.0  0.0 -2.0 -1.0 -1.0 -1.0 -1.0 -1.0 -2.0 -1.0 -1.0 -1.0 -1.0  1.0  0.0  0.0  0.0 -3.0 -1.0 -2.0 -1.0 -4.0
+B -2.0  4.0 -3.0  4.0  1.0 -3.0 -1.0  0.0 -3.0 -3.0  0.0 -4.0 -3.0  4.0 -1.0 -2.0  0.0 -1.0  0.0 -1.0 -3.0 -3.0 -4.0 -1.0 -3.0  0.0 -4.0
+C  0.0 -3.0  9.0 -3.0 -4.0 -2.0 -3.0 -3.0 -1.0 -1.0 -3.0 -1.0 -1.0 -3.0 -1.0 -3.0 -3.0 -3.0 -1.0 -1.0  9.0 -1.0 -2.0 -1.0 -2.0 -3.0 -4.0
+D -2.0  4.0 -3.0  6.0  2.0 -3.0 -1.0 -1.0 -3.0 -3.0 -1.0 -4.0 -3.0  1.0 -1.0 -1.0  0.0 -2.0  0.0 -1.0 -3.0 -3.0 -4.0 -1.0 -3.0  1.0 -4.0
+E -1.0  1.0 -4.0  2.0  5.0 -3.0 -2.0  0.0 -3.0 -3.0  1.0 -3.0 -2.0  0.0 -1.0 -1.0  2.0  0.0  0.0 -1.0 -4.0 -2.0 -3.0 -1.0 -2.0  4.0 -4.0
+F -2.0 -3.0 -2.0 -3.0 -3.0  6.0 -3.0 -1.0  0.0  0.0 -3.0  0.0  0.0 -3.0 -1.0 -4.0 -3.0 -3.0 -2.0 -2.0 -2.0 -1.0  1.0 -1.0  3.0 -3.0 -4.0
+G  0.0 -1.0 -3.0 -1.0 -2.0 -3.0  6.0 -2.0 -4.0 -4.0 -2.0 -4.0 -3.0  0.0 -1.0 -2.0 -2.0 -2.0  0.0 -2.0 -3.0 -3.0 -2.0 -1.0 -3.0 -2.0 -4.0
+H -2.0  0.0 -3.0 -1.0  0.0 -1.0 -2.0  8.0 -3.0 -3.0 -1.0 -3.0 -2.0  1.0 -1.0 -2.0  0.0  0.0 -1.0 -2.0 -3.0 -3.0 -2.0 -1.0  2.0  0.0 -4.0
+I -1.0 -3.0 -1.0 -3.0 -3.0  0.0 -4.0 -3.0  4.0  3.0 -3.0  2.0  1.0 -3.0 -1.0 -3.0 -3.0 -3.0 -2.0 -1.0 -1.0  3.0 -3.0 -1.0 -1.0 -3.0 -4.0
+J -1.0 -3.0 -1.0 -3.0 -3.0  0.0 -4.0 -3.0  3.0  3.0 -3.0  3.0  2.0 -3.0 -1.0 -3.0 -2.0 -2.0 -2.0 -1.0 -1.0  2.0 -2.0 -1.0 -1.0 -3.0 -4.0
+K -1.0  0.0 -3.0 -1.0  1.0 -3.0 -2.0 -1.0 -3.0 -3.0  5.0 -2.0 -1.0  0.0 -1.0 -1.0  1.0  2.0  0.0 -1.0 -3.0 -2.0 -3.0 -1.0 -2.0  1.0 -4.0
+L -1.0 -4.0 -1.0 -4.0 -3.0  0.0 -4.0 -3.0  2.0  3.0 -2.0  4.0  2.0 -3.0 -1.0 -3.0 -2.0 -2.0 -2.0 -1.0 -1.0  1.0 -2.0 -1.0 -1.0 -3.0 -4.0
+M -1.0 -3.0 -1.0 -3.0 -2.0  0.0 -3.0 -2.0  1.0  2.0 -1.0  2.0  5.0 -2.0 -1.0 -2.0  0.0 -1.0 -1.0 -1.0 -1.0  1.0 -1.0 -1.0 -1.0 -1.0 -4.0
+N -2.0  4.0 -3.0  1.0  0.0 -3.0  0.0  1.0 -3.0 -3.0  0.0 -3.0 -2.0  6.0 -1.0 -2.0  0.0  0.0  1.0  0.0 -3.0 -3.0 -4.0 -1.0 -2.0  0.0 -4.0
+O -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -4.0
+P -1.0 -2.0 -3.0 -1.0 -1.0 -4.0 -2.0 -2.0 -3.0 -3.0 -1.0 -3.0 -2.0 -2.0 -1.0  7.0 -1.0 -2.0 -1.0 -1.0 -3.0 -2.0 -4.0 -1.0 -3.0 -1.0 -4.0
+Q -1.0  0.0 -3.0  0.0  2.0 -3.0 -2.0  0.0 -3.0 -2.0  1.0 -2.0  0.0  0.0 -1.0 -1.0  5.0  1.0  0.0 -1.0 -3.0 -2.0 -2.0 -1.0 -1.0  4.0 -4.0
+R -1.0 -1.0 -3.0 -2.0  0.0 -3.0 -2.0  0.0 -3.0 -2.0  2.0 -2.0 -1.0  0.0 -1.0 -2.0  1.0  5.0 -1.0 -1.0 -3.0 -3.0 -3.0 -1.0 -2.0  0.0 -4.0
+S  1.0  0.0 -1.0  0.0  0.0 -2.0  0.0 -1.0 -2.0 -2.0  0.0 -2.0 -1.0  1.0 -1.0 -1.0  0.0 -1.0  4.0  1.0 -1.0 -2.0 -3.0 -1.0 -2.0  0.0 -4.0
+T  0.0 -1.0 -1.0 -1.0 -1.0 -2.0 -2.0 -2.0 -1.0 -1.0 -1.0 -1.0 -1.0  0.0 -1.0 -1.0 -1.0 -1.0  1.0  5.0 -1.0  0.0 -2.0 -1.0 -2.0 -1.0 -4.0
+U  0.0 -3.0  9.0 -3.0 -4.0 -2.0 -3.0 -3.0 -1.0 -1.0 -3.0 -1.0 -1.0 -3.0 -1.0 -3.0 -3.0 -3.0 -1.0 -1.0  9.0 -1.0 -2.0 -1.0 -2.0 -3.0 -4.0
+V  0.0 -3.0 -1.0 -3.0 -2.0 -1.0 -3.0 -3.0  3.0  2.0 -2.0  1.0  1.0 -3.0 -1.0 -2.0 -2.0 -3.0 -2.0  0.0 -1.0  4.0 -3.0 -1.0 -1.0 -2.0 -4.0
+W -3.0 -4.0 -2.0 -4.0 -3.0  1.0 -2.0 -2.0 -3.0 -2.0 -3.0 -2.0 -1.0 -4.0 -1.0 -4.0 -2.0 -3.0 -3.0 -2.0 -2.0 -3.0 11.0 -1.0  2.0 -2.0 -4.0
+X -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -4.0
+Y -2.0 -3.0 -2.0 -3.0 -2.0  3.0 -3.0  2.0 -1.0 -1.0 -2.0 -1.0 -1.0 -2.0 -1.0 -3.0 -1.0 -2.0 -2.0 -2.0 -2.0 -1.0  2.0 -1.0  7.0 -2.0 -4.0
+Z -1.0  0.0 -3.0  1.0  4.0 -3.0 -2.0  0.0 -3.0 -3.0  1.0 -3.0 -1.0  0.0 -1.0 -1.0  4.0  0.0  0.0 -1.0 -3.0 -2.0 -2.0 -1.0 -2.0  4.0 -4.0
+* -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0 -4.0  1.0
 """,
         )
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -1764,11 +1764,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
         lines = str(aligner).splitlines()
         self.assertEqual(len(lines), 15)
         self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        self.assertEqual(
-            lines[1],
-            "  substitution_matrix: <Array object at %s>"
-            % hex(id(aligner.substitution_matrix)),
-        )
+        self.assertRegex(lines[1], "^  substitution_matrix: <Array object at .*>$")
         self.assertEqual(lines[2], "  target_internal_open_gap_score: -0.500000")
         self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -0.500000")
@@ -1867,11 +1863,7 @@ AT-T
         lines = str(aligner).splitlines()
         self.assertEqual(len(lines), 15)
         self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        self.assertEqual(
-            lines[1],
-            "  substitution_matrix: <Array object at %s>"
-            % hex(id(aligner.substitution_matrix)),
-        )
+        self.assertRegex(lines[1], "^  substitution_matrix: <Array object at .*>$")
         self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
         self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
@@ -1938,11 +1930,7 @@ ATT
         lines = str(aligner).splitlines()
         self.assertEqual(len(lines), 15)
         self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        self.assertEqual(
-            lines[1],
-            "  substitution_matrix: <Array object at %s>"
-            % hex(id(aligner.substitution_matrix)),
-        )
+        self.assertRegex(lines[1], "^  substitution_matrix: <Array object at .*>$")
         self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
         self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
@@ -2012,11 +2000,7 @@ ATAT
         lines = str(aligner).splitlines()
         self.assertEqual(len(lines), 15)
         self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        self.assertEqual(
-            lines[1],
-            "  substitution_matrix: <Array object at %s>"
-            % hex(id(aligner.substitution_matrix)),
-        )
+        self.assertRegex(lines[1], "^  substitution_matrix: <Array object at .*>$")
         self.assertEqual(lines[2], "  target_internal_open_gap_score: -0.500000")
         self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -0.500000")
@@ -2117,11 +2101,7 @@ AT-T
         lines = str(aligner).splitlines()
         self.assertEqual(len(lines), 15)
         self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        self.assertEqual(
-            lines[1],
-            "  substitution_matrix: <Array object at %s>"
-            % hex(id(aligner.substitution_matrix)),
-        )
+        self.assertRegex(lines[1], "^  substitution_matrix: <Array object at .*>$")
         self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
         self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
@@ -2190,11 +2170,7 @@ ATT
         lines = str(aligner).splitlines()
         self.assertEqual(len(lines), 15)
         self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        self.assertEqual(
-            lines[1],
-            "  substitution_matrix: <Array object at %s>"
-            % hex(id(aligner.substitution_matrix)),
-        )
+        self.assertRegex(lines[1], "^  substitution_matrix: <Array object at .*>$")
         self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
         self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
         self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
@@ -3592,11 +3568,11 @@ Pairwise sequence aligner with parameters
 class TestPredefinedScoringSchemes(unittest.TestCase):
     def test_blastn(self):
         aligner = Align.PairwiseAligner(scoring="blastn")
-        self.assertEqual(
+        self.assertRegex(
             str(aligner),
             """\
-Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at %s>
+^Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at .*>
   target_internal_open_gap_score: -7.000000
   target_internal_extend_gap_score: -2.000000
   target_left_open_gap_score: -7.000000
@@ -3610,8 +3586,7 @@ Pairwise sequence aligner with parameters
   query_right_open_gap_score: -7.000000
   query_right_extend_gap_score: -2.000000
   mode: global
-"""
-            % hex(id(aligner.substitution_matrix)),
+$""",
         )
         self.assertEqual(
             str(aligner.substitution_matrix[:, :]),
@@ -3637,11 +3612,11 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
 
     def test_megablast(self):
         aligner = Align.PairwiseAligner(scoring="megablast")
-        self.assertEqual(
+        self.assertRegex(
             str(aligner),
             """\
-Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at %s>
+^Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at .*>
   target_internal_open_gap_score: -2.500000
   target_internal_extend_gap_score: -2.500000
   target_left_open_gap_score: -2.500000
@@ -3655,8 +3630,7 @@ Pairwise sequence aligner with parameters
   query_right_open_gap_score: -2.500000
   query_right_extend_gap_score: -2.500000
   mode: global
-"""
-            % hex(id(aligner.substitution_matrix)),
+$""",
         )
         self.assertEqual(
             str(aligner.substitution_matrix[:, :]),
@@ -3682,11 +3656,11 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
 
     def test_blastp(self):
         aligner = Align.PairwiseAligner(scoring="blastp")
-        self.assertEqual(
+        self.assertRegex(
             str(aligner),
             """\
-Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at %s>
+^Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at .*>
   target_internal_open_gap_score: -12.000000
   target_internal_extend_gap_score: -1.000000
   target_left_open_gap_score: -12.000000
@@ -3700,8 +3674,7 @@ Pairwise sequence aligner with parameters
   query_right_open_gap_score: -12.000000
   query_right_extend_gap_score: -1.000000
   mode: global
-"""
-            % hex(id(aligner.substitution_matrix)),
+$""",
         )
         self.assertEqual(
             str(aligner.substitution_matrix[:, :]),

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -1761,23 +1761,26 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
         aligner.open_gap_score = -0.5
         aligner.extend_gap_score = 0.0
         self.assertEqual(aligner.algorithm, "Gotoh local alignment algorithm")
-        lines = str(aligner).splitlines()
-        self.assertEqual(len(lines), 15)
-        self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        self.assertRegex(lines[1], "^  substitution_matrix: <Array object at .*>$")
-        self.assertEqual(lines[2], "  target_internal_open_gap_score: -0.500000")
-        self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
-        self.assertEqual(lines[4], "  target_left_open_gap_score: -0.500000")
-        self.assertEqual(lines[5], "  target_left_extend_gap_score: 0.000000")
-        self.assertEqual(lines[6], "  target_right_open_gap_score: -0.500000")
-        self.assertEqual(lines[7], "  target_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[8], "  query_internal_open_gap_score: -0.500000")
-        self.assertEqual(lines[9], "  query_internal_extend_gap_score: 0.000000")
-        self.assertEqual(lines[10], "  query_left_open_gap_score: -0.500000")
-        self.assertEqual(lines[11], "  query_left_extend_gap_score: 0.000000")
-        self.assertEqual(lines[12], "  query_right_open_gap_score: -0.500000")
-        self.assertEqual(lines[13], "  query_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[14], "  mode: local")
+        self.assertRegex(
+            str(aligner),
+            """\
+^Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at .*>
+  target_internal_open_gap_score: -0.500000
+  target_internal_extend_gap_score: 0.000000
+  target_left_open_gap_score: -0.500000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -0.500000
+  target_right_extend_gap_score: 0.000000
+  query_internal_open_gap_score: -0.500000
+  query_internal_extend_gap_score: 0.000000
+  query_left_open_gap_score: -0.500000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -0.500000
+  query_right_extend_gap_score: 0.000000
+  mode: local
+$""",
+        )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
@@ -1860,23 +1863,26 @@ AT-T
         aligner.substitution_matrix = substitution_matrix
         aligner.open_gap_score = -1.0
         aligner.extend_gap_score = 0.0
-        lines = str(aligner).splitlines()
-        self.assertEqual(len(lines), 15)
-        self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        self.assertRegex(lines[1], "^  substitution_matrix: <Array object at .*>$")
-        self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
-        self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
-        self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
-        self.assertEqual(lines[5], "  target_left_extend_gap_score: 0.000000")
-        self.assertEqual(lines[6], "  target_right_open_gap_score: -1.000000")
-        self.assertEqual(lines[7], "  target_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[8], "  query_internal_open_gap_score: -1.000000")
-        self.assertEqual(lines[9], "  query_internal_extend_gap_score: 0.000000")
-        self.assertEqual(lines[10], "  query_left_open_gap_score: -1.000000")
-        self.assertEqual(lines[11], "  query_left_extend_gap_score: 0.000000")
-        self.assertEqual(lines[12], "  query_right_open_gap_score: -1.000000")
-        self.assertEqual(lines[13], "  query_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[14], "  mode: local")
+        self.assertRegex(
+            str(aligner),
+            """\
+^Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at .*>
+  target_internal_open_gap_score: -1.000000
+  target_internal_extend_gap_score: 0.000000
+  target_left_open_gap_score: -1.000000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -1.000000
+  target_right_extend_gap_score: 0.000000
+  query_internal_open_gap_score: -1.000000
+  query_internal_extend_gap_score: 0.000000
+  query_left_open_gap_score: -1.000000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -1.000000
+  query_right_extend_gap_score: 0.000000
+  mode: local
+$""",
+        )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
@@ -1927,23 +1933,26 @@ ATT
         aligner.substitution_matrix = substitution_matrix
         aligner.open_gap_score = -1.0
         aligner.extend_gap_score = 0.0
-        lines = str(aligner).splitlines()
-        self.assertEqual(len(lines), 15)
-        self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        self.assertRegex(lines[1], "^  substitution_matrix: <Array object at .*>$")
-        self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
-        self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
-        self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
-        self.assertEqual(lines[5], "  target_left_extend_gap_score: 0.000000")
-        self.assertEqual(lines[6], "  target_right_open_gap_score: -1.000000")
-        self.assertEqual(lines[7], "  target_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[8], "  query_internal_open_gap_score: -1.000000")
-        self.assertEqual(lines[9], "  query_internal_extend_gap_score: 0.000000")
-        self.assertEqual(lines[10], "  query_left_open_gap_score: -1.000000")
-        self.assertEqual(lines[11], "  query_left_extend_gap_score: 0.000000")
-        self.assertEqual(lines[12], "  query_right_open_gap_score: -1.000000")
-        self.assertEqual(lines[13], "  query_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[14], "  mode: local")
+        self.assertRegex(
+            str(aligner),
+            """\
+^Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at .*>
+  target_internal_open_gap_score: -1.000000
+  target_internal_extend_gap_score: 0.000000
+  target_left_open_gap_score: -1.000000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -1.000000
+  target_right_extend_gap_score: 0.000000
+  query_internal_open_gap_score: -1.000000
+  query_internal_extend_gap_score: 0.000000
+  query_left_open_gap_score: -1.000000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -1.000000
+  query_right_extend_gap_score: 0.000000
+  mode: local
+$""",
+        )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
@@ -1997,23 +2006,26 @@ ATAT
         aligner.open_gap_score = -0.5
         aligner.extend_gap_score = 0.0
         self.assertEqual(aligner.algorithm, "Gotoh local alignment algorithm")
-        lines = str(aligner).splitlines()
-        self.assertEqual(len(lines), 15)
-        self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        self.assertRegex(lines[1], "^  substitution_matrix: <Array object at .*>$")
-        self.assertEqual(lines[2], "  target_internal_open_gap_score: -0.500000")
-        self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
-        self.assertEqual(lines[4], "  target_left_open_gap_score: -0.500000")
-        self.assertEqual(lines[5], "  target_left_extend_gap_score: 0.000000")
-        self.assertEqual(lines[6], "  target_right_open_gap_score: -0.500000")
-        self.assertEqual(lines[7], "  target_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[8], "  query_internal_open_gap_score: -0.500000")
-        self.assertEqual(lines[9], "  query_internal_extend_gap_score: 0.000000")
-        self.assertEqual(lines[10], "  query_left_open_gap_score: -0.500000")
-        self.assertEqual(lines[11], "  query_left_extend_gap_score: 0.000000")
-        self.assertEqual(lines[12], "  query_right_open_gap_score: -0.500000")
-        self.assertEqual(lines[13], "  query_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[14], "  mode: local")
+        self.assertRegex(
+            str(aligner),
+            """\
+^Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at .*>
+  target_internal_open_gap_score: -0.500000
+  target_internal_extend_gap_score: 0.000000
+  target_left_open_gap_score: -0.500000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -0.500000
+  target_right_extend_gap_score: 0.000000
+  query_internal_open_gap_score: -0.500000
+  query_internal_extend_gap_score: 0.000000
+  query_left_open_gap_score: -0.500000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -0.500000
+  query_right_extend_gap_score: 0.000000
+  mode: local
+$""",
+        )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
@@ -2098,23 +2110,26 @@ AT-T
         aligner.substitution_matrix = substitution_matrix
         aligner.open_gap_score = -1.0
         aligner.extend_gap_score = 0.0
-        lines = str(aligner).splitlines()
-        self.assertEqual(len(lines), 15)
-        self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        self.assertRegex(lines[1], "^  substitution_matrix: <Array object at .*>$")
-        self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
-        self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
-        self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
-        self.assertEqual(lines[5], "  target_left_extend_gap_score: 0.000000")
-        self.assertEqual(lines[6], "  target_right_open_gap_score: -1.000000")
-        self.assertEqual(lines[7], "  target_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[8], "  query_internal_open_gap_score: -1.000000")
-        self.assertEqual(lines[9], "  query_internal_extend_gap_score: 0.000000")
-        self.assertEqual(lines[10], "  query_left_open_gap_score: -1.000000")
-        self.assertEqual(lines[11], "  query_left_extend_gap_score: 0.000000")
-        self.assertEqual(lines[12], "  query_right_open_gap_score: -1.000000")
-        self.assertEqual(lines[13], "  query_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[14], "  mode: local")
+        self.assertRegex(
+            str(aligner),
+            """\
+^Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at .*
+  target_internal_open_gap_score: -1.000000
+  target_internal_extend_gap_score: 0.000000
+  target_left_open_gap_score: -1.000000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -1.000000
+  target_right_extend_gap_score: 0.000000
+  query_internal_open_gap_score: -1.000000
+  query_internal_extend_gap_score: 0.000000
+  query_left_open_gap_score: -1.000000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -1.000000
+  query_right_extend_gap_score: 0.000000
+  mode: local
+$""",
+        )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
@@ -2167,23 +2182,26 @@ ATT
         aligner.substitution_matrix = substitution_matrix
         aligner.open_gap_score = -1.0
         aligner.extend_gap_score = 0.0
-        lines = str(aligner).splitlines()
-        self.assertEqual(len(lines), 15)
-        self.assertEqual(lines[0], "Pairwise sequence aligner with parameters")
-        self.assertRegex(lines[1], "^  substitution_matrix: <Array object at .*>$")
-        self.assertEqual(lines[2], "  target_internal_open_gap_score: -1.000000")
-        self.assertEqual(lines[3], "  target_internal_extend_gap_score: 0.000000")
-        self.assertEqual(lines[4], "  target_left_open_gap_score: -1.000000")
-        self.assertEqual(lines[5], "  target_left_extend_gap_score: 0.000000")
-        self.assertEqual(lines[6], "  target_right_open_gap_score: -1.000000")
-        self.assertEqual(lines[7], "  target_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[8], "  query_internal_open_gap_score: -1.000000")
-        self.assertEqual(lines[9], "  query_internal_extend_gap_score: 0.000000")
-        self.assertEqual(lines[10], "  query_left_open_gap_score: -1.000000")
-        self.assertEqual(lines[11], "  query_left_extend_gap_score: 0.000000")
-        self.assertEqual(lines[12], "  query_right_open_gap_score: -1.000000")
-        self.assertEqual(lines[13], "  query_right_extend_gap_score: 0.000000")
-        self.assertEqual(lines[14], "  mode: local")
+        self.assertRegex(
+            str(aligner),
+            """\
+^Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at .*>
+  target_internal_open_gap_score: -1.000000
+  target_internal_extend_gap_score: 0.000000
+  target_left_open_gap_score: -1.000000
+  target_left_extend_gap_score: 0.000000
+  target_right_open_gap_score: -1.000000
+  target_right_extend_gap_score: 0.000000
+  query_internal_open_gap_score: -1.000000
+  query_internal_extend_gap_score: 0.000000
+  query_left_open_gap_score: -1.000000
+  query_left_extend_gap_score: 0.000000
+  query_right_open_gap_score: -1.000000
+  query_right_extend_gap_score: 0.000000
+  mode: local
+$""",
+        )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
@@ -3572,7 +3590,7 @@ class TestPredefinedScoringSchemes(unittest.TestCase):
             str(aligner),
             """\
 ^Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at .*>
+  substitution_matrix: <Array object at .*
   target_internal_open_gap_score: -7.000000
   target_internal_extend_gap_score: -2.000000
   target_left_open_gap_score: -7.000000
@@ -3616,7 +3634,7 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
             str(aligner),
             """\
 ^Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at .*>
+  substitution_matrix: <Array object at .*
   target_internal_open_gap_score: -2.500000
   target_internal_extend_gap_score: -2.500000
   target_left_open_gap_score: -2.500000
@@ -3660,7 +3678,7 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
             str(aligner),
             """\
 ^Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at .*>
+  substitution_matrix: <Array object at .*
   target_internal_open_gap_score: -12.000000
   target_internal_extend_gap_score: -1.000000
   target_left_open_gap_score: -12.000000


### PR DESCRIPTION
This PR adds the gap scores and substitution matrix for blastn, megablast, and blastp as scoring options when initializing a `PairwiseAligner` object.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

