### PR TITLE
fix compiler warnings

### DIFF
--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -5757,7 +5757,7 @@ exit: \
 /* -------------- allocation & deallocation ------------- */
 
 static PathGenerator*
-PathGenerator_create_NWSW(Py_ssize_t nA, Py_ssize_t nB, Mode mode, unsigned char strand)
+PathGenerator_create_NWSW(int nA, int nB, Mode mode, unsigned char strand)
 {
     int i;
     unsigned char trace = 0;
@@ -5805,7 +5805,7 @@ exit:
 }
 
 static PathGenerator*
-PathGenerator_create_Gotoh(Py_ssize_t nA, Py_ssize_t nB, Mode mode, unsigned char strand)
+PathGenerator_create_Gotoh(int nA, int nB, Mode mode, unsigned char strand)
 {
     int i;
     unsigned char trace;
@@ -5893,7 +5893,7 @@ exit:
 }
 
 static PathGenerator*
-PathGenerator_create_WSB(Py_ssize_t nA, Py_ssize_t nB, Mode mode, unsigned char strand)
+PathGenerator_create_WSB(int nA, int nB, Mode mode, unsigned char strand)
 {
     int i, j;
     int* trace;
@@ -5989,8 +5989,8 @@ exit:
 
 static PyObject*
 Aligner_needlemanwunsch_score_compare(Aligner* self,
-                                      const int* sA, Py_ssize_t nA,
-                                      const int* sB, Py_ssize_t nB,
+                                      const int* sA, int nA,
+                                      const int* sB, int nB,
                                       unsigned char strand)
 {
     const double match = self->match;
@@ -6001,8 +6001,8 @@ Aligner_needlemanwunsch_score_compare(Aligner* self,
 
 static PyObject*
 Aligner_needlemanwunsch_score_matrix(Aligner* self,
-                                     const int* sA, Py_ssize_t nA,
-                                     const int* sB, Py_ssize_t nB,
+                                     const int* sA, int nA,
+                                     const int* sB, int nB,
                                      unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
@@ -6012,8 +6012,8 @@ Aligner_needlemanwunsch_score_matrix(Aligner* self,
 
 static PyObject*
 Aligner_smithwaterman_score_compare(Aligner* self,
-                                    const int* sA, Py_ssize_t nA,
-                                    const int* sB, Py_ssize_t nB)
+                                    const int* sA, int nA,
+                                    const int* sB, int nB)
 {
     const double match = self->match;
     const double mismatch = self->mismatch;
@@ -6023,8 +6023,8 @@ Aligner_smithwaterman_score_compare(Aligner* self,
 
 static PyObject*
 Aligner_smithwaterman_score_matrix(Aligner* self,
-                                   const int* sA, Py_ssize_t nA,
-                                   const int* sB, Py_ssize_t nB)
+                                   const int* sA, int nA,
+                                   const int* sB, int nB)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
     const double* scores = self->substitution_matrix.buf;
@@ -6033,8 +6033,8 @@ Aligner_smithwaterman_score_matrix(Aligner* self,
 
 static PyObject*
 Aligner_needlemanwunsch_align_compare(Aligner* self,
-                                      const int* sA, Py_ssize_t nA,
-                                      const int* sB, Py_ssize_t nB,
+                                      const int* sA, int nA,
+                                      const int* sB, int nB,
                                       unsigned char strand)
 {
     const double match = self->match;
@@ -6045,8 +6045,8 @@ Aligner_needlemanwunsch_align_compare(Aligner* self,
 
 static PyObject*
 Aligner_needlemanwunsch_align_matrix(Aligner* self,
-                                     const int* sA, Py_ssize_t nA,
-                                     const int* sB, Py_ssize_t nB,
+                                     const int* sA, int nA,
+                                     const int* sB, int nB,
                                      unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
@@ -6056,8 +6056,8 @@ Aligner_needlemanwunsch_align_matrix(Aligner* self,
 
 static PyObject*
 Aligner_smithwaterman_align_compare(Aligner* self,
-                                    const int* sA, Py_ssize_t nA,
-                                    const int* sB, Py_ssize_t nB,
+                                    const int* sA, int nA,
+                                    const int* sB, int nB,
                                     unsigned char strand)
 {
     const double match = self->match;
@@ -6068,8 +6068,8 @@ Aligner_smithwaterman_align_compare(Aligner* self,
 
 static PyObject*
 Aligner_smithwaterman_align_matrix(Aligner* self,
-                                   const int* sA, Py_ssize_t nA,
-                                   const int* sB, Py_ssize_t nB,
+                                   const int* sA, int nA,
+                                   const int* sB, int nB,
                                    unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
@@ -6079,8 +6079,8 @@ Aligner_smithwaterman_align_matrix(Aligner* self,
 
 static PyObject*
 Aligner_gotoh_global_score_compare(Aligner* self,
-                                   const int* sA, Py_ssize_t nA,
-                                   const int* sB, Py_ssize_t nB,
+                                   const int* sA, int nA,
+                                   const int* sB, int nB,
                                    unsigned char strand)
 {
     const double match = self->match;
@@ -6091,8 +6091,8 @@ Aligner_gotoh_global_score_compare(Aligner* self,
 
 static PyObject*
 Aligner_gotoh_global_score_matrix(Aligner* self,
-                                  const int* sA, Py_ssize_t nA,
-                                  const int* sB, Py_ssize_t nB,
+                                  const int* sA, int nA,
+                                  const int* sB, int nB,
                                   unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
@@ -6102,8 +6102,8 @@ Aligner_gotoh_global_score_matrix(Aligner* self,
 
 static PyObject*
 Aligner_gotoh_local_score_compare(Aligner* self,
-                                  const int* sA, Py_ssize_t nA,
-                                  const int* sB, Py_ssize_t nB)
+                                  const int* sA, int nA,
+                                  const int* sB, int nB)
 {
     const double match = self->match;
     const double mismatch = self->mismatch;
@@ -6113,8 +6113,8 @@ Aligner_gotoh_local_score_compare(Aligner* self,
 
 static PyObject*
 Aligner_gotoh_local_score_matrix(Aligner* self,
-                                 const int* sA, Py_ssize_t nA,
-                                 const int* sB, Py_ssize_t nB)
+                                 const int* sA, int nA,
+                                 const int* sB, int nB)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
     const double* scores = self->substitution_matrix.buf;
@@ -6123,8 +6123,8 @@ Aligner_gotoh_local_score_matrix(Aligner* self,
 
 static PyObject*
 Aligner_gotoh_global_align_compare(Aligner* self,
-                                   const int* sA, Py_ssize_t nA,
-                                   const int* sB, Py_ssize_t nB,
+                                   const int* sA, int nA,
+                                   const int* sB, int nB,
                                    unsigned char strand)
 {
     const double match = self->match;
@@ -6135,8 +6135,8 @@ Aligner_gotoh_global_align_compare(Aligner* self,
 
 static PyObject*
 Aligner_gotoh_global_align_matrix(Aligner* self,
-                                  const int* sA, Py_ssize_t nA,
-                                  const int* sB, Py_ssize_t nB,
+                                  const int* sA, int nA,
+                                  const int* sB, int nB,
                                   unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
@@ -6146,8 +6146,8 @@ Aligner_gotoh_global_align_matrix(Aligner* self,
 
 static PyObject*
 Aligner_gotoh_local_align_compare(Aligner* self,
-                                  const int* sA, Py_ssize_t nA,
-                                  const int* sB, Py_ssize_t nB,
+                                  const int* sA, int nA,
+                                  const int* sB, int nB,
                                   unsigned char strand)
 {
     const double match = self->match;
@@ -6158,8 +6158,8 @@ Aligner_gotoh_local_align_compare(Aligner* self,
 
 static PyObject*
 Aligner_gotoh_local_align_matrix(Aligner* self,
-                                 const int* sA, Py_ssize_t nA,
-                                 const int* sB, Py_ssize_t nB,
+                                 const int* sA, int nA,
+                                 const int* sB, int nB,
                                  unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
@@ -6209,8 +6209,8 @@ _call_target_gap_function(Aligner* aligner, int i, int j, double* score)
 
 static PyObject*
 Aligner_watermansmithbeyer_global_score_compare(Aligner* self,
-                                                const int* sA, Py_ssize_t nA,
-                                                const int* sB, Py_ssize_t nB,
+                                                const int* sA, int nA,
+                                                const int* sB, int nB,
                                                 unsigned char strand)
 {
     const double match = self->match;
@@ -6232,8 +6232,8 @@ Aligner_watermansmithbeyer_global_score_compare(Aligner* self,
 
 static PyObject*
 Aligner_watermansmithbeyer_global_score_matrix(Aligner* self,
-                                               const int* sA, Py_ssize_t nA,
-                                               const int* sB, Py_ssize_t nB,
+                                               const int* sA, int nA,
+                                               const int* sB, int nB,
                                                unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
@@ -6252,8 +6252,8 @@ Aligner_watermansmithbeyer_global_score_matrix(Aligner* self,
 
 static PyObject*
 Aligner_watermansmithbeyer_local_score_compare(Aligner* self,
-                                               const int* sA, Py_ssize_t nA,
-                                               const int* sB, Py_ssize_t nB,
+                                               const int* sA, int nA,
+                                               const int* sB, int nB,
                                                unsigned char strand)
 {
     const double match = self->match;
@@ -6276,8 +6276,8 @@ Aligner_watermansmithbeyer_local_score_compare(Aligner* self,
 
 static PyObject*
 Aligner_watermansmithbeyer_local_score_matrix(Aligner* self,
-                                              const int* sA, Py_ssize_t nA,
-                                              const int* sB, Py_ssize_t nB,
+                                              const int* sA, int nA,
+                                              const int* sB, int nB,
                                               unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
@@ -6299,8 +6299,8 @@ Aligner_watermansmithbeyer_local_score_matrix(Aligner* self,
 
 static PyObject*
 Aligner_watermansmithbeyer_global_align_compare(Aligner* self,
-                                                const int* sA, Py_ssize_t nA,
-                                                const int* sB, Py_ssize_t nB,
+                                                const int* sA, int nA,
+                                                const int* sB, int nB,
                                                 unsigned char strand)
 {
     const double match = self->match;
@@ -6322,8 +6322,8 @@ Aligner_watermansmithbeyer_global_align_compare(Aligner* self,
 
 static PyObject*
 Aligner_watermansmithbeyer_global_align_matrix(Aligner* self,
-                                               const int* sA, Py_ssize_t nA,
-                                               const int* sB, Py_ssize_t nB,
+                                               const int* sA, int nA,
+                                               const int* sB, int nB,
                                                unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
@@ -6344,8 +6344,8 @@ Aligner_watermansmithbeyer_global_align_matrix(Aligner* self,
 
 static PyObject*
 Aligner_watermansmithbeyer_local_align_compare(Aligner* self,
-                                               const int* sA, Py_ssize_t nA,
-                                               const int* sB, Py_ssize_t nB,
+                                               const int* sA, int nA,
+                                               const int* sB, int nB,
                                                unsigned char strand)
 {
     const double match = self->match;
@@ -6370,8 +6370,8 @@ Aligner_watermansmithbeyer_local_align_compare(Aligner* self,
 
 static PyObject*
 Aligner_watermansmithbeyer_local_align_matrix(Aligner* self,
-                                              const int* sA, Py_ssize_t nA,
-                                              const int* sB, Py_ssize_t nB,
+                                              const int* sA, int nA,
+                                              const int* sB, int nB,
                                               unsigned char strand)
 {
     const Py_ssize_t n = self->substitution_matrix.shape[0];
@@ -6700,8 +6700,8 @@ Aligner_score(Aligner* self, PyObject* args, PyObject* keywords)
 {
     const int* sA;
     const int* sB;
-    Py_ssize_t nA;
-    Py_ssize_t nB;
+    int nA;
+    int nB;
     Py_buffer bA = {0};
     Py_buffer bB = {0};
     const Mode mode = self->mode;
@@ -6720,10 +6720,16 @@ Aligner_score(Aligner* self, PyObject* args, PyObject* keywords)
                                     strand_converter, &strand))
         return NULL;
 
+    nA = (int) (bA.len / bA.itemsize);
+    nB = (int) (bB.len / bB.itemsize);
+    if (nA != bA.len / bA.itemsize || nB != bB.len / bB.itemsize) {
+        sequence_converter(NULL, &bA);
+        sequence_converter(NULL, &bB);
+        PyErr_SetString(PyExc_ValueError, "sequences too long");
+        return 0;
+    }
     sA = bA.buf;
-    nA = bA.len / bA.itemsize;
     sB = bB.buf;
-    nB = bB.len / bB.itemsize;
 
     switch (algorithm) {
         case NeedlemanWunschSmithWaterman:
@@ -6793,8 +6799,8 @@ Aligner_align(Aligner* self, PyObject* args, PyObject* keywords)
 {
     const int* sA;
     const int* sB;
-    Py_ssize_t nA;
-    Py_ssize_t nB;
+    int nA;
+    int nB;
     Py_buffer bA = {0};
     Py_buffer bB = {0};
     const Mode mode = self->mode;
@@ -6813,10 +6819,16 @@ Aligner_align(Aligner* self, PyObject* args, PyObject* keywords)
                                     strand_converter, &strand))
         return NULL;
 
+    nA = (int) (bA.len / bA.itemsize);
+    nB = (int) (bB.len / bB.itemsize);
+    if (nA != bA.len / bA.itemsize || nB != bB.len / bB.itemsize) {
+        sequence_converter(NULL, &bA);
+        sequence_converter(NULL, &bB);
+        PyErr_SetString(PyExc_ValueError, "sequences too long");
+        return 0;
+    }
     sA = bA.buf;
-    nA = bA.len / bA.itemsize;
     sB = bB.buf;
-    nB = bB.len / bB.itemsize;
 
     switch (algorithm) {
         case NeedlemanWunschSmithWaterman:

--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -6429,7 +6429,7 @@ convert_1bytes_to_ints(const int mapping[], Py_ssize_t n, const unsigned char s[
 static int*
 convert_2bytes_to_ints(const int mapping[], Py_ssize_t n, const Py_UCS2 s[])
 {
-    unsigned char c;
+    Py_UCS2 c;
     Py_ssize_t i;
     int index;
     int* indices;
@@ -6514,6 +6514,10 @@ convert_objects_to_ints(Py_buffer* view, PyObject* alphabet, PyObject* sequence)
     alphabet = PySequence_Fast(alphabet, NULL); /* should never fail */
     n = PySequence_Size(sequence);
     m = PySequence_Size(alphabet);
+    if (m != (int)m) {
+        PyErr_SetString(PyExc_ValueError, "alphabet is too long");
+        goto exit;
+    }
     indices = PyMem_Malloc(n*sizeof(int));
     if (!indices) {
         PyErr_NoMemory();
@@ -6525,7 +6529,7 @@ convert_objects_to_ints(Py_buffer* view, PyObject* alphabet, PyObject* sequence)
             obj2 = PySequence_Fast_GET_ITEM(alphabet, j);
             equal = PyObject_RichCompareBool(obj1, obj2, Py_EQ);
             if (equal == 1) /* obj1 == obj2 */ {
-                indices[i] = j;
+                indices[i] = (int)j;
                 break;
             }
             else if (equal == -1) /* error */ {


### PR DESCRIPTION
Fix compiler warnings in `Bio/Align/_aligners.c`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

