### PR TITLE
subclass Confidence from float and PhyloElement

### DIFF
--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -23,7 +23,7 @@ from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation
 from Bio.SeqRecord import SeqRecord
-from Bio import BiopythonWarning, BiopythonDeprecationWarning
+from Bio import BiopythonWarning
 
 from Bio.Phylo import BaseTree
 
@@ -638,10 +638,6 @@ class Confidence(float, PhyloElement):
     @property
     def value(self):
         """Return the float value of the Confidence object."""
-        warnings.warn(
-            "The ``value`` attribute is deprecated; please use ``float(self)`` instead.",
-            BiopythonDeprecationWarning,
-        )
         return float(self)
 
 

--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -23,7 +23,7 @@ from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
 from Bio.SeqFeature import SeqFeature, FeatureLocation
 from Bio.SeqRecord import SeqRecord
-from Bio import BiopythonWarning
+from Bio import BiopythonWarning, BiopythonDeprecationWarning
 
 from Bio.Phylo import BaseTree
 
@@ -615,7 +615,7 @@ class CladeRelation(PhyloElement):
         self.confidence = confidence
 
 
-class Confidence(PhyloElement):
+class Confidence(float, PhyloElement):
     """A general purpose confidence element.
 
     For example, this can be used to express the bootstrap support value of a
@@ -629,146 +629,20 @@ class Confidence(PhyloElement):
 
     """
 
-    def __init__(self, value, type="unknown"):
-        """Initialize values for the Confidence object."""
-        self.value = value
-        self.type = type
+    def __new__(cls, value, type="unknown"):
+        """Create and return a Confidence object with the specified value and type."""
+        obj = super(Confidence, cls).__new__(cls, value)
+        obj.type = type
+        return obj
 
-    # Comparison operators
-
-    def __hash__(self):
-        """Return the hash value of the object.
-
-        Hash values are integers. They are used to quickly compare dictionary
-        keys during a dictionary lookup. Numeric values that compare equal have
-        the same hash value (even if they are of different types, as is the
-        case for 1 and 1.0).
-        """
-        return id(self)
-
-    def __eq__(self, other):
-        """Check for equality between Confidence objects."""
-        if isinstance(other, Confidence):
-            return self.value == other.value
-        return self.value == other
-
-    def __ne__(self, other):
-        """Check for inequality between two Confidence objects."""
-        if isinstance(other, Confidence):
-            return self.value != other.value
-        return self.value != other
-
-    # Ordering -- see functools.total_ordering in Py2.7
-
-    def __lt__(self, other):
-        """Return True if confidence is less than the other confidence."""
-        if isinstance(other, Confidence):
-            return self.value < other.value
-        return self.value < other
-
-    def __le__(self, other):
-        """Return True if confidence is less than or equal to the other confidence."""
-        return self < other or self == other
-
-    def __gt__(self, other):
-        """Return True if confidence is grater than the other confidence."""
-        return not (self <= other)
-
-    def __ge__(self, other):
-        """Return True if confidence is grater than or equal to the other confidence."""
-        return not (self.value < other)
-
-    # Arithmetic operators, including reverse
-
-    def __add__(self, other):
-        """Conduct addition between values of two Confidence objects."""
-        return self.value + other
-
-    def __radd__(self, other):
-        """Conduct reverse addition between values of two Confidence objects."""
-        return other + self.value
-
-    def __sub__(self, other):
-        """Conduct subtraction between values of two Confidence objects."""
-        return self.value - other
-
-    def __rsub__(self, other):
-        """Conduct reverse subtraction between values of two Confidence objects."""
-        return other - self.value
-
-    def __mul__(self, other):
-        """Conduct multiplication between values of two Confidence objects."""
-        return self.value * other
-
-    def __rmul__(self, other):
-        """Conduct reverse multiplication between values of two Confidence objects."""
-        return other * self.value
-
-    def __truediv__(self, other):
-        """Conduct division between values of two Confidence objects."""
-        return self.value.__truediv__(other)
-
-    def __rtruediv__(self, other):
-        """Conduct reverse division between values of two Confidence objects."""
-        return other.__rtruediv__(self.value)
-
-    def __floordiv__(self, other):
-        """C-style and old-style division."""
-        return self.value.__floordiv__(other)
-
-    def __rfloordiv__(self, other):
-        """Conduct revers C-style and old-style division."""
-        return other.__floordiv__(self.value)
-
-    def __mod__(self, other):
-        """Conduct modulus between values of two Confidence objects."""
-        return self.value % other
-
-    def __rmod__(self, other):
-        """Conduct reverse modulus between values of two Confidence objects."""
-        return other % self.value
-
-    def __divmod__(self, other):
-        """Return quotient and remainder, dividing the Confidence value by the given value."""
-        return divmod(self.value, other)
-
-    def __rdivmod__(self, other):
-        """Return quotient and remainder, dividing the given value by the Confidence value."""
-        return divmod(other, self.value)
-
-    def __pow__(self, other, modulo=None):
-        """Return the value of Confidence object raised to the given power."""
-        if modulo is not None:
-            return pow(self.value, other, modulo)
-        return pow(self.value, other)
-
-    def __rpow__(self, other):
-        """Return the given value raised to the power of the Confidence object value."""
-        return pow(other, self.value)
-
-    # Unary arithmetic operations: -, +, abs()
-
-    def __neg__(self):
-        """Conduct negation of a Confidence object."""
-        return -self.value
-
-    def __pos__(self):
-        """Return the value of a Confidence object."""
-        return self.value
-
-    def __abs__(self):
-        """Return absolute value of Confidence object."""
-        return abs(self.value)
-
-    # Explicit coercion to numeric types: float, int
-
-    def __float__(self):
-        """Return float value of Confidence object."""
-        return float(self.value)
-
-    def __int__(self):
-        """Return integer value of Confidence object."""
-        return int(self.value)
+    @property
+    def value(self):
+        """Return the float value of the Confidence object."""
+        warnings.warn(
+            "The ``value`` attribute is deprecated; please use ``float(self)`` instead.",
+            BiopythonDeprecationWarning,
+        )
+        return float(self)
 
 
 class Date(PhyloElement):

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -148,12 +148,6 @@ Bio.Phylo.CDAOIO.CDAOError
 This exception was deprecated as of Release 1.70 as it was no longer used
 within Biopython, and removed in Release 1.75.
 
-Bio.Phylo,PhyloXML
-------------------
-The ``value`` attribute of the ``Confidence`` class was deprecated in release
-1.80, as ``Confidence`` now inherits from ``float``. Please use ``float(self)``
-instead.
-
 Bio.DocSQL
 ----------
 This was deprecated in Biopython 1.69, and removed in Release 1.71.

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -148,6 +148,12 @@ Bio.Phylo.CDAOIO.CDAOError
 This exception was deprecated as of Release 1.70 as it was no longer used
 within Biopython, and removed in Release 1.75.
 
+Bio.Phylo,PhyloXML
+------------------
+The ``value`` attribute of the ``Confidence`` class was deprecated in release
+1.80, as ``Confidence`` now inherits from ``float``. Please use ``float(self)``
+instead.
+
 Bio.DocSQL
 ----------
 This was deprecated in Biopython 1.69, and removed in Release 1.71.


### PR DESCRIPTION
Fix for issue #4090 . Subclass `Confidence` from both `float` and `PhyloElement` to ensure that `Confidence` objects always behave as `float` objects, and to fix the bug in `hash`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

