### PR TITLE
deprecate title2ids

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -12,6 +12,9 @@
 
 You are expected to use this module via the Bio.SeqIO functions.
 """
+import warnings
+
+from Bio import BiopythonDeprecationWarning
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
@@ -143,9 +146,9 @@ class FastaIterator(SequenceIterator):
         Arguments:
          - source - input stream opened in text mode, or a path to a file
          - alphabet - optional alphabet, not used. Leave as None.
-         - title2ids - A function that, when given the title of the FASTA
-           file (without the beginning >), will return the id, name and
-           description (in that order) for the record as a tuple of strings.
+         - title2ids (DEPRECAATED) - A function that, when given the title of
+           the FASTA file (without the beginning >), will return the id, name
+           and description (in that order) for the record as a tuple of strings.
            If this is not given, then the entire title line will be used
            as the description, and the first word as the id and name.
 
@@ -162,7 +165,7 @@ class FastaIterator(SequenceIterator):
         alpha
         delta
 
-        However, you can supply a title2ids function to alter this:
+        However, you can supply a title2ids function to alter this (DEPRECATED):
 
         >>> def take_upper(title):
         ...     return title.split(None, 1)[0].upper(), "", title
@@ -176,9 +179,46 @@ class FastaIterator(SequenceIterator):
         ALPHA
         DELTA
 
+        Instead of title2ids, please use a generator function to modify the
+        records:
+
+        >>> def modify_records(records):
+        ...     for record in records:
+        ...         record.id = record.id.upper()
+        ...         yield record
+        ...
+        >>> with open('Fasta/dups.fasta') as handle:
+        ...     for record in modify_records(FastaIterator(handle)):
+        ...         print(record.id)
+        ...
+        ALPHA
+        BETA
+        GAMMA
+        ALPHA
+        DELTA
+
         """
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
+        if title2ids is not None:
+            warnings.warn(
+                "The title2ids argument is deprecated. Instead, please use a "
+                "generator function to modify records returned by the parser. "
+                "For example, to change the record IDs to uppercase, and "
+                "delete the description attribute, use\n"
+                "\n"
+                ">>> def modify_records(records):\n"
+                "...     for record in records:\n"
+                "...         record.id = record.id.upper()\n"
+                "...         del record.description\n"
+                "...         yield record\n"
+                "...\n"
+                ">>> with open('Fasta/dups.fasta') as handle:\n"
+                "...     for record in modify_records(FastaIterator(handle)):\n"
+                "...         print(record)\n"
+                "\n",
+                BiopythonDeprecationWarning,
+            )
         self.title2ids = title2ids
         super().__init__(source, mode="t", fmt="Fasta")
 

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -146,7 +146,7 @@ class FastaIterator(SequenceIterator):
         Arguments:
          - source - input stream opened in text mode, or a path to a file
          - alphabet - optional alphabet, not used. Leave as None.
-         - title2ids (DEPRECAATED) - A function that, when given the title of
+         - title2ids (DEPRECATED) - A function that, when given the title of
            the FASTA file (without the beginning >), will return the id, name
            and description (in that order) for the record as a tuple of strings.
            If this is not given, then the entire title line will be used

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -586,6 +586,10 @@ deprecated in Release 1.64, and removed in Release 1.67. Use function
 list(SimpleFastaParser(handle)) from Bio.SeqIO.FastaIO instead (but
 ideally convert your code to using an iterator approach).
 
+The 'title2ids' argument to FastaIterator in Bio.SeqIO.FastaIO and
+FastqPhredIterator in Bio.SeqIO.QualityIO was deprecated in Release 1.80.
+Please use a generator function to modify the records returned by the parser.
+
 Function Tm_staluc in Bio.SeqUtils.MeltingTemp was deprecated in Release 1.78,
 and removed in Release 1.80.
 

--- a/Tests/test_SeqIO_FastaIO.py
+++ b/Tests/test_SeqIO_FastaIO.py
@@ -8,6 +8,7 @@ import unittest
 
 from io import StringIO
 
+from Bio import BiopythonDeprecationWarning
 from Bio import SeqIO
 from Bio.SeqIO.FastaIO import FastaIterator
 from Bio.SeqIO.FastaIO import FastaTwoLineParser
@@ -87,8 +88,10 @@ class TitleFunctions(unittest.TestCase):
         msg = f"Test failure parsing file {filename}"
         title, seq = read_title_and_seq(filename)  # crude parser
         idn, name, descr = title_to_ids(title)
-        # First check using Bio.SeqIO.FastaIO directly with title function.
-        records = FastaIterator(filename, title2ids=title_to_ids)
+        # First check using Bio.SeqIO.FastaIO directly with title2ids function.
+        # (DEPRECATED)
+        with self.assertWarns(BiopythonDeprecationWarning):
+            records = FastaIterator(filename, title2ids=title_to_ids)
         record = next(records)
         with self.assertRaises(StopIteration):
             next(records)
@@ -108,7 +111,9 @@ class TitleFunctions(unittest.TestCase):
     def multi_check(self, filename):
         """Test parsing multi-record FASTA files."""
         msg = f"Test failure parsing file {filename}"
-        re_titled = list(FastaIterator(filename, title2ids=title_to_ids))
+        # title2ids is deprecated
+        with self.assertWarns(BiopythonDeprecationWarning):
+            re_titled = list(FastaIterator(filename, title2ids=title_to_ids))
         default = list(SeqIO.parse(filename, "fasta"))
         self.assertEqual(len(re_titled), len(default), msg=msg)
         for old, new in zip(default, re_titled):


### PR DESCRIPTION
In `FastaIterator` in `Bio.SeqIO.FastaIO` and in `FastqPhredIterator` in `Bio.SeqIO.QualityIO`, deprecate the `title2ids` argument, as this can be handled by applying a generator function to the records returned by the parser.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

