### PR TITLE
Bio.Align.Generic.Alignment was removed

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -120,9 +120,6 @@ class MultipleSeqAlignment:
     TATACATTAAGTATACCAGA gi|6273289|gb|AF191663.1|AF191
     TATACATTAAGTGTACCAGA gi|6273291|gb|AF191665.1|AF191
 
-    Note - This object replaced the older Alignment object defined in module
-    Bio.Align.Generic but is not fully backwards compatible with it.
-
     Note - This object does NOT attempt to model the kind of alignments used
     in next generation sequencing with multiple sequencing reads which are
     much shorter than the alignment, and where there is usually a consensus or

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -722,7 +722,6 @@ class SeqRecord:
         and binary formats are not supported).
         """
         # See also the __format__ method
-        # See also the Bio.Align.Generic.Alignment class and its format()
         return self.__format__(format)
 
     def __format__(self, format_spec):


### PR DESCRIPTION
`Bio.Align.Generic.Alignment` was removed in commit #422b5051624bcf3c0c145e9e951f551d86b52931

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
