### PR TITLE
remove float

### DIFF
--- a/Tests/test_Affy.py
+++ b/Tests/test_Affy.py
@@ -320,9 +320,6 @@ class AffyTest(unittest.TestCase):
             *(preHeaders[header] for header in preHeadersOrder),
         )
 
-        def packData(intensity, sdev, pixel):
-            return struct.pack("< f f h", intensity, sdev, pixel)
-
         f.write(headersEncoded)
         for header in headers:
             try:
@@ -334,9 +331,9 @@ class AffyTest(unittest.TestCase):
         f.write(prePadding)
         f.write(b"\x00" * 15)
         for i in range(25):
-            f.write(packData(float(i), float(-i), 9))
+            f.write(struct.pack("< f f h", i, -i, 9))  # intensity, sdev, pixel
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(verbosity=0)
+    runner = unittest.TextTestRunner(verbosity=2)
     unittest.main(testRunner=runner)

--- a/Tests/test_Compass.py
+++ b/Tests/test_Compass.py
@@ -26,7 +26,7 @@ class CompassTest(unittest.TestCase):
 
         self.assertEqual("60456.blo.gz.aln", com_record.query)
         self.assertEqual("60456.blo.gz.aln", com_record.hit)
-        self.assertEqual(0.5, com_record.gap_threshold)
+        self.assertAlmostEqual(0.5, com_record.gap_threshold)
 
         self.assertEqual(388, com_record.query_length)
         self.assertEqual(386, com_record.query_filtered_length)
@@ -34,12 +34,12 @@ class CompassTest(unittest.TestCase):
         self.assertEqual(386, com_record.hit_filtered_length)
 
         self.assertEqual(399, com_record.query_nseqs)
-        self.assertEqual(12.972, com_record.query_neffseqs)
+        self.assertAlmostEqual(12.972, com_record.query_neffseqs)
         self.assertEqual(399, com_record.hit_nseqs)
-        self.assertEqual(12.972, com_record.hit_neffseqs)
+        self.assertAlmostEqual(12.972, com_record.hit_neffseqs)
 
         self.assertEqual(2759, com_record.sw_score)
-        self.assertEqual(float("0.00e+00"), com_record.evalue)
+        self.assertAlmostEqual(0.0, com_record.evalue)
 
     def testCompassParser(self):
         with open(self.test_files[0]) as handle:
@@ -60,15 +60,15 @@ class CompassTest(unittest.TestCase):
 
             com_record = next(records)
             self.assertEqual("allscop//14982.blo.gz.aln", com_record.hit)
-            self.assertEqual(float("1.01e+03"), com_record.evalue)
+            self.assertAlmostEqual(1.01e03, com_record.evalue)
 
             com_record = next(records)
             self.assertEqual("allscop//14983.blo.gz.aln", com_record.hit)
-            self.assertEqual(float("1.01e+03"), com_record.evalue)
+            self.assertAlmostEqual(1.01e03, com_record.evalue)
 
             com_record = next(records)
             self.assertEqual("allscop//14984.blo.gz.aln", com_record.hit)
-            self.assertEqual(float("5.75e+02"), com_record.evalue)
+            self.assertAlmostEqual(5.75e02, com_record.evalue)
 
     def testAlignmentParsingOne(self):
         with open(self.test_files[1]) as handle:

--- a/Tests/test_MarkovModel.py
+++ b/Tests/test_MarkovModel.py
@@ -468,17 +468,14 @@ class TestMarkovModel(unittest.TestCase):
         lp_transition = log([[0.7, 0.3], [0.5, 0.5]])
         lp_emission = log([[0.6, 0.1, 0.3], [0.1, 0.7, 0.2]])
 
-        output1 = [0, 1, 0]
-        output2 = -3.968593356916541
-
         viterbi_output = MarkovModel._viterbi(
             len(states), lp_initial, lp_transition, lp_emission, outputs
         )
         self.assertEqual(len(viterbi_output[0][0]), 3)
