### PR TITLE
remove deprecated argument from Bio.Phylo.BaseTree

### DIFF
--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -486,7 +486,7 @@ def read(handle, validate=True, escape=False, ignore_errors=False):
     by HTML escape characters to guarantee that the returned strings are
     valid HTML fragments. For example, a less-than sign (<) is replaced by
     &lt;. If escape is False (default), the string is returned as is.
-    
+
     If ignore_errors is False (default), any error messages in the XML file
     will raise a RuntimeError. If ignore_errors is True, error messages will
     be stored as ErrorElement items, without raising an exception.
@@ -544,7 +544,7 @@ def parse(handle, validate=True, escape=False, ignore_errors=False):
     by HTML escape characters to guarantee that the returned strings are
     valid HTML fragments. For example, a less-than sign (<) is replaced by
     &lt;. If escape is False (default), the string is returned as is.
-    
+
     If ignore_errors is False (default), any error messages in the XML file
     will raise a RuntimeError. If ignore_errors is True, error messages will
     be stored as ErrorElement items, without raising an exception.

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -18,8 +18,6 @@ import random
 import re
 import warnings
 
-from Bio import BiopythonDeprecationWarning
-
 
 # General tree-traversal algorithms
 
@@ -972,21 +970,13 @@ class Tree(TreeElement, TreeMixin):
             # Follow python convention and default to using __str__
             return str(self)
 
-    def format(self, fmt=None, format=None):
+    def format(self, fmt=None):
         """Serialize the tree as a string in the specified file format.
 
         :param fmt: a lower-case string supported by ``Bio.Phylo.write``
             as an output file format.
 
         """
-        if format is not None:
-            if fmt is not None:
-                raise ValueError("The ``format`` argument has been renamed to ``fmt``.")
-            warnings.warn(
-                "The ``format`` argument has been renamed to ``fmt``.",
-                BiopythonDeprecationWarning,
-            )
-            fmt = format
         return self.__format__(fmt)
 
     # Pretty-printer for the entire tree hierarchy


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

