### PR TITLE
Minor style change from trying ruff as a flake8 alternative

### DIFF
--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -117,7 +117,7 @@ class MMCIF2Dict(dict):
                     if line.startswith(";"):
                         yield "\n".join(token_buffer)
                         line = line[1:]
-                        if line and not line[0] in self.whitespace_chars:
+                        if line and line[0] not in self.whitespace_chars:
                             raise ValueError("Missing whitespace")
                         break
                     token_buffer.append(line)


### PR DESCRIPTION
Trying ruff 0.0.114 as an alternative to flake8,

```
$ ruff Bio --extend-ignore E501,B007,E741,F401,F841,D105,B009,B010,B011 Bio/PDB/MMCIF2Dict.py:120:41: E713 Test for membership should be `not in`
```

Curiously flake8 and pycodestyle didn't catch this usage.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
