### PR TITLE
Don't use islower

### DIFF
--- a/Bio/SeqUtils/CodonUsage.py
+++ b/Bio/SeqUtils/CodonUsage.py
@@ -141,8 +141,7 @@ class CodonAdaptationIndex:
         if self.index == {}:
             self.set_cai_index(SharpEcoliIndex)
 
-        if dna_sequence.islower():
-            dna_sequence = dna_sequence.upper()
+        dna_sequence = dna_sequence.upper()
 
         for i in range(0, len(dna_sequence), 3):
             codon = dna_sequence[i : i + 3]


### PR DESCRIPTION
Don't use `islower` here; `islower` returns whether all characters are lowercase, while we would need to know if any characters are lowercase. 

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

