### PR TITLE
Support multi-line qualifier values

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -405,15 +405,21 @@ class _InsdcWriter(SequenceWriter):
             if len(line) <= self.MAX_WIDTH:
                 self.handle.write(line + "\n")
                 return
-            # Insert line break...
-            for index in range(
-                min(len(line) - 1, self.MAX_WIDTH), self.QUALIFIER_INDENT + 1, -1
-            ):
-                if line[index] == " ":
-                    break
-            if line[index] != " ":
-                # No nice place to break...
-                index = self.MAX_WIDTH
+            
+            max_index = min(len(line) - 1, self.MAX_WIDTH)
+            # Find a line break in the line if it exists
+            index = line[:max_index + 1].find("\n")
+            
+            if index == -1:
+                # Insert line break...
+                for index in range(
+                    max_index, self.QUALIFIER_INDENT + 1, -1
+                ):
+                    if line[index] == " ":
+                        break
+                if line[index] != " ":
+                    # No nice place to break...
+                    index = self.MAX_WIDTH
             assert index <= self.MAX_WIDTH
             self.handle.write(line[:index] + "\n")
             line = self.QUALIFIER_INDENT_STR + line[index:].lstrip()


### PR DESCRIPTION
Currently if a qualifier value is a multi-line string, SeqIO.write writes a genbank file in an incorrect format since it uses double-quotes for a multi-line qualifier value which isn't supported by the genbank file format. There are two ways to rectify this:
1. Use single quotes for qualifier values when writing a value which is a multi-line string
2. Break multi-line strings at their new-line character and use double-quotes as normal

This PR implements the second approach.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
