### PR TITLE
Remove calls to float

### DIFF
--- a/Bio/Graphics/BasicChromosome.py
+++ b/Bio/Graphics/BasicChromosome.py
@@ -538,7 +538,7 @@ def _spring_layout(desired, minimum, maximum, gap=0):
             "Data %f to %f out of bounds (%f to %f)"
             % (min(desired), max(desired), minimum, maximum)
         )
-    equal_step = float(maximum - minimum) / (count - 1)
+    equal_step = (maximum - minimum) / (count - 1)
 
     if equal_step < gap:
         import warnings

--- a/Bio/Graphics/ColorSpiral.py
+++ b/Bio/Graphics/ColorSpiral.py
@@ -87,7 +87,7 @@ class ColorSpiral:
         """
         # We use the offset to skip a number of similar colours near to HSV axis
         assert offset > 0 and offset < 1, "offset must be in (0,1)"
-        v_rate = (self._v_final - self._v_init) / float(k)
+        v_rate = (self._v_final - self._v_init) / k
         # Generator for colours: we have divided the arc length into sections
         # of equal length, and step along them
         for n in range(1, k + 1):

--- a/Bio/Graphics/DisplayRepresentation.py
+++ b/Bio/Graphics/DisplayRepresentation.py
@@ -88,9 +88,7 @@ class ChromosomeCounts:
         are instead counts divided by some number.
         """
         try:
-            self._count_info[segment_name] = float(
-                self._count_info[segment_name]
-            ) / float(scale_value)
+            self._count_info[segment_name] /= scale_value
         except KeyError:
             raise KeyError(f"Segment name {segment_name} not found.") from None
 

--- a/Bio/Graphics/Distribution.py
+++ b/Bio/Graphics/Distribution.py
@@ -66,10 +66,8 @@ class DistributionPage:
         end_x_pos = width - inch * 0.5
         cur_y_pos = height - 1.5 * inch
         end_y_pos = 0.5 * inch
-        x_pos_change = (end_x_pos - cur_x_pos) / float(self.number_of_columns)
-        num_y_rows = math.ceil(
-            float(len(self.distributions)) / float(self.number_of_columns)
-        )
+        x_pos_change = (end_x_pos - cur_x_pos) / self.number_of_columns
+        num_y_rows = math.ceil(len(self.distributions) / self.number_of_columns)
         y_pos_change = (cur_y_pos - end_y_pos) / num_y_rows
 
         self._draw_distributions(

--- a/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
+++ b/Bio/Graphics/GenomeDiagram/_CircularDrawer.py
@@ -309,7 +309,7 @@ class CircularDrawer(AbstractDrawer):
 
         startangle, startcos, startsin = self.canvas_angle(locstart)
         endangle, endcos, endsin = self.canvas_angle(locend)
-        midangle, midcos, midsin = self.canvas_angle(float(locend + locstart) / 2)
+        midangle, midcos, midsin = self.canvas_angle((locend + locstart) / 2)
 
         # Distribution dictionary for various ways of drawing the feature
         # Each method takes the inner and outer radii, the start and end angle
@@ -1114,7 +1114,7 @@ class CircularDrawer(AbstractDrawer):
 
         strokecolor, color = _stroke_and_fill_colors(color, border)
 
-        if abs(float(endangle - startangle)) > 0.01:
+        if abs(endangle - startangle) > 0.01:
             # Wide arc, must use full curves
             p = ArcPath(strokeColor=strokecolor, fillColor=color, strokewidth=0)
             # Note reportlab counts angles anti-clockwise from the horizontal
@@ -1298,7 +1298,7 @@ class CircularDrawer(AbstractDrawer):
         strokecolor, color = _stroke_and_fill_colors(color, border)
 
         startangle, endangle = min(startangle, endangle), max(startangle, endangle)
-        angle = float(endangle - startangle)
+        angle = endangle - startangle
 
         middle_radius = 0.5 * (inner_radius + outer_radius)
         boxheight = outer_radius - inner_radius
@@ -1421,7 +1421,7 @@ class CircularDrawer(AbstractDrawer):
                 f"Invalid orientation {orientation!r}, should be 'left' or 'right'"
             )
 
