### PR TITLE
PairwiseAligner SeqRecord & bytes

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3110,7 +3110,7 @@ class PairwiseAligner(_aligners.PairwiseAligner):
 
     def align(self, seqA, seqB, strand="+"):
         """Return the alignments of two sequences using PairwiseAligner."""
-        if isinstance(seqA, (Seq, MutableSeq)):
+        if isinstance(seqA, (Seq, MutableSeq, SeqRecord)):
             sA = bytes(seqA)
         else:
             sA = seqA
@@ -3118,7 +3118,7 @@ class PairwiseAligner(_aligners.PairwiseAligner):
             sB = seqB
         else:  # strand == "-":
             sB = reverse_complement(seqB, inplace=False)
-        if isinstance(sB, (Seq, MutableSeq)):
+        if isinstance(seqB, (Seq, MutableSeq, SeqRecord)):
             sB = bytes(sB)
         score, paths = _aligners.PairwiseAligner.align(self, sA, sB, strand)
         alignments = PairwiseAlignments(seqA, seqB, score, paths)
@@ -3126,11 +3126,11 @@ class PairwiseAligner(_aligners.PairwiseAligner):
 
     def score(self, seqA, seqB, strand="+"):
         """Return the alignments score of two sequences using PairwiseAligner."""
-        if isinstance(seqA, (Seq, MutableSeq)):
+        if isinstance(seqA, (Seq, MutableSeq, SeqRecord)):
             seqA = bytes(seqA)
         if strand == "-":
             seqB = reverse_complement(seqB, inplace=False)
-        if isinstance(seqB, (Seq, MutableSeq)):
+        if isinstance(seqB, (Seq, MutableSeq, SeqRecord)):
             seqB = bytes(seqB)
         return _aligners.PairwiseAligner.score(self, seqA, seqB, strand)
 

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -603,6 +603,9 @@ class SeqRecord:
         """
         return char in self.seq
 
+    def __bytes__(self):
+        return bytes(self.seq)
+
     def __str__(self):
         """Return a human readable summary of the record and its annotation (string).
 

--- a/Tests/test_SeqRecord.py
+++ b/Tests/test_SeqRecord.py
@@ -167,6 +167,9 @@ class SeqRecordMethods(unittest.TestCase):
     def test_contains(self):
         self.assertIn(Seq("ABC"), self.record)
 
+    def test_bytes(self):
+        self.assertEqual(b"ABCDEFGHIJKLMNOPQRSTUVWZYX", bytes(self.record))
+
     def test_str(self):
         expected = """
 ID: TestID


### PR DESCRIPTION
This PR allows the `PairwiseAligner` in `Bio.Align` to accept `SeqRecord` objects in addition to plain strings and `Seq` objects, and adds a `__bytes__` method to `SeqRecord` that returns the `bytes` contents of `record.seq`.
See also #4181 .

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
