### PR TITLE
Entrez parser ignore_errors

### DIFF
--- a/Bio/Entrez/DTDs/elink.dtd
+++ b/Bio/Entrez/DTDs/elink.dtd
@@ -1,0 +1,88 @@
+<!--    
+                This is the Current DTD for Entrez eLink
+$Id: eLink_101123.dtd 349314 2012-01-09 23:26:00Z fialkov $
+-->
+<!-- ================================================================= -->
+
+<!ELEMENT	ERROR			(#PCDATA)>	<!-- .+ -->
+<!ELEMENT	Info			(#PCDATA)>	<!-- .+ -->
+
+<!ELEMENT	Id				(#PCDATA)>	<!-- \d+ -->
+<!ATTLIST	Id		
+			HasLinkOut  (Y|N)	#IMPLIED	
+			HasNeighbor (Y|N)	#IMPLIED
+			>
+
+<!ELEMENT	Score			(#PCDATA)>	<!-- \d+ -->
+<!ELEMENT	DbFrom			(#PCDATA)>	<!-- \S+ -->
+<!ELEMENT	DbTo			(#PCDATA)>	<!-- \S+ -->
+<!ELEMENT	LinkName		(#PCDATA)>	<!-- \S+ -->
+<!ELEMENT	WebEnv			(#PCDATA)>	<!-- \S+ -->
+<!ELEMENT	MenuTag			(#PCDATA)>	<!-- \S+ -->
+<!ELEMENT	HtmlTag			(#PCDATA)>	<!-- \S+ -->
+<!ELEMENT	Priority		(#PCDATA)>	<!-- \S+ -->
+
+<!ELEMENT	IdList		(Id*)>
+
+<!-- cmd=neighbor -->
+<!ELEMENT	Link		(Id, Score?)>
+<!ELEMENT	QueryKey		(#PCDATA)>
+
+<!ELEMENT	LinkSetDb	(DbTo, LinkName, (Link*|Info), ERROR?)>
+<!ELEMENT	LinkSetDbHistory	(DbTo, LinkName, (QueryKey|Info), ERROR?)>
+
+<!-- cmd=llinks -->
+
+<!ELEMENT	Url			    (#PCDATA)>	<!-- \S+ -->
+<!ATTLIST	Url			LNG     (DA|DE|EN|EL|ES|FR|IT|IW|JA|NL|NO|RU|SV|ZH)     "EN">
+
+<!ELEMENT	IconUrl			(#PCDATA)>	<!-- \S+ -->
+<!ATTLIST	IconUrl		LNG     (DA|DE|EN|EL|ES|FR|IT|IW|JA|NL|NO|RU|SV|ZH)     "EN">
+
+<!ELEMENT	SubjectType		(#PCDATA)>	<!-- .+ -->
+<!ELEMENT	Category		(#PCDATA)>	<!-- .+ -->
+<!ELEMENT	Attribute		(#PCDATA)>	<!-- .+ -->
+<!--ELEMENT	LinkName		(#PCDATA)-->	<!--defined in neighbor section--><!-- \S+ -->
+<!ELEMENT	Name			(#PCDATA)>	<!-- .+ -->
+<!ELEMENT	NameAbbr		(#PCDATA)>	<!-- \S+ -->
+<!ELEMENT	SubProvider		(#PCDATA)>
+
+<!ELEMENT   FirstChar		(#PCDATA)>
+
+<!ELEMENT	Provider (
+				Name,
+				NameAbbr,
+				Id,
+				Url,
+				IconUrl?
+			)>
+
+<!ELEMENT	ObjUrl	(
+				Url,
+				IconUrl?,
+				LinkName?,
+                SubjectType*,
+				Category*,
+                Attribute*,
+                Provider,
+                SubProvider?
+			)>
+
+<!ELEMENT	IdUrlSet	(Id,(ObjUrl+|Info))>
+
+<!ELEMENT   FirstChars  (FirstChar*)>
+
+<!ELEMENT	LinkInfo	(DbTo, LinkName, MenuTag?, HtmlTag?, Url?, Priority)>
+<!ELEMENT	IdLinkSet	(Id, LinkInfo*)>
+<!ELEMENT	IdUrlList	(IdUrlSet* | FirstChars*)>
+
+<!-- cmd=ncheck & lcheck & acheck -->
+<!ELEMENT	IdCheckList	((Id|IdLinkSet)*,ERROR?)>
+
+
+<!-- Common -->
+<!ELEMENT	LinkSet		(DbFrom, 
+				((IdList?, ((ERROR?, LinkSetDb)*  |  (LinkSetDbHistory*, WebEnv))) | IdUrlList | IdCheckList | ERROR), ERROR?  
+				)>
+
+<!ELEMENT	eLinkResult	(LinkSet*, ERROR?)>

--- a/Bio/Entrez/DTDs/epost.dtd
+++ b/Bio/Entrez/DTDs/epost.dtd
@@ -1,0 +1,14 @@
+<!--    
+                This is the Current DTD for Entrez ePost
+$Id: ePost_020511.dtd 161288 2009-05-26 18:34:21Z fialkov $
+-->
+<!-- ================================================================= -->
+
+<!ELEMENT	Id		(#PCDATA)>	<!-- \d+ -->
+
+<!ELEMENT	InvalidIdList	(Id+)>
+<!ELEMENT       QueryKey        (#PCDATA)>	<!-- \d+ -->
+<!ELEMENT       WebEnv          (#PCDATA)>	<!-- \S+ -->
+<!ELEMENT       ERROR           (#PCDATA)>	<!-- .+ -->
+
+<!ELEMENT     ePostResult       (InvalidIdList?,(QueryKey,WebEnv)?,ERROR?)>

--- a/Bio/Entrez/DTDs/esummary_gene.dtd
+++ b/Bio/Entrez/DTDs/esummary_gene.dtd
@@ -1,0 +1,179 @@
+<!-- DocSum DTD for gene database -->
+
+<!--~~ !dtd
+~~json
+   <json type='esummary' version='0.3'>
+       <config lcnames='true'/>
+   </json>
+~~-->
+
+<!ENTITY	 % T_string		"(#PCDATA)">
+<!ENTITY	 % T_int		"(#PCDATA)">
+
+<!-- Definition of List type: T_MimListType -->
+<!ELEMENT	int	%T_int;>
+<!ENTITY	 % T_MimListType	"(int)*">
+
+<!-- Members definition of Structure type: T_GenomicInfoType -->
+<!ELEMENT	ChrLoc		%T_string;>
+<!ELEMENT	ChrAccVer		%T_string;>
+<!--~~ <ChrStart>
+~~json <number/>
+~~-->
+<!ELEMENT	ChrStart		%T_int;>
+<!--~~ <ChrStop>
+~~json <number/>
+~~-->
+<!ELEMENT	ChrStop		%T_int;>
+<!--~~ <ExonCount>
+~~json <number/>
+~~-->
+<!ELEMENT	ExonCount		%T_int;>
+
+<!-- Definition of Structure type: T_GenomicInfoType -->
+<!--~~ <GenomicInfoType>
+~~json <object/>
+~~-->
+<!ENTITY	 % T_GenomicInfoType "(
+			ChrLoc?,
+			ChrAccVer?,
+			ChrStart?,
+			ChrStop?,
+			ExonCount?
+			)
+			">
+
+<!-- Definition of List type: T_GenomicInfoListType -->
+<!ELEMENT	GenomicInfoType	%T_GenomicInfoType;>
+<!ENTITY	 % T_GenomicInfoListType	"(GenomicInfoType)*">
+
+<!-- Members definition of Structure type: T_OrganismType -->
+<!ELEMENT	ScientificName		%T_string;>
+<!ELEMENT	CommonName		%T_string;>
+<!--~~ <TaxID>
+~~json <number/>
+~~-->
+<!ELEMENT	TaxID		%T_int;>
+
+<!-- Definition of Structure type: T_OrganismType -->
+<!--~~ <OrganismType>
+~~json <object/>
+~~-->
+<!ENTITY	 % T_OrganismType "(
+			ScientificName?,
+			CommonName?,
+			TaxID?
+			)
+			">
+
+<!-- Members definition of Structure type: T_LocationHistType -->
+<!ELEMENT	AnnotationRelease		%T_string;>
+<!ELEMENT	AssemblyAccVer		%T_string;>
+<!-- Already defined ...
+	ChrAccVer	 as 	%T_string;
+ ... Already defined -->
+<!-- Already defined ...
+	ChrStart	 as 	%T_int;
+ ... Already defined -->
+<!-- Already defined ...
+	ChrStop	 as 	%T_int;
+ ... Already defined -->
+
+<!-- Definition of Structure type: T_LocationHistType -->
+<!--~~ <LocationHistType>
+~~json <object/>
+~~-->
+<!ENTITY	 % T_LocationHistType "(
+			AnnotationRelease?,
+			AssemblyAccVer?,
+			ChrAccVer?,
+			ChrStart?,
+			ChrStop?
+			)
+			">
+
+<!-- Definition of List type: T_LocationHistListType -->
+<!ELEMENT	LocationHistType	%T_LocationHistType;>
+<!ENTITY	 % T_LocationHistListType	"(LocationHistType)*">
+
+<!-- Members definition of Structure type: T_DocSum -->
+<!ELEMENT	Name		%T_string;>
+<!ELEMENT	Description		%T_string;>
+<!--~~ <Status>
+~~json <number/>
+~~-->
+<!ELEMENT	Status		%T_int;>
+<!--~~ <CurrentID>
+~~json <number/>
+~~-->
+<!ELEMENT	CurrentID		%T_int;>
+<!ELEMENT	Chromosome		%T_string;>
+<!ELEMENT	GeneticSource		%T_string;>
+<!ELEMENT	MapLocation		%T_string;>
+<!ELEMENT	OtherAliases		%T_string;>
+<!ELEMENT	OtherDesignations		%T_string;>
+<!ELEMENT	NomenclatureSymbol		%T_string;>
+<!ELEMENT	NomenclatureName		%T_string;>
+<!ELEMENT	NomenclatureStatus		%T_string;>
+<!ELEMENT	Mim		%T_MimListType;>
+<!ELEMENT	GenomicInfo		%T_GenomicInfoListType;>
+<!--~~ <GeneWeight>
+~~json <number/>
+~~-->
+<!ELEMENT	GeneWeight		%T_int;>
+<!ELEMENT	Summary		%T_string;>
+<!ELEMENT	ChrSort		%T_string;>
+<!-- Already defined ...
+	ChrStart	 as 	%T_int;
+ ... Already defined -->
+<!ELEMENT	Organism		%T_OrganismType;>
+<!ELEMENT	LocationHist		%T_LocationHistListType;>
+<!ELEMENT	error		%T_string;>
+
+<!-- Definition of Structure type: T_DocSum -->
+<!--~~ <DocumentSummary>
+~~json <object name='@uid'/>
+~~-->
+<!ENTITY	 % T_DocSum "((
+			Name?,
+			Description?,
+			Status?,
+			CurrentID?,
+			Chromosome?,
+			GeneticSource?,
+			MapLocation?,
+			OtherAliases?,
+			OtherDesignations?,
+			NomenclatureSymbol?,
+			NomenclatureName?,
+			NomenclatureStatus?,
+			Mim?,
+			GenomicInfo?,
+			GeneWeight?,
+			Summary?,
+			ChrSort?,
+			ChrStart?,
+			Organism?,
+			LocationHist?
+			)
+			| error)
+			">
+
+<!ELEMENT DocumentSummary %T_DocSum;>
+<!ATTLIST DocumentSummary uid CDATA #IMPLIED>
+
+<!ELEMENT DbBuild      %T_string;>
+<!ELEMENT DocumentSummarySet (DbBuild?, DocumentSummary*)>
+<!ATTLIST DocumentSummarySet status CDATA #REQUIRED>
+<!--~~ <DocumentSummarySet>
+~~json
+   <object key="result">
+       <array key="uids" select='DocumentSummary/@uid'/>
+       <members select='DocumentSummary'/>
+   </object>
+~~-->
+<!--~~ <eSummaryResult>
+~~ json <member/>
+~~-->
+
+<!ELEMENT eSummaryResult (DocumentSummarySet?)>

--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -236,6 +236,24 @@ class OrderedListElement(list):
         self[-1].append(value)
 
 
+class ErrorElement(str):
+    """NCBI Entrez XML element containing an error message."""
+
+    def __new__(cls, value, *args, **kwargs):
+        """Create an ErrorElement."""
+        return str.__new__(cls, value)
+
+    def __init__(self, value, tag):
+        """Initialize an ErrorElement."""
+        self.tag = tag
+        self.key = tag
+
+    def __repr__(self):
+        """Return the error message as a string."""
+        text = str.__repr__(self)
+        return f"ErrorElement({text})"
+
+
 class NotXMLError(ValueError):
     """Failed to parse file as XML."""
 
@@ -337,7 +355,7 @@ class DataHandler(metaclass=DataHandlerMeta):
 
     del Entrez
 
-    def __init__(self, validate, escape):
+    def __init__(self, validate, escape, ignore_errors):
         """Create a DataHandler object."""
         self.dtd_urls = []
         self.element = None
@@ -350,6 +368,7 @@ class DataHandler(metaclass=DataHandlerMeta):
         self.items = set()
         self.errors = set()
         self.validating = validate
+        self.ignore_errors = ignore_errors
         self.parser = expat.ParserCreate(namespace_separator=" ")
         self.parser.SetParamEntityParsing(expat.XML_PARAM_ENTITY_PARSING_ALWAYS)
         self.parser.XmlDeclHandler = self.xmlDeclHandler
@@ -733,7 +752,7 @@ class DataHandler(metaclass=DataHandlerMeta):
         self.allowed_tags = None
 
     def endRawElementHandler(self, name):
-        """Handle start of an XML raw element."""
+        """Handle end of an XML raw element."""
         self.level -= 1
         if self.level == 0:
             self.parser.EndElementHandler = self.endStringElementHandler
@@ -746,22 +765,30 @@ class DataHandler(metaclass=DataHandlerMeta):
         self.data.append(tag)
 
     def endSkipElementHandler(self, name):
-        """Handle start of an XML skip element."""
+        """Handle end of an XML skip element."""
         self.level -= 1
         if self.level == 0:
             self.parser.StartElementHandler = self.startElementHandler
             self.parser.EndElementHandler = self.endElementHandler
 
-    def endErrorElementHandler(self, name):
-        """Handle start of an XML error element."""
-        if self.data:
-            # error found:
-            value = "".join(self.data)
-            raise RuntimeError(value)
-        # no error found:
-        if self.element is not None:
+    def endErrorElementHandler(self, tag):
+        """Handle end of an XML error element."""
+        element = self.element
+        if element is not None:
+            self.parser.StartElementHandler = self.startElementHandler
             self.parser.EndElementHandler = self.endElementHandler
             self.parser.CharacterDataHandler = self.skipCharacterDataHandler
+        data = "".join(self.data)
+        if data == "":
+            return
+        if self.ignore_errors is False:
+            raise RuntimeError(data)
+        self.data = []
+        value = ErrorElement(data, tag)
+        if element is None:
+            self.record = element
+        else:
+            element.store(value)
 
     def endElementHandler(self, name):
         """Handle end of an XML element."""
@@ -928,9 +955,9 @@ class DataHandler(metaclass=DataHandlerMeta):
         # only once, and which can occur multiple times.
         single = []
         multiple = []
+        errors = []
         # The 'count' function is called recursively to make sure all the
-        # children in this model are counted. Error keys are ignored;
-        # they raise an exception in Python.
+        # children in this model are counted.
 
         def count(model):
             quantifier, key, children = model[1:]
@@ -944,7 +971,9 @@ class DataHandler(metaclass=DataHandlerMeta):
                 else:
                     for child in children:
                         count(child)
-            elif key.upper() != "ERROR":
+            elif key.upper() == "ERROR":
+                errors.append(key)
+            else:
                 if quantifier in (
                     expat.model.XML_CQUANT_NONE,
                     expat.model.XML_CQUANT_OPT,
@@ -958,10 +987,10 @@ class DataHandler(metaclass=DataHandlerMeta):
 
         count(model)
         if len(single) == 0 and len(multiple) == 1:
-            allowed_tags = frozenset(multiple)
+            allowed_tags = frozenset(multiple + errors)
             self.constructors[name] = (ListElement, (allowed_tags,))
         else:
-            allowed_tags = frozenset(single + multiple)
+            allowed_tags = frozenset(single + multiple + errors)
             repeated_tags = frozenset(multiple)
             args = (allowed_tags, repeated_tags)
             self.constructors[name] = (DictionaryElement, args)

--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -484,7 +484,6 @@ class DataHandler(metaclass=DataHandlerMeta):
                 # Then the first record is finished, while the second record
                 # is still a work in progress.
                 record = records.pop(0)
-                del record.key
                 yield record
 
         # We have reached the end of the XML file
@@ -494,9 +493,7 @@ class DataHandler(metaclass=DataHandlerMeta):
             raise CorruptedXMLError("Premature end of data")
 
         # Send out the remaining records
-        for record in records:
-            del record.key
-            yield record
+        yield from records
 
     def xmlDeclHandler(self, version, encoding, standalone):
         """Set XML handlers when an XML declaration is found."""

--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -455,7 +455,7 @@ def ecitmatch(**keywds):
     return _open(request)
 
 
-def read(handle, validate=True, escape=False):
+def read(handle, validate=True, escape=False, ignore_errors=False):
     """Parse an XML file from the NCBI Entrez Utilities into python objects.
 
     This function parses an XML file created by NCBI's Entrez Utilities,
@@ -495,12 +495,12 @@ def read(handle, validate=True, escape=False):
     """
     from .Parser import DataHandler
 
-    handler = DataHandler(validate, escape)
+    handler = DataHandler(validate, escape, ignore_errors)
     record = handler.read(handle)
     return record
 
 
-def parse(handle, validate=True, escape=False):
+def parse(handle, validate=True, escape=False, ignore_errors=False):
     """Parse an XML file from the NCBI Entrez Utilities into python objects.
 
     This function parses an XML file created by NCBI's Entrez Utilities,
@@ -549,7 +549,7 @@ def parse(handle, validate=True, escape=False):
     """
     from .Parser import DataHandler
 
-    handler = DataHandler(validate, escape)
+    handler = DataHandler(validate, escape, ignore_errors)
     records = handler.parse(handle)
     return records
 

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -669,14 +669,9 @@ which is a valid HTML fragment. By default, \verb+escape+ is \verb+False+.
 
 \section{Handling errors}
 
-Three things can go wrong when parsing an XML file:
-\begin{itemize}
-\item The file may not be an XML file to begin with;
-\item The file may end prematurely or otherwise be corrupted;
-\item The file may be correct XML, but contain items that are not represented in the associated DTD.
-\end{itemize}
+\subsection*{The file is not an XML file}
 
-The first case occurs if, for example, you try to parse a Fasta file as if it were an XML file:
+For example, this error occurs if you try to parse a Fasta file as if it were an XML file:
 
 %doctest ../Tests/GenBank
 \begin{minted}{pycon}
@@ -689,7 +684,10 @@ Bio.Entrez.Parser.NotXMLError: Failed to parse the XML data (syntax error: line 
 \end{minted}
 Here, the parser didn't find the \verb|<?xml ...| tag with which an XML file is supposed to start, and therefore decides (correctly) that the file is not an XML file.
 
+\subsection*{The file ends prematurely or is otherwise corrupted}
+
 When your file is in the XML format but is corrupted (for example, by ending prematurely), the parser will raise a CorruptedXMLError.
+
 Here is an example of an XML file that ends prematurely:
 \begin{minted}{text}
 <?xml version="1.0"?>
@@ -717,7 +715,9 @@ Bio.Entrez.Parser.CorruptedXMLError: Failed to parse the XML data (no element fo
 \end{minted}
 Note that the error message tells you at what point in the XML file the error was detected.
 
-The third type of error occurs if the XML file contains tags that do not have a description in the corresponding DTD file. This is an example of such an XML file:
+\subsection*{The file contains items that are missing from the associated DTD}
+
+This is an example of an XML file containing tags that do not have a description in the corresponding DTD file:
 
 \begin{minted}{text}
 <?xml version="1.0"?>
@@ -769,6 +769,44 @@ Optionally, you can instruct the parser to skip such tags instead of raising a V
 \end{minted}
 Of course, the information contained in the XML tags that are not in the DTD are not present in the record returned by \verb|Entrez.read|.
 
+\subsection*{The file contains an error message}
+
+This may occur, for example, when you attempt to access a PubMed record for a nonexistent PubMed ID. By default, this will raise a \verb+RuntimeError+:
+
+%doctest . internet
+\begin{minted}{pycon}
+>>> from Bio import Entrez
+>>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
+>>> stream = Entrez.esummary(db="pubmed", id="99999999")
+>>> record = Entrez.read(stream)
+Traceback (most recent call last):
+...
+RuntimeError: UID=99999999: cannot get document summary
+\end{minted}
+
+If you are accessing multiple PubMed records, the \verb+RuntimeError+ would prevent you from receiving results for any of the PubMed records if one of the PubMed IDs is incorrect. To circumvent this, you can set the \verb+ignore_errors+ argument to \verb+True+. This will return the requested results for the valid PubMed IDs, and an \verb+ErrorElement+ for the incorrect ID:
+
+%doctest . internet
+\begin{minted}{pycon}
+>>> from Bio import Entrez
+>>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
+>>> stream = Entrez.esummary(db="pubmed", id="19304878,99999999,31278684")
+>>> record = Entrez.read(stream, ignore_errors=True)
+>>> len(record)
+3
+>>> record[0].tag
+'DocSum'
+>>> record[0]["Title"]
+'Biopython: freely available Python tools for computational molecular biology and bioinformatics.'
+>>> record[1].tag
+'ERROR'
+>>> record[1]
+ErrorElement('UID=99999999: cannot get document summary')
+>>> record[2].tag
+'DocSum'
+>>> record[2]["Title"]
+'Sharing Programming Resources Between Bio* Projects.'
+\end{minted}
 
 \section{Specialized parsers}
 \label{sec:entrez-specialized-parsers}

--- a/Tests/test_Entrez.py
+++ b/Tests/test_Entrez.py
@@ -429,7 +429,7 @@ class CustomDirectoryTest(unittest.TestCase):
         import os
         import shutil
 
-        handler = Parser.DataHandler(validate=False, escape=False)
+        handler = Parser.DataHandler(validate=False, escape=False, ignore_errors=False)
 
         # Create a temporary directory
         tmpdir = tempfile.mkdtemp()

--- a/Tests/test_Entrez_parser.py
+++ b/Tests/test_Entrez_parser.py
@@ -1778,7 +1778,6 @@ class EPostTest(unittest.TestCase):
         self.assertEqual(len(record.attributes), 0)
         self.assertEqual(record["ERROR"], "Wrong DB name")
         self.assertEqual(record["ERROR"].tag, "ERROR")
-        self.assertEqual(record["ERROR"].key, "ERROR")
 
     def test_invalid(self):
         """Test parsing XML returned by EPost with invalid id (overflow tag)."""
@@ -2195,7 +2194,6 @@ class ESummaryTest(unittest.TestCase):
         self.assertEqual(len(record.attributes), 0)
         self.assertEqual(record[0], "Neither query_key nor id specified")
         self.assertEqual(record[0].tag, "ERROR")
-        self.assertEqual(record[0].key, "ERROR")
 
     def test_integer_none(self):
         """Test parsing ESummary XML where an Integer is not defined."""

--- a/Tests/test_Entrez_parser.py
+++ b/Tests/test_Entrez_parser.py
@@ -77,14 +77,16 @@ class GeneralTests(unittest.TestCase):
                 "biosample.xml",  # DTD not specified in XML file
                 "einfo3.xml",  # DTD incomplete
                 "einfo4.xml",  # XML corrupted
-                "epost2.xml",  # XML returned by EPost with incorrect arguments
-                "esummary8.xml",  # XML returned by ESummary with incorrect arguments
                 "journals.xml",  # Missing XML declaration
             ):
                 continue
             path = os.path.join(directory, filename)
             with open(path, "rb") as stream:
-                record = Entrez.read(stream)
+                if filename in ("epost2.xml", "esummary8.xml", "esummary10.xml"):
+                    # these include an ErrorElement
+                    record = Entrez.read(stream, ignore_errors=True)
+                else:
+                    record = Entrez.read(stream)
             with BytesIO() as stream:
                 pickle.dump(record, stream)
                 stream.seek(0)
@@ -1770,6 +1772,13 @@ class EPostTest(unittest.TestCase):
         # >>> Bio.Entrez.epost(db="nothing")
         with open("Entrez/epost2.xml", "rb") as handle:
             self.assertRaises(RuntimeError, Entrez.read, handle)
+        with open("Entrez/epost2.xml", "rb") as handle:
+            record = Entrez.read(handle, ignore_errors=True)
+        self.assertEqual(len(record), 1)
+        self.assertEqual(len(record.attributes), 0)
+        self.assertEqual(record["ERROR"], "Wrong DB name")
+        self.assertEqual(record["ERROR"].tag, "ERROR")
+        self.assertEqual(record["ERROR"].key, "ERROR")
 
     def test_invalid(self):
         """Test parsing XML returned by EPost with invalid id (overflow tag)."""
@@ -2180,6 +2189,13 @@ class ESummaryTest(unittest.TestCase):
         # >>> Bio.Entrez.esummary()
         with open("Entrez/esummary8.xml", "rb") as handle:
             self.assertRaises(RuntimeError, Entrez.read, handle)
+        with open("Entrez/esummary8.xml", "rb") as handle:
+            record = Entrez.read(handle, ignore_errors=True)
+        self.assertEqual(len(record), 1)
+        self.assertEqual(len(record.attributes), 0)
+        self.assertEqual(record[0], "Neither query_key nor id specified")
+        self.assertEqual(record[0].tag, "ERROR")
+        self.assertEqual(record[0].key, "ERROR")
 
     def test_integer_none(self):
         """Test parsing ESummary XML where an Integer is not defined."""


### PR DESCRIPTION
This PR adds a `ignore_errors` argument to `Entrez.read` and `Entrez.parse` to create error elements instead of raising a `RuntimeError`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


Closes #4166
