### PR TITLE
StructureAlignment with Alignment objects

### DIFF
--- a/Bio/PDB/StructureAlignment.py
+++ b/Bio/PDB/StructureAlignment.py
@@ -27,7 +27,10 @@ class StructureAlignment:
            correspond to the structures
 
         """
-        length = fasta_align.get_alignment_length()
+        try:  # MultipleSeqAlignment object
+            ncolumns = fasta_align.get_alignment_length()
+        except AttributeError:  # Alignment object
+            nrows, ncolumns = fasta_align.shape
         # Get the residues in the models
         rl1 = Selection.unfold_entities(m1, "R")
         rl2 = Selection.unfold_entities(m2, "R")
@@ -39,7 +42,7 @@ class StructureAlignment:
         map21 = {}
         # List of residue pairs (None if -)
         duos = []
-        for i in range(length):
+        for i in range(ncolumns):
             column = fasta_align[:, i]
             aa1 = column[si]
             aa2 = column[sj]

--- a/Tests/test_PDB_StructureAlignment.py
+++ b/Tests/test_PDB_StructureAlignment.py
@@ -13,6 +13,7 @@ import unittest
 
 from Bio.PDB import StructureAlignment
 from Bio.PDB import PDBParser
+from Bio import Align
 from Bio import AlignIO
 
 
@@ -24,23 +25,33 @@ class StructureAlignTests(unittest.TestCase):
         p = PDBParser(QUIET=1)
 
         al_file = "PDB/alignment_file.fa"
+
+        # Using Bio.AlignIO, which returns a MultipleSeqAlignment object:
         with open(al_file) as handle:
             records = AlignIO.read(handle, "fasta")
+
+        # Using Bio.Align, which returns an Alignment object:
+        with open(al_file) as handle:
+            alignment = Align.read(handle, "fasta")
 
         s1 = p.get_structure("1", "PDB/2XHE.pdb")
         s2 = p.get_structure("2", "PDB/1A8O.pdb")
         m1 = s1[0]
         m2 = s2[0]
-        al = StructureAlignment(records, m1, m2)
-        self.assertNotEqual(al.map12, al.map21)
-        self.assertTrue(len(al.map12), 566)
-        self.assertTrue(len(al.map21), 70)
-        chain1_A = m1["A"]
-        chain2_A = m2["A"]
-        self.assertEqual(chain1_A[202].get_resname(), "ILE")
-        self.assertEqual(chain2_A[202].get_resname(), "LEU")
-        self.assertEqual(chain1_A[291].get_resname(), chain2_A[180].get_resname())
-        self.assertNotEqual(chain1_A[291].get_resname(), chain2_A[181].get_resname())
+
+        for argument in (records, alignment):
+            al = StructureAlignment(argument, m1, m2)
+            self.assertNotEqual(al.map12, al.map21)
+            self.assertTrue(len(al.map12), 566)
+            self.assertTrue(len(al.map21), 70)
+            chain1_A = m1["A"]
+            chain2_A = m2["A"]
+            self.assertEqual(chain1_A[202].get_resname(), "ILE")
+            self.assertEqual(chain2_A[202].get_resname(), "LEU")
+            self.assertEqual(chain1_A[291].get_resname(), chain2_A[180].get_resname())
+            self.assertNotEqual(
+                chain1_A[291].get_resname(), chain2_A[181].get_resname()
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR updates `PDB.StructureAlignment` to ensure it works both with `MultipleSeqAlignment` objects and with `Alignment` objects.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

