### PR TITLE
Remove Entrez efetch test with biosystems db

### DIFF
--- a/Tests/test_Entrez_online.py
+++ b/Tests/test_Entrez_online.py
@@ -123,14 +123,6 @@ class EntrezOnlineCase(unittest.TestCase):
         self.assertEqual("19304878", record["PMID"])
         self.assertEqual("10.1093/bioinformatics/btp163 [doi]", record["LID"])
 
-    def test_efetch_biosystems_xml(self):
-        """Test Entrez parser with XML from biosystems."""
-        handle = Entrez.efetch(id="1134002", db="biosystems", retmode="xml")
-        records = list(Entrez.parse(handle))
-        handle.close()
-        self.assertEqual(len(records), 1)
-        self.assertEqual(records[0]["System_sysid"]["Sys-id"]["Sys-id_bsid"], "1134002")
-
     def test_efetch_taxonomy_xml(self):
         """Test Entrez using a integer id - like a taxon id."""
         handle = Entrez.efetch(db="taxonomy", id=3702, retmode="XML")


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

NCBI [retired](https://ncbiinsights.ncbi.nlm.nih.gov/2021/08/10/retire-biosystems-database/) the biosystems database earlier this year. This is causing `test_efetch_biosystems_xml` in `test_Entrez_online.py` to fail. There are other test cases for the `efetch` function using different databases, so I simply removed it.

Closes #4086
