### PR TITLE
Test on Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,9 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        # TODO - Try Python 3.11 again, was Python 3.11.0 was
+        # failing when trying to delete SQlite databases.
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -116,7 +116,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
 
@@ -215,7 +215,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -251,7 +251,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -11,8 +11,8 @@ The latest news is at the top of this file.
 (In progress, not yet released): Biopython 1.80
 ===============================================
 
-This release of Biopython supports Python 3.7, 3.8, 3.9 and 3.10. It has also
-been tested on PyPy3.7 v7.3.5.
+This release of Biopython supports Python 3.7, 3.8, 3.9, 3.10, 3.11. It has
+also been tested on PyPy3.7 v7.3.5.
 
 Functions ``read``, ``parse``, and ``write`` were added to ``Bio.Align`` to
 read and write ``Alignment`` objects.
@@ -59,14 +59,14 @@ property giving the numerical identifier for the REBASE database identifier
 from which the enzyme object was created, and a `uri` property with a canonical
 `identifiers.org` link to the database, for use in linked-data representations.
 
-Additionally, a number of small bugs and typos have been fixed with additions
-to the test suite.
-
 Add new ``gc_fraction`` function in ``SeqUtils`` and marks ``GC`` for future
 deprecation.
 
 Support for the old format (dating back to 2004) of the GN line in SwissProt
 files was dropped in ``Bio.SwissProt``.
+
+Additionally, a number of small bugs and typos have been fixed with additions
+to the test suite.
 
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:

--- a/README.rst
+++ b/README.rst
@@ -83,12 +83,12 @@ install Biopython yourself. This is described below.
 Python Requirements
 ===================
 
-We currently recommend using Python 3.9 from http://www.python.org
+We currently recommend using Python 3.10 from http://www.python.org
 
 Biopython is currently supported and tested on the following Python
 implementations:
 
-- Python 3.7, 3.8, 3.9, and 3.10 -- see http://www.python.org
+- Python 3.7, 3.8, 3.9, 3.10 and 3.11 -- see http://www.python.org
 
 - PyPy3.7 v7.3.5 -- or later, see http://www.pypy.org
 


### PR DESCRIPTION
Preparatory work for the overdue next release.

I would like to phase out Python 3.7 support, but currently PyPy still targets that version of the Python language - so not yet?

Also now recommending Python 3.10 (was Python 3.9), not suggesting Python 3.11 at this point as it is still quite new and not all third packages will have been update for it yet (e.g. providing wheels).

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