-        self.assertEqual(viterbi_output[0][0][0], output1[0])
-        self.assertEqual(viterbi_output[0][0][1], output1[1])
-        self.assertEqual(viterbi_output[0][0][2], output1[2])
-        self.assertEqual(float(f"{viterbi_output[0][1]:.3f}"), float(f"{output2:.3f}"))
+        self.assertEqual(viterbi_output[0][0][0], 0)
+        self.assertEqual(viterbi_output[0][0][1], 1)
+        self.assertEqual(viterbi_output[0][0][2], 0)
+        self.assertAlmostEqual(viterbi_output[0][1], -3.968593356916541)
 
     def test_normalize_and_copy_and_check(self):
         matrix_in1 = array([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6], [7.7, 8.8, 9.9]])
@@ -559,23 +556,10 @@ class TestMarkovModel(unittest.TestCase):
         matrix = array([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6], [7.7, 8.8, 9.9]])
         matrix1 = array([1, 2, 3])
 
-        output = 10.304721798
-        output1 = 3.40760596444
-        self.assertEqual(
-            float(f"{MarkovModel._logsum(matrix):.3f}"), float(f"{output:.3f}")
-        )
-        self.assertEqual(
-            float(f"{MarkovModel._logsum(matrix1):.3f}"), float(f"{output1:.3f}")
-        )
-
-        output2 = 29873.342245
-        output3 = 30.1928748506
-        self.assertEqual(
-            float(f"{MarkovModel._exp_logsum(matrix):.3f}"), float(f"{output2:.3f}")
-        )
-        self.assertEqual(
-            float(f"{MarkovModel._exp_logsum(matrix1):.3f}"), float(f"{output3:.3f}")
-        )
+        self.assertAlmostEqual(MarkovModel._logsum(matrix), 10.304721798)
+        self.assertAlmostEqual(MarkovModel._logsum(matrix1), 3.40760596444)
+        self.assertAlmostEqual(MarkovModel._exp_logsum(matrix), 29873.342245)
+        self.assertAlmostEqual(MarkovModel._exp_logsum(matrix1), 30.1928748506)
 
     def test_logvecadd(self):
         vec1 = log(array([1, 2, 3, 4]))

--- a/Tests/test_ProtParam.py
+++ b/Tests/test_ProtParam.py
@@ -42,9 +42,7 @@ class ProtParamTest(unittest.TestCase):
             percent_dict = analysis.get_amino_acids_percent()
             seq_len = len(self.text)
             for i in percent_dict:
-                self.assertAlmostEqual(
-                    percent_dict[i], self.text.count(i) / float(seq_len)
-                )
+                self.assertAlmostEqual(percent_dict[i], self.text.count(i) / seq_len)
 
     def test_get_molecular_weight(self):
         """Calculate protein molecular weight."""

--- a/Tests/test_SVDSuperimposer.py
+++ b/Tests/test_SVDSuperimposer.py
@@ -51,10 +51,7 @@ class SVDSuperimposerTest(unittest.TestCase):
         y = array([[1.91, 1.82, 1.73], [1.64, 1.55, 1.46], [1.37, 1.28, 1.19]])
         self.sup.set(x, y)
         self.assertIsNone(self.sup.init_rms)
-        init_rms = 0.8049844719
-        self.assertTrue(
-            float(f"{self.sup.get_init_rms():.3f}"), float(f"{init_rms:.3f}")
-        )
+        self.assertAlmostEqual(self.sup.get_init_rms(), 0.8049844719)
 
     def test_oldTest(self):
         self.assertTrue(
@@ -98,8 +95,7 @@ class SVDSuperimposerTest(unittest.TestCase):
         self.assertIsNone(self.sup.rms)
         self.assertIsNone(self.sup.init_rms)
 
-        rms = 0.00304266526014
-        self.assertEqual(float(f"{self.sup.get_rms():.3f}"), float(f"{rms:.3f}"))
+        self.assertAlmostEqual(self.sup.get_rms(), 0.00304266526014)
 
         rot_get, tran_get = self.sup.get_rotran()
         self.assertTrue(


### PR DESCRIPTION
Remove unnecessary calls to `float` in tests.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

