### PR TITLE
add an alignment property to the Phylogeny class

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1027,7 +1027,7 @@ class Alignment:
 
         Arguments:
          - sequences   - A list of the sequences (Seq, MutableSeq, SeqRecord,
-                         or string objects)that were aligned.
+                         or string objects) that were aligned.
          - coordinates - The sequence coordinates that define the alignment.
                          If None (the default value), assume that the sequences
                          align to each other without any gaps.
@@ -1042,12 +1042,15 @@ class Alignment:
                 # its length are known.
                 pass
             else:
-                if len(lengths) != 1:
+                if len(lengths) == 0:
+                    coordinates = numpy.empty((0, 0), dtype=int)
+                elif len(lengths) == 1:
+                    length = lengths.pop()
+                    coordinates = numpy.array([[0, length]] * len(sequences))
+                else:
                     raise ValueError(
                         "sequences must have the same length if coordinates is None"
                     )
-                length = lengths.pop()
-                coordinates = numpy.array([[0, length]] * len(sequences))
         self.coordinates = coordinates
 
     def __array__(self, dtype=None):
@@ -2260,6 +2263,8 @@ class Alignment:
         """
         coordinates = numpy.array(self.coordinates)
         n = len(coordinates)
+        if n == 0:  # no sequences
+            return (0, 0)
         for i in range(n):
             if coordinates[i, 0] > coordinates[i, -1]:  # mapped to reverse strand
                 k = len(self.sequences[i])

--- a/Tests/test_Align_Alignment.py
+++ b/Tests/test_Align_Alignment.py
@@ -23,6 +23,19 @@ from Bio.SeqRecord import SeqRecord
 from Bio.SeqUtils import gc_fraction
 
 
+class TestAlignment(unittest.TestCase):
+    def test_empty_alignment(self):
+        alignment = Align.Alignment([])
+        self.assertEqual(
+            repr(alignment),
+            "<Alignment object (0 rows x 0 columns) at 0x%x>" % id(alignment),
+        )
+        self.assertEqual(len(alignment), 0)
+        self.assertEqual(len(alignment.sequences), 0)
+        self.assertEqual(alignment.shape, (0, 0))
+        self.assertEqual(alignment.coordinates.shape, (0, 0))
+
+
 class TestPairwiseAlignment(unittest.TestCase):
     target = "AACCGGGACCG"
     query = "ACGGAAC"

--- a/Tests/test_PhyloXML.py
+++ b/Tests/test_PhyloXML.py
@@ -14,7 +14,7 @@ from itertools import chain
 
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.Align import MultipleSeqAlignment
+from Bio.Align import Alignment, MultipleSeqAlignment
 from Bio.Phylo import PhyloXML as PX, PhyloXMLIO
 
 # Example PhyloXML files
@@ -703,6 +703,41 @@ class MethodTests(unittest.TestCase):
         self.assertIsInstance(aln, MultipleSeqAlignment)
         self.assertEqual(len(aln), 3)
         self.assertEqual(aln.get_alignment_length(), 7)
+
+    def test_alignment(self):
+        tree = self.phyloxml.phylogenies[0]
+        aln = tree.alignment
+        self.assertIsInstance(aln, Alignment)
+        self.assertEqual(len(aln), 0)
+        self.assertEqual(aln.shape, (0, 0))
+        # Add sequences to the terminals
+        for tip, seqstr in zip(tree.get_terminals(), ("AA--TTA", "AA--TTG", "AACCTTC")):
+            tip.sequences.append(
+                PX.Sequence.from_seqrecord(
+                    SeqRecord(Seq(seqstr), id=str(tip)), is_aligned=True
+                )
+            )
+        # Check the alignment
+        aln = tree.alignment
+        self.assertIsInstance(aln, Alignment)
+        self.assertEqual(aln.shape, (3, 7))
+        self.assertEqual(aln.sequences[0].id, ":A")
+        self.assertEqual(aln.sequences[1].id, ":B")
+        self.assertEqual(aln.sequences[2].id, ":C")
+        self.assertEqual(aln.sequences[0].seq, "AATTA")
+        self.assertEqual(aln.sequences[1].seq, "AATTG")
+        self.assertEqual(aln.sequences[2].seq, "AACCTTC")
+        self.assertEqual(aln[0], "AA--TTA")
+        self.assertEqual(aln[1], "AA--TTG")
+        self.assertEqual(aln[2], "AACCTTC")
+        self.assertEqual(
+            str(aln),
+            """\
+:A                0 AA--TTA 5
+:B                0 AA--TTG 5
+:C                0 AACCTTC 7
+""",
+        )
 
     # Syntax sugar
 


### PR DESCRIPTION
This PR adds an `alignment` property to the `Phylogeny` class.
This property returns an `Alignment` object.
(The existing `to_alignment` method returns a `MultipleSeqAlignment` object.)

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

