### PR TITLE
fix NEWS to include the change in alignment printing in release 1.80

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -23,7 +23,10 @@ also been tested on PyPy3.7 v7.3.5.
 Functions ``read``, ``parse``, and ``write`` were added to ``Bio.Align`` to
 read and write ``Alignment`` objects.  String formatting and printing output
 of ``Alignment`` objects from ``Bio.Align`` were changed to support these new
-functions.
+functions. To obtain a string showing the aligned sequence with the appropriate
+gap characters (as previously shown when calling ``format`` on an alignment),
+use ``alignment[i]``, where ``alignment`` is an ``Alignment`` object and ``i``
+is the index of the aligned sequence.
 
 Because dict retains the item order by default since Python3.6, all instances
 of ``collections.OrderedDict`` have been replaced by either standard ``dict``

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -21,7 +21,9 @@ This release of Biopython supports Python 3.7, 3.8, 3.9, 3.10, 3.11. It has
 also been tested on PyPy3.7 v7.3.5.
 
 Functions ``read``, ``parse``, and ``write`` were added to ``Bio.Align`` to
-read and write ``Alignment`` objects.
+read and write ``Alignment`` objects.  String formatting and printing output
+of ``Alignment`` objects from ``Bio.Align`` were changed to support these new
+functions.
 
 Because dict retains the item order by default since Python3.6, all instances
 of ``collections.OrderedDict`` have been replaced by either standard ``dict``


### PR DESCRIPTION
In Biopython release 1.80, calling `format` on an `Alignment` generates a different string from the one generated in release 1.79. This PR adds a comment to the `NEWS` file to alert users to this change. See #4183  for more information.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


