### PR TITLE
Typo fix in GenBank Feature class documentation

### DIFF
--- a/Bio/GenBank/Record.py
+++ b/Bio/GenBank/Record.py
@@ -612,7 +612,7 @@ class Feature:
     Attributes:
      - key - The key name of the feature (ie. source)
      - location - The string specifying the location of the feature.
-     - qualfiers - A list of Qualifier objects in the feature.
+     - qualifiers - A list of Qualifier objects in the feature.
 
     """
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

A mere typo that bit me when copying and pasting from the doc.

`qualfiers` ==> `qualifiers`