### PR TITLE
deprecate ungap

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2118,7 +2118,7 @@ class Seq(_SeqAbstractBaseClass):
         return str(self).encode(encoding, errors)
 
     def ungap(self, gap="-"):
-        """Return a copy of the sequence without the gap character(s) (OBSOLETE).
+        """Return a copy of the sequence without the gap character(s) (DEPRECATED).
 
         The gap character now defaults to the minus sign, and can only
         be specified via the method argument. This is no longer possible
@@ -2131,8 +2131,13 @@ class Seq(_SeqAbstractBaseClass):
         >>> my_dna.ungap("-")
         Seq('ATATGAAATTTGAAAA')
 
-        This method is OBSOLETE; please use my_dna.replace(gap, "") instead.
+        This method is DEPRECATED; please use my_dna.replace(gap, "") instead.
         """
+        warnings.warn(
+            """\
+myseq.ungap(gap) is deprecated; please use myseq.replace(gap, "") instead.""",
+            BiopythonDeprecationWarning,
+        )
         if not gap:
             raise ValueError("Gap character required.")
         elif len(gap) != 1 or not isinstance(gap, str):

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -198,7 +198,7 @@ Bio.Seq.MutableSeq(myseq) or Bio.Seq.Seq(mymutableseq), respectively.
 
 Bio.Seq.Seq.ungap()
 -------------------
-Declared obsolete in release 1.79.
+Declared obsolete in release 1.79, and deprecated in release 1.80.
 Instead of myseq.ungap(), please use myseq.replace("-", "").
 
 Bio.Seq.UnknownSeq


### PR DESCRIPTION
This PR deprecates the `ungap` method of `Seq` objects. This method was declared obsolete in release 1.79, and is currently not being used anywhere in Biopython.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


