### PR TITLE
remove calls to float

### DIFF
--- a/Bio/HMM/DynamicProgramming.py
+++ b/Bio/HMM/DynamicProgramming.py
@@ -243,9 +243,7 @@ class ScaledDPAlgorithms(AbstractDPAlgorithms):
         seq_letter = self._seq.emissions[sequence_pos]
         cur_emission_prob = self._mm.emission_prob[(cur_state, seq_letter)]
         # divide by the scaling value
-        scale_emission_prob = float(cur_emission_prob) / float(
-            self._s_values[sequence_pos]
-        )
+        scale_emission_prob = cur_emission_prob / self._s_values[sequence_pos]
 
         # loop over all of the possible states at the position
         state_pos_sum = 0
@@ -305,7 +303,7 @@ class ScaledDPAlgorithms(AbstractDPAlgorithms):
 
         # if we have a probability for a transition, return it
         if have_transition:
-            return state_pos_sum / float(self._s_values[sequence_pos])
+            return state_pos_sum / self._s_values[sequence_pos]
         # otherwise we have no probability (ie. we can't do this transition)
         # and return None
         else:

--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -225,17 +225,17 @@ class MarkovModelBuilder:
         each set of transitions adds up to 1.
         """
         # set initial state probabilities
-        new_initial_prob = float(1) / float(len(self.transition_prob))
+        new_initial_prob = 1.0 / len(self.transition_prob)
         for state in self._state_alphabet:
             self.initial_prob[state] = new_initial_prob
 
         # set the transitions
-        new_trans_prob = float(1) / float(len(self.transition_prob))
+        new_trans_prob = 1.0 / len(self.transition_prob)
         for key in self.transition_prob:
             self.transition_prob[key] = new_trans_prob
 
         # set the emissions
-        new_emission_prob = float(1) / float(len(self.emission_prob))
+        new_emission_prob = 1.0 / len(self.emission_prob)
         for key in self.emission_prob:
             self.emission_prob[key] = new_emission_prob
 

--- a/Bio/HMM/Trainer.py
+++ b/Bio/HMM/Trainer.py
@@ -142,7 +142,7 @@ class AbstractTrainer:
                 pass
 
             # now calculate the ml and add it to the estimation
-            cur_ml = float(counts[cur_item]) / float(cur_letter_counts)
+            cur_ml = counts[cur_item] / cur_letter_counts
             ml_estimation[cur_item] = cur_ml
 
         return ml_estimation
@@ -299,7 +299,7 @@ class BaumWelchTrainer(AbstractTrainer):
                     )
 
                 # update the transition approximation
-                transition_counts[(k, l)] += float(estimated_counts) / training_seq_prob
+                transition_counts[(k, l)] += estimated_counts / training_seq_prob
 
         return transition_counts
 
@@ -341,7 +341,7 @@ class BaumWelchTrainer(AbstractTrainer):
                         expected_times += forward_vars[(k, i)] * backward_vars[(k, i)]
 
                 # add to E_{k}(b)
-                emission_counts[(k, b)] += float(expected_times) / training_seq_prob
+                emission_counts[(k, b)] += expected_times / training_seq_prob
 
         return emission_counts
 

--- a/Tests/test_HMMGeneral.py
+++ b/Tests/test_HMMGeneral.py
@@ -397,12 +397,12 @@ class AbstractTrainerTest(unittest.TestCase):
 
         # now make sure we are getting back the right thing
         result_tests = []
-        result_tests.append([("A", "A"), float(10) / float(45)])
-        result_tests.append([("A", "B"), float(20) / float(45)])
-        result_tests.append([("A", "C"), float(15) / float(45)])
-        result_tests.append([("B", "B"), float(5) / float(5)])
-        result_tests.append([("C", "A"), float(15) / float(25)])
-        result_tests.append([("C", "C"), float(10) / float(25)])
+        result_tests.append([("A", "A"), 10 / 45])
+        result_tests.append([("A", "B"), 20 / 45])
+        result_tests.append([("A", "C"), 15 / 45])
+        result_tests.append([("B", "B"), 5 / 5])
+        result_tests.append([("C", "A"), 15 / 25])
+        result_tests.append([("C", "C"), 10 / 25])
 
         for test_result in result_tests:
             self.assertEqual(results[test_result[0]], test_result[1])


### PR DESCRIPTION
Remove unnecessary calls to `float` from `Bio.HMM`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

