### PR TITLE
Add optional authentication for qblast, and email and tool variables.

### DIFF
--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -12,6 +12,12 @@
 
 This module provides code to work with the WWW version of BLAST
 provided by the NCBI. https://blast.ncbi.nlm.nih.gov/
+
+Variables:
+
+    - email        Set the Blast email parameter (default is None).
+    - tool         Set the Blast tool parameter (default is ``biopython``).
+
 """
 
 
@@ -20,11 +26,16 @@ import warnings
 from io import StringIO
 import time
 
-from urllib.request import urlopen
 from urllib.parse import urlencode
+from urllib.request import build_opener, install_opener
+from urllib.request import urlopen, urlretrieve, urlparse, urlcleanup
+from urllib.request import HTTPPasswordMgrWithDefaultRealm, HTTPBasicAuthHandler
 from urllib.request import Request
 
 from Bio import BiopythonWarning
+
+email = None
+tool = "biopython"
 
 
 NCBI_BLAST_URL = "https://blast.ncbi.nlm.nih.gov/Blast.cgi"
@@ -79,6 +90,8 @@ def qblast(
     megablast=None,
     template_type=None,
     template_length=None,
+    username=None,
+    password=None,
 ):
     """BLAST search using NCBI's QBLAST server or a cloud service provider.
 
