### PR TITLE
remove unnecessary string conversion

### DIFF
--- a/Bio/SeqUtils/MeltingTemp.py
+++ b/Bio/SeqUtils/MeltingTemp.py
@@ -521,14 +521,14 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
 
     Examples
     --------
-    >>> from Bio.SeqUtils import MeltingTemp as mt
-    >>> print('%0.2f' % mt.salt_correction(Na=50, method=1))
+    >>> from Bio.SeqUtils.MeltingTemp import salt_correction
+    >>> print('%0.2f' % salt_correction(Na=50, method=1))
     -21.60
-    >>> print('%0.2f' % mt.salt_correction(Na=50, method=2))
+    >>> print('%0.2f' % salt_correction(Na=50, method=2))
     -21.85
-    >>> print('%0.2f' % mt.salt_correction(Na=100, Tris=20, method=2))
+    >>> print('%0.2f' % salt_correction(Na=100, Tris=20, method=2))
     -16.45
-    >>> print('%0.2f' % mt.salt_correction(Na=100, Tris=20, Mg=1.5, method=2))
+    >>> print('%0.2f' % salt_correction(Na=100, Tris=20, Mg=1.5, method=2))
     -10.99
 
     """
@@ -536,8 +536,6 @@ def salt_correction(Na=0, K=0, Tris=0, Mg=0, dNTPs=0, method=1, seq=None):
         raise ValueError(
             "sequence is missing (is needed to calculate GC content or sequence length)."
         )
-    if seq:
-        seq = str(seq)
     corr = 0
     if not method:
         return corr


### PR DESCRIPTION
Removing an unnecessary string conversion in `salt_correction` in `Bio.SeqUtils.Meltingtemp`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

