### PR TITLE
switch to instance class contructor where usefull

### DIFF
--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -897,7 +897,7 @@ class SeqRecord:
         if not isinstance(other, SeqRecord):
             # Assume it is a string or a Seq.
             # Note can't transfer any per-letter-annotations
-            return SeqRecord(
+            return type(self)(
                 self.seq + other,
                 id=self.id,
                 name=self.name,
@@ -907,7 +907,7 @@ class SeqRecord:
                 dbxrefs=self.dbxrefs[:],
             )
         # Adding two SeqRecord objects... must merge annotation.
-        answer = SeqRecord(
+        answer = type(self)(
             self.seq + other.seq, features=self.features[:], dbxrefs=self.dbxrefs[:]
         )
         # Will take all the features and all the db cross refs,
@@ -962,7 +962,7 @@ class SeqRecord:
         # Assume it is a string or a Seq.
         # Note can't transfer any per-letter-annotations
         offset = len(other)
-        return SeqRecord(
+        return type(self)(
             other + self.seq,
             id=self.id,
             name=self.name,
@@ -1006,7 +1006,7 @@ class SeqRecord:
         "#$%&'()
         <BLANKLINE>
         """
-        return SeqRecord(
+        return type(self)(
             self.seq.upper(),
             id=self.id,
             name=self.name,
@@ -1049,7 +1049,7 @@ class SeqRecord:
         >>> old.dbxrefs == new.dbxrefs
         True
         """
-        return SeqRecord(
+        return type(self)(
             self.seq.lower(),
             id=self.id,
             name=self.name,
@@ -1240,7 +1240,7 @@ class SeqRecord:
             )  # TODO: remove inplace=False
         if isinstance(self.seq, MutableSeq):
             seq = Seq(seq)
-        answer = SeqRecord(seq)
+        answer = type(self)(seq)
         if isinstance(id, str):
             answer.id = id
         elif id:


### PR DESCRIPTION

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, ~~have run ``pre-commit`` locally,~~ 
 and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This takes off the burden of having to override methods such as `__add__` of child classes such as `pydna.Dseqrecord` (See https://stackoverflow.com/a/14209708/1870254 , example line that would be made obsolete:        https://github.com/BjornFJohansson/pydna/blob/88dd388109428920092279bfb3b237c688318911/src/pydna/seqrecord.py#L642)

If this is judged as favorable, it might be good to check if there are other places (e.g. in `Seq.py`) where such a change would be useful. 

