### PR TITLE
SeqFeature position code cleanup

### DIFF
--- a/Bio/Align/psl.py
+++ b/Bio/Align/psl.py
@@ -33,7 +33,7 @@ from Bio.Align import Alignment
 from Bio.Align import interfaces
 from Bio.Seq import Seq, reverse_complement, UndefinedSequenceError
 from Bio.SeqRecord import SeqRecord
-from Bio.SeqFeature import SeqFeature, ExactPosition, FeatureLocation, CompoundLocation
+from Bio.SeqFeature import SeqFeature, ExactPosition, SimpleLocation, CompoundLocation
 from Bio import BiopythonExperimentalWarning
 
 import warnings
@@ -484,7 +484,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                         locations = []
                         for tEnd, qEnd in coordinates[:, 1:].transpose():
                             if qStart < qEnd and tStart < tEnd:
-                                location = FeatureLocation(
+                                location = SimpleLocation(
                                     ExactPosition(tStart),
                                     ExactPosition(tEnd),
                                     strand=+1,
@@ -504,7 +504,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                         locations = []
                         for tStart, qEnd in coordinates[:, 1:].transpose():
                             if qStart < qEnd and tStart < tEnd:
-                                location = FeatureLocation(
+                                location = SimpleLocation(
                                     ExactPosition(tStart),
                                     ExactPosition(tEnd),
                                     strand=-1,

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -144,15 +144,10 @@ _oneof_location = r"(?:[<>]?\d+|%s)\.\.(?:[<>]?\d+|%s)" % (
     _oneof_position,
     _oneof_position,
 )
-_complex_location = (
-    r"(?:[a-zA-Z][a-zA-Z0-9_\.\|]*[a-zA-Z0-9]?\:)?(?:!,+)|%s|%s|%s|%s|%s"
-    % (
-        _pair_location,
-        _between_location,
-        _within_location,
-        _solo_bond,
-        _solo_location,
-    )
+_complex_location = r"(?:[a-zA-Z][a-zA-Z0-9_\.\|]*[a-zA-Z0-9]?\:)?(?:!,.+)|%s|%s|%s" % (
+    _within_location,
+    _solo_bond,
+    _solo_location,
 )
 _ref_oneof_location = (
     r"(?:[a-zA-Z][a-zA-Z0-9_\.\|]*[a-zA-Z0-9]?\:)?%s" % _oneof_location

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -69,24 +69,14 @@ _re_complemented = re.compile(r"^complement\((?P<inner>\S*)\)$")
 
 _re_compounded = re.compile(r"^(?P<operator>join|order|bond)\((?P<locations>\S+)\)$")
 
-
-reference = r"(?:[a-zA-Z][a-zA-Z0-9_\.\|]*[a-zA-Z0-9]?\:)"
+_reference = r"(?:[a-zA-Z][a-zA-Z0-9_\.\|]*[a-zA-Z0-9]?\:)"
 _oneof_position = r"one\-of\(\d+(?:,\d+)+\)"
 
-_oneof_location = r"[<>]?(?:\d+|%s)\.\.[<>]?(?:\d+|%s)" % (
-    _oneof_position,
-    _oneof_position,
-)
-_any_location = r"%s|[^,]+" % _oneof_location
+_oneof_location = rf"[<>]?(?:\d+|{_oneof_position})\.\.[<>]?(?:\d+|{_oneof_position})"
 
-_possibly_complemented_complex_location = (
-    r"(%s?%s|complement\(%s\)|%s|complement\(%s\))"
-    % (reference, _oneof_location, _oneof_location, "[^,]+", "[^,]+")
-)
+_any_location = rf"({_reference}?{_oneof_location}|complement\({_oneof_location}\)|[^,]+|complement\([^,]+\))"
 
-pattern = re.compile(_possibly_complemented_complex_location)
-
-_split = pattern.split
+_split = re.compile(_any_location).split
 
 assert _split("123..145")[1::2] == ["123..145"]
 assert _split("123..145,200..209")[1::2] == [
@@ -696,8 +686,8 @@ def fromstring(location_line, length, circular=False, stranded=True):
         parts = [location_line]
     else:
         operator = m.group("operator")
-        # parts = _re_complex_locations.split(m.group("locations"))[1::2]
         parts = _split(m.group("locations"))[1::2]
+        # assert parts[0] == "" and parts[-11] == ""
     locs = []
     for part in parts:
         m = _re_complemented.match(part)

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -123,7 +123,7 @@ assert _split(
 
 _solo_location = r"[<>]?\d+"
 _re_solo_location = re.compile("^%s$" % _solo_location)
-_pair_location = r"[<>]?\d+\.\.[<>]?\d+"
+_pair_location = r"[<>]?-?\d+\.\.[<>]?-?\d+"
 _re_pair_location = re.compile(r"^([<>]?\d+)\.\.([<>]?\d+)$")
 _between_location = r"\d+\^\d+"
 _re_between_location = re.compile(r"^(\d+)\^(\d+)$")
@@ -146,12 +146,12 @@ assert _re_oneof_location.match("one-of(6,9)..one-of(101,104)")
 assert _re_oneof_location.match("6..one-of(101,104)")
 
 _re_location_category = re.compile(
-    r"^(?P<pair>%s)|(?P<between>%s)$"
+    r"^(?P<pair>%s)|(?P<between>%s)|(?P<within>%s)|(?P<oneof>%s)$"
     % (
         _pair_location,
         _between_location,
-        # _within_location,
-        # _oneof_location,
+        _within_location,
+        _oneof_location,
         # _solo_bond,
         # _solo_location,
     )
@@ -644,7 +644,7 @@ def fromstring(location_line, length, circular=False, stranded=True):
                 if value is not None:
                     break
             assert value == part
-            if key == "pair":
+            if key in ("pair", "within", "oneof"):
                 s, e = part.split("..")
                 # Attempt to fix features that span the origin
                 s_pos = SeqFeature.Position.fromstring(s, -1)
@@ -706,62 +706,27 @@ def fromstring(location_line, length, circular=False, stranded=True):
                 # loc will be a list of one or two SimpleLocation items.
                 locs.extend(loc.parts)
                 continue
-        loc = None
-        try:
-            s, e = part.split("..")
-        except ValueError:
-            if part.startswith("bond(") and part.endswith(")"):
-                # e.g. bond(196)
-                # e.g. join(bond(284),bond(305),bond(309),bond(305))
-                warnings.warn(
-                    "Dropping bond qualifier in feature location",
-                    BiopythonParserWarning,
-                )
-                s = part[5:-1]
-                e = part[5:-1]
-            else:
-                # e.g. "123"
-                s = part
-                e = part
-
+        if part.startswith("bond(") and part.endswith(")"):
+            # e.g. bond(196)
+            # e.g. join(bond(284),bond(305),bond(309),bond(305))
+            warnings.warn(
+                "Dropping bond qualifier in feature location",
+                BiopythonParserWarning,
+            )
+            s = part[5:-1]
+            e = part[5:-1]
         else:
-            # Attempt to fix features that span the origin
-            s_pos = SeqFeature.Position.fromstring(s, -1)
-            e_pos = SeqFeature.Position.fromstring(e)
-            if int(s_pos) > int(e_pos):
-                if not circular:
-                    warnings.warn(
-                        "It appears that %r is a feature that spans "
-                        "the origin, but the sequence topology is "
-                        "undefined. Skipping feature." % part,
-                        BiopythonParserWarning,
-                    )
-                    return
-                warnings.warn(
-                    "Attempting to fix invalid location %r as "
-                    "it looks like incorrect origin wrapping. "
-                    "Please fix input file, this could have "
-                    "unintended behavior." % part,
-                    BiopythonParserWarning,
-                )
+            # e.g. "123"
+            s = part
+            e = part
 
-                f1 = SeqFeature.SimpleLocation(s_pos, length, part_strand)
-                f2 = SeqFeature.SimpleLocation(0, int(e_pos), part_strand)
+        start = SeqFeature.Position.fromstring(s, -1)
+        end = SeqFeature.Position.fromstring(e)
 
-                if part_strand == -1:
-                    # For complementary features spanning the origin
-                    loc = f2 + f1
-                else:
-                    loc = f1 + f2
+        if start < 0:
+            break
 
-        if loc is None:
-            start = SeqFeature.Position.fromstring(s, -1)
-            end = SeqFeature.Position.fromstring(e)
-
-            if start < 0:
-                break
-
-            loc = SeqFeature.SimpleLocation(start, end, part_strand, ref=ref)
+        loc = SeqFeature.SimpleLocation(start, end, part_strand, ref=ref)
 
         if operator is None:
             return loc

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -661,7 +661,7 @@ def fromstring(location_line, length, circular=False, stranded=True):
                 s = part
                 e = part
 
-        if loc is None:
+        else:
             # Attempt to fix features that span the origin
             s_pos = SeqFeature.Position.fromstring(s, -1)
             e_pos = SeqFeature.Position.fromstring(e)
@@ -673,7 +673,7 @@ def fromstring(location_line, length, circular=False, stranded=True):
                         "undefined. Skipping feature." % part,
                         BiopythonParserWarning,
                     )
-                    continue
+                    return
                 warnings.warn(
                     "Attempting to fix invalid location %r as "
                     "it looks like incorrect origin wrapping. "
@@ -705,7 +705,7 @@ def fromstring(location_line, length, circular=False, stranded=True):
         # loc will be a list of one or two SimpleLocation items.
         locs.extend(loc.parts)
     else:
-        if len(locs) <= 1:  # bond, or origin-spanning feature but not circular
+        if len(locs) == 1:  # bond
             return loc
         # Historically a join on the reverse strand has been represented
         # in Biopython with both the parent SeqFeature and its children

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -660,61 +660,11 @@ def fromstring(location_line, length, circular=False, stranded=True):
         return
     operator = m.group("operator")
     if operator is None:
-        m = _re_complex_location.match(location_line)  # e.g. "AL121804.2:41..610"
-        ref = m.group("ref")
-        location = m.group("location")
-        m = _re_pair_location.match(location)
-        if m is None:
-            m = _re_within_location.match(location)
-        if m is None:
-            m = _re_oneof_location.match(location)
-        if m is not None:
-            s, e = m.groups()
-            s = SeqFeature.Position.fromstring(s, -1)
-            e = SeqFeature.Position.fromstring(e)
-            if s > e:
-                if not circular:
-                    warnings.warn(
-                        "It appears that %r is a feature that spans "
-                        "the origin, but the sequence topology is "
-                        "undefined. Skipping feature." % location_line,
-                        BiopythonParserWarning,
-                    )
-                    return None
-                else:
-                    warnings.warn(
-                        "Attempting to fix invalid location %r as "
-                        "it looks like incorrect origin wrapping. "
-                        "Please fix input file, this could have "
-                        "unintended behavior." % location_line,
-                        BiopythonParserWarning,
-                    )
-
-                    f1 = SeqFeature.SimpleLocation(s, length, strand)
-                    f2 = SeqFeature.SimpleLocation(0, e, strand)
-
-                    if strand == -1:
-                        # For complementary features spanning the origin
-                        return f2 + f1
-                    else:
-                        return f1 + f2
-            else:
-                return SeqFeature.SimpleLocation(s, e, strand, ref=ref)
-        m = _re_solo_location.match(location)
-        if m is not None:
-            position = m.group()
-            start = SeqFeature.Position.fromstring(position, -1)
-            end = SeqFeature.Position.fromstring(position)
-            return SeqFeature.SimpleLocation(start, end, strand, ref=ref)
-        m = _re_between_location.match(location)
-        if m is not None:
-            s, e = map(int, m.groups())
-            if s + 1 == e or (s == length and e == 1):
-                return SeqFeature.SimpleLocation(s, s, strand, ref=ref)
-            raise ValueError(f"Invalid between location {location_line!r}")
+        parts = [location_line]
+    else:
+        parts = _re_complex_locations.split(m.group("location"))[1::2]
     locs = []
-    parts = _re_complex_locations.split(m.group("location"))
-    for part in parts[1::2]:
+    for part in parts:
         if part.startswith("complement("):
             assert part[-1] == ")"
             part = part[11:-1]
@@ -727,14 +677,16 @@ def fromstring(location_line, length, circular=False, stranded=True):
             # Using _loc to return a CompoundLocation of the
             # wrapped feature and returning the two SimpleLocation
             # objects to extend to the list of feature locations.
-            loc = _loc(part, length, part_strand, is_circular=circular).parts
+            loc = _loc(part, length, part_strand, is_circular=circular)
 
         except ValueError:
             print(location_line)
             print(part)
             raise
+        if operator is None:
+            return loc
         # loc will be a list of one or two SimpleLocation items.
-        locs.extend(loc)
+        locs.extend(loc.parts)
     # Historically a join on the reverse strand has been represented
     # in Biopython with both the parent SeqFeature and its children
     # (the exons for a CDS) all given a strand of -1.  Likewise, for

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -144,6 +144,33 @@ _oneof_location = r"(?:[<>]?\d+|%s)\.\.(?:[<>]?\d+|%s)" % (
     _oneof_position,
     _oneof_position,
 )
+_complex_location = (
+    r"(?:[a-zA-Z][a-zA-Z0-9_\.\|]*[a-zA-Z0-9]?\:)?(?:!,+)|%s|%s|%s|%s|%s"
+    % (
+        _pair_location,
+        _between_location,
+        _within_location,
+        _solo_bond,
+        _solo_location,
+    )
+)
+_ref_oneof_location = (
+    r"(?:[a-zA-Z][a-zA-Z0-9_\.\|]*[a-zA-Z0-9]?\:)?%s" % _oneof_location
+)
+
+_possibly_complemented_complex_location = (
+    r"((?:%s)|(?:complement\((?:%s)\))|(?:%s)|(?:complement\((?:%s)\)))"
+    % (
+        _ref_oneof_location,
+        _ref_oneof_location,
+        _complex_location,
+        _complex_location,
+    )
+)
+_re_complex_locations = re.compile(
+    r"(?:,)?%s" % _possibly_complemented_complex_location
+)
+
 _complex_location = r"(?:[a-zA-Z][a-zA-Z0-9_\.\|]*[a-zA-Z0-9]?\:)?%s|%s|%s|%s|%s|%s" % (
     _pair_location,
     _between_location,
@@ -152,13 +179,7 @@ _complex_location = r"(?:[a-zA-Z][a-zA-Z0-9_\.\|]*[a-zA-Z0-9]?\:)?%s|%s|%s|%s|%s
     _solo_bond,
     _solo_location,
 )
-_possibly_complemented_complex_location = r"((?:%s)|(?:complement\((?:%s)\)))" % (
-    _complex_location,
-    _complex_location,
-)
-_re_complex_locations = re.compile(
-    r"(?:,)?%s" % _possibly_complemented_complex_location
-)
+
 
 assert _re_complex_locations.split("123..145")[1::2] == ["123..145"]
 assert _re_complex_locations.split("123..145,200..209")[1::2] == [

--- a/Bio/GenBank/__init__.py
+++ b/Bio/GenBank/__init__.py
@@ -622,22 +622,6 @@ def fromstring(location_line, length, circular=False, stranded=True):
             ref, part = part.split(":")
         except ValueError:
             ref = None
-        if _solo_bond.search(part):
-            # e.g. bond(196)
-            # e.g. join(bond(284),bond(305),bond(309),bond(305))
-            warnings.warn(
-                "Dropping bond qualifier in feature location", BiopythonParserWarning
-            )
-            # There ought to be a better way to do this...
-            for x in _solo_bond.finditer(part):
-                x = x.group()
-                part = part.replace(x, x[5:-1])
-        # There is likely a problem with origin wrapping.
-        # Using _loc to return a CompoundLocation of the
-        # wrapped feature and returning the two SimpleLocation
-        # objects to extend to the list of feature locations.
-        # loc = _loc(part, length, part_strand, is_circular=circular, ref=ref)
-
         m = _re_location_category.match(part)
         if m is not None:
             for key, value in m.groupdict().items():
@@ -650,6 +634,10 @@ def fromstring(location_line, length, circular=False, stranded=True):
                 s_pos = SeqFeature.Position.fromstring(s, -1)
                 e_pos = SeqFeature.Position.fromstring(e)
                 if int(s_pos) > int(e_pos):
+                    # There is likely a problem with origin wrapping.
+                    # Create a CompoundLocation of the # wrapped feature,
+                    # consisting of two SimpleLocation objects to extend to
+                    # the list of feature locations.
                     if not circular:
                         warnings.warn(
                             "It appears that %r is a feature that spans "

--- a/Bio/Graphics/GenomeDiagram/_Feature.py
+++ b/Bio/Graphics/GenomeDiagram/_Feature.py
@@ -129,7 +129,7 @@ class Feature:
         """Examine wrapped feature and set some properties accordingly (PRIVATE)."""
         self.locations = []
         bounds = []
-        # This will be a list of length one for simple SimpleLocation:
+        # This will be a list of length one for SimpleLocation:
         for location in self._feature.location.parts:
             start = int(location.start)
             end = int(location.end)

--- a/Bio/Graphics/GenomeDiagram/_Feature.py
+++ b/Bio/Graphics/GenomeDiagram/_Feature.py
@@ -129,7 +129,7 @@ class Feature:
         """Examine wrapped feature and set some properties accordingly (PRIVATE)."""
         self.locations = []
         bounds = []
-        # This will be a list of length one for simple FeatureLocation:
+        # This will be a list of length one for simple SimpleLocation:
         for location in self._feature.location.parts:
             start = int(location.start)
             end = int(location.end)

--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -21,7 +21,7 @@ import warnings
 
 from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
-from Bio.SeqFeature import SeqFeature, FeatureLocation
+from Bio.SeqFeature import SeqFeature, SimpleLocation
 from Bio.SeqRecord import SeqRecord
 from Bio import BiopythonWarning
 
@@ -1141,7 +1141,7 @@ class ProteinDomain(PhyloElement):
 
     def to_seqfeature(self):
         """Create a SeqFeature from the ProteinDomain Object."""
-        feat = SeqFeature(location=FeatureLocation(self.start, self.end), id=self.value)
+        feat = SeqFeature(location=SimpleLocation(self.start, self.end), id=self.value)
         try:
             confidence = self.confidence
         except AttributeError:

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -133,20 +133,6 @@ class SeqFeature:
         >>> f3.strand == f3.location.strand == -1
         True
 
-        An invalid strand will trigger an exception:
-
-        >>> f4 = SeqFeature(SimpleLocation(50, 60, strand=2))
-        Traceback (most recent call last):
-           ...
-        ValueError: Strand should be +1, -1, 0 or None, not 2
-
-        Similarly if set via the SimpleLocation directly:
-
-        >>> loc4 = SimpleLocation(50, 60, strand=2)
-        Traceback (most recent call last):
-           ...
-        ValueError: Strand should be +1, -1, 0 or None, not 2
-
         For exact start/end positions, an integer can be used (as shown above)
         as shorthand for the ExactPosition object. For non-exact locations, the
         SimpleLocation must be specified via the appropriate position objects.
@@ -187,7 +173,7 @@ class SeqFeature:
         if qualifiers is not None:
             self.qualifiers.update(qualifiers)
         if sub_features is not None:
-            raise TypeError("Rather than sub_features, use a CompoundSimpleLocation")
+            raise TypeError("Rather than sub_features, use a CompoundLocation")
         if ref is not None:
             warnings.warn(
                 "Using the ref argument is deprecated, and will be removed in a future release. "
@@ -1080,7 +1066,7 @@ class SimpleLocation:
         """Read only list of sections (always one, the SimpleLocation object).
 
         This is a convenience property allowing you to write code handling
-        both simple SimpleLocation objects (with one part) and more complex
+        both SimpleLocation objects (with one part) and more complex
         CompoundLocation objects (with multiple parts) interchangeably.
         """
         return [self]
@@ -1235,9 +1221,9 @@ class CompoundLocation:
         >>> f.end == max(f) + 1
         True
 
-        This is consistent with the behavior of the simple SimpleLocation for
-        a single region, where again the 'start' and 'end' do not necessarily
-        give the biological start and end, but rather the 'minimal' and 'maximal'
+        This is consistent with the behavior of the SimpleLocation for a single
+        region, where again the 'start' and 'end' do not necessarily give the
+        biological start and end, but rather the 'minimal' and 'maximal'
         coordinate boundaries.
 
         Note that adding locations provides a more intuitive method of

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -39,8 +39,8 @@ This has the advantages of allowing us to handle fuzzy stuff in case anyone
 needs it, and also be compatible with BioPerl etc and BioSQL.
 
 Classes:
- - FeatureLocation - Specify the start and end location of a feature.
- - CompoundLocation - Collection of FeatureLocation objects (for joins etc).
+ - SimpleLocation - Specify the start and end location of a feature.
+ - CompoundLocation - Collection of SimpleLocation objects (for joins etc).
  - ExactPosition - Specify the position as being exact.
  - WithinPosition - Specify a position occurring within some range.
  - BetweenPosition - Specify a position occurring between a range (OBSOLETE?).
@@ -78,7 +78,7 @@ class SeqFeature:
     """Represent a Sequence Feature on an object.
 
     Attributes:
-     - location - the location of the feature on the sequence (FeatureLocation)
+     - location - the location of the feature on the sequence (SimpleLocation)
      - type - the specified type of the feature (ie. CDS, exon, repeat...)
      - location_operator - a string specifying how this SeqFeature may
        be related to others. For example, in the example GenBank feature
@@ -117,39 +117,39 @@ class SeqFeature:
     ):
         """Initialize a SeqFeature on a sequence.
 
-        location can either be a FeatureLocation (with strand argument also
+        location can either be a SimpleLocation (with strand argument also
         given if required), or None.
 
         e.g. With no strand, on the forward strand, and on the reverse strand:
 
-        >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
-        >>> f1 = SeqFeature(FeatureLocation(5, 10), type="domain")
+        >>> from Bio.SeqFeature import SeqFeature, SimpleLocation
+        >>> f1 = SeqFeature(SimpleLocation(5, 10), type="domain")
         >>> f1.strand == f1.location.strand == None
         True
-        >>> f2 = SeqFeature(FeatureLocation(7, 110, strand=1), type="CDS")
+        >>> f2 = SeqFeature(SimpleLocation(7, 110, strand=1), type="CDS")
         >>> f2.strand == f2.location.strand == +1
         True
-        >>> f3 = SeqFeature(FeatureLocation(9, 108, strand=-1), type="CDS")
+        >>> f3 = SeqFeature(SimpleLocation(9, 108, strand=-1), type="CDS")
         >>> f3.strand == f3.location.strand == -1
         True
 
         An invalid strand will trigger an exception:
 
-        >>> f4 = SeqFeature(FeatureLocation(50, 60, strand=2))
+        >>> f4 = SeqFeature(SimpleLocation(50, 60, strand=2))
         Traceback (most recent call last):
            ...
         ValueError: Strand should be +1, -1, 0 or None, not 2
 
-        Similarly if set via the FeatureLocation directly:
+        Similarly if set via the SimpleLocation directly:
 
-        >>> loc4 = FeatureLocation(50, 60, strand=2)
+        >>> loc4 = SimpleLocation(50, 60, strand=2)
         Traceback (most recent call last):
            ...
         ValueError: Strand should be +1, -1, 0 or None, not 2
 
         For exact start/end positions, an integer can be used (as shown above)
         as shorthand for the ExactPosition object. For non-exact locations, the
-        FeatureLocation must be specified via the appropriate position objects.
+        SimpleLocation must be specified via the appropriate position objects.
 
         Note that the strand, ref and ref_db arguments to the SeqFeature are
         now deprecated and will later be removed. Set them via the location
@@ -160,11 +160,11 @@ class SeqFeature:
         """
         if (
             location is not None
-            and not isinstance(location, FeatureLocation)
+            and not isinstance(location, SimpleLocation)
             and not isinstance(location, CompoundLocation)
         ):
             raise TypeError(
-                "FeatureLocation, CompoundLocation (or None) required for the location"
+                "SimpleLocation, CompoundLocation (or None) required for the location"
             )
         self.location = location
         self.type = type
@@ -187,7 +187,7 @@ class SeqFeature:
         if qualifiers is not None:
             self.qualifiers.update(qualifiers)
         if sub_features is not None:
-            raise TypeError("Rather than sub_features, use a CompoundFeatureLocation")
+            raise TypeError("Rather than sub_features, use a CompoundSimpleLocation")
         if ref is not None:
             warnings.warn(
                 "Using the ref argument is deprecated, and will be removed in a future release. "
@@ -382,13 +382,13 @@ class SeqFeature:
         optional dictionary references.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
+        >>> from Bio.SeqFeature import SeqFeature, SimpleLocation
         >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL")
-        >>> f = SeqFeature(FeatureLocation(8, 15), type="domain")
+        >>> f = SeqFeature(SimpleLocation(8, 15), type="domain")
         >>> f.extract(seq)
         Seq('VALIVIC')
 
-        If the FeatureLocation is None, e.g. when parsing invalid locus
+        If the SimpleLocation is None, e.g. when parsing invalid locus
         locations in the GenBank parser, extract() will raise a ValueError.
 
         >>> from Bio.Seq import Seq
@@ -448,13 +448,13 @@ class SeqFeature:
            Will override a codon_start qualifier
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
+        >>> from Bio.SeqFeature import SeqFeature, SimpleLocation
         >>> seq = Seq("GGTTACACTTACCGATAATGTCTCTGATGA")
-        >>> f = SeqFeature(FeatureLocation(0, 30), type="CDS")
+        >>> f = SeqFeature(SimpleLocation(0, 30), type="CDS")
         >>> f.qualifiers['transl_table'] = [11]
 
         Note that features of type CDS are subject to the usual
-        checks at translation. But you can override this behaviour
+        checks at translation. But you can override this behavior
         by giving explicit arguments:
 
         >>> f.translate(seq, cds=False)
@@ -507,14 +507,14 @@ class SeqFeature:
     def __bool__(self):
         """Boolean value of an instance of this class (True).
 
-        This behaviour is for backwards compatibility, since until the
+        This behavior is for backwards compatibility, since until the
         __len__ method was added, a SeqFeature always evaluated as True.
 
         Note that in comparison, Seq objects, strings, lists, etc, will all
         evaluate to False if they have length zero.
 
         WARNING: The SeqFeature may in future evaluate to False when its
-        length is zero (in order to better match normal python behaviour)!
+        length is zero (in order to better match normal python behavior)!
         """
         return True
 
@@ -522,9 +522,9 @@ class SeqFeature:
         """Return the length of the region where the feature is located.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
+        >>> from Bio.SeqFeature import SeqFeature, SimpleLocation
         >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL")
-        >>> f = SeqFeature(FeatureLocation(8, 15), type="domain")
+        >>> f = SeqFeature(SimpleLocation(8, 15), type="domain")
         >>> len(f)
         7
         >>> f.extract(seq)
@@ -552,8 +552,8 @@ class SeqFeature:
         The iteration order is strand aware, and can be thought of as moving
         along the feature using the parent sequence coordinates:
 
-        >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
-        >>> f = SeqFeature(FeatureLocation(5, 10, strand=-1), type="domain")
+        >>> from Bio.SeqFeature import SeqFeature, SimpleLocation
+        >>> f = SeqFeature(SimpleLocation(5, 10, strand=-1), type="domain")
         >>> len(f)
         5
         >>> for i in f: print(i)
@@ -575,8 +575,8 @@ class SeqFeature:
     def __contains__(self, value):
         """Check if an integer position is within the feature.
 
-        >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
-        >>> f = SeqFeature(FeatureLocation(5, 10, strand=-1), type="domain")
+        >>> from Bio.SeqFeature import SeqFeature, SimpleLocation
+        >>> f = SeqFeature(SimpleLocation(5, 10, strand=-1), type="domain")
         >>> len(f)
         5
         >>> [i for i in range(15) if i in f]
@@ -609,9 +609,9 @@ class SeqFeature:
         Note that additional care may be required with fuzzy locations, for
         example just before a BeforePosition:
 
-        >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
+        >>> from Bio.SeqFeature import SeqFeature, SimpleLocation
         >>> from Bio.SeqFeature import BeforePosition
-        >>> f = SeqFeature(FeatureLocation(BeforePosition(3), 8), type="domain")
+        >>> f = SeqFeature(SimpleLocation(BeforePosition(3), 8), type="domain")
         >>> len(f)
         5
         >>> [i for i in range(10) if i in f]
@@ -681,7 +681,7 @@ class Reference:
         """Check if two Reference objects should be considered equal.
 
         Note prior to Biopython 1.70 the location was not compared, as
-        until then __eq__ for the FeatureLocation class was not defined.
+        until then __eq__ for the SimpleLocation class was not defined.
         """
         return (
             self.authors == other.authors
@@ -698,10 +698,10 @@ class Reference:
 # --- Handling feature locations
 
 
-class FeatureLocation:
+class SimpleLocation:
     """Specify the location of a feature along a sequence.
 
-    The FeatureLocation is used for simple continuous features, which can
+    The SimpleLocation is used for simple continuous features, which can
     be described as running from a start position to and end position
     (optionally with a strand and reference information).  More complex
     locations made up from several non-continuous parts (e.g. a coding
@@ -712,8 +712,8 @@ class FeatureLocation:
     thus a GenBank entry of 123..150 (one based counting) becomes a location
     of [122:150] (zero based counting).
 
-    >>> from Bio.SeqFeature import FeatureLocation
-    >>> f = FeatureLocation(122, 150)
+    >>> from Bio.SeqFeature import SimpleLocation
+    >>> f = SimpleLocation(122, 150)
     >>> print(f)
     [122:150]
     >>> print(f.start)
@@ -726,21 +726,21 @@ class FeatureLocation:
     Note the strand defaults to None. If you are working with nucleotide
     sequences you'd want to be explicit if it is the forward strand:
 
-    >>> from Bio.SeqFeature import FeatureLocation
-    >>> f = FeatureLocation(122, 150, strand=+1)
+    >>> from Bio.SeqFeature import SimpleLocation
+    >>> f = SimpleLocation(122, 150, strand=+1)
     >>> print(f)
     [122:150](+)
     >>> print(f.strand)
     1
 
-    Note that for a parent sequence of length n, the FeatureLocation
+    Note that for a parent sequence of length n, the SimpleLocation
     start and end must satisfy the inequality 0 <= start <= end <= n.
     This means even for features on the reverse strand of a nucleotide
     sequence, we expect the 'start' coordinate to be less than the
     'end'.
 
-    >>> from Bio.SeqFeature import FeatureLocation
-    >>> r = FeatureLocation(122, 150, strand=-1)
+    >>> from Bio.SeqFeature import SimpleLocation
+    >>> r = SimpleLocation(122, 150, strand=-1)
     >>> print(r)
     [122:150](-)
     >>> print(r.start)
@@ -774,23 +774,23 @@ class FeatureLocation:
 
         i.e. Short form:
 
-        >>> from Bio.SeqFeature import FeatureLocation
-        >>> loc = FeatureLocation(5, 10, strand=-1)
+        >>> from Bio.SeqFeature import SimpleLocation
+        >>> loc = SimpleLocation(5, 10, strand=-1)
         >>> print(loc)
         [5:10](-)
 
         Explicit form:
 
-        >>> from Bio.SeqFeature import FeatureLocation, ExactPosition
-        >>> loc = FeatureLocation(ExactPosition(5), ExactPosition(10), strand=-1)
+        >>> from Bio.SeqFeature import SimpleLocation, ExactPosition
+        >>> loc = SimpleLocation(ExactPosition(5), ExactPosition(10), strand=-1)
         >>> print(loc)
         [5:10](-)
 
         Other fuzzy positions are used similarly,
 
-        >>> from Bio.SeqFeature import FeatureLocation
+        >>> from Bio.SeqFeature import SimpleLocation
         >>> from Bio.SeqFeature import BeforePosition, AfterPosition
-        >>> loc2 = FeatureLocation(BeforePosition(5), AfterPosition(10), strand=-1)
+        >>> loc2 = SimpleLocation(BeforePosition(5), AfterPosition(10), strand=-1)
         >>> print(loc2)
         [<5:>10](-)
 
@@ -800,7 +800,7 @@ class FeatureLocation:
         when the strand does not apply (dot in GFF3), e.g. features on
         proteins.
 
-        >>> loc = FeatureLocation(5, 10, strand=+1)
+        >>> loc = SimpleLocation(5, 10, strand=+1)
         >>> print(loc)
         [5:10](+)
         >>> print(loc.strand)
@@ -810,7 +810,7 @@ class FeatureLocation:
         sequence you are working with, but an explicit accession can
         be given with the optional ref and db_ref strings:
 
-        >>> loc = FeatureLocation(105172, 108462, ref="AL391218.9", strand=1)
+        >>> loc = SimpleLocation(105172, 108462, ref="AL391218.9", strand=1)
         >>> print(loc)
         AL391218.9[105172:108462](+)
         >>> print(loc.ref)
@@ -860,7 +860,7 @@ class FeatureLocation:
     )
 
     def __str__(self):
-        """Return a representation of the FeatureLocation object (with python counting).
+        """Return a representation of the SimpleLocation object (with python counting).
 
         For the simple case this uses the python splicing syntax, [122:150]
         (zero based counting) which GenBank would call 123..150 (one based
@@ -883,7 +883,7 @@ class FeatureLocation:
             return answer + "(?)"
 
     def __repr__(self):
-        """Represent the FeatureLocation object as a string for debugging."""
+        """Represent the SimpleLocation object as a string for debugging."""
         optional = ""
         if self.strand is not None:
             optional += f", strand={self.strand!r}"
@@ -894,13 +894,13 @@ class FeatureLocation:
         return f"{self.__class__.__name__}({self.start!r}, {self.end!r}{optional})"
 
     def __add__(self, other):
-        """Combine location with another FeatureLocation object, or shift it.
+        """Combine location with another SimpleLocation object, or shift it.
 
         You can add two feature locations to make a join CompoundLocation:
 
-        >>> from Bio.SeqFeature import FeatureLocation
-        >>> f1 = FeatureLocation(5, 10)
-        >>> f2 = FeatureLocation(20, 30)
+        >>> from Bio.SeqFeature import SimpleLocation
+        >>> f1 = SimpleLocation(5, 10)
+        >>> f2 = SimpleLocation(20, 30)
         >>> combined = f1 + f2
         >>> print(combined)
         join{[5:10], [20:30]}
@@ -918,10 +918,10 @@ class FeatureLocation:
         >>> print(join)
         join{[5:10], [20:30]}
 
-        Furthermore, you can combine a FeatureLocation with a CompoundLocation
+        Furthermore, you can combine a SimpleLocation with a CompoundLocation
         in this way.
 
-        Separately, adding an integer will give a new FeatureLocation with
+        Separately, adding an integer will give a new SimpleLocation with
         its start and end offset by that amount. For example:
 
         >>> print(f1)
@@ -933,7 +933,7 @@ class FeatureLocation:
 
         This can be useful when editing annotation.
         """
-        if isinstance(other, FeatureLocation):
+        if isinstance(other, SimpleLocation):
             return CompoundLocation([self, other])
         elif isinstance(other, int):
             return self._shift(other)
@@ -942,7 +942,7 @@ class FeatureLocation:
             return NotImplemented
 
     def __radd__(self, other):
-        """Return a FeatureLocation object by shifting the location by an integer amount."""
+        """Return a SimpleLocation object by shifting the location by an integer amount."""
         if isinstance(other, int):
             return self._shift(other)
         else:
@@ -951,38 +951,38 @@ class FeatureLocation:
     def __nonzero__(self):
         """Return True regardless of the length of the feature.
 
-        This behaviour is for backwards compatibility, since until the
-        __len__ method was added, a FeatureLocation always evaluated as True.
+        This behavior is for backwards compatibility, since until the
+        __len__ method was added, a SimpleLocation always evaluated as True.
 
         Note that in comparison, Seq objects, strings, lists, etc, will all
         evaluate to False if they have length zero.
 
-        WARNING: The FeatureLocation may in future evaluate to False when its
-        length is zero (in order to better match normal python behaviour)!
+        WARNING: The SimpleLocation may in future evaluate to False when its
+        length is zero (in order to better match normal python behavior)!
         """
         return True
 
     def __len__(self):
-        """Return the length of the region described by the FeatureLocation object.
+        """Return the length of the region described by the SimpleLocation object.
 
         Note that extra care may be needed for fuzzy locations, e.g.
 
-        >>> from Bio.SeqFeature import FeatureLocation
+        >>> from Bio.SeqFeature import SimpleLocation
         >>> from Bio.SeqFeature import BeforePosition, AfterPosition
-        >>> loc = FeatureLocation(BeforePosition(5), AfterPosition(10))
+        >>> loc = SimpleLocation(BeforePosition(5), AfterPosition(10))
         >>> len(loc)
         5
         """
         return int(self._end) - int(self._start)
 
     def __contains__(self, value):
-        """Check if an integer position is within the FeatureLocation object.
+        """Check if an integer position is within the SimpleLocation object.
 
         Note that extra care may be needed for fuzzy locations, e.g.
 
-        >>> from Bio.SeqFeature import FeatureLocation
+        >>> from Bio.SeqFeature import SimpleLocation
         >>> from Bio.SeqFeature import BeforePosition, AfterPosition
-        >>> loc = FeatureLocation(BeforePosition(5), AfterPosition(10))
+        >>> loc = SimpleLocation(BeforePosition(5), AfterPosition(10))
         >>> len(loc)
         5
         >>> [i for i in range(15) if i in loc]
@@ -991,7 +991,7 @@ class FeatureLocation:
         if not isinstance(value, int):
             raise ValueError(
                 "Currently we only support checking for integer "
-                "positions being within a FeatureLocation."
+                "positions being within a SimpleLocation."
             )
         if value < self._start or value >= self._end:
             return False
@@ -999,11 +999,11 @@ class FeatureLocation:
             return True
 
     def __iter__(self):
-        """Iterate over the parent positions within the FeatureLocation object.
+        """Iterate over the parent positions within the SimpleLocation object.
 
-        >>> from Bio.SeqFeature import FeatureLocation
+        >>> from Bio.SeqFeature import SimpleLocation
         >>> from Bio.SeqFeature import BeforePosition, AfterPosition
-        >>> loc = FeatureLocation(BeforePosition(5), AfterPosition(10))
+        >>> loc = SimpleLocation(BeforePosition(5), AfterPosition(10))
         >>> len(loc)
         5
         >>> for i in loc: print(i)
@@ -1019,7 +1019,7 @@ class FeatureLocation:
 
         Note this is strand aware:
 
-        >>> loc = FeatureLocation(BeforePosition(5), AfterPosition(10), strand = -1)
+        >>> loc = SimpleLocation(BeforePosition(5), AfterPosition(10), strand = -1)
         >>> list(loc)
         [9, 8, 7, 6, 5]
         """
@@ -1030,7 +1030,7 @@ class FeatureLocation:
 
     def __eq__(self, other):
         """Implement equality by comparing all the location attributes."""
-        if not isinstance(other, FeatureLocation):
+        if not isinstance(other, SimpleLocation):
             return False
         return (
             self._start == other.start
@@ -1041,14 +1041,14 @@ class FeatureLocation:
         )
 
     def _shift(self, offset):
-        """Return a copy of the FeatureLocation shifted by an offset (PRIVATE).
+        """Return a copy of the SimpleLocation shifted by an offset (PRIVATE).
 
         Returns self when location is relative to an external reference.
         """
         # TODO - What if offset is a fuzzy position?
         if self.ref or self.ref_db:
             return self
-        return FeatureLocation(
+        return SimpleLocation(
             start=self._start + offset,
             end=self._end + offset,
             strand=self.strand,
@@ -1069,7 +1069,7 @@ class FeatureLocation:
         else:
             # 0 or None
             flip_strand = self.strand
-        return FeatureLocation(
+        return SimpleLocation(
             start=self._end._flip(length),
             end=self._start._flip(length),
             strand=flip_strand,
@@ -1077,10 +1077,10 @@ class FeatureLocation:
 
     @property
     def parts(self):
-        """Read only list of sections (always one, the FeatureLocation object).
+        """Read only list of sections (always one, the SimpleLocation object).
 
         This is a convenience property allowing you to write code handling
-        both simple FeatureLocation objects (with one part) and more complex
+        both simple SimpleLocation objects (with one part) and more complex
         CompoundLocation objects (with multiple parts) interchangeably.
         """
         return [self]
@@ -1142,7 +1142,7 @@ class FeatureLocation:
             raise
 
     def extract(self, parent_sequence, references=None):
-        """Extract the sequence from supplied parent sequence using the FeatureLocation object.
+        """Extract the sequence from supplied parent sequence using the SimpleLocation object.
 
         The parent_sequence can be a Seq like object or a string, and will
         generally return an object of the same type. The exception to this is
@@ -1151,9 +1151,9 @@ class FeatureLocation:
         in the optional dictionary references.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.SeqFeature import FeatureLocation
+        >>> from Bio.SeqFeature import SimpleLocation
         >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL")
-        >>> feature_loc = FeatureLocation(8, 15)
+        >>> feature_loc = SimpleLocation(8, 15)
         >>> feature_loc.extract(seq)
         Seq('VALIVIC')
 
@@ -1181,15 +1181,18 @@ class FeatureLocation:
         return f_seq
 
 
+FeatureLocation = SimpleLocation  # OBSOLETE; for backward compatability only.
+
+
 class CompoundLocation:
     """For handling joins etc where a feature location has several parts."""
 
     def __init__(self, parts, operator="join"):
         """Initialize the class.
 
-        >>> from Bio.SeqFeature import FeatureLocation, CompoundLocation
-        >>> f1 = FeatureLocation(10, 40, strand=+1)
-        >>> f2 = FeatureLocation(50, 59, strand=+1)
+        >>> from Bio.SeqFeature import SimpleLocation, CompoundLocation
+        >>> f1 = SimpleLocation(10, 40, strand=+1)
+        >>> f2 = SimpleLocation(50, 59, strand=+1)
         >>> f = CompoundLocation([f1, f2])
         >>> len(f) == len(f1) + len(f2) == 39 == len(list(f))
         True
@@ -1206,8 +1209,8 @@ class CompoundLocation:
         automatically - in the case of mixed strands on the sub-locations
         the overall strand is set to None.
 
-        >>> f = CompoundLocation([FeatureLocation(3, 6, strand=+1),
-        ...                       FeatureLocation(10, 13, strand=-1)])
+        >>> f = CompoundLocation([SimpleLocation(3, 6, strand=+1),
+        ...                       SimpleLocation(10, 13, strand=-1)])
         >>> print(f.strand)
         None
         >>> len(f)
@@ -1232,7 +1235,7 @@ class CompoundLocation:
         >>> f.end == max(f) + 1
         True
 
-        This is consistent with the behaviour of the simple FeatureLocation for
+        This is consistent with the behavior of the simple SimpleLocation for
         a single region, where again the 'start' and 'end' do not necessarily
         give the biological start and end, but rather the 'minimal' and 'maximal'
         coordinate boundaries.
@@ -1240,7 +1243,7 @@ class CompoundLocation:
         Note that adding locations provides a more intuitive method of
         construction:
 
-        >>> f = FeatureLocation(3, 6, strand=+1) + FeatureLocation(10, 13, strand=-1)
+        >>> f = SimpleLocation(3, 6, strand=+1) + SimpleLocation(10, 13, strand=-1)
         >>> len(f)
         6
         >>> list(f)
@@ -1249,10 +1252,10 @@ class CompoundLocation:
         self.operator = operator
         self.parts = list(parts)
         for loc in self.parts:
-            if not isinstance(loc, FeatureLocation):
+            if not isinstance(loc, SimpleLocation):
                 raise ValueError(
                     "CompoundLocation should be given a list of "
-                    "FeatureLocation objects, not %s" % loc.__class__
+                    "SimpleLocation objects, not %s" % loc.__class__
                 )
         if len(parts) < 2:
             raise ValueError(
@@ -1294,9 +1297,9 @@ class CompoundLocation:
         If all the parts have the same strand, that is returned. Otherwise
         for mixed strands, this returns None.
 
-        >>> from Bio.SeqFeature import FeatureLocation, CompoundLocation
-        >>> f1 = FeatureLocation(15, 17, strand=1)
-        >>> f2 = FeatureLocation(20, 30, strand=-1)
+        >>> from Bio.SeqFeature import SimpleLocation, CompoundLocation
+        >>> f1 = SimpleLocation(15, 17, strand=1)
+        >>> f2 = SimpleLocation(20, 30, strand=-1)
         >>> f = f1 + f2
         >>> f1.strand
         1
@@ -1323,27 +1326,27 @@ class CompoundLocation:
     def __add__(self, other):
         """Combine locations, or shift the location by an integer offset.
 
-        >>> from Bio.SeqFeature import FeatureLocation
-        >>> f1 = FeatureLocation(15, 17) + FeatureLocation(20, 30)
+        >>> from Bio.SeqFeature import SimpleLocation
+        >>> f1 = SimpleLocation(15, 17) + SimpleLocation(20, 30)
         >>> print(f1)
         join{[15:17], [20:30]}
 
-        You can add another FeatureLocation:
+        You can add another SimpleLocation:
 
-        >>> print(f1 + FeatureLocation(40, 50))
+        >>> print(f1 + SimpleLocation(40, 50))
         join{[15:17], [20:30], [40:50]}
-        >>> print(FeatureLocation(5, 10) + f1)
+        >>> print(SimpleLocation(5, 10) + f1)
         join{[5:10], [15:17], [20:30]}
 
         You can also add another CompoundLocation:
 
-        >>> f2 = FeatureLocation(40, 50) + FeatureLocation(60, 70)
+        >>> f2 = SimpleLocation(40, 50) + SimpleLocation(60, 70)
         >>> print(f2)
         join{[40:50], [60:70]}
         >>> print(f1 + f2)
         join{[15:17], [20:30], [40:50], [60:70]}
 
-        Also, as with the FeatureLocation, adding an integer shifts the
+        Also, as with the SimpleLocation, adding an integer shifts the
         location's coordinates by that offset:
 
         >>> print(f1 + 100)
@@ -1353,7 +1356,7 @@ class CompoundLocation:
         >>> print(f1 + (-5))
         join{[10:12], [15:25]}
         """
-        if isinstance(other, FeatureLocation):
+        if isinstance(other, SimpleLocation):
             return CompoundLocation(self.parts + [other], self.operator)
         elif isinstance(other, CompoundLocation):
             if self.operator != other.operator:
@@ -1369,7 +1372,7 @@ class CompoundLocation:
 
     def __radd__(self, other):
         """Add a feature to the left."""
-        if isinstance(other, FeatureLocation):
+        if isinstance(other, SimpleLocation):
             return CompoundLocation([other] + self.parts, self.operator)
         elif isinstance(other, int):
             return self._shift(other)
@@ -1386,14 +1389,14 @@ class CompoundLocation:
     def __nonzero__(self):
         """Return True regardless of the length of the feature.
 
-        This behaviour is for backwards compatibility, since until the
-        __len__ method was added, a FeatureLocation always evaluated as True.
+        This behavior is for backwards compatibility, since until the
+        __len__ method was added, a SimpleLocation always evaluated as True.
 
         Note that in comparison, Seq objects, strings, lists, etc, will all
         evaluate to False if they have length zero.
 
-        WARNING: The FeatureLocation may in future evaluate to False when its
-        length is zero (in order to better match normal python behaviour)!
+        WARNING: The SimpleLocation may in future evaluate to False when its
+        length is zero (in order to better match normal python behavior)!
         """
         return True
 
@@ -1438,10 +1441,10 @@ class CompoundLocation:
         case regions and the lower case runs of n are not used:
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.SeqFeature import FeatureLocation
+        >>> from Bio.SeqFeature import SimpleLocation
         >>> dna = Seq("nnnnnAGCATCCTGCTGTACnnnnnnnnGAGAMTGCCATGCCCCTGGAGTGAnnnnn")
-        >>> small = FeatureLocation(5, 20, strand=1)
-        >>> large = FeatureLocation(28, 52, strand=1)
+        >>> small = SimpleLocation(5, 20, strand=1)
+        >>> large = SimpleLocation(28, 52, strand=1)
         >>> location = small + large
         >>> print(small)
         [5:20](+)
@@ -1584,10 +1587,10 @@ class CompoundLocation:
         in the optional dictionary references.
 
         >>> from Bio.Seq import Seq
-        >>> from Bio.SeqFeature import FeatureLocation, CompoundLocation
+        >>> from Bio.SeqFeature import SimpleLocation, CompoundLocation
         >>> seq = Seq("MKQHKAMIVALIVICITAVVAAL")
-        >>> fl1 = FeatureLocation(2, 8)
-        >>> fl2 = FeatureLocation(10, 15)
+        >>> fl1 = SimpleLocation(2, 8)
+        >>> fl2 = SimpleLocation(10, 15)
         >>> fl3 = CompoundLocation([fl1,fl2])
         >>> fl3.extract(seq)
         Seq('QHKAMILIVIC')
@@ -1885,7 +1888,7 @@ class WithinPosition(int, Position):
     True
 
     Note this also applies for comparison to other position objects,
-    where again the integer behaviour is used:
+    where again the integer behavior is used:
 
     >>> p == 10
     True
@@ -2024,7 +2027,7 @@ class BetweenPosition(int, Position):
     >>> p2 == 123
     True
 
-    Note this potentially surprising behaviour:
+    Note this potentially surprising behavior:
 
     >>> BetweenPosition(123, left=123, right=456) == ExactPosition(123)
     True
@@ -2123,7 +2126,7 @@ class BeforePosition(int, Position):
     >>> p + 10
     BeforePosition(15)
 
-    Note this potentially surprising behaviour:
+    Note this potentially surprising behavior:
 
     >>> p == ExactPosition(5)
     True
@@ -2187,7 +2190,7 @@ class AfterPosition(int, Position):
     >>> isinstance(p, int)
     True
 
-    Note this potentially surprising behaviour:
+    Note this potentially surprising behavior:
 
     >>> p == ExactPosition(7)
     True
@@ -2261,7 +2264,7 @@ class OneOfPosition(int, Position):
         choices is a list of Position derived objects, specifying possible
         locations.
 
-        position is an integer specifying the default behaviour.
+        position is an integer specifying the default behavior.
         """
         if position not in choices:
             raise ValueError(

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1693,6 +1693,10 @@ class Position(ABC):
         4
 
         """
+        if offset != 0 and offset != -1:
+            raise ValueError(
+                "To convert one-based indices to zero-based indices, offset must be either 0 (for end positions) or -1 (for start positions)."
+            )
         if text == "?":
             return UnknownPosition()
         if text.startswith("?"):

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1632,6 +1632,7 @@ class Position(ABC):
         )
         return 0
 
+    @staticmethod
     def fromstring(text, offset=0):
         """Build a Position object from the text string.
 

--- a/Bio/SeqIO/GckIO.py
+++ b/Bio/SeqIO/GckIO.py
@@ -12,7 +12,7 @@ from Textco BioSoftware, Inc.
 from struct import unpack
 
 from Bio.Seq import Seq
-from Bio.SeqFeature import FeatureLocation
+from Bio.SeqFeature import SimpleLocation
 from Bio.SeqFeature import SeqFeature
 from Bio.SeqRecord import SeqRecord
 
@@ -118,7 +118,7 @@ def _parse(handle):
             # 2 (forward strand), and 3 (both strands). All are
             # treated as a forward strand.
             strand = 1
-        location = FeatureLocation(start, end, strand=strand)
+        location = SimpleLocation(start, end, strand=strand)
 
         # It looks like any value > 0 indicates a CDS...
         if type > 0:

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -312,19 +312,19 @@ def _insdc_location_string_ignoring_strand_and_subfeatures(location, rec_length)
 
 
 def _insdc_location_string(location, rec_length):
-    """Build a GenBank/EMBL location from a (Compound) FeatureLocation (PRIVATE).
+    """Build a GenBank/EMBL location from a (Compound) SimpleLocation (PRIVATE).
 
     There is a choice of how to show joins on the reverse complement strand,
     GenBank used "complement(join(1,10),(20,100))" while EMBL used to use
     "join(complement(20,100),complement(1,10))" instead (but appears to have
     now adopted the GenBank convention). Notice that the order of the entries
     is reversed! This function therefore uses the first form. In this situation
-    we expect the CompoundFeatureLocation and its parts to all be marked as
+    we expect the CompoundLocation and its parts to all be marked as
     strand == -1, and to be in the order 19:100 then 0:10.
     """
     try:
         parts = location.parts
-        # CompoundFeatureLocation
+        # CompoundLocation
         if location.strand == -1:
             # Special case, put complement outside the join/order/... and reverse order
             return "complement(%s(%s))" % (
@@ -342,7 +342,7 @@ def _insdc_location_string(location, rec_length):
                 ",".join(_insdc_location_string(p, rec_length) for p in parts),
             )
     except AttributeError:
-        # Simple FeatureLocation
+        # Simple SimpleLocation
         loc = _insdc_location_string_ignoring_strand_and_subfeatures(
             location, rec_length
         )

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -243,7 +243,7 @@ def _insdc_feature_position_string(pos, offset=0):
         return "one-of(%s)" % ",".join(
             _insdc_feature_position_string(p, offset) for p in pos.position_choices
         )
-    elif isinstance(pos, SeqFeature.AbstractPosition):
+    elif isinstance(pos, SeqFeature.Position):
         raise NotImplementedError("Please report this as a bug in Biopython.")
     else:
         raise ValueError("Expected a SeqFeature position object.")

--- a/Bio/SeqIO/SnapGeneIO.py
+++ b/Bio/SeqIO/SnapGeneIO.py
@@ -15,7 +15,7 @@ from struct import unpack
 from xml.dom.minidom import parseString
 
 from Bio.Seq import Seq
-from Bio.SeqFeature import FeatureLocation
+from Bio.SeqFeature import SimpleLocation
 from Bio.SeqFeature import SeqFeature
 from Bio.SeqRecord import SeqRecord
 
@@ -115,11 +115,11 @@ def _parse_location(rangespec, strand, record):
     start = start - 1
     if start > end:
         # Range wrapping the end of the sequence
-        l1 = FeatureLocation(start, len(record), strand=strand)
-        l2 = FeatureLocation(0, end, strand=strand)
+        l1 = SimpleLocation(start, len(record), strand=strand)
+        l2 = SimpleLocation(0, end, strand=strand)
         location = l1 + l2
     else:
-        location = FeatureLocation(start, end, strand=strand)
+        location = SimpleLocation(start, end, strand=strand)
     return location
 
 

--- a/Bio/SeqIO/SwissIO.py
+++ b/Bio/SeqIO/SwissIO.py
@@ -20,38 +20,6 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
 
-def _make_position(location_string, offset=0):
-    """Turn a Swiss location position into a SeqFeature position object (PRIVATE).
-
-    An offset of -1 is used with a start location to make it pythonic.
-    """
-    if location_string == "?":
-        return SeqFeature.UnknownPosition()
-    # Hack so that feature from 0 to 0 becomes 0 to 0, not -1 to 0.
-    try:
-        return SeqFeature.ExactPosition(max(0, offset + int(location_string)))
-    except ValueError:
-        pass
-    if location_string.startswith("<"):
-        try:
-            return SeqFeature.BeforePosition(max(0, offset + int(location_string[1:])))
-        except ValueError:
-            pass
-    elif location_string.startswith(">"):  # e.g. ">13"
-        try:
-            return SeqFeature.AfterPosition(max(0, offset + int(location_string[1:])))
-        except ValueError:
-            pass
-    elif location_string.startswith("?"):  # e.g. "?22"
-        try:
-            return SeqFeature.UncertainPosition(
-                max(0, offset + int(location_string[1:]))
-            )
-        except ValueError:
-            pass
-    raise NotImplementedError(f"Cannot parse location '{location_string}'")
-
-
 def SwissIterator(source):
     """Break up a Swiss-Prot/UniProt file into SeqRecord objects.
 

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -345,7 +345,7 @@ class Parser:
                                         )
                                         start = int(pair[1].split("-")[0]) - 1
                                         end = int(pair[1].split("-")[1])
-                                        feature.location = SeqFeature.FeatureLocation(
+                                        feature.location = SeqFeature.SimpleLocation(
                                             start, end
                                         )
                                         # self.ParsedSeqRecord.features.append(feature)
@@ -464,7 +464,7 @@ class Parser:
                         start_position = _parse_position(element, -1)
                         element = feature_element.findall(NS + "end")[0]
                         end_position = _parse_position(element)
-                    feature.location = SeqFeature.FeatureLocation(
+                    feature.location = SeqFeature.SimpleLocation(
                         start_position, end_position
                     )
                 else:

--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -18,7 +18,7 @@ from struct import unpack
 from Bio import BiopythonWarning
 from Bio.Seq import Seq
 from Bio.SeqFeature import ExactPosition
-from Bio.SeqFeature import FeatureLocation
+from Bio.SeqFeature import SimpleLocation
 from Bio.SeqFeature import SeqFeature
 from Bio.SeqRecord import SeqRecord
 
@@ -134,7 +134,7 @@ def _read_feature(handle, record):
     # Assemble the feature
     # Shift start by -1 as XDNA feature coordinates are 1-based
     # while Biopython uses 0-based counting.
-    location = FeatureLocation(start - 1, end, strand=strand)
+    location = SimpleLocation(start - 1, end, strand=strand)
     qualifiers = {}
     if name:
         qualifiers["label"] = [name]

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -366,13 +366,13 @@ class SeqRecord:
 
         >>> from Bio.Seq import Seq
         >>> from Bio.SeqRecord import SeqRecord
-        >>> from Bio.SeqFeature import SeqFeature, FeatureLocation
+        >>> from Bio.SeqFeature import SeqFeature, SimpleLocation
         >>> rec = SeqRecord(Seq("MAAGVKQLADDRTLLMAGVSHDLRTPLTRIRLAT"
         ...                     "EMMSEQDGYLAESINKDIEECNAIIEQFIDYLR"),
         ...                 id="1JOY", name="EnvZ",
         ...                 description="Homodimeric domain of EnvZ from E. coli")
         >>> rec.letter_annotations["secondary_structure"] = "  S  SSSSSSHHHHHTTTHHHHHHHHHHHHHHHHHHHHHHTHHHHHHHHHHHHHHHHHHHHHTT  "
-        >>> rec.features.append(SeqFeature(FeatureLocation(20, 21),
+        >>> rec.features.append(SeqFeature(SimpleLocation(20, 21),
         ...                     type = "Site"))
 
         Now let's have a quick look at the full record,

--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -20,15 +20,7 @@ Functions:
 import io
 import re
 
-from Bio.SeqFeature import (
-    SeqFeature,
-    FeatureLocation,
-    ExactPosition,
-    BeforePosition,
-    AfterPosition,
-    UncertainPosition,
-    UnknownPosition,
-)
+from Bio.SeqFeature import SeqFeature, FeatureLocation, Position
 
 
 class SwissProtParserError(ValueError):
@@ -725,31 +717,11 @@ def _read_ft(record, line):
             isoform_id = None
             description = line[34:75].rstrip()
             qualifiers = {"description": description}
-        if from_res == "?":
-            from_res = UnknownPosition()
-        elif from_res.startswith("?"):
-            position = int(from_res[1:]) - 1  # Python zero-based counting
-            from_res = UncertainPosition(position)
-        elif from_res.startswith("<"):
-            position = int(from_res[1:]) - 1  # Python zero-based counting
-            from_res = BeforePosition(position)
-        else:
-            position = int(from_res) - 1  # Python zero-based counting
-            from_res = ExactPosition(position)
+        from_res = Position.fromstring(from_res, -1)
         if to_res == "":
-            position = from_res + 1
-            to_res = ExactPosition(position)
-        elif to_res == "?":
-            to_res = UnknownPosition()
-        elif to_res.startswith("?"):
-            position = int(to_res[1:])
-            to_res = UncertainPosition(position)
-        elif to_res.startswith(">"):
-            position = int(to_res[1:])
-            to_res = AfterPosition(position)
+            to_res = from_res + 1
         else:
-            position = int(to_res)
-            to_res = ExactPosition(position)
+            to_res = Position.fromstring(to_res)
         location = FeatureLocation(from_res, to_res, ref=isoform_id)
         feature = FeatureTable(
             location=location, type=name, id=None, qualifiers=qualifiers

--- a/Bio/SwissProt/__init__.py
+++ b/Bio/SwissProt/__init__.py
@@ -20,7 +20,7 @@ Functions:
 import io
 import re
 
-from Bio.SeqFeature import SeqFeature, FeatureLocation, Position
+from Bio.SeqFeature import SeqFeature, SimpleLocation, Position
 
 
 class SwissProtParserError(ValueError):
@@ -149,7 +149,7 @@ class FeatureTable(SeqFeature):
     attributes are used as follows:
 
      - ``location``: location of the feature on the canonical or isoform
-       sequence; the location is stored as an instance of FeatureLocation,
+       sequence; the location is stored as an instance of SimpleLocation,
        defined in Bio.SeqFeature, with the ref attribute set to the isoform
        ID referring to the canonical or isoform sequence on which the feature
        is defined
@@ -722,7 +722,7 @@ def _read_ft(record, line):
             to_res = from_res + 1
         else:
             to_res = Position.fromstring(to_res)
-        location = FeatureLocation(from_res, to_res, ref=isoform_id)
+        location = SimpleLocation(from_res, to_res, ref=isoform_id)
         feature = FeatureTable(
             location=location, type=name, id=None, qualifiers=qualifiers
         )

--- a/BioSQL/BioSeq.py
+++ b/BioSQL/BioSeq.py
@@ -275,7 +275,7 @@ def _retrieve_features(adaptor, primary_id):
                 adaptor, location_id
             )
             dbname, version = lookup.get(location_id, (None, None))
-            feature.location = SeqFeature.FeatureLocation(start, end)
+            feature.location = SeqFeature.SimpleLocation(start, end)
             feature.strand = strand
             feature.ref_db = dbname
             feature.ref = version
@@ -285,7 +285,7 @@ def _retrieve_features(adaptor, primary_id):
                 location_id, start, end, strand = location
                 dbname, version = lookup.get(location_id, (None, None))
                 locs.append(
-                    SeqFeature.FeatureLocation(
+                    SeqFeature.SimpleLocation(
                         start, end, strand=strand, ref=version, ref_db=dbname
                     )
                 )
@@ -393,7 +393,7 @@ def _retrieve_reference(adaptor, primary_id):
         if (start is not None) or (end is not None):
             if start is not None:
                 start -= 1  # python counting
-            reference.location = [SeqFeature.FeatureLocation(start, end)]
+            reference.location = [SeqFeature.SimpleLocation(start, end)]
         # Don't replace the default "" with None.
         if authors:
             reference.authors = authors

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -946,7 +946,7 @@ class DatabaseLoader:
                 % feature.location_operator,
                 BiopythonWarning,
             )
-        # This will be a list of length one for simple FeatureLocation:
+        # This will be a list of length one for simple SimpleLocation:
         parts = feature.location.parts
         if parts and {loc.strand for loc in parts} == {-1}:
             # To mimic prior behaviour of Biopython+BioSQL, reverse order
@@ -956,7 +956,7 @@ class DatabaseLoader:
             self._insert_location(loc, rank + 1, seqfeature_id)
 
     def _insert_location(self, location, rank, seqfeature_id):
-        """Add SeqFeatue location to seqfeature_location table (PRIVATE).
+        """Add SeqFeature location to seqfeature_location table (PRIVATE).
 
         TODO - Add location operator to location_qualifier_value?
         """

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -946,7 +946,7 @@ class DatabaseLoader:
                 % feature.location_operator,
                 BiopythonWarning,
             )
-        # This will be a list of length one for simple SimpleLocation:
+        # This will be a list of length one for a SimpleLocation:
         parts = feature.location.parts
         if parts and {loc.strand for loc in parts} == {-1}:
             # To mimic prior behaviour of Biopython+BioSQL, reverse order

--- a/Doc/Tutorial/chapter_graphics.tex
+++ b/Doc/Tutorial/chapter_graphics.tex
@@ -223,9 +223,9 @@ but just the coordinates for a feature you want to draw.  You have to create
 minimal \verb|SeqFeature| object, but this is easy:
 
 \begin{minted}{python}
-from Bio.SeqFeature import SeqFeature, FeatureLocation
+from Bio.SeqFeature import SeqFeature, SimpleLocation
 
-my_seq_feature = SeqFeature(FeatureLocation(50, 100), strand=+1)
+my_seq_feature = SeqFeature(SimpleLocation(50, 100), strand=+1)
 \end{minted}
 
 For strand, use \texttt{+1} for the forward strand, \texttt{-1} for the
@@ -233,7 +233,7 @@ reverse strand, and \texttt{None} for both.  Here is a short self contained
 example:
 
 \begin{minted}{python}
-from Bio.SeqFeature import SeqFeature, FeatureLocation
+from Bio.SeqFeature import SeqFeature, SimpleLocation
 from Bio.Graphics import GenomeDiagram
 from reportlab.lib.units import cm
 
@@ -242,11 +242,11 @@ gdt_features = gdd.new_track(1, greytrack=False)
 gds_features = gdt_features.new_set()
 
 # Add three features to show the strand options,
-feature = SeqFeature(FeatureLocation(25, 125), strand=+1)
+feature = SeqFeature(SimpleLocation(25, 125), strand=+1)
 gds_features.add_feature(feature, name="Forward", label=True)
-feature = SeqFeature(FeatureLocation(150, 250), strand=None)
+feature = SeqFeature(SimpleLocation(150, 250), strand=None)
 gds_features.add_feature(feature, name="Strandless", label=True)
-feature = SeqFeature(FeatureLocation(275, 375), strand=-1)
+feature = SeqFeature(SimpleLocation(275, 375), strand=-1)
 gds_features.add_feature(feature, name="Reverse", label=True)
 
 gdd.draw(format="linear", pagesize=(15 * cm, 4 * cm), fragments=1, start=0, end=400)
@@ -496,7 +496,7 @@ from reportlab.lib import colors
 from reportlab.lib.units import cm
 from Bio.Graphics import GenomeDiagram
 from Bio import SeqIO
-from Bio.SeqFeature import SeqFeature, FeatureLocation
+from Bio.SeqFeature import SeqFeature, SimpleLocation
 
 record = SeqIO.read("NC_005816.gb", "genbank")
 
@@ -529,7 +529,7 @@ for site, name, color in [
         index = record.seq.find(site, start=index)
         if index == -1:
             break
-        feature = SeqFeature(FeatureLocation(index, index + len(site)))
+        feature = SeqFeature(SimpleLocation(index, index + len(site)))
         gd_feature_set.add_feature(
             feature,
             color=color,

--- a/Doc/Tutorial/chapter_seq_annot.tex
+++ b/Doc/Tutorial/chapter_seq_annot.tex
@@ -333,11 +333,11 @@ clarify the terminology we're using:
 
 I just mention this because sometimes I get confused between the two.
 
-\subsubsection{FeatureLocation object}
+\subsubsection{SimpleLocation object}
 
 Unless you work with eukaryotic genes, most \verb|SeqFeature| locations are
 extremely simple - you just need start and end coordinates and a strand.
-That's essentially all the basic \verb|FeatureLocation| object does.
+That's essentially all the basic \verb|SimpleLocation| object does.
 
 %TODO -- add example here
 
@@ -408,7 +408,7 @@ Here's an example where we create a location with fuzzy end points:
 >>> from Bio import SeqFeature
 >>> start_pos = SeqFeature.AfterPosition(5)
 >>> end_pos = SeqFeature.BetweenPosition(9, left=8, right=9)
->>> my_location = SeqFeature.FeatureLocation(start_pos, end_pos)
+>>> my_location = SeqFeature.SimpleLocation(start_pos, end_pos)
 \end{minted}
 
 Note that the details of some of the fuzzy-locations changed in Biopython 1.59,
@@ -417,7 +417,7 @@ which integer position should be used for slicing etc. For a start position this
 is generally the lower (left) value, while for an end position this would generally
 be the higher (right) value.
 
-If you print out a \verb|FeatureLocation| object, you can get a nice representation of the information:
+If you print out a \verb|SimpleLocation| object, you can get a nice representation of the information:
 
 %cont-doctest
 \begin{minted}{pycon}
@@ -454,7 +454,7 @@ Similarly, to make it easy to create a position without worrying about fuzzy pos
 
 %cont-doctest
 \begin{minted}{pycon}
->>> exact_location = SeqFeature.FeatureLocation(5, 9)
+>>> exact_location = SeqFeature.SimpleLocation(5, 9)
 >>> print(exact_location)
 [5:9]
 >>> exact_location.start
@@ -504,9 +504,9 @@ A \verb|SeqFeature| or location object doesn't directly contain a sequence, inst
 %doctest
 \begin{minted}{pycon}
 >>> from Bio.Seq import Seq
->>> from Bio.SeqFeature import SeqFeature, FeatureLocation
+>>> from Bio.SeqFeature import SeqFeature, SimpleLocation
 >>> seq = Seq("ACCGAGACGGCAAAGGCTAGCATAGGTATGAGACTTCCTTCCTGCCAGTGCTGAGGAACTGGGAGCCTAC")
->>> feature = SeqFeature(FeatureLocation(5, 18, strand=-1), type="gene")
+>>> feature = SeqFeature(SimpleLocation(5, 18, strand=-1), type="gene")
 \end{minted}
 
 You could take the parent sequence, slice it to extract 5:18, and then take the reverse complement.
@@ -541,7 +541,7 @@ that of the region of sequence it describes.
 13
 \end{minted}
 
-For simple \verb|FeatureLocation| objects the length is just
+For simple \verb|SimpleLocation| objects the length is just
 the difference between the start and end positions. However,
 for a \verb|CompoundLocation| the length is the sum of the
 constituent regions.

--- a/Doc/examples/ACT_example.py
+++ b/Doc/examples/ACT_example.py
@@ -12,7 +12,7 @@ from reportlab.lib import colors
 from reportlab.lib.units import cm
 
 from Bio.Graphics.GenomeDiagram import Diagram, CrossLink
-from Bio.SeqFeature import SeqFeature, FeatureLocation
+from Bio.SeqFeature import SeqFeature, SimpleLocation
 from Bio import SeqIO
 
 # Modify this line to point at the Artemis/ACT example data which is online at:
@@ -98,10 +98,10 @@ for i, crunch_file in enumerate(comparisons):
                 c = colors.Color(1, 0, 0, alpha=0.25)
                 b = False
             q_feature = q_set.add_feature(
-                SeqFeature(FeatureLocation(q_start - 1, q_end)), color=c, border=b
+                SeqFeature(SimpleLocation(q_start - 1, q_end)), color=c, border=b
             )
             s_feature = s_set.add_feature(
-                SeqFeature(FeatureLocation(s_start - 1, s_end)), color=c, border=b
+                SeqFeature(SimpleLocation(s_start - 1, s_end)), color=c, border=b
             )
             gd_diagram.cross_track_links.append(CrossLink(q_feature, s_feature, c, b))
             # NOTE: We are using the same colour for all the matches,

--- a/Doc/examples/Proux_et_al_2002_Figure_6.py
+++ b/Doc/examples/Proux_et_al_2002_Figure_6.py
@@ -20,7 +20,7 @@ from Bio.Graphics import GenomeDiagram
 from Bio.Graphics.GenomeDiagram import CrossLink
 
 from Bio import SeqIO
-from Bio.SeqFeature import SeqFeature, FeatureLocation
+from Bio.SeqFeature import SeqFeature, SimpleLocation
 
 name = "Proux Fig 6"
 
@@ -182,13 +182,13 @@ for X, Y, X_vs_Y in [
         border = colors.lightgrey
         f_x = get_feature(features_X, x)
         F_x = set_X.add_feature(
-            SeqFeature(FeatureLocation(f_x.location.start, f_x.location.end, strand=0)),
+            SeqFeature(SimpleLocation(f_x.location.start, f_x.location.end, strand=0)),
             color=color,
             border=border,
         )
         f_y = get_feature(features_Y, y)
         F_y = set_Y.add_feature(
-            SeqFeature(FeatureLocation(f_y.location.start, f_y.location.end, strand=0)),
+            SeqFeature(SimpleLocation(f_y.location.start, f_y.location.end, strand=0)),
             color=color,
             border=border,
         )

--- a/Tests/seq_tests_common.py
+++ b/Tests/seq_tests_common.py
@@ -9,7 +9,7 @@ import unittest
 from Bio.Seq import UnknownSeq, UndefinedSequenceError
 from Bio.SeqUtils.CheckSum import seguid
 from Bio.SeqFeature import ExactPosition, UnknownPosition
-from Bio.SeqFeature import FeatureLocation, CompoundLocation, SeqFeature
+from Bio.SeqFeature import SimpleLocation, CompoundLocation, SeqFeature
 from Bio.SeqRecord import SeqRecord
 
 from test_SeqIO import SeqIOTestBaseClass
@@ -50,8 +50,8 @@ class SeqRecordTestBaseClass(unittest.TestCase):
         else:
             # BioSQL can only store ONE location!
             # TODO - Check BioPerl with a GenBank file with multiple ref locations
-            self.assertIsInstance(r1.location[0], FeatureLocation)
-            self.assertIsInstance(r2.location[0], FeatureLocation)
+            self.assertIsInstance(r1.location[0], SimpleLocation)
+            self.assertIsInstance(r2.location[0], SimpleLocation)
             self.assertEqual(r1.location[0].start, r2.location[0].start)
             self.assertEqual(r1.location[0].end, r2.location[0].end)
 
@@ -99,7 +99,7 @@ class SeqRecordTestBaseClass(unittest.TestCase):
 
         self.assertEqual(len(old_f.location.parts), len(new_f.location.parts))
         for old_sub, new_sub in zip(old_f.location.parts, new_f.location.parts):
-            # These are FeatureLocation objects
+            # These are SimpleLocation objects
             # Note UnknownPosition != UnknownPosition (just like NaN != NaN)
             if isinstance(old_sub.start, UnknownPosition):
                 self.assertIsInstance(new_sub.start, UnknownPosition)

--- a/Tests/test_Align_bigpsl.py
+++ b/Tests/test_Align_bigpsl.py
@@ -11,7 +11,7 @@ from io import StringIO
 from Bio.Align import Alignment
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.SeqFeature import FeatureLocation, ExactPosition, CompoundLocation
+from Bio.SeqFeature import SimpleLocation, ExactPosition, CompoundLocation
 from Bio import SeqIO
 from Bio import BiopythonExperimentalWarning
 

--- a/Tests/test_Align_psl.py
+++ b/Tests/test_Align_psl.py
@@ -11,7 +11,7 @@ from io import StringIO
 from Bio.Align import Alignment
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.SeqFeature import FeatureLocation, ExactPosition, CompoundLocation
+from Bio.SeqFeature import SimpleLocation, ExactPosition, CompoundLocation
 from Bio import SeqIO
 from Bio import BiopythonExperimentalWarning
 
@@ -2686,7 +2686,7 @@ class TestAlign_dnax_prot(unittest.TestCase):
             feature = alignment.target.features[0]
             self.assertEqual(
                 feature.location,
-                FeatureLocation(
+                SimpleLocation(
                     ExactPosition(75566694), ExactPosition(75566850), strand=+1
                 ),
             )
@@ -2731,7 +2731,7 @@ class TestAlign_dnax_prot(unittest.TestCase):
             feature = alignment.target.features[0]
             self.assertEqual(
                 feature.location,
-                FeatureLocation(
+                SimpleLocation(
                     ExactPosition(75560749), ExactPosition(75560881), strand=+1
                 ),
             )
@@ -2778,10 +2778,10 @@ class TestAlign_dnax_prot(unittest.TestCase):
                 feature.location,
                 CompoundLocation(
                     [
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(75549820), ExactPosition(75549865), strand=+1
                         ),
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(75567225), ExactPosition(75567312), strand=+1
                         ),
                     ],
@@ -2831,10 +2831,10 @@ class TestAlign_dnax_prot(unittest.TestCase):
                 feature.location,
                 CompoundLocation(
                     [
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(75604767), ExactPosition(75604827), strand=+1
                         ),
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(75605728), ExactPosition(75605809), strand=+1
                         ),
                     ],
@@ -2879,7 +2879,7 @@ class TestAlign_dnax_prot(unittest.TestCase):
             feature = alignment.target.features[0]
             self.assertEqual(
                 feature.location,
-                FeatureLocation(
+                SimpleLocation(
                     ExactPosition(75594914), ExactPosition(75594989), strand=+1
                 ),
             )
@@ -2920,7 +2920,7 @@ class TestAlign_dnax_prot(unittest.TestCase):
             feature = alignment.target.features[0]
             self.assertEqual(
                 feature.location,
-                FeatureLocation(
+                SimpleLocation(
                     ExactPosition(75569459), ExactPosition(75569507), strand=+1
                 ),
             )
@@ -2961,7 +2961,7 @@ class TestAlign_dnax_prot(unittest.TestCase):
             feature = alignment.target.features[0]
             self.assertEqual(
                 feature.location,
-                FeatureLocation(
+                SimpleLocation(
                     ExactPosition(41260685), ExactPosition(41260787), strand=+1
                 ),
             )
@@ -3008,10 +3008,10 @@ class TestAlign_dnax_prot(unittest.TestCase):
                 feature.location,
                 CompoundLocation(
                     [
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(41257605), ExactPosition(41257731), strand=+1
                         ),
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(41263227), ExactPosition(41263290), strand=+1
                         ),
                     ],
@@ -3249,25 +3249,25 @@ QFLKQLGLHPNWQFVDVYGMDPELLSMVPRPVCAVLLLFPITDEKVDLHFIALVHVDGHLYEL
                 feature.location,
                 CompoundLocation(
                     [
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(9712654), ExactPosition(9712786), strand=+1
                         ),
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(9715941), ExactPosition(9716097), strand=+1
                         ),
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(9716445), ExactPosition(9716532), strand=+1
                         ),
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(9718374), ExactPosition(9718422), strand=+1
                         ),
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(9739264), ExactPosition(9739339), strand=+1
                         ),
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(9743706), ExactPosition(9743766), strand=+1
                         ),
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(9744511), ExactPosition(9744592), strand=+1
                         ),
                     ],
@@ -3324,10 +3324,10 @@ QFLKQLGLHPNWQFVDVYGMDPELLSMVPRPVCAVLLLFPITDEKVDLHFIALVHVDGHLYEL
                 feature.location,
                 CompoundLocation(
                     [
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(2103463), ExactPosition(2103523), strand=+1
                         ),
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(2103522), ExactPosition(2104149), strand=+1
                         ),
                     ],
@@ -3382,10 +3382,10 @@ QFLKQLGLHPNWQFVDVYGMDPELLSMVPRPVCAVLLLFPITDEKVDLHFIALVHVDGHLYEL
                 feature.location,
                 CompoundLocation(
                     [
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(20872472), ExactPosition(20873021), strand=-1
                         ),
-                        FeatureLocation(
+                        SimpleLocation(
                             ExactPosition(20872390), ExactPosition(20872471), strand=-1
                         ),
                     ],

--- a/Tests/test_GenomeDiagram.py
+++ b/Tests/test_GenomeDiagram.py
@@ -36,7 +36,7 @@ except ImportError:
     renderPM = None
 
 from Bio import SeqIO
-from Bio.SeqFeature import SeqFeature, FeatureLocation
+from Bio.SeqFeature import SeqFeature, SimpleLocation
 
 from Bio.Graphics.GenomeDiagram import FeatureSet, GraphSet, Track, Diagram
 from Bio.Graphics.GenomeDiagram import CrossLink
@@ -389,7 +389,7 @@ class LabelTest(unittest.TestCase):
                 strand = -1
                 name = "Reverse"
                 color = colors.blue
-            feature = SeqFeature(FeatureLocation(start, end, strand=strand))
+            feature = SeqFeature(SimpleLocation(start, end, strand=strand))
             self.gds_features.add_feature(
                 feature, name=name, color=color, label=True, **kwargs
             )
@@ -427,11 +427,11 @@ class SigilsTest(unittest.TestCase):
         # We'll just use one feature set for these features,
         self.gds_features = self.gdt_features.new_set()
         # Add three features to show the strand options,
-        feature = SeqFeature(FeatureLocation(25, 125, strand=+1))
+        feature = SeqFeature(SimpleLocation(25, 125, strand=+1))
         self.gds_features.add_feature(feature, name="Forward", **kwargs)
-        feature = SeqFeature(FeatureLocation(150, 250, strand=None))
+        feature = SeqFeature(SimpleLocation(150, 250, strand=None))
         self.gds_features.add_feature(feature, name="strandless", **kwargs)
-        feature = SeqFeature(FeatureLocation(275, 375, strand=-1))
+        feature = SeqFeature(SimpleLocation(275, 375, strand=-1))
         self.gds_features.add_feature(feature, name="Reverse", **kwargs)
 
     def finish(self, name, circular=True):
@@ -563,69 +563,69 @@ class SigilsTest(unittest.TestCase):
         # - Red arrows should be small triangles (so short no shaft shown)
 
         # Forward strand:
-        feature = SeqFeature(FeatureLocation(15, 30, strand=-1))
+        feature = SeqFeature(SimpleLocation(15, 30, strand=-1))
         self.gds_features.add_feature(feature, color="blue")
-        feature = SeqFeature(FeatureLocation(15, 30, strand=+1))
+        feature = SeqFeature(SimpleLocation(15, 30, strand=+1))
         self.gds_features.add_feature(feature, color="grey")
         self.gds_features.add_feature(
             feature, name="Forward", sigil=glyph, arrowhead_length=0.05
         )
 
-        feature = SeqFeature(FeatureLocation(55, 60, strand=-1))
+        feature = SeqFeature(SimpleLocation(55, 60, strand=-1))
         self.gds_features.add_feature(feature, color="blue")
-        feature = SeqFeature(FeatureLocation(55, 60, strand=+1))
+        feature = SeqFeature(SimpleLocation(55, 60, strand=+1))
         self.gds_features.add_feature(feature, color="grey")
         self.gds_features.add_feature(
             feature, name="Forward", sigil=glyph, arrowhead_length=1000, color="red"
         )
 
-        feature = SeqFeature(FeatureLocation(75, 125, strand=-1))
+        feature = SeqFeature(SimpleLocation(75, 125, strand=-1))
         self.gds_features.add_feature(feature, color="blue")
-        feature = SeqFeature(FeatureLocation(75, 125, strand=+1))
+        feature = SeqFeature(SimpleLocation(75, 125, strand=+1))
         self.gds_features.add_feature(feature, color="grey")
         self.gds_features.add_feature(
             feature, name="Forward", sigil=glyph, arrowhead_length=0.05
         )
 
         # Strandless:
-        feature = SeqFeature(FeatureLocation(140, 155, strand=None))
+        feature = SeqFeature(SimpleLocation(140, 155, strand=None))
         self.gds_features.add_feature(feature, color="grey")
         self.gds_features.add_feature(
             feature, name="Strandless", sigil=glyph, arrowhead_length=0.05
         )
 
-        feature = SeqFeature(FeatureLocation(180, 185, strand=None))
+        feature = SeqFeature(SimpleLocation(180, 185, strand=None))
         self.gds_features.add_feature(feature, color="grey")
         self.gds_features.add_feature(
             feature, name="Strandless", sigil=glyph, arrowhead_length=1000, color="red"
         )
 
-        feature = SeqFeature(FeatureLocation(200, 250, strand=None))
+        feature = SeqFeature(SimpleLocation(200, 250, strand=None))
         self.gds_features.add_feature(feature, color="grey")
         self.gds_features.add_feature(
             feature, name="Strandless", sigil=glyph, arrowhead_length=0.05
         )
 
         # Reverse strand:
-        feature = SeqFeature(FeatureLocation(265, 280, strand=+1))
+        feature = SeqFeature(SimpleLocation(265, 280, strand=+1))
         self.gds_features.add_feature(feature, color="blue")
-        feature = SeqFeature(FeatureLocation(265, 280, strand=-1))
+        feature = SeqFeature(SimpleLocation(265, 280, strand=-1))
         self.gds_features.add_feature(feature, color="grey")
         self.gds_features.add_feature(
             feature, name="Reverse", sigil=glyph, arrowhead_length=0.05
         )
 
-        feature = SeqFeature(FeatureLocation(305, 310, strand=+1))
+        feature = SeqFeature(SimpleLocation(305, 310, strand=+1))
         self.gds_features.add_feature(feature, color="blue")
-        feature = SeqFeature(FeatureLocation(305, 310, strand=-1))
+        feature = SeqFeature(SimpleLocation(305, 310, strand=-1))
         self.gds_features.add_feature(feature, color="grey")
         self.gds_features.add_feature(
             feature, name="Reverse", sigil=glyph, arrowhead_length=1000, color="red"
         )
 
-        feature = SeqFeature(FeatureLocation(325, 375, strand=+1))
+        feature = SeqFeature(SimpleLocation(325, 375, strand=+1))
         self.gds_features.add_feature(feature, color="blue")
-        feature = SeqFeature(FeatureLocation(325, 375, strand=-1))
+        feature = SeqFeature(SimpleLocation(325, 375, strand=-1))
         self.gds_features.add_feature(feature, color="grey")
         self.gds_features.add_feature(
             feature, name="Reverse", sigil=glyph, arrowhead_length=0.05
@@ -657,11 +657,11 @@ class SigilsTest(unittest.TestCase):
         self.gds_features = self.gdt_features.new_set()
         if glyph in ["BIGARROW"]:
             # These straddle the axis, so don't want to draw them on top of each other
-            feature = SeqFeature(FeatureLocation(25, 375, strand=None))
+            feature = SeqFeature(SimpleLocation(25, 375, strand=None))
             self.gds_features.add_feature(feature, color="lightblue")
-            feature = SeqFeature(FeatureLocation(25, 375, strand=+1))
+            feature = SeqFeature(SimpleLocation(25, 375, strand=+1))
         else:
-            feature = SeqFeature(FeatureLocation(25, 375, strand=+1))
+            feature = SeqFeature(SimpleLocation(25, 375, strand=+1))
             self.gds_features.add_feature(feature, color="lightblue")
         self.gds_features.add_feature(
             feature, name="Forward", sigil=glyph, color="blue", arrowhead_length=2.0
@@ -671,11 +671,11 @@ class SigilsTest(unittest.TestCase):
             # These straddle the axis, so don't want to draw them on top of each other
             self.gdt_features = self.gdd.new_track(1, greytrack=True, height=3)
             self.gds_features = self.gdt_features.new_set()
-            feature = SeqFeature(FeatureLocation(25, 375, strand=None))
+            feature = SeqFeature(SimpleLocation(25, 375, strand=None))
             self.gds_features.add_feature(feature, color="pink")
-            feature = SeqFeature(FeatureLocation(25, 375, strand=-1))
+            feature = SeqFeature(SimpleLocation(25, 375, strand=-1))
         else:
-            feature = SeqFeature(FeatureLocation(25, 375, strand=-1))
+            feature = SeqFeature(SimpleLocation(25, 375, strand=-1))
             self.gds_features.add_feature(feature, color="pink")
         self.gds_features.add_feature(
             feature, name="Reverse", sigil=glyph, color="red", arrowhead_length=2.0
@@ -684,7 +684,7 @@ class SigilsTest(unittest.TestCase):
         self.gdt_features = self.gdd.new_track(1, greytrack=True, height=3)
         # We'll just use one feature set for these features,
         self.gds_features = self.gdt_features.new_set()
-        feature = SeqFeature(FeatureLocation(25, 375, strand=None))
+        feature = SeqFeature(SimpleLocation(25, 375, strand=None))
         self.gds_features.add_feature(feature, color="lightgreen")
         self.gds_features.add_feature(
             feature, name="Standless", sigil=glyph, color="green", arrowhead_length=2.0
@@ -942,7 +942,7 @@ class DiagramTest(unittest.TestCase):
                 index = genbank_entry.seq.find(site, start=index)
                 if index == -1:
                     break
-                feature = SeqFeature(FeatureLocation(index, index + 6, strand=None))
+                feature = SeqFeature(SimpleLocation(index, index + 6, strand=None))
 
                 # This URL should work in SVG output from recent versions
                 # of ReportLab.  You need ReportLab 2.4 or later
@@ -1050,7 +1050,7 @@ class DiagramTest(unittest.TestCase):
                     # Background for CDS,
                     a = gdfsA.add_feature(
                         SeqFeature(
-                            FeatureLocation(
+                            SimpleLocation(
                                 feature.location.start, feature.location.end, strand=0
                             )
                         ),
@@ -1059,7 +1059,7 @@ class DiagramTest(unittest.TestCase):
                     # Background for gene,
                     b = gdfsB.add_feature(
                         SeqFeature(
-                            FeatureLocation(
+                            SimpleLocation(
                                 prev_gene.location.start,
                                 prev_gene.location.end,
                                 strand=0,
@@ -1075,83 +1075,47 @@ class DiagramTest(unittest.TestCase):
 
         # Some cross links on the same linear diagram fragment,
         f, c = fill_and_border(colors.red)
-        a = gdfsA.add_feature(
-            SeqFeature(FeatureLocation(2220, 2230)), color=f, border=c
-        )
-        b = gdfsB.add_feature(
-            SeqFeature(FeatureLocation(2200, 2210)), color=f, border=c
-        )
+        a = gdfsA.add_feature(SeqFeature(SimpleLocation(2220, 2230)), color=f, border=c)
+        b = gdfsB.add_feature(SeqFeature(SimpleLocation(2200, 2210)), color=f, border=c)
         gdd.cross_track_links.append(CrossLink(a, b, f, c))
 
         f, c = fill_and_border(colors.blue)
-        a = gdfsA.add_feature(
-            SeqFeature(FeatureLocation(2150, 2200)), color=f, border=c
-        )
-        b = gdfsB.add_feature(
-            SeqFeature(FeatureLocation(2220, 2290)), color=f, border=c
-        )
+        a = gdfsA.add_feature(SeqFeature(SimpleLocation(2150, 2200)), color=f, border=c)
+        b = gdfsB.add_feature(SeqFeature(SimpleLocation(2220, 2290)), color=f, border=c)
         gdd.cross_track_links.append(CrossLink(a, b, f, c, flip=True))
 
         f, c = fill_and_border(colors.green)
-        a = gdfsA.add_feature(
-            SeqFeature(FeatureLocation(2250, 2560)), color=f, border=c
-        )
-        b = gdfsB.add_feature(
-            SeqFeature(FeatureLocation(2300, 2860)), color=f, border=c
-        )
+        a = gdfsA.add_feature(SeqFeature(SimpleLocation(2250, 2560)), color=f, border=c)
+        b = gdfsB.add_feature(SeqFeature(SimpleLocation(2300, 2860)), color=f, border=c)
         gdd.cross_track_links.append(CrossLink(a, b, f, c))
 
         # Some cross links where both parts are saddling the linear diagram fragment boundary,
         f, c = fill_and_border(colors.red)
-        a = gdfsA.add_feature(
-            SeqFeature(FeatureLocation(3155, 3250)), color=f, border=c
-        )
-        b = gdfsB.add_feature(
-            SeqFeature(FeatureLocation(3130, 3300)), color=f, border=c
-        )
+        a = gdfsA.add_feature(SeqFeature(SimpleLocation(3155, 3250)), color=f, border=c)
+        b = gdfsB.add_feature(SeqFeature(SimpleLocation(3130, 3300)), color=f, border=c)
         gdd.cross_track_links.append(CrossLink(a, b, f, c))
         # Nestled within that (drawn on top),
         f, c = fill_and_border(colors.blue)
-        a = gdfsA.add_feature(
-            SeqFeature(FeatureLocation(3160, 3275)), color=f, border=c
-        )
-        b = gdfsB.add_feature(
-            SeqFeature(FeatureLocation(3180, 3225)), color=f, border=c
-        )
+        a = gdfsA.add_feature(SeqFeature(SimpleLocation(3160, 3275)), color=f, border=c)
+        b = gdfsB.add_feature(SeqFeature(SimpleLocation(3180, 3225)), color=f, border=c)
         gdd.cross_track_links.append(CrossLink(a, b, f, c, flip=True))
 
         # Some cross links where two features are on either side of the linear diagram fragment boundary,
         f, c = fill_and_border(colors.green)
-        a = gdfsA.add_feature(
-            SeqFeature(FeatureLocation(6450, 6550)), color=f, border=c
-        )
-        b = gdfsB.add_feature(
-            SeqFeature(FeatureLocation(6265, 6365)), color=f, border=c
-        )
+        a = gdfsA.add_feature(SeqFeature(SimpleLocation(6450, 6550)), color=f, border=c)
+        b = gdfsB.add_feature(SeqFeature(SimpleLocation(6265, 6365)), color=f, border=c)
         gdd.cross_track_links.append(CrossLink(a, b, color=f, border=c))
         f, c = fill_and_border(colors.gold)
-        a = gdfsA.add_feature(
-            SeqFeature(FeatureLocation(6265, 6365)), color=f, border=c
-        )
-        b = gdfsB.add_feature(
-            SeqFeature(FeatureLocation(6450, 6550)), color=f, border=c
-        )
+        a = gdfsA.add_feature(SeqFeature(SimpleLocation(6265, 6365)), color=f, border=c)
+        b = gdfsB.add_feature(SeqFeature(SimpleLocation(6450, 6550)), color=f, border=c)
         gdd.cross_track_links.append(CrossLink(a, b, color=f, border=c))
         f, c = fill_and_border(colors.red)
-        a = gdfsA.add_feature(
-            SeqFeature(FeatureLocation(6275, 6375)), color=f, border=c
-        )
-        b = gdfsB.add_feature(
-            SeqFeature(FeatureLocation(6430, 6530)), color=f, border=c
-        )
+        a = gdfsA.add_feature(SeqFeature(SimpleLocation(6275, 6375)), color=f, border=c)
+        b = gdfsB.add_feature(SeqFeature(SimpleLocation(6430, 6530)), color=f, border=c)
         gdd.cross_track_links.append(CrossLink(a, b, color=f, border=c, flip=True))
         f, c = fill_and_border(colors.blue)
-        a = gdfsA.add_feature(
-            SeqFeature(FeatureLocation(6430, 6530)), color=f, border=c
-        )
-        b = gdfsB.add_feature(
-            SeqFeature(FeatureLocation(6275, 6375)), color=f, border=c
-        )
+        a = gdfsA.add_feature(SeqFeature(SimpleLocation(6430, 6530)), color=f, border=c)
+        b = gdfsB.add_feature(SeqFeature(SimpleLocation(6275, 6375)), color=f, border=c)
         gdd.cross_track_links.append(CrossLink(a, b, color=f, border=c, flip=True))
 
         cds_count = 0

--- a/Tests/test_GraphicsChromosome.py
+++ b/Tests/test_GraphicsChromosome.py
@@ -31,7 +31,7 @@ except ImportError:
     ) from None
 
 # local stuff
-from Bio.SeqFeature import SeqFeature, FeatureLocation
+from Bio.SeqFeature import SeqFeature, SimpleLocation
 from Bio.Graphics import BasicChromosome
 from Bio.Graphics.DisplayRepresentation import ChromosomeCounts
 
@@ -342,7 +342,7 @@ class OrganismSubAnnotationsTest(unittest.TestCase):
                 # Features as SeqFeatures
                 features = [
                     SeqFeature(
-                        FeatureLocation(start, end, strand),
+                        SimpleLocation(start, end, strand),
                         qualifiers={"name": [label], "color": [color]},
                     )
                     for (start, end, strand, label) in features

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -19,7 +19,7 @@ from Bio.SeqFeature import BeforePosition
 from Bio.SeqFeature import BetweenPosition
 from Bio.SeqFeature import CompoundLocation
 from Bio.SeqFeature import ExactPosition
-from Bio.SeqFeature import FeatureLocation
+from Bio.SeqFeature import SimpleLocation
 from Bio.SeqFeature import OneOfPosition
 from Bio.SeqFeature import SeqFeature
 from Bio.SeqFeature import UnknownPosition
@@ -55,77 +55,77 @@ class TestReference(unittest.TestCase):
         )
 
 
-class TestFeatureLocation(unittest.TestCase):
-    """Tests for the SeqFeature.FeatureLocation class."""
+class TestSimpleLocation(unittest.TestCase):
+    """Tests for the SeqFeature.SimpleLocation class."""
 
     def test_eq_identical(self):
         """Test two identical locations are equal."""
-        loc1 = FeatureLocation(23, 42, 1)
-        loc2 = FeatureLocation(23, 42, 1)
+        loc1 = SimpleLocation(23, 42, 1)
+        loc2 = SimpleLocation(23, 42, 1)
         self.assertEqual(loc1, loc2)
 
-        loc1 = FeatureLocation(23, 42, -1)
-        loc2 = FeatureLocation(23, 42, -1)
+        loc1 = SimpleLocation(23, 42, -1)
+        loc2 = SimpleLocation(23, 42, -1)
         self.assertEqual(loc1, loc2)
 
-        loc1 = FeatureLocation(BeforePosition(23), AfterPosition(42), 1)
-        loc2 = FeatureLocation(23, 42, 1)
+        loc1 = SimpleLocation(BeforePosition(23), AfterPosition(42), 1)
+        loc2 = SimpleLocation(23, 42, 1)
         self.assertEqual(loc1, loc2)
 
-        loc1 = FeatureLocation(23, 42, 1, "foo", "bar")
-        loc2 = FeatureLocation(23, 42, 1, "foo", "bar")
+        loc1 = SimpleLocation(23, 42, 1, "foo", "bar")
+        loc2 = SimpleLocation(23, 42, 1, "foo", "bar")
         self.assertEqual(loc1, loc2)
 
     def test_eq_not_identical(self):
         """Test two different locations are not equal."""
-        loc1 = FeatureLocation(22, 42, 1)
-        loc2 = FeatureLocation(23, 42, 1)
+        loc1 = SimpleLocation(22, 42, 1)
+        loc2 = SimpleLocation(23, 42, 1)
         self.assertNotEqual(loc1, loc2)
 
-        loc1 = FeatureLocation(23, 42, 1)
-        loc2 = FeatureLocation(23, 43, 1)
+        loc1 = SimpleLocation(23, 42, 1)
+        loc2 = SimpleLocation(23, 43, 1)
         self.assertNotEqual(loc1, loc2)
 
-        loc1 = FeatureLocation(23, 42, 1)
-        loc2 = FeatureLocation(23, 42, -1)
+        loc1 = SimpleLocation(23, 42, 1)
+        loc2 = SimpleLocation(23, 42, -1)
         self.assertNotEqual(loc1, loc2)
 
-        loc1 = FeatureLocation(23, 42, 1)
+        loc1 = SimpleLocation(23, 42, 1)
         loc2 = (23, 42, 1)
         self.assertNotEqual(loc1, loc2)
 
-        loc1 = FeatureLocation(23, 42, 1, "foo")
-        loc2 = FeatureLocation(23, 42, 1, "bar")
+        loc1 = SimpleLocation(23, 42, 1, "foo")
+        loc2 = SimpleLocation(23, 42, 1, "bar")
         self.assertNotEqual(loc1, loc2)
 
-        loc1 = FeatureLocation(23, 42, 1, "foo", "bar")
-        loc2 = FeatureLocation(23, 42, 1, "foo", "baz")
+        loc1 = SimpleLocation(23, 42, 1, "foo", "bar")
+        loc2 = SimpleLocation(23, 42, 1, "foo", "baz")
         self.assertNotEqual(loc1, loc2)
 
     def test_start_before_end(self):
         expected = "must be greater than or equal to start location"
         with self.assertRaises(ValueError) as err:
-            FeatureLocation(42, 23, 1)
+            SimpleLocation(42, 23, 1)
         self.assertIn(expected, str(err.exception))
 
         with self.assertRaises(ValueError) as err:
-            FeatureLocation(42, 0, 1)
+            SimpleLocation(42, 0, 1)
         self.assertIn(expected, str(err.exception))
 
         with self.assertRaises(ValueError) as err:
-            FeatureLocation(BeforePosition(42), AfterPosition(23), -1)
+            SimpleLocation(BeforePosition(42), AfterPosition(23), -1)
         self.assertIn(expected, str(err.exception))
 
         with self.assertRaises(ValueError) as err:
-            FeatureLocation(42, AfterPosition(0), 1)
+            SimpleLocation(42, AfterPosition(0), 1)
         self.assertIn(expected, str(err.exception))
 
         # Features with UnknownPositions should pass check
-        FeatureLocation(42, UnknownPosition())
-        FeatureLocation(UnknownPosition(), 42)
+        SimpleLocation(42, UnknownPosition())
+        SimpleLocation(UnknownPosition(), 42)
 
         # Same start and end should pass check
-        FeatureLocation(42, 42)
+        SimpleLocation(42, 42)
 
 
 class TestCompoundLocation(unittest.TestCase):
@@ -133,39 +133,35 @@ class TestCompoundLocation(unittest.TestCase):
 
     def test_eq_identical(self):
         """Test two identical locations are equal."""
-        loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
-        loc2 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
+        loc1 = SimpleLocation(12, 17, 1) + SimpleLocation(23, 42, 1)
+        loc2 = SimpleLocation(12, 17, 1) + SimpleLocation(23, 42, 1)
         self.assertEqual(loc1, loc2)
 
-        loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
-        loc2 = CompoundLocation(
-            [FeatureLocation(12, 17, 1), FeatureLocation(23, 42, 1)]
-        )
+        loc1 = SimpleLocation(12, 17, 1) + SimpleLocation(23, 42, 1)
+        loc2 = CompoundLocation([SimpleLocation(12, 17, 1), SimpleLocation(23, 42, 1)])
         self.assertEqual(loc1, loc2)
 
     def test_eq_not_identical(self):
         """Test two different locations are not equal."""
-        loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
+        loc1 = SimpleLocation(12, 17, 1) + SimpleLocation(23, 42, 1)
         loc2 = (
-            FeatureLocation(12, 17, 1)
-            + FeatureLocation(23, 42, 1)
-            + FeatureLocation(50, 60, 1)
+            SimpleLocation(12, 17, 1)
+            + SimpleLocation(23, 42, 1)
+            + SimpleLocation(50, 60, 1)
         )
         self.assertNotEqual(loc1, loc2)
 
-        loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
-        loc2 = FeatureLocation(12, 17, -1) + FeatureLocation(23, 42, -1)
+        loc1 = SimpleLocation(12, 17, 1) + SimpleLocation(23, 42, 1)
+        loc2 = SimpleLocation(12, 17, -1) + SimpleLocation(23, 42, -1)
         self.assertNotEqual(loc1, loc2)
 
-        loc1 = CompoundLocation(
-            [FeatureLocation(12, 17, 1), FeatureLocation(23, 42, 1)]
-        )
+        loc1 = CompoundLocation([SimpleLocation(12, 17, 1), SimpleLocation(23, 42, 1)])
         loc2 = CompoundLocation(
-            [FeatureLocation(12, 17, 1), FeatureLocation(23, 42, 1)], "order"
+            [SimpleLocation(12, 17, 1), SimpleLocation(23, 42, 1)], "order"
         )
         self.assertNotEqual(loc1, loc2)
 
-        loc1 = FeatureLocation(12, 17, 1) + FeatureLocation(23, 42, 1)
+        loc1 = SimpleLocation(12, 17, 1) + SimpleLocation(23, 42, 1)
         loc2 = 5
         self.assertNotEqual(loc1, loc2)
 
@@ -176,7 +172,7 @@ class TestSeqFeature(unittest.TestCase):
     def test_eq_identical(self):
         f1 = SeqFeature(
             type="CDS",
-            location=FeatureLocation(0, 182, 1),
+            location=SimpleLocation(0, 182, 1),
             qualifiers={
                 "product": ["interferon beta, fibroblast"],
             },
@@ -187,7 +183,7 @@ class TestSeqFeature(unittest.TestCase):
     def test_translation_checks_cds(self):
         """Test that a CDS feature is subject to respective checks."""
         seq = Seq.Seq("GGTTACACTTACCGATAATGTCTCTGATGA")
-        f = SeqFeature(FeatureLocation(0, 30), type="CDS")
+        f = SeqFeature(SimpleLocation(0, 30), type="CDS")
         f.qualifiers["transl_table"] = [11]
         with self.assertRaises(TranslationError):
             f.translate(seq)
@@ -212,9 +208,9 @@ class TestLocations(unittest.TestCase):
         self.assertEqual(str(before_pos), "<15")
         self.assertEqual(str(after_pos), ">40")
         # put these into Locations
-        location1 = FeatureLocation(exact_pos, within_pos_e)
-        location2 = FeatureLocation(before_pos, between_pos_e)
-        location3 = FeatureLocation(within_pos_s, after_pos)
+        location1 = SimpleLocation(exact_pos, within_pos_e)
+        location2 = SimpleLocation(before_pos, between_pos_e)
+        location3 = SimpleLocation(within_pos_s, after_pos)
         self.assertEqual(str(location1), "[5:(10.13)]")
         self.assertEqual(str(location1.start), "5")
         self.assertEqual(str(location1.end), "(10.13)")
@@ -268,7 +264,7 @@ class TestExtract(unittest.TestCase):
         """Test location with reference to another record."""
         parent_record = SeqRecord.SeqRecord(seq=Seq.Seq("actg"))
         another_record = SeqRecord.SeqRecord(seq=Seq.Seq("gtcagctac"))
-        location = FeatureLocation(5, 8, ref="ANOTHER.7")
+        location = SimpleLocation(5, 8, ref="ANOTHER.7")
         with self.assertRaisesRegex(
             ValueError,
             r"Feature references another sequence \(ANOTHER\.7\), references mandatory",
@@ -289,7 +285,7 @@ class TestExtract(unittest.TestCase):
         """Test location with reference to another sequence."""
         parent_sequence = Seq.Seq("actg")
         another_sequence = Seq.Seq("gtcagctac")
-        location = FeatureLocation(5, 8, ref="ANOTHER.7")
+        location = SimpleLocation(5, 8, ref="ANOTHER.7")
         sequence = location.extract(
             parent_sequence, references={"ANOTHER.7": another_sequence}
         )
@@ -300,7 +296,7 @@ class TestExtract(unittest.TestCase):
         """Test compound location with reference to another record."""
         parent_record = SeqRecord.SeqRecord(Seq.Seq("aaccaaccaaccaaccaa"))
         another_record = SeqRecord.SeqRecord(Seq.Seq("ttggttggttggttggtt"))
-        location = FeatureLocation(2, 6) + FeatureLocation(5, 8, ref="ANOTHER.7")
+        location = SimpleLocation(2, 6) + SimpleLocation(5, 8, ref="ANOTHER.7")
         with self.assertRaisesRegex(
             ValueError,
             r"Feature references another sequence \(ANOTHER\.7\), references mandatory",
@@ -321,7 +317,7 @@ class TestExtract(unittest.TestCase):
         """Test compound location with reference to another sequence."""
         parent_sequence = Seq.Seq("aaccaaccaaccaaccaa")
         another_sequence = Seq.Seq("ttggttggttggttggtt")
-        location = FeatureLocation(2, 6) + FeatureLocation(5, 8, ref="ANOTHER.7")
+        location = SimpleLocation(2, 6) + SimpleLocation(5, 8, ref="ANOTHER.7")
         sequence = location.extract(
             parent_sequence, references={"ANOTHER.7": another_sequence}
         )

--- a/Tests/test_SeqIO_Insdc.py
+++ b/Tests/test_SeqIO_Insdc.py
@@ -9,7 +9,7 @@ from io import StringIO
 
 from Bio import SeqIO
 from Bio.Seq import Seq
-from Bio.SeqFeature import FeatureLocation
+from Bio.SeqFeature import SimpleLocation
 from Bio.SeqFeature import SeqFeature
 from Bio.SeqRecord import SeqRecord
 from seq_tests_common import SeqRecordTestBaseClass
@@ -59,7 +59,7 @@ class TestEmbl(unittest.TestCase):
 
     def test_writing_empty_qualifiers(self):
         f = SeqFeature(
-            FeatureLocation(5, 20, strand=+1),
+            SimpleLocation(5, 20, strand=+1),
             type="region",
             qualifiers={"empty": None, "zero": 0, "one": 1, "text": "blah"},
         )

--- a/Tests/test_SeqIO_Xdna.py
+++ b/Tests/test_SeqIO_Xdna.py
@@ -13,7 +13,7 @@ from Bio import BiopythonWarning
 from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqFeature import BeforePosition
-from Bio.SeqFeature import FeatureLocation
+from Bio.SeqFeature import SimpleLocation
 from Bio.SeqFeature import SeqFeature
 from Bio.SeqRecord import SeqRecord
 
@@ -203,13 +203,13 @@ class TestXdnaWriter(unittest.TestCase):
         # Fabricate a record with > 255 features
         record = SeqRecord(Seq("ACGT"))
         for i in range(260):
-            feature = SeqFeature(FeatureLocation(1, 2), type="misc_feature")
+            feature = SeqFeature(SimpleLocation(1, 2), type="misc_feature")
             record.features.append(feature)
         with self.assertWarnsRegex(BiopythonWarning, "Too many features"):
             SeqIO.write([record], h, "xdna")
 
         # Now a record with a fuzzy-located feature
-        feature = SeqFeature(FeatureLocation(BeforePosition(2), 3), type="misc_feature")
+        feature = SeqFeature(SimpleLocation(BeforePosition(2), 3), type="misc_feature")
         record.features = [feature]
         with self.assertWarnsRegex(
             BiopythonWarning, r"Dropping \d+ features with fuzzy locations"
@@ -219,7 +219,7 @@ class TestXdnaWriter(unittest.TestCase):
         # Now a record with a feature with a qualifier too long
         qualifiers = {"note": ["x" * 260]}
         feature = SeqFeature(
-            FeatureLocation(2, 3), type="misc_feature", qualifiers=qualifiers
+            SimpleLocation(2, 3), type="misc_feature", qualifiers=qualifiers
         )
         record.features = [feature]
         with self.assertWarnsRegex(

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -23,7 +23,7 @@ from Bio.SeqFeature import AfterPosition
 from Bio.SeqFeature import BeforePosition
 from Bio.SeqFeature import CompoundLocation
 from Bio.SeqFeature import ExactPosition
-from Bio.SeqFeature import FeatureLocation
+from Bio.SeqFeature import SimpleLocation
 from Bio.SeqFeature import OneOfPosition
 from Bio.SeqFeature import SeqFeature
 from Bio.SeqFeature import UnknownPosition
@@ -227,8 +227,8 @@ class GenBankLocations(SeqIOFeatureTestBaseClass):
         # These two are equivalent locations
         ncbi_str = "complement(join(84..283,1149..1188))"
         embl_str = "join(complement(1149..1188),complement(84..283))"
-        exon1 = FeatureLocation(1148, 1188, strand=-1)
-        exon2 = FeatureLocation(83, 283, strand=-1)
+        exon1 = SimpleLocation(1148, 1188, strand=-1)
+        exon2 = SimpleLocation(83, 283, strand=-1)
         expected_loc = exon1 + exon2
         self.check_loc(expected_loc, ncbi_str)
         self.check_loc(expected_loc, embl_str, round_trip=False)
@@ -237,32 +237,32 @@ class GenBankLocations(SeqIOFeatureTestBaseClass):
     def test_mixed_strand(self):
         # Trans-spliced example from NC_000932
         loc_str = "join(complement(69611..69724),139856..140087,140625..140650)"
-        exon1 = FeatureLocation(69610, 69724, strand=-1)
-        exon2 = FeatureLocation(139855, 140087, strand=+1)
-        exon3 = FeatureLocation(140624, 140650, strand=+1)
+        exon1 = SimpleLocation(69610, 69724, strand=-1)
+        exon2 = SimpleLocation(139855, 140087, strand=+1)
+        exon3 = SimpleLocation(140624, 140650, strand=+1)
         expected_loc = exon1 + exon2 + exon3
         self.check_loc(expected_loc, loc_str)
         # Made up example putting reverse-complement exon in middle,
         loc_str = "join(69611..69724,complement(139856..140087),140625..140650)"
-        exon1 = FeatureLocation(69610, 69724, strand=+1)
-        exon2 = FeatureLocation(139855, 140087, strand=-1)
-        exon3 = FeatureLocation(140624, 140650, strand=+1)
+        exon1 = SimpleLocation(69610, 69724, strand=+1)
+        exon2 = SimpleLocation(139855, 140087, strand=-1)
+        exon3 = SimpleLocation(140624, 140650, strand=+1)
         expected_loc = exon1 + exon2 + exon3
         self.check_loc(expected_loc, loc_str)
         # Made up example putting reverse-complement exon at end,
         loc_str = "join(69611..69724,139856..140087,complement(140625..140650))"
-        exon1 = FeatureLocation(69610, 69724, strand=+1)
-        exon2 = FeatureLocation(139855, 140087, strand=+1)
-        exon3 = FeatureLocation(140624, 140650, strand=-1)
+        exon1 = SimpleLocation(69610, 69724, strand=+1)
+        exon2 = SimpleLocation(139855, 140087, strand=+1)
+        exon3 = SimpleLocation(140624, 140650, strand=-1)
         expected_loc = exon1 + exon2 + exon3
         self.check_loc(expected_loc, loc_str)
         # Another made up example
         loc_str = (
             "join(complement(69611..69724),139856..140087,complement(140625..140650))"
         )
-        exon1 = FeatureLocation(69610, 69724, strand=-1)
-        exon2 = FeatureLocation(139855, 140087, strand=+1)
-        exon3 = FeatureLocation(140624, 140650, strand=-1)
+        exon1 = SimpleLocation(69610, 69724, strand=-1)
+        exon2 = SimpleLocation(139855, 140087, strand=+1)
+        exon3 = SimpleLocation(140624, 140650, strand=-1)
         expected_loc = exon1 + exon2 + exon3
         self.check_loc(expected_loc, loc_str)
 
@@ -329,7 +329,7 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
     def test_simple_rna(self):
         """Feature on RNA (simple, default strand)."""
         s = Seq("GAUCRYWSMKHBVDN")
-        f = SeqFeature(FeatureLocation(5, 10))
+        f = SeqFeature(SimpleLocation(5, 10))
         self.assertIsNone(f.strand)
         self.assertIsNone(f.location.strand)
         self.check(s, f, "YWSMK", "6..10")
@@ -337,43 +337,43 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
     def test_simple_dna(self):
         """Feature on DNA (simple, default strand)."""
         s = Seq("GATCRYWSMKHBVDN")
-        f = SeqFeature(FeatureLocation(5, 10))
+        f = SeqFeature(SimpleLocation(5, 10))
         self.check(s, f, "YWSMK", "6..10")
 
     def test_single_letter_dna(self):
         """Feature on DNA (single letter, default strand)."""
         s = Seq("GATCRYWSMKHBVDN")
-        f = SeqFeature(FeatureLocation(5, 6))
+        f = SeqFeature(SimpleLocation(5, 6))
         self.check(s, f, "Y", "6")
 
     def test_zero_len_dna(self):
         """Feature on DNA (between location, zero length, default strand)."""
         s = Seq("GATCRYWSMKHBVDN")
-        f = SeqFeature(FeatureLocation(5, 5))
+        f = SeqFeature(SimpleLocation(5, 5))
         self.check(s, f, "", "5^6")
 
     def test_zero_len_dna_end(self):
         """Feature on DNA (between location at end, zero length, default strand)."""
         s = Seq("GATCRYWSMKHBVDN")
-        f = SeqFeature(FeatureLocation(15, 15))
+        f = SeqFeature(SimpleLocation(15, 15))
         self.check(s, f, "", "15^1")
 
     def test_simple_dna_strand0(self):
         """Feature on DNA (simple, strand 0)."""
         s = Seq("GATCRYWSMKHBVDN")
-        f = SeqFeature(FeatureLocation(5, 10, strand=0))
+        f = SeqFeature(SimpleLocation(5, 10, strand=0))
         self.check(s, f, "YWSMK", "6..10")
 
     def test_simple_dna_strand_none(self):
         """Feature on DNA (simple, strand None)."""
         s = Seq("GATCRYWSMKHBVDN")
-        f = SeqFeature(FeatureLocation(5, 10), strand=None)
+        f = SeqFeature(SimpleLocation(5, 10), strand=None)
         self.check(s, f, "YWSMK", "6..10")
 
     def test_simple_dna_strand1(self):
         """Feature on DNA (simple, strand +1)."""
         s = Seq("GATCRYWSMKHBVDN")
-        f = SeqFeature(FeatureLocation(5, 10, strand=1))
+        f = SeqFeature(SimpleLocation(5, 10, strand=1))
         self.assertEqual(f.strand, +1)
         self.assertEqual(f.location.strand, +1)
         self.check(s, f, "YWSMK", "6..10")
@@ -381,7 +381,7 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
     def test_simple_dna_strand_minus(self):
         """Feature on DNA (simple, strand -1)."""
         s = Seq("GATCRYWSMKHBVDN")
-        f = SeqFeature(FeatureLocation(5, 10, strand=-1))
+        f = SeqFeature(SimpleLocation(5, 10, strand=-1))
         self.assertEqual(f.strand, -1)
         self.assertEqual(f.location.strand, -1)
         self.check(s, f, "MKSWR", "complement(6..10)")
@@ -389,16 +389,16 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
     def test_simple_dna_join(self):
         """Feature on DNA (join, strand +1)."""
         s = Seq("GATCRYWSMKHBVDN")
-        f1 = SeqFeature(FeatureLocation(5, 10, strand=1))
-        f2 = SeqFeature(FeatureLocation(12, 15, strand=1))
+        f1 = SeqFeature(SimpleLocation(5, 10, strand=1))
+        f2 = SeqFeature(SimpleLocation(12, 15, strand=1))
         f = make_join_feature([f1, f2])
         self.check(s, f, "YWSMKVDN", "join(6..10,13..15)")
 
     def test_simple_dna_join_strand_minus(self):
         """Feature on DNA (join, strand -1)."""
         s = Seq("AAAAACCCCCTTTTTGGGGG")
-        f1 = SeqFeature(FeatureLocation(5, 10, strand=-1))
-        f2 = SeqFeature(FeatureLocation(12, 15, strand=-1))
+        f1 = SeqFeature(SimpleLocation(5, 10, strand=-1))
+        f2 = SeqFeature(SimpleLocation(12, 15, strand=-1))
         f = make_join_feature([f1, f2])
         self.check(
             s, f, reverse_complement("CCCCCTTT"), "complement(join(6..10,13..15))"
@@ -407,8 +407,8 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
     def test_simple_dna_join_before(self):
         """Feature on DNA (join, strand -1, before position)."""
         s = Seq("AAAAACCCCCTTTTTGGGGG")
-        f1 = SeqFeature(FeatureLocation(BeforePosition(5), 10, strand=-1))
-        f2 = SeqFeature(FeatureLocation(12, 15, strand=-1))
+        f1 = SeqFeature(SimpleLocation(BeforePosition(5), 10, strand=-1))
+        f2 = SeqFeature(SimpleLocation(12, 15, strand=-1))
         f = make_join_feature([f1, f2])
         self.check(
             s, f, reverse_complement("CCCCCTTT"), "complement(join(<6..10,13..15))"
@@ -417,8 +417,8 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
     def test_simple_dna_join_after(self):
         """Feature on DNA (join, strand -1, after position)."""
         s = Seq("AAAAACCCCCTTTTTGGGGG")
-        f1 = SeqFeature(FeatureLocation(5, 10, strand=-1))
-        f2 = SeqFeature(FeatureLocation(12, AfterPosition(15), strand=-1))
+        f1 = SeqFeature(SimpleLocation(5, 10, strand=-1))
+        f2 = SeqFeature(SimpleLocation(12, AfterPosition(15), strand=-1))
         f = make_join_feature([f1, f2])
         self.check(
             s, f, reverse_complement("CCCCCTTT"), "complement(join(6..10,13..>15))"
@@ -427,8 +427,8 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
     def test_mixed_strand_dna_join(self):
         """Feature on DNA (join, mixed strand)."""
         s = Seq("AAAAACCCCCTTTTTGGGGG")
-        f1 = SeqFeature(FeatureLocation(5, 10, strand=+1))
-        f2 = SeqFeature(FeatureLocation(12, 15, strand=-1))
+        f1 = SeqFeature(SimpleLocation(5, 10, strand=+1))
+        f2 = SeqFeature(SimpleLocation(12, 15, strand=-1))
         f = make_join_feature([f1, f2])
         self.check(
             s, f, "CCCCC" + reverse_complement("TTT"), "join(6..10,complement(13..15))"
@@ -437,9 +437,9 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
     def test_mixed_strand_dna_multi_join(self):
         """Feature on DNA (multi-join, mixed strand)."""
         s = Seq("AAAAACCCCCTTTTTGGGGG")
-        f1 = SeqFeature(FeatureLocation(5, 10, strand=+1))
-        f2 = SeqFeature(FeatureLocation(12, 15, strand=-1))
-        f3 = SeqFeature(FeatureLocation(BeforePosition(0), 5, strand=+1))
+        f1 = SeqFeature(SimpleLocation(5, 10, strand=+1))
+        f2 = SeqFeature(SimpleLocation(12, 15, strand=-1))
+        f3 = SeqFeature(SimpleLocation(BeforePosition(0), 5, strand=+1))
         f = make_join_feature([f1, f2, f3])
         self.check(
             s,
@@ -451,23 +451,23 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
     def test_protein_simple(self):
         """Feature on protein (simple)."""
         s = Seq("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-        f = SeqFeature(FeatureLocation(5, 10))
+        f = SeqFeature(SimpleLocation(5, 10))
         self.check(s, f, "FGHIJ", "6..10")
 
     def test_protein_join(self):
         """Feature on protein (join)."""
         s = Seq("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-        f1 = SeqFeature(FeatureLocation(5, 10))
-        f2 = SeqFeature(FeatureLocation(15, 20))
+        f1 = SeqFeature(SimpleLocation(5, 10))
+        f2 = SeqFeature(SimpleLocation(15, 20))
         f = make_join_feature([f1, f2])
         self.check(s, f, "FGHIJPQRST", "join(6..10,16..20)")
 
     def test_protein_join_fuzzy(self):
         """Feature on protein (fuzzy join)."""
         s = Seq("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-        f1 = SeqFeature(FeatureLocation(BeforePosition(5), 10))
+        f1 = SeqFeature(SimpleLocation(BeforePosition(5), 10))
         f2 = SeqFeature(
-            FeatureLocation(
+            SimpleLocation(
                 OneOfPosition(15, (ExactPosition(15), ExactPosition(16))),
                 AfterPosition(20),
             )
@@ -478,21 +478,21 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
     def test_protein_multi_join(self):
         """Feature on protein (multi-join)."""
         s = Seq("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-        f1 = SeqFeature(FeatureLocation(1, 2))
-        f2 = SeqFeature(FeatureLocation(8, 9))
-        f3 = SeqFeature(FeatureLocation(14, 16))
-        f4 = SeqFeature(FeatureLocation(24, 25))
-        f5 = SeqFeature(FeatureLocation(19, 20))
-        f6 = SeqFeature(FeatureLocation(7, 8))
-        f7 = SeqFeature(FeatureLocation(14, 15))
-        f8 = SeqFeature(FeatureLocation(13, 14))
+        f1 = SeqFeature(SimpleLocation(1, 2))
+        f2 = SeqFeature(SimpleLocation(8, 9))
+        f3 = SeqFeature(SimpleLocation(14, 16))
+        f4 = SeqFeature(SimpleLocation(24, 25))
+        f5 = SeqFeature(SimpleLocation(19, 20))
+        f6 = SeqFeature(SimpleLocation(7, 8))
+        f7 = SeqFeature(SimpleLocation(14, 15))
+        f8 = SeqFeature(SimpleLocation(13, 14))
         f = make_join_feature([f1, f2, f3, f4, f5, f6, f7, f8])
         self.check(s, f, "BIOPYTHON", "join(2,9,15..16,25,20,8,15,14)")
 
     def test_protein_between(self):
         """Feature on protein (between location, zero length)."""
         s = Seq("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
-        f = SeqFeature(FeatureLocation(5, 5))
+        f = SeqFeature(SimpleLocation(5, 5))
         self.check(s, f, "", "5^6")
 
     def test_protein_oneof(self):
@@ -500,11 +500,11 @@ class SeqFeatureExtractionWritingReading(SeqIOFeatureTestBaseClass):
         s = Seq("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
         start = OneOfPosition(5, (ExactPosition(5), ExactPosition(7)))
         end = OneOfPosition(11, (ExactPosition(10), ExactPosition(11)))
-        f = SeqFeature(FeatureLocation(start, 10))
+        f = SeqFeature(SimpleLocation(start, 10))
         self.check(s, f, "FGHIJ", "one-of(6,8)..10")
-        f = SeqFeature(FeatureLocation(start, end))
+        f = SeqFeature(SimpleLocation(start, end))
         self.check(s, f, "FGHIJK", "one-of(6,8)..one-of(10,11)")
-        f = SeqFeature(FeatureLocation(5, end))
+        f = SeqFeature(SimpleLocation(5, end))
         self.check(s, f, "FGHIJK", "6..one-of(10,11)")
 
 
@@ -513,10 +513,10 @@ class SeqFeatureCreation(unittest.TestCase):
 
     def test_qualifiers(self):
         """Pass in qualifiers to SeqFeatures."""
-        f = SeqFeature(FeatureLocation(10, 20, strand=+1), type="CDS")
+        f = SeqFeature(SimpleLocation(10, 20, strand=+1), type="CDS")
         self.assertEqual(f.qualifiers, {})
         f = SeqFeature(
-            FeatureLocation(10, 20, strand=+1),
+            SimpleLocation(10, 20, strand=+1),
             type="CDS",
             qualifiers={"test": ["a test"]},
         )
@@ -545,14 +545,14 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         """GenBank/EMBL write/read simple exact locations."""
         # Note we don't have to explicitly give an ExactPosition object,
         # an integer will also work:
-        f = SeqFeature(FeatureLocation(10, 20, strand=+1), type="CDS")
+        f = SeqFeature(SimpleLocation(10, 20, strand=+1), type="CDS")
         self.assertEqual(_get_location_string(f, 100), "11..20")
         self.assertEqual(_get_location_string(f._flip(20), 20), "complement(1..10)")
         self.assertEqual(_get_location_string(f._flip(100), 100), "complement(81..90)")
         self.assertEqual(f._flip(100).strand, -1)
         self.record.features.append(f)
 
-        f = SeqFeature(FeatureLocation(30, 40, strand=-1), type="CDS")
+        f = SeqFeature(SimpleLocation(30, 40, strand=-1), type="CDS")
         self.assertEqual(_get_location_string(f, 100), "complement(31..40)")
         self.assertEqual(_get_location_string(f._flip(40), 40), "1..10")
         self.assertEqual(_get_location_string(f._flip(100), 100), "61..70")
@@ -560,7 +560,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.record.features.append(f)
 
         f = SeqFeature(
-            FeatureLocation(ExactPosition(50), ExactPosition(60), strand=+1),
+            SimpleLocation(ExactPosition(50), ExactPosition(60), strand=+1),
             type="CDS",
         )
         self.assertEqual(_get_location_string(f, 100), "51..60")
@@ -574,7 +574,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         # limitations of the GenBank (and EMBL) feature location scheme
         for s in [0, None]:
             # Check flipping of a simple strand 0 feature:
-            f = SeqFeature(FeatureLocation(0, 100, strand=s), type="source")
+            f = SeqFeature(SimpleLocation(0, 100, strand=s), type="source")
             self.assertEqual(_get_location_string(f, 100), "1..100")
             self.assertEqual(_get_location_string(f._flip(100), 100), "1..100")
             self.assertEqual(_get_location_string(f._flip(200), 200), "101..200")
@@ -583,13 +583,13 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
     def test_between(self):
         """GenBank/EMBL write/read simple between locations."""
         # Note we don't use the BetweenPosition any more!
-        f = SeqFeature(FeatureLocation(10, 10, strand=+1), type="variation")
+        f = SeqFeature(SimpleLocation(10, 10, strand=+1), type="variation")
         self.assertEqual(_get_location_string(f, 100), "10^11")
         self.assertEqual(_get_location_string(f._flip(20), 20), "complement(10^11)")
         self.assertEqual(_get_location_string(f._flip(100), 100), "complement(90^91)")
         self.assertEqual(f._flip(100).strand, -1)
         self.record.features.append(f)
-        f = SeqFeature(FeatureLocation(20, 20, strand=-1), type="variation")
+        f = SeqFeature(SimpleLocation(20, 20, strand=-1), type="variation")
         self.assertEqual(_get_location_string(f, 100), "complement(20^21)")
         self.assertEqual(_get_location_string(f._flip(40), 40), "20^21")
         self.assertEqual(_get_location_string(f._flip(100), 100), "80^81")
@@ -599,21 +599,21 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
 
     def test_unknown(self):
         """GenBank/EMBL write/read with unknown end points."""
-        f = SeqFeature(FeatureLocation(10, 15, strand=+1), type="region")
+        f = SeqFeature(SimpleLocation(10, 15, strand=+1), type="region")
         self.assertEqual(_get_location_string(f, 100), "11..15")
         self.record.features.append(f)
-        f = SeqFeature(FeatureLocation(10, UnknownPosition(), strand=+1), type="region")
+        f = SeqFeature(SimpleLocation(10, UnknownPosition(), strand=+1), type="region")
         self.assertEqual(_get_location_string(f, 100), "11..>11")
         self.record.features.append(f)
-        f = SeqFeature(FeatureLocation(UnknownPosition(), 15, strand=+1), type="region")
+        f = SeqFeature(SimpleLocation(UnknownPosition(), 15, strand=+1), type="region")
         self.assertEqual(_get_location_string(f, 100), "<15..15")
         self.record.features.append(f)
-        f = SeqFeature(FeatureLocation(10, 15, strand=-1), type="region")
+        f = SeqFeature(SimpleLocation(10, 15, strand=-1), type="region")
         self.assertEqual(_get_location_string(f, 100), "complement(11..15)")
-        f = SeqFeature(FeatureLocation(10, UnknownPosition(), strand=-1), type="region")
+        f = SeqFeature(SimpleLocation(10, UnknownPosition(), strand=-1), type="region")
         self.assertEqual(_get_location_string(f, 100), "complement(11..>11)")
         self.record.features.append(f)
-        f = SeqFeature(FeatureLocation(UnknownPosition(), 15, strand=-1), type="region")
+        f = SeqFeature(SimpleLocation(UnknownPosition(), 15, strand=-1), type="region")
         self.assertEqual(_get_location_string(f, 100), "complement(<15..15)")
         self.record.features.append(f)
         # This doesn't round trip
@@ -621,8 +621,8 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
 
     def test_join(self):
         """GenBank/EMBL write/read simple join locations."""
-        f1 = SeqFeature(FeatureLocation(10, 20, strand=+1))
-        f2 = SeqFeature(FeatureLocation(25, 40, strand=+1))
+        f1 = SeqFeature(SimpleLocation(10, 20, strand=+1))
+        f2 = SeqFeature(SimpleLocation(25, 40, strand=+1))
         f = make_join_feature([f1, f2])
         self.record.features.append(f)
         self.assertEqual(_get_location_string(f, 500), "join(11..20,26..40)")
@@ -635,9 +635,9 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.assertEqual(f._flip(100).strand, -1)
         for sub_loc in f._flip(100).location.parts:
             self.assertEqual(sub_loc.strand, -1)
-        f1 = SeqFeature(FeatureLocation(110, 120, strand=+1))
-        f2 = SeqFeature(FeatureLocation(125, 140, strand=+1))
-        f3 = SeqFeature(FeatureLocation(145, 150, strand=+1))
+        f1 = SeqFeature(SimpleLocation(110, 120, strand=+1))
+        f2 = SeqFeature(SimpleLocation(125, 140, strand=+1))
+        f3 = SeqFeature(SimpleLocation(145, 150, strand=+1))
         f = make_join_feature([f1, f2, f3], "CDS")
         self.assertEqual(
             _get_location_string(f, 500), "join(111..120,126..140,146..150)"
@@ -651,8 +651,8 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         for sub_loc in f._flip(100).location.parts:
             self.assertEqual(sub_loc.strand, -1)
         self.record.features.append(f)
-        f1 = SeqFeature(FeatureLocation(210, 220, strand=-1))
-        f2 = SeqFeature(FeatureLocation(225, 240, strand=-1))
+        f1 = SeqFeature(SimpleLocation(210, 220, strand=-1))
+        f2 = SeqFeature(SimpleLocation(225, 240, strand=-1))
         f = make_join_feature([f1, f2], ftype="gene")
         self.assertEqual(
             _get_location_string(f, 500), "complement(join(211..220,226..240))"
@@ -663,9 +663,9 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         for sub_loc in f._flip(100).location.parts:
             self.assertEqual(sub_loc.strand, +1)
         self.record.features.append(f)
-        f1 = SeqFeature(FeatureLocation(310, 320, strand=-1))
-        f2 = SeqFeature(FeatureLocation(325, 340, strand=-1))
-        f3 = SeqFeature(FeatureLocation(345, 350, strand=-1))
+        f1 = SeqFeature(SimpleLocation(310, 320, strand=-1))
+        f2 = SeqFeature(SimpleLocation(325, 340, strand=-1))
+        f3 = SeqFeature(SimpleLocation(345, 350, strand=-1))
         f = make_join_feature([f1, f2, f3], "CDS")
         self.assertEqual(
             _get_location_string(f, 500), "complement(join(311..320,326..340,346..350))"
@@ -682,8 +682,8 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
     def test_fuzzy_join(self):
         """Features: write/read fuzzy join locations."""
         s = "N" * 500
-        f1 = SeqFeature(FeatureLocation(BeforePosition(10), 20, strand=+1))
-        f2 = SeqFeature(FeatureLocation(25, AfterPosition(40), strand=+1))
+        f1 = SeqFeature(SimpleLocation(BeforePosition(10), 20, strand=+1))
+        f2 = SeqFeature(SimpleLocation(25, AfterPosition(40), strand=+1))
         f = make_join_feature([f1, f2])
         self.record.features.append(f)
         self.assertEqual(_get_location_string(f, 500), "join(<11..20,26..>40)")
@@ -699,15 +699,15 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
             self.assertEqual(sub_loc.strand, -1)
 
         f1 = SeqFeature(
-            FeatureLocation(
+            SimpleLocation(
                 OneOfPosition(107, [ExactPosition(107), ExactPosition(110)]),
                 120,
                 strand=+1,
             ),
         )
-        f2 = SeqFeature(FeatureLocation(125, 140, strand=+1))
+        f2 = SeqFeature(SimpleLocation(125, 140, strand=+1))
         f3 = SeqFeature(
-            FeatureLocation(145, WithinPosition(160, left=150, right=160), strand=+1)
+            SimpleLocation(145, WithinPosition(160, left=150, right=160), strand=+1)
         )
         f = make_join_feature([f1, f2, f3], "CDS")
         self.assertEqual(
@@ -728,9 +728,9 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
             self.assertEqual(sub_loc.strand, -1)
         self.record.features.append(f)
 
-        f1 = SeqFeature(FeatureLocation(BeforePosition(210), 220, strand=-1))
+        f1 = SeqFeature(SimpleLocation(BeforePosition(210), 220, strand=-1))
         f2 = SeqFeature(
-            FeatureLocation(225, WithinPosition(244, left=240, right=244), strand=-1)
+            SimpleLocation(225, WithinPosition(244, left=240, right=244), strand=-1)
         )
         f = make_join_feature([f1, f2], "gene")
         self.assertEqual(
@@ -749,12 +749,12 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
             self.assertEqual(sub_loc.strand, +1)
         self.record.features.append(f)
 
-        f1 = SeqFeature(FeatureLocation(AfterPosition(310), 320, strand=-1))
+        f1 = SeqFeature(SimpleLocation(AfterPosition(310), 320, strand=-1))
         # Note - is one-of(340,337) allowed or should it be one-of(337,340)?
         pos = OneOfPosition(340, [ExactPosition(340), ExactPosition(337)])
-        f2 = SeqFeature(FeatureLocation(325, pos, strand=-1))
+        f2 = SeqFeature(SimpleLocation(325, pos, strand=-1))
         f3 = SeqFeature(
-            FeatureLocation(345, WithinPosition(355, left=350, right=355), strand=-1)
+            SimpleLocation(345, WithinPosition(355, left=350, right=355), strand=-1)
         )
         f = make_join_feature([f1, f2, f3], "CDS")
         self.assertEqual(
@@ -778,7 +778,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
     def test_before(self):
         """Features: write/read simple before locations."""
         s = "N" * 200
-        f = SeqFeature(FeatureLocation(BeforePosition(5), 10, strand=+1), type="CDS")
+        f = SeqFeature(SimpleLocation(BeforePosition(5), 10, strand=+1), type="CDS")
         self.assertEqual(_get_location_string(f, 100), "<6..10")
         self.assertEqual(len(f), len(f.extract(s)))
         self.assertEqual(_get_location_string(f._flip(20), 20), "complement(11..>15)")
@@ -787,7 +787,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.record.features.append(f)
 
         f = SeqFeature(
-            FeatureLocation(BeforePosition(15), BeforePosition(20), strand=+1),
+            SimpleLocation(BeforePosition(15), BeforePosition(20), strand=+1),
             type="CDS",
         )
         self.assertEqual(_get_location_string(f, 100), "<16..<20")
@@ -797,7 +797,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.assertEqual(f._flip(100).strand, -1)
         self.record.features.append(f)
 
-        f = SeqFeature(FeatureLocation(25, BeforePosition(30), strand=+1), type="CDS")
+        f = SeqFeature(SimpleLocation(25, BeforePosition(30), strand=+1), type="CDS")
         self.assertEqual(_get_location_string(f, 100), "26..<30")
         self.assertEqual(len(f), len(f.extract(s)))
         self.assertEqual(_get_location_string(f._flip(40), 40), "complement(>11..15)")
@@ -805,7 +805,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.assertEqual(f._flip(100).strand, -1)
         self.record.features.append(f)
 
-        f = SeqFeature(FeatureLocation(BeforePosition(35), 40, strand=-1), type="CDS")
+        f = SeqFeature(SimpleLocation(BeforePosition(35), 40, strand=-1), type="CDS")
         self.assertEqual(_get_location_string(f, 100), "complement(<36..40)")
         self.assertEqual(len(f), len(f.extract(s)))
         self.assertEqual(_get_location_string(f._flip(40), 40), "1..>5")
@@ -814,7 +814,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.record.features.append(f)
 
         f = SeqFeature(
-            FeatureLocation(BeforePosition(45), BeforePosition(50), strand=-1),
+            SimpleLocation(BeforePosition(45), BeforePosition(50), strand=-1),
             type="CDS",
         )
         self.assertEqual(_get_location_string(f, 100), "complement(<46..<50)")
@@ -824,7 +824,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.assertEqual(f._flip(100).strand, +1)
         self.record.features.append(f)
 
-        f = SeqFeature(FeatureLocation(55, BeforePosition(60), strand=-1), type="CDS")
+        f = SeqFeature(SimpleLocation(55, BeforePosition(60), strand=-1), type="CDS")
         self.assertEqual(_get_location_string(f, 100), "complement(56..<60)")
         self.assertEqual(len(f), len(f.extract(s)))
         self.assertEqual(_get_location_string(f._flip(100), 100), ">41..45")
@@ -837,7 +837,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
     def test_after(self):
         """Features: write/read simple after locations."""
         s = "N" * 200
-        f = SeqFeature(FeatureLocation(AfterPosition(5), 10, strand=+1), type="CDS")
+        f = SeqFeature(SimpleLocation(AfterPosition(5), 10, strand=+1), type="CDS")
         self.assertEqual(_get_location_string(f, 100), ">6..10")
         self.assertEqual(len(f), len(f.extract(s)))
         self.assertEqual(_get_location_string(f._flip(100), 100), "complement(91..<95)")
@@ -846,7 +846,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.record.features.append(f)
 
         f = SeqFeature(
-            FeatureLocation(AfterPosition(15), AfterPosition(20), strand=+1),
+            SimpleLocation(AfterPosition(15), AfterPosition(20), strand=+1),
             type="CDS",
         )
         self.assertEqual(_get_location_string(f, 100), ">16..>20")
@@ -856,7 +856,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.assertEqual(f._flip(100).strand, -1)
         self.record.features.append(f)
 
-        f = SeqFeature(FeatureLocation(25, AfterPosition(30), strand=+1), type="CDS")
+        f = SeqFeature(SimpleLocation(25, AfterPosition(30), strand=+1), type="CDS")
         self.assertEqual(_get_location_string(f, 100), "26..>30")
         self.assertEqual(len(f), len(f.extract(s)))
         self.assertEqual(_get_location_string(f._flip(30), 30), "complement(<1..5)")
@@ -864,7 +864,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.assertEqual(f._flip(100).strand, -1)
         self.record.features.append(f)
 
-        f = SeqFeature(FeatureLocation(AfterPosition(35), 40, strand=-1), type="CDS")
+        f = SeqFeature(SimpleLocation(AfterPosition(35), 40, strand=-1), type="CDS")
         self.assertEqual(_get_location_string(f, 100), "complement(>36..40)")
         self.assertEqual(len(f), len(f.extract(s)))
         self.assertEqual(_get_location_string(f._flip(100), 100), "61..<65")
@@ -873,7 +873,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.record.features.append(f)
 
         f = SeqFeature(
-            FeatureLocation(AfterPosition(45), AfterPosition(50), strand=-1),
+            SimpleLocation(AfterPosition(45), AfterPosition(50), strand=-1),
             type="CDS",
         )
         self.assertEqual(_get_location_string(f, 100), "complement(>46..>50)")
@@ -883,7 +883,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.assertEqual(f._flip(100).strand, +1)
         self.record.features.append(f)
 
-        f = SeqFeature(FeatureLocation(55, AfterPosition(60), strand=-1), type="CDS")
+        f = SeqFeature(SimpleLocation(55, AfterPosition(60), strand=-1), type="CDS")
         self.assertEqual(_get_location_string(f, 100), "complement(56..>60)")
         self.assertEqual(len(f), len(f.extract(s)))
         self.assertEqual(_get_location_string(f._flip(100), 100), "<41..45")
@@ -897,7 +897,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         """Features: write/read simple one-of locations."""
         s = "N" * 100
         start = OneOfPosition(0, [ExactPosition(0), ExactPosition(3), ExactPosition(6)])
-        f = SeqFeature(FeatureLocation(start, 21, strand=+1), type="CDS")
+        f = SeqFeature(SimpleLocation(start, 21, strand=+1), type="CDS")
         self.assertEqual(_get_location_string(f, 100), "one-of(1,4,7)..21")
         self.assertEqual(len(f), len(f.extract(s)))
         self.assertEqual(
@@ -909,7 +909,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
 
         start = OneOfPosition(10, [ExactPosition(x) for x in [10, 13, 16]])
         end = OneOfPosition(50, [ExactPosition(x) for x in [41, 44, 50]])
-        f = SeqFeature(FeatureLocation(start, end, strand=+1), type="gene")
+        f = SeqFeature(SimpleLocation(start, end, strand=+1), type="gene")
         self.assertEqual(
             _get_location_string(f, 100), "one-of(11,14,17)..one-of(41,44,50)"
         )
@@ -923,7 +923,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.record.features.append(f)
 
         end = OneOfPosition(33, [ExactPosition(x) for x in [30, 33]])
-        f = SeqFeature(FeatureLocation(27, end, strand=+1), type="gene")
+        f = SeqFeature(SimpleLocation(27, end, strand=+1), type="gene")
         self.assertEqual(_get_location_string(f, 100), "28..one-of(30,33)")
         self.assertEqual(len(f), len(f.extract(s)))
         self.assertEqual(
@@ -934,7 +934,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.record.features.append(f)
 
         start = OneOfPosition(36, [ExactPosition(x) for x in [36, 40]])
-        f = SeqFeature(FeatureLocation(start, 46, strand=-1), type="CDS")
+        f = SeqFeature(SimpleLocation(start, 46, strand=-1), type="CDS")
         self.assertEqual(_get_location_string(f, 100), "complement(one-of(37,41)..46)")
         self.assertEqual(len(f), len(f.extract(s)))
         self.assertEqual(_get_location_string(f._flip(50), 50), "5..one-of(10,14)")
@@ -944,7 +944,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
 
         start = OneOfPosition(45, [ExactPosition(x) for x in [45, 60]])
         end = OneOfPosition(90, [ExactPosition(x) for x in [70, 90]])
-        f = SeqFeature(FeatureLocation(start, end, strand=-1), type="CDS")
+        f = SeqFeature(SimpleLocation(start, end, strand=-1), type="CDS")
         self.assertEqual(
             _get_location_string(f, 100), "complement(one-of(46,61)..one-of(70,90))"
         )
@@ -957,7 +957,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.record.features.append(f)
 
         end = OneOfPosition(63, [ExactPosition(x) for x in [60, 63]])
-        f = SeqFeature(FeatureLocation(55, end, strand=-1), type="tRNA")
+        f = SeqFeature(SimpleLocation(55, end, strand=-1), type="tRNA")
         self.assertEqual(_get_location_string(f, 100), "complement(56..one-of(60,63))")
         self.assertEqual(len(f), len(f.extract(s)))
         self.assertEqual(_get_location_string(f._flip(100), 100), "one-of(38,41)..45")
@@ -971,7 +971,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         """Features: write/read simple within locations."""
         s = "N" * 100
         f = SeqFeature(
-            FeatureLocation(WithinPosition(2, left=2, right=8), 10, strand=+1),
+            SimpleLocation(WithinPosition(2, left=2, right=8), 10, strand=+1),
             type="CDS",
         )
         self.assertEqual(_get_location_string(f, 100), "(3.9)..10")
@@ -984,7 +984,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.record.features.append(f)
 
         f = SeqFeature(
-            FeatureLocation(
+            SimpleLocation(
                 WithinPosition(12, left=12, right=18),
                 WithinPosition(28, left=20, right=28),
                 strand=+1,
@@ -1001,7 +1001,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.record.features.append(f)
 
         f = SeqFeature(
-            FeatureLocation(25, WithinPosition(33, left=30, right=33), strand=+1),
+            SimpleLocation(25, WithinPosition(33, left=30, right=33), strand=+1),
             type="misc_feature",
         )
         self.assertEqual(_get_location_string(f, 100), "26..(30.33)")
@@ -1014,7 +1014,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.record.features.append(f)
 
         f = SeqFeature(
-            FeatureLocation(WithinPosition(35, left=35, right=39), 40, strand=-1),
+            SimpleLocation(WithinPosition(35, left=35, right=39), 40, strand=-1),
             type="rRNA",
         )
         self.assertEqual(_get_location_string(f, 100), "complement((36.40)..40)")
@@ -1024,7 +1024,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.record.features.append(f)
 
         f = SeqFeature(
-            FeatureLocation(
+            SimpleLocation(
                 WithinPosition(45, left=45, right=47),
                 WithinPosition(53, left=50, right=53),
                 strand=-1,
@@ -1039,7 +1039,7 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
         self.record.features.append(f)
 
         f = SeqFeature(
-            FeatureLocation(55, WithinPosition(65, left=60, right=65), strand=-1),
+            SimpleLocation(55, WithinPosition(65, left=60, right=65), strand=-1),
             type="CDS",
         )
         self.assertEqual(_get_location_string(f, 100), "complement(56..(60.65))")

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -20,7 +20,7 @@ from Bio.Seq import Seq
 from Bio.SeqFeature import AfterPosition
 from Bio.SeqFeature import BeforePosition
 from Bio.SeqFeature import ExactPosition
-from Bio.SeqFeature import FeatureLocation
+from Bio.SeqFeature import SimpleLocation
 from Bio.SeqFeature import OneOfPosition
 from Bio.SeqFeature import SeqFeature
 from Bio.SeqFeature import WithinPosition
@@ -134,16 +134,16 @@ class SeqRecordMethods(unittest.TestCase):
 
     def setUp(self):
         f0 = SeqFeature(
-            FeatureLocation(0, 26),
+            SimpleLocation(0, 26),
             type="source",
             qualifiers={"mol_type": ["fake protein"]},
         )
-        f1 = SeqFeature(FeatureLocation(0, ExactPosition(10)))
+        f1 = SeqFeature(SimpleLocation(0, ExactPosition(10)))
         f2 = SeqFeature(
-            FeatureLocation(WithinPosition(12, left=12, right=15), BeforePosition(22))
+            SimpleLocation(WithinPosition(12, left=12, right=15), BeforePosition(22))
         )
         f3 = SeqFeature(
-            FeatureLocation(
+            SimpleLocation(
                 AfterPosition(16),
                 OneOfPosition(26, [ExactPosition(25), AfterPosition(26)]),
             )
@@ -387,7 +387,7 @@ class SeqRecordMethodsMore(unittest.TestCase):
             name="TestName",
             description="TestDescription",
             dbxrefs=["TestDbxrefs"],
-            features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
+            features=[SeqFeature(SimpleLocation(0, 3), type="Site")],
             annotations={"organism": "bombyx"},
             letter_annotations={"test": "abcd"},
         )
@@ -420,14 +420,14 @@ class SeqRecordMethodsMore(unittest.TestCase):
         )
 
         self.assertEqual(
-            "[SeqFeature(FeatureLocation(ExactPosition(1), ExactPosition(4)), type='Site')]",
+            "[SeqFeature(SimpleLocation(ExactPosition(1), ExactPosition(4)), type='Site')]",
             repr(rc.features),
         )
         rc2 = s.reverse_complement(
-            features=[SeqFeature(FeatureLocation(1, 4), type="Site")]
+            features=[SeqFeature(SimpleLocation(1, 4), type="Site")]
         )
         self.assertEqual(
-            "[SeqFeature(FeatureLocation(ExactPosition(1), ExactPosition(4)), type='Site')]",
+            "[SeqFeature(SimpleLocation(ExactPosition(1), ExactPosition(4)), type='Site')]",
             repr(rc2.features),
         )
 
@@ -456,7 +456,7 @@ class SeqRecordMethodsMore(unittest.TestCase):
             name="TestName",
             description="TestDescription",
             dbxrefs=["TestDbxrefs"],
-            features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
+            features=[SeqFeature(SimpleLocation(0, 3), type="Site")],
             annotations={"organism": "bombyx"},
             letter_annotations={"test": "abcdefghi"},
         )
@@ -546,7 +546,7 @@ class TestTranslation(unittest.TestCase):
             name="TestName",
             description="TestDescription",
             dbxrefs=["TestDbxrefs"],
-            features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
+            features=[SeqFeature(SimpleLocation(0, 3), type="Site")],
             annotations={"organism": "bombyx"},
             letter_annotations={"test": "abcdefghi"},
         )
@@ -595,7 +595,7 @@ class TestTranslation(unittest.TestCase):
             name="Bar",
             description="Baz",
             dbxrefs=["Nope"],
-            features=[SeqFeature(FeatureLocation(0, 3), type="Site")],
+            features=[SeqFeature(SimpleLocation(0, 3), type="Site")],
             annotations={"a": "team"},
             letter_annotations={"aa": ["Met", "Val"]},
         )

--- a/Tests/test_Uniprot.py
+++ b/Tests/test_Uniprot.py
@@ -45,7 +45,7 @@ class TestUniprot(SeqRecordTestBaseClass):
         self.assertEqual(len(seq_record.features), 1)
         self.assertEqual(
             repr(seq_record.features[0]),
-            "SeqFeature(FeatureLocation(ExactPosition(0), ExactPosition(116)), type='chain', id='PRO_0000377969', qualifiers=...)",
+            "SeqFeature(SimpleLocation(ExactPosition(0), ExactPosition(116)), type='chain', id='PRO_0000377969', qualifiers=...)",
         )
 
         self.assertEqual(
@@ -434,7 +434,7 @@ class TestUniprot(SeqRecordTestBaseClass):
 
         self.assertEqual(
             repr(seq_record.features[1]),
-            "SeqFeature(FeatureLocation(ExactPosition(17), ExactPosition(43)), type='propeptide', id='PRO_0000009556', qualifiers=...)",
+            "SeqFeature(SimpleLocation(ExactPosition(17), ExactPosition(43)), type='propeptide', id='PRO_0000009556', qualifiers=...)",
         )
 
         self.assertEqual(


### PR DESCRIPTION
This PR replaces duplicated code in `Bio.SwissProt._read_ft` and `Bio.GenBank._pos` by a factory function for position objects in `Bio.SeqFeature`, and removes `_make_position` from `Bio.SeqIO.SwissIO.py` as it is not being used. See #4061 ,
Probably we should do the same for `FeatureLocation` objects, but one thing at a time.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

