### PR TITLE
Fix Alignment.__repr__ if coordinates is None

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1972,6 +1972,11 @@ class Alignment:
         >>> alignment  # doctest:+ELLIPSIS
         <Alignment object (2 rows x 5 columns) at 0x...>
         """
+        if self.coordinates is None:
+            return "<%s object at 0x%x>" % (
+                self.__class__.__name__,
+                id(self),
+            )
         n, m = self.shape
         return "<%s object (%i rows x %i columns) at 0x%x>" % (
             self.__class__.__name__,

--- a/Bio/Align/tabular.py
+++ b/Bio/Align/tabular.py
@@ -188,6 +188,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 query_annotations["acc."] = column
             elif field == "query acc.ver":
                 query_annotations["acc.ver"] = column
+                if query_id is None:
+                    query_id = column
             elif field == "query length":
                 if query_size is None:
                     query_size = int(column)
@@ -223,6 +225,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 target_annotations["% coverage"] = float(column)
             elif field == "subject acc.ver":
                 target_annotations["acc.ver"] = column
+                if target_id is None:
+                    target_id = column
             elif field == "subject length":
                 target_length = int(column)
             elif field == "query seq":


### PR DESCRIPTION
In `Bio.Align`, fix `repr(alignment)` in case `alignment.coordinates` is `None`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
