### PR TITLE
Enhance Entrez docstring with information about the new PubMed web.

### DIFF
--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -55,6 +55,12 @@ does a maximum of three tries before giving up, and sleeps for 15
 seconds between tries. You can tweak these parameters by setting
 ``Bio.Entrez.max_tries`` and ``Bio.Entrez.sleep_between_tries``.
 
+Please note that, when using the ``Bio.Entrez``with the ``pubmed``
+database, the results differ from the web version of PubMed,
+https://pubmed.ncbi.nlm.nih.gov/, due to a new release of PubMed. Please
+check here https://dataguide.nlm.nih.gov/eutilities/how_eutilities_works.html
+for more information.
+
 The Entrez module also provides an XML parser which takes a handle
 as input.
 

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -215,6 +215,11 @@ True
 \end{minted}
 In this output, you see PubMed IDs (including 19304878 which is the PMID for the Biopython application note), which can be retrieved by EFetch (see section \ref{sec:efetch}).
 
+Please note that, when using the \verb+Bio.Entrez+ with the PubMed database, the results differ from the web version of PubMed, 
+\url{https://pubmed.ncbi.nlm.nih.gov/}, due to a new release of PubMed. Please 
+check \url{https://dataguide.nlm.nih.gov/eutilities/how_eutilities_works.html}
+for more information.
+
 You can also use ESearch to search GenBank. Here we'll do a quick
 search for the \emph{matK} gene in \emph{Cypripedioideae} orchids
 (see Section~\ref{sec:entrez-einfo} about EInfo for one way to


### PR DESCRIPTION
Add information about API mistmatch to Entrez docstring

Improve text

Add tutorial

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*). 

_I think this is a pretty basic documentation PR, so I don't need to be added to the list of actual contributors_

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This addresses #4160 by adding a caveat to the documentation of `Entrez` on why results are different.
