### PR TITLE
remove float

### DIFF
--- a/Bio/Phylo/_utils.py
+++ b/Bio/Phylo/_utils.py
@@ -123,9 +123,7 @@ def draw_ascii(tree, file=None, column_width=80):
             depths = tree.depths(unit_branch_lengths=True)
         # Potential drawing overflow due to rounding -- 1 char per tree layer
         fudge_margin = int(math.ceil(math.log(len(taxa), 2)))
-        cols_per_branch_unit = (drawing_width - fudge_margin) / float(
-            max(depths.values())
-        )
+        cols_per_branch_unit = (drawing_width - fudge_margin) / max(depths.values())
         return {
             clade: int(blen * cols_per_branch_unit + 1.0)
             for clade, blen in depths.items()


### PR DESCRIPTION
Remove a call to `float` that is no longer needed with python3.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

