### PR TITLE
Correct the number of flexibility scores

### DIFF
--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -166,7 +166,7 @@ class ProteinAnalysis:
         weights = [0.25, 0.4375, 0.625, 0.8125, 1]
         scores = []
 
-        for i in range(self.length - window_size):
+        for i in range(self.length - window_size + 1):
             subsequence = self.sequence[i : i + window_size]
             score = 0.0
 


### PR DESCRIPTION
For a sequence of length `L` and a window size `W`, the number of flexibility scores we can calculate is `L - W + 1`, not `L - W` as in the current code. For example, a sequence of length 9 should have 1 score, but it is '0' in the current version.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