@@ -152,78 +165,88 @@ def qblast(
     # Additional parameters are taken from http://www.ncbi.nlm.nih.gov/BLAST/Doc/node9.html on 8 Oct 2010
     # To perform a PSI-BLAST or PHI-BLAST search the service ("Put" and "Get" commands) must be specified
     # (e.g. psi_blast = NCBIWWW.qblast("blastp", "refseq_protein", input_sequence, service="psi"))
-    parameters = [
-        ("AUTO_FORMAT", auto_format),
-        ("COMPOSITION_BASED_STATISTICS", composition_based_statistics),
-        ("DATABASE", database),
-        ("DB_GENETIC_CODE", db_genetic_code),
-        ("ENDPOINTS", endpoints),
-        ("ENTREZ_QUERY", entrez_query),
-        ("EXPECT", expect),
-        ("FILTER", filter),
-        ("GAPCOSTS", gapcosts),
-        ("GENETIC_CODE", genetic_code),
-        ("HITLIST_SIZE", hitlist_size),
-        ("I_THRESH", i_thresh),
-        ("LAYOUT", layout),
-        ("LCASE_MASK", lcase_mask),
-        ("MEGABLAST", megablast),
-        ("MATRIX_NAME", matrix_name),
-        ("NUCL_PENALTY", nucl_penalty),
-        ("NUCL_REWARD", nucl_reward),
-        ("OTHER_ADVANCED", other_advanced),
-        ("PERC_IDENT", perc_ident),
-        ("PHI_PATTERN", phi_pattern),
-        ("PROGRAM", program),
-        # ('PSSM',pssm), - It is possible to use PSI-BLAST via this API?
-        ("QUERY", sequence),
-        ("QUERY_FILE", query_file),
-        ("QUERY_BELIEVE_DEFLINE", query_believe_defline),
-        ("QUERY_FROM", query_from),
-        ("QUERY_TO", query_to),
-        # ('RESULTS_FILE',...), - Can we use this parameter?
-        ("SEARCHSP_EFF", searchsp_eff),
-        ("SERVICE", service),
-        ("SHORT_QUERY_ADJUST", short_query),
-        ("TEMPLATE_TYPE", template_type),
-        ("TEMPLATE_LENGTH", template_length),
-        ("THRESHOLD", threshold),
-        ("UNGAPPED_ALIGNMENT", ungapped_alignment),
-        ("WORD_SIZE", word_size),
-        ("CMD", "Put"),
-    ]
-    query = [x for x in parameters if x[1] is not None]
-    message = urlencode(query).encode()
+    parameters = {
+        "AUTO_FORMAT": auto_format,
+        "COMPOSITION_BASED_STATISTICS": composition_based_statistics,
+        "DATABASE": database,
+        "DB_GENETIC_CODE": db_genetic_code,
+        "ENDPOINTS": endpoints,
+        "ENTREZ_QUERY": entrez_query,
+        "EXPECT": expect,
+        "FILTER": filter,
+        "GAPCOSTS": gapcosts,
+        "GENETIC_CODE": genetic_code,
+        "HITLIST_SIZE": hitlist_size,
+        "I_THRESH": i_thresh,
+        "LAYOUT": layout,
+        "LCASE_MASK": lcase_mask,
+        "MEGABLAST": megablast,
+        "MATRIX_NAME": matrix_name,
+        "NUCL_PENALTY": nucl_penalty,
+        "NUCL_REWARD": nucl_reward,
+        "OTHER_ADVANCED": other_advanced,
+        "PERC_IDENT": perc_ident,
+        "PHI_PATTERN": phi_pattern,
+        "PROGRAM": program,
+        # ('PSSM': pssm: - It is possible to use PSI-BLAST via this API?
+        "QUERY": sequence,
+        "QUERY_FILE": query_file,
+        "QUERY_BELIEVE_DEFLINE": query_believe_defline,
+        "QUERY_FROM": query_from,
+        "QUERY_TO": query_to,
+        # 'RESULTS_FILE': ...: - Can we use this parameter?
+        "SEARCHSP_EFF": searchsp_eff,
+        "SERVICE": service,
+        "SHORT_QUERY_ADJUST": short_query,
+        "TEMPLATE_TYPE": template_type,
+        "TEMPLATE_LENGTH": template_length,
+        "THRESHOLD": threshold,
+        "UNGAPPED_ALIGNMENT": ungapped_alignment,
+        "WORD_SIZE": word_size,
+        "CMD": "Put",
+    }
 
+    if username is not None and password is not None:
+        # handle authentication for BLAST cloud
+        password_mgr = HTTPPasswordMgrWithDefaultRealm()
+        password_mgr.add_password(None, url_base, username, password)
+        handler = HTTPBasicAuthHandler(password_mgr)
+        opener = build_opener(handler)
+        install_opener(opener)
+
+    if url_base == NCBI_BLAST_URL:
+        parameters.update({"email": email, "tool": tool})
+    parameters = {key: value for key, value in parameters.items() if value is not None}
+    message = urlencode(parameters).encode()
+    request = Request(url_base, message, {"User-Agent": "BiopythonClient"})
     # Send off the initial query to qblast.
     # Note the NCBI do not currently impose a rate limit here, other
     # than the request not to make say 50 queries at once using multiple
     # threads.
-    request = Request(url_base, message, {"User-Agent": "BiopythonClient"})
     handle = urlopen(request)
 
     # Format the "Get" command, which gets the formatted results from qblast
     # Parameters taken from http://www.ncbi.nlm.nih.gov/BLAST/Doc/node6.html on 9 July 2007
     rid, rtoe = _parse_qblast_ref_page(handle)
-    parameters = [
-        ("ALIGNMENTS", alignments),
-        ("ALIGNMENT_VIEW", alignment_view),
-        ("DESCRIPTIONS", descriptions),
-        ("ENTREZ_LINKS_NEW_WINDOW", entrez_links_new_window),
-        ("EXPECT_LOW", expect_low),
-        ("EXPECT_HIGH", expect_high),
-        ("FORMAT_ENTREZ_QUERY", format_entrez_query),
-        ("FORMAT_OBJECT", format_object),
-        ("FORMAT_TYPE", format_type),
-        ("NCBI_GI", ncbi_gi),
-        ("RID", rid),
-        ("RESULTS_FILE", results_file),
-        ("SERVICE", service),
-        ("SHOW_OVERVIEW", show_overview),
-        ("CMD", "Get"),
-    ]
-    query = [x for x in parameters if x[1] is not None]
-    message = urlencode(query).encode()
+    parameters = {
+        "ALIGNMENTS": alignments,
+        "ALIGNMENT_VIEW": alignment_view,
+        "DESCRIPTIONS": descriptions,
+        "ENTREZ_LINKS_NEW_WINDOW": entrez_links_new_window,
+        "EXPECT_LOW": expect_low,
+        "EXPECT_HIGH": expect_high,
+        "FORMAT_ENTREZ_QUERY": format_entrez_query,
+        "FORMAT_OBJECT": format_object,
+        "FORMAT_TYPE": format_type,
+        "NCBI_GI": ncbi_gi,
+        "RID": rid,
+        "RESULTS_FILE": results_file,
+        "SERVICE": service,
+        "SHOW_OVERVIEW": show_overview,
+        "CMD": "Get",
+    }
+    parameters = {key: value for key, value in parameters.items() if value is not None}
+    message = urlencode(parameters).encode()
 
     # Poll NCBI until the results are ready.
     # https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=DeveloperInfo

--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -90,7 +90,7 @@ def qblast(
     megablast=None,
     template_type=None,
     template_length=None,
-    username=None,
+    username="blast",
     password=None,
 ):
     """BLAST search using NCBI's QBLAST server or a cloud service provider.
@@ -206,7 +206,7 @@ def qblast(
         "CMD": "Put",
     }
 
-    if username is not None and password is not None:
+    if password is not None:
         # handle authentication for BLAST cloud
         password_mgr = HTTPPasswordMgrWithDefaultRealm()
         password_mgr.add_password(None, url_base, username, password)

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -283,6 +283,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Shyam Saladi <https://github.com/smsaladi>
 - Siong Kong <https://github.com/siongkong>
 - Sjoerd de Vries <https://github.com/sjdv1982>
+- Soroush Saffari <https://github.com/sorsaffari>
 - Sourav Singh <https://github.com/souravsingh>
 - Spencer Bliven <https://github.com/sbliven>
 - Stefans Mezulis <https://github.com/StefansM>

--- a/Doc/Tutorial/chapter_blast.tex
+++ b/Doc/Tutorial/chapter_blast.tex
@@ -77,7 +77,6 @@ described in section~\ref{sec:parsing-blast} below.
 For more about the optional BLAST arguments, we refer you to the NCBI's own
 documentation, or that built into Biopython:
 
-%doctest
 \begin{minted}{pycon}
 >>> from Bio.Blast import NCBIWWW
 >>> help(NCBIWWW.qblast)

--- a/Doc/Tutorial/chapter_blast.tex
+++ b/Doc/Tutorial/chapter_blast.tex
@@ -42,7 +42,22 @@ can either be the sequence itself, the sequence in fasta format,
 or an identifier like a GI number.
 \end{itemize}
 
-The \verb|qblast| function also take a number of other option arguments
+NCBI guidelines, from \url{https://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&PAGE_TYPE=BlastDocs&DOC_TYPE=DeveloperInfo} state:
+\begin{enumerate}
+\item Do not contact the server more often than once every 10 seconds.
+\item Do not poll for any single RID more often than once a minute.
+\item Use the URL parameter email and tool, so that the NCBI can contact you if there is a problem.
+\item Run scripts weekends or between 9 pm and 5 am Eastern time on weekdays if more than 50 searches will be submitted.
+\end{enumerate}
+
+To fulfill the third point, one can set the \verb|NCBIWWW.email| variable.
+%doctest
+\begin{minted}{pycon}
+>>> from Bio.Blast import NCBIWWW
+>>> NCBIWWW.email = "A.N.Other@example.com"
+\end{minted}
+
+The \verb|qblast| function also takes a number of other option arguments,
 which are basically analogous to the different parameters you can set
 on the BLAST web page.  We'll just highlight a few of them here:
 
@@ -62,6 +77,7 @@ described in section~\ref{sec:parsing-blast} below.
 For more about the optional BLAST arguments, we refer you to the NCBI's own
 documentation, or that built into Biopython:
 
+%doctest
 \begin{minted}{pycon}
 >>> from Bio.Blast import NCBIWWW
 >>> help(NCBIWWW.qblast)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -95,6 +95,7 @@ possible, especially the following contributors:
 - Sebastian Bassi
 - Sean Aubin
 - Sean Workman (first contribution)
+- Soroush Saffari (first contribution)
 - Tim Burke
 - Valentin Vareškić (first contribution)
 

--- a/Tests/test_NCBI_qblast.py
+++ b/Tests/test_NCBI_qblast.py
@@ -41,6 +41,9 @@ from Bio.Blast import NCBIXML
 import requires_internet
 
 
+NCBIWWW.email = "biopython@biopython.org"
+
+
 try:
     requires_internet.check()
     # this will set 'require_internet.check.available' (if not already done before)


### PR DESCRIPTION
This PR adds `tool` and `email` variables to `Bio.Blast.NCBIWWW`, and optional `username` and `password` arguments to `qblast`. This PR supersedes #2866 and #1819, but is simpler as we only need to consider python3 now.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