-        angle = float(endangle - startangle)  # angle subtended by arc
+        angle = endangle - startangle  # angle subtended by arc
         middle_radius = 0.5 * (inner_radius + outer_radius)
         boxheight = outer_radius - inner_radius
         shaft_height = boxheight * shaft_height_ratio
@@ -1615,7 +1615,7 @@ class CircularDrawer(AbstractDrawer):
         strokecolor, color = _stroke_and_fill_colors(color, border)
 
         startangle, endangle = min(startangle, endangle), max(startangle, endangle)
-        angle = float(endangle - startangle)  # angle subtended by arc
+        angle = endangle - startangle  # angle subtended by arc
         height = outer_radius - inner_radius
 
         assert startangle <= endangle and angle >= 0

--- a/Bio/Graphics/GenomeDiagram/_Graph.py
+++ b/Bio/Graphics/GenomeDiagram/_Graph.py
@@ -136,10 +136,7 @@ class GraphData:
     def mean(self):
         """Return the mean value for the data points (float)."""
         data = list(self.data.values())
-        sum = 0.0
-        for item in data:
-            sum += float(item)
-        return sum / len(data)
+        return sum(data) / len(data)
 
     def stdev(self):
         """Return the sample standard deviation for the data (float)."""
@@ -147,7 +144,7 @@ class GraphData:
         m = self.mean()
         runtotal = 0.0
         for entry in data:
-            runtotal += float((entry - m) ** 2)
+            runtotal += (entry - m) ** 2
         # This is sample standard deviation; population stdev would involve
         # division by len(data), rather than len(data)-1
         return sqrt(runtotal / (len(data) - 1))

--- a/Tests/test_GenomeDiagram.py
+++ b/Tests/test_GenomeDiagram.py
@@ -167,7 +167,7 @@ def calc_gc_skew(sequence):
     if g + c == 0:
         return 0.0  # TODO - return NaN or None here?
     else:
-        return (g - c) / float(g + c)
+        return (g - c) / (g + c)
 
 
 def calc_at_skew(sequence):
@@ -184,7 +184,7 @@ def calc_at_skew(sequence):
     if a + t == 0:
         return 0.0  # TODO - return NaN or None here?
     else:
-        return (a - t) / float(a + t)
+        return (a - t) / (a + t)
 
 
 def calc_dinucleotide_counts(sequence):

--- a/Tests/test_NCBI_qblast.py
+++ b/Tests/test_NCBI_qblast.py
@@ -288,7 +288,8 @@ class TestQblast(unittest.TestCase):
             )
 
         # Check the recorded input parameters agree with those requested
-        self.assertEqual(float(record.expect), e_value)
+        print("BUH!!", record.expect, type(record.expect), e_value, type(e_value))
+        self.assertEqual(record.expect, e_value)
         self.assertEqual(record.application.lower(), program)
         self.assertLessEqual(len(record.alignments), 10)
         self.assertLessEqual(len(record.descriptions), 10)

--- a/Tests/test_NCBI_qblast.py
+++ b/Tests/test_NCBI_qblast.py
@@ -288,8 +288,7 @@ class TestQblast(unittest.TestCase):
             )
 
         # Check the recorded input parameters agree with those requested
-        print("BUH!!", record.expect, type(record.expect), e_value, type(e_value))
-        self.assertEqual(record.expect, e_value)
+        self.assertEqual(float(record.expect), e_value)
         self.assertEqual(record.application.lower(), program)
         self.assertLessEqual(len(record.alignments), 10)
         self.assertLessEqual(len(record.descriptions), 10)


### PR DESCRIPTION
In `Bio.Graphics`, remove some calls to `float` that are not needed with python3

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

