### PR TITLE
Bio.Phylo support for Alignment and MultipleSeqAlignment

### DIFF
--- a/Bio/Phylo/Consensus.py
+++ b/Bio/Phylo/Consensus.py
@@ -17,9 +17,7 @@ import itertools
 
 from ast import literal_eval
 from Bio.Phylo import BaseTree
-from Bio.Align import Alignment, MultipleSeqAlignment
-from Bio.Seq import Seq
-from Bio.SeqRecord import SeqRecord
+from Bio.Align import MultipleSeqAlignment
 
 
 class _BitString(str):
@@ -565,11 +563,11 @@ def bootstrap(msa, times):
         yield item
 
 
-def bootstrap_trees(msa, times, tree_constructor):
+def bootstrap_trees(alignment, times, tree_constructor):
     """Generate bootstrap replicate trees from a multiple sequence alignment.
 
     :Parameters:
-        msa : MultipleSeqAlignment
+        alignment : Alignment or MultipleSeqAlignment object
             multiple sequence alignment to generate replicates.
         times : int
             number of bootstrap times.
@@ -577,20 +575,16 @@ def bootstrap_trees(msa, times, tree_constructor):
             tree constructor to be used to build trees.
 
     """
-    alignment = Alignment([str(row.seq) for row in msa])
-    alignment.sequences = [
-        SeqRecord(Seq(seq), row.id) for row, seq in zip(msa, alignment.sequences)
-    ]
-    if False and isinstance(msa, MultipleSeqAlignment):
-        length = len(msa[0])
+    if isinstance(alignment, MultipleSeqAlignment):
+        length = len(alignment[0])
         for i in range(times):
-            bootstrapped_msa = None
+            bootstrapped_alignment = None
             for j in range(length):
                 col = random.randint(0, length - 1)
-                if bootstrapped_msa is None:
-                    bootstrapped_msa = msa[:, col : col + 1]
+                if bootstrapped_alignment is None:
+                    bootstrapped_alignment = alignment[:, col : col + 1]
                 else:
-                    bootstrapped_msa += msa[:, col : col + 1]
+                    bootstrapped_alignment += alignment[:, col : col + 1]
             tree = tree_constructor.build_tree(alignment)
             yield tree
     else:
@@ -601,11 +595,11 @@ def bootstrap_trees(msa, times, tree_constructor):
             yield tree
 
 
-def bootstrap_consensus(msa, times, tree_constructor, consensus):
+def bootstrap_consensus(alignment, times, tree_constructor, consensus):
     """Consensus tree of a series of bootstrap trees for a multiple sequence alignment.
 
     :Parameters:
-        msa : MultipleSeqAlignment
+        alignment : Alignment or MultipleSeqAlignment object
             Multiple sequence alignment to generate replicates.
         times : int
             Number of bootstrap times.
@@ -616,8 +610,8 @@ def bootstrap_consensus(msa, times, tree_constructor, consensus):
             ``majority_consensus``, ``adam_consensus``.
 
     """
-    trees = bootstrap_trees(msa, times, tree_constructor)
-    tree = consensus(list(trees))
+    trees = bootstrap_trees(alignment, times, tree_constructor)
+    tree = consensus(trees)
     return tree
 
 

--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -301,7 +301,9 @@ class _Matrix:
         """Get a lower triangular matrix string."""
         matrix_string = "\n".join(
             [
-                self.names[i] + "\t" + "\t".join([str(n) for n in self.matrix[i]])
+                self.names[i]
+                + "\t"
+                + "\t".join([format(n, "f") for n in self.matrix[i]])
                 for i in range(0, len(self))
             ]
         )
@@ -394,30 +396,30 @@ class DistanceCalculator:
     >>> calculator = DistanceCalculator('identity')
     >>> dm = calculator.get_distance(aln)
     >>> print(dm)  # doctest:+NORMALIZE_WHITESPACE
-    Alpha   0
-    Beta    0.23076923076923073     0
-    Gamma   0.3846153846153846      0.23076923076923073     0
-    Delta   0.5384615384615384      0.5384615384615384      0.5384615384615384     0
-    Epsilon 0.6153846153846154      0.3846153846153846      0.46153846153846156    0.15384615384615385      0
-            Alpha   Beta    Gamma   Delta   Epsilon
+    Alpha	0.000000
+    Beta	0.230769	0.000000
+    Gamma	0.384615	0.230769	0.000000
+    Delta	0.538462	0.538462	0.538462	0.000000
+    Epsilon	0.615385	0.384615	0.461538	0.153846	0.000000
+        Alpha	Beta	Gamma	Delta	Epsilon
 
     Protein calculator with 'blosum62' model::
 
     >>> calculator = DistanceCalculator('blosum62')
     >>> dm = calculator.get_distance(aln)
     >>> print(dm)  # doctest:+NORMALIZE_WHITESPACE
-    Alpha   0
-    Beta    0.36904761904761907     0
-    Gamma   0.49397590361445787     0.25                    0
-    Delta   0.5853658536585367      0.5476190476190477      0.5662650602409638	0
-    Epsilon 0.7                     0.3555555555555555      0.48888888888888893    0.2222222222222222       0
-            Alpha   Beta    Gamma   Delta   Epsilon
+    Alpha	0.000000
+    Beta	0.369048	0.000000
+    Gamma	0.493976	0.250000	0.000000
+    Delta	0.585366	0.547619	0.566265	0.000000
+    Epsilon	0.700000	0.355556	0.488889	0.222222	0.000000
+        Alpha	Beta	Gamma	Delta	Epsilon
 
-    Same calculation, using the new Alignment objects:
+    Same calculation, using the new Alignment object:
 
     >>> from Bio.Phylo.TreeConstruction import DistanceCalculator
     >>> from Bio import Align
-    >>> aln = Align.read(open('TreeConstruction/msa.phy'), 'phylip')
+    >>> aln = Align.read('TreeConstruction/msa.phy', 'phylip')
     >>> print(aln)
     Alpha             0 AACGTGGCCACAT 13
     Beta              0 AAGGTCGCCACAC 13
@@ -431,24 +433,25 @@ class DistanceCalculator:
     >>> calculator = DistanceCalculator('identity')
     >>> dm = calculator.get_distance(aln)
     >>> print(dm)  # doctest:+NORMALIZE_WHITESPACE
-    Alpha   0
-    Beta    0.23076923076923073     0
-    Gamma   0.3846153846153846      0.23076923076923073     0
-    Delta   0.5384615384615384      0.5384615384615384      0.5384615384615384     0
-    Epsilon 0.6153846153846154      0.3846153846153846      0.46153846153846156    0.15384615384615385      0
-            Alpha   Beta    Gamma   Delta   Epsilon
+    Alpha	0.000000
+    Beta	0.230769	0.000000
+    Gamma	0.384615	0.230769	0.000000
+    Delta	0.538462	0.538462	0.538462	0.000000
+    Epsilon	0.615385	0.384615	0.461538	0.153846	0.000000
+        Alpha	Beta	Gamma	Delta	Epsilon
 
     Protein calculator with 'blosum62' model::
 
     >>> calculator = DistanceCalculator('blosum62')
     >>> dm = calculator.get_distance(aln)
     >>> print(dm)  # doctest:+NORMALIZE_WHITESPACE
-    Alpha   0
-    Beta    0.36904761904761907     0
-    Gamma   0.49397590361445787     0.25                    0
-    Delta   0.5853658536585367      0.5476190476190477      0.5662650602409638	0
-    Epsilon 0.7                     0.3555555555555555      0.48888888888888893    0.2222222222222222       0
-            Alpha   Beta    Gamma   Delta   Epsilon
+    Alpha	0.000000
+    Beta	0.369048	0.000000
+    Gamma	0.493976	0.250000	0.000000
+    Delta	0.585366	0.547619	0.566265	0.000000
+    Epsilon	0.700000	0.355556	0.488889	0.222222	0.000000
+        Alpha	Beta	Gamma	Delta	Epsilon
+
     """
 
     protein_alphabet = set("ABCDEFGHIKLMNPQRSTVWXYZ")

--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -11,7 +11,7 @@ import itertools
 import copy
 import numbers
 from Bio.Phylo import BaseTree
-from Bio.Align import MultipleSeqAlignment
+from Bio.Align import Alignment, MultipleSeqAlignment
 from Bio.Align import substitution_matrices
 
 
@@ -521,13 +521,23 @@ class DistanceCalculator:
                 DNA or Protein multiple sequence alignment.
 
         """
-        if not isinstance(msa, MultipleSeqAlignment):
-            raise TypeError("Must provide a MultipleSeqAlignment object.")
+        if isinstance(msa, Alignment):
+            names = [s.id for s in msa.sequences]
+            dm = DistanceMatrix(names)
+            n = len(names)
+            for i1 in range(n):
+                for i2 in range(i1 + 1, n):
+                    dm[names[i1], names[i2]] = self._pairwise(msa[i1], msa[i2])
+        elif isinstance(msa, MultipleSeqAlignment):
+            names = [s.id for s in msa]
+            dm = DistanceMatrix(names)
+            for seq1, seq2 in itertools.combinations(msa, 2):
+                dm[seq1.id, seq2.id] = self._pairwise(seq1, seq2)
+        else:
+            raise TypeError(
+                "Must provide an Alignment object or a MultipleSeqAlignment object."
+            )
 
-        names = [s.id for s in msa]
-        dm = DistanceMatrix(names)
-        for seq1, seq2 in itertools.combinations(msa, 2):
-            dm[seq1.id, seq2.id] = self._pairwise(seq1, seq2)
         return dm
 
 

--- a/Bio/Phylo/TreeConstruction.py
+++ b/Bio/Phylo/TreeConstruction.py
@@ -15,6 +15,9 @@ from Bio.Align import Alignment, MultipleSeqAlignment
 from Bio.Align import substitution_matrices
 
 
+# flake8: noqa
+
+
 class _Matrix:
     """Base class for distance matrix or scoring matrix.
 
@@ -357,10 +360,10 @@ _DistanceMatrix = DistanceMatrix
 
 
 class DistanceCalculator:
-    """Class to calculate the distance matrix from a DNA or Protein.
+    """Calculates the distance matrix from a DNA or protein sequence alignment.
 
-    Multiple Sequence Alignment(MSA) and the given name of the
-    substitution model.
+    This class calculates the distance matrix from a multiple sequence alignment
+    of DNA or protein sequences, and the given name of the substitution model.
 
     Currently only scoring matrices are used.
 
@@ -375,50 +378,77 @@ class DistanceCalculator:
     --------
     Loading a small PHYLIP alignment from which to compute distances::
 
-        from Bio.Phylo.TreeConstruction import DistanceCalculator
-        from Bio import AlignIO
-        aln = AlignIO.read(open('TreeConstruction/msa.phy'), 'phylip')
-        print(aln)
-
-    Output::
-
-        Alignment with 5 rows and 13 columns
-        AACGTGGCCACAT Alpha
-        AAGGTCGCCACAC Beta
-        CAGTTCGCCACAA Gamma
-        GAGATTTCCGCCT Delta
-        GAGATCTCCGCCC Epsilon
+    >>> from Bio.Phylo.TreeConstruction import DistanceCalculator
+    >>> from Bio import AlignIO
+    >>> aln = AlignIO.read(open('TreeConstruction/msa.phy'), 'phylip')
+    >>> print(aln)
+    Alignment with 5 rows and 13 columns
+    AACGTGGCCACAT Alpha
+    AAGGTCGCCACAC Beta
+    CAGTTCGCCACAA Gamma
+    GAGATTTCCGCCT Delta
+    GAGATCTCCGCCC Epsilon
 
     DNA calculator with 'identity' model::
 
-        calculator = DistanceCalculator('identity')
-        dm = calculator.get_distance(aln)
-        print(dm)
-
-    Output::
-
-        Alpha	0
-        Beta	0.23076923076923073	0
-        Gamma	0.3846153846153846	0.23076923076923073	0
-        Delta	0.5384615384615384	0.5384615384615384	0.5384615384615384	0
-        Epsilon	0.6153846153846154	0.3846153846153846	0.46153846153846156	0.15384615384615385	0
-            Alpha	Beta	Gamma	Delta	Epsilon
+    >>> calculator = DistanceCalculator('identity')
+    >>> dm = calculator.get_distance(aln)
+    >>> print(dm)  # doctest:+NORMALIZE_WHITESPACE
+    Alpha   0
+    Beta    0.23076923076923073     0
+    Gamma   0.3846153846153846      0.23076923076923073     0
+    Delta   0.5384615384615384      0.5384615384615384      0.5384615384615384     0
+    Epsilon 0.6153846153846154      0.3846153846153846      0.46153846153846156    0.15384615384615385      0
+            Alpha   Beta    Gamma   Delta   Epsilon
 
     Protein calculator with 'blosum62' model::
 
-        calculator = DistanceCalculator('blosum62')
-        dm = calculator.get_distance(aln)
-        print(dm)
+    >>> calculator = DistanceCalculator('blosum62')
+    >>> dm = calculator.get_distance(aln)
+    >>> print(dm)  # doctest:+NORMALIZE_WHITESPACE
+    Alpha   0
+    Beta    0.36904761904761907     0
+    Gamma   0.49397590361445787     0.25                    0
+    Delta   0.5853658536585367      0.5476190476190477      0.5662650602409638	0
+    Epsilon 0.7                     0.3555555555555555      0.48888888888888893    0.2222222222222222       0
+            Alpha   Beta    Gamma   Delta   Epsilon
 
-    Output::
+    Same calculation, using the new Alignment objects:
 
-        Alpha	0
-        Beta	0.36904761904761907	0
-        Gamma	0.49397590361445787	0.25	0
-        Delta	0.5853658536585367	0.5476190476190477	0.5662650602409638	0
-        Epsilon	0.7	0.3555555555555555	0.48888888888888893	0.2222222222222222	0
-            Alpha	Beta	Gamma	Delta	Epsilon
+    >>> from Bio.Phylo.TreeConstruction import DistanceCalculator
+    >>> from Bio import Align
+    >>> aln = Align.read(open('TreeConstruction/msa.phy'), 'phylip')
+    >>> print(aln)
+    Alpha             0 AACGTGGCCACAT 13
+    Beta              0 AAGGTCGCCACAC 13
+    Gamma             0 CAGTTCGCCACAA 13
+    Delta             0 GAGATTTCCGCCT 13
+    Epsilon           0 GAGATCTCCGCCC 13
+    <BLANKLINE>
 
+    DNA calculator with 'identity' model::
+
+    >>> calculator = DistanceCalculator('identity')
+    >>> dm = calculator.get_distance(aln)
+    >>> print(dm)  # doctest:+NORMALIZE_WHITESPACE
+    Alpha   0
+    Beta    0.23076923076923073     0
+    Gamma   0.3846153846153846      0.23076923076923073     0
+    Delta   0.5384615384615384      0.5384615384615384      0.5384615384615384     0
+    Epsilon 0.6153846153846154      0.3846153846153846      0.46153846153846156    0.15384615384615385      0
+            Alpha   Beta    Gamma   Delta   Epsilon
+
+    Protein calculator with 'blosum62' model::
+
+    >>> calculator = DistanceCalculator('blosum62')
+    >>> dm = calculator.get_distance(aln)
+    >>> print(dm)  # doctest:+NORMALIZE_WHITESPACE
+    Alpha   0
+    Beta    0.36904761904761907     0
+    Gamma   0.49397590361445787     0.25                    0
+    Delta   0.5853658536585367      0.5476190476190477      0.5662650602409638	0
+    Epsilon 0.7                     0.3555555555555555      0.48888888888888893    0.2222222222222222       0
+            Alpha   Beta    Gamma   Delta   Epsilon
     """
 
     protein_alphabet = set("ABCDEFGHIKLMNPQRSTVWXYZ")
@@ -514,11 +544,11 @@ class DistanceCalculator:
         return 1 - (score / max_score)
 
     def get_distance(self, msa):
-        """Return a DistanceMatrix for MSA object.
+        """Return a DistanceMatrix for an Alignment or MultipleSeqAlignment object.
 
         :Parameters:
-            msa : MultipleSeqAlignment
-                DNA or Protein multiple sequence alignment.
+            msa : Alignment or MultipleSeqAlignment object representing a
+                DNA or protein multiple sequence alignment.
 
         """
         if isinstance(msa, Alignment):
@@ -526,7 +556,7 @@ class DistanceCalculator:
             dm = DistanceMatrix(names)
             n = len(names)
             for i1 in range(n):
-                for i2 in range(i1 + 1, n):
+                for i2 in range(i1):
                     dm[names[i1], names[i2]] = self._pairwise(msa[i1], msa[i2])
         elif isinstance(msa, MultipleSeqAlignment):
             names = [s.id for s in msa]
@@ -545,7 +575,7 @@ class TreeConstructor:
     """Base class for all tree constructor."""
 
     def build_tree(self, msa):
-        """Caller to built the tree from a MultipleSeqAlignment object.
+        """Caller to build the tree from an Alignment or MultipleSeqAlignment object.
 
         This should be implemented in subclass.
         """
@@ -567,45 +597,39 @@ class DistanceTreeConstructor(TreeConstructor):
     Loading a small PHYLIP alignment from which to compute distances, and then
     build a upgma Tree::
 
-        from Bio.Phylo.TreeConstruction import DistanceTreeConstructor
-        from Bio.Phylo.TreeConstruction import DistanceCalculator
-        from Bio import AlignIO
-        aln = AlignIO.read(open('TreeConstruction/msa.phy'), 'phylip')
-        constructor = DistanceTreeConstructor()
-        calculator = DistanceCalculator('identity')
-        dm = calculator.get_distance(aln)
-        upgmatree = constructor.upgma(dm)
-        print(upgmatree)
-
-    Output::
-
-        Tree(rooted=True)
-            Clade(branch_length=0, name='Inner4')
-                Clade(branch_length=0.18749999999999994, name='Inner1')
-                    Clade(branch_length=0.07692307692307693, name='Epsilon')
-                    Clade(branch_length=0.07692307692307693, name='Delta')
-                Clade(branch_length=0.11057692307692304, name='Inner3')
-                    Clade(branch_length=0.038461538461538464, name='Inner2')
-                        Clade(branch_length=0.11538461538461536, name='Gamma')
-                        Clade(branch_length=0.11538461538461536, name='Beta')
-                    Clade(branch_length=0.15384615384615383, name='Alpha')
+    >>> from Bio.Phylo.TreeConstruction import DistanceTreeConstructor
+    >>> from Bio.Phylo.TreeConstruction import DistanceCalculator
+    >>> from Bio import AlignIO
+    >>> aln = AlignIO.read(open('TreeConstruction/msa.phy'), 'phylip')
+    >>> constructor = DistanceTreeConstructor()
+    >>> calculator = DistanceCalculator('identity')
+    >>> dm = calculator.get_distance(aln)
+    >>> upgmatree = constructor.upgma(dm)
+    >>> print(upgmatree)
+    Tree(rooted=True)
+        Clade(branch_length=0, name='Inner4')
+            Clade(branch_length=0.18749999999999994, name='Inner1')
+                Clade(branch_length=0.07692307692307693, name='Epsilon')
+                Clade(branch_length=0.07692307692307693, name='Delta')
+            Clade(branch_length=0.11057692307692304, name='Inner3')
+                Clade(branch_length=0.038461538461538464, name='Inner2')
+                    Clade(branch_length=0.11538461538461536, name='Gamma')
+                    Clade(branch_length=0.11538461538461536, name='Beta')
+                Clade(branch_length=0.15384615384615383, name='Alpha')
 
     Build a NJ Tree::
 
-        njtree = constructor.nj(dm)
-        print(njtree)
-
-    Output::
-
-        Tree(rooted=False)
-            Clade(branch_length=0, name='Inner3')
-                Clade(branch_length=0.18269230769230765, name='Alpha')
-                Clade(branch_length=0.04807692307692307, name='Beta')
-                Clade(branch_length=0.04807692307692307, name='Inner2')
-                    Clade(branch_length=0.27884615384615385, name='Inner1')
-                        Clade(branch_length=0.051282051282051266, name='Epsilon')
-                        Clade(branch_length=0.10256410256410259, name='Delta')
-                    Clade(branch_length=0.14423076923076922, name='Gamma')
+    >>> njtree = constructor.nj(dm)
+    >>> print(njtree)
+    Tree(rooted=False)
+        Clade(branch_length=0, name='Inner3')
+            Clade(branch_length=0.18269230769230765, name='Alpha')
+            Clade(branch_length=0.04807692307692307, name='Beta')
+            Clade(branch_length=0.04807692307692307, name='Inner2')
+                Clade(branch_length=0.27884615384615385, name='Inner1')
+                    Clade(branch_length=0.051282051282051266, name='Epsilon')
+                    Clade(branch_length=0.10256410256410259, name='Delta')
+                Clade(branch_length=0.14423076923076922, name='Gamma')
 
     """
 
@@ -619,7 +643,7 @@ class DistanceTreeConstructor(TreeConstructor):
             self.distance_calculator = distance_calculator
         else:
             raise TypeError("Must provide a DistanceCalculator object.")
-        if isinstance(method, str) and method in self.methods:
+        if method in self.methods:
             self.method = method
         else:
             raise TypeError(
@@ -869,7 +893,7 @@ class NNITreeSearcher(TreeSearcher):
         :Parameters:
            starting_tree : Tree
                starting tree of NNI method.
-           alignment : MultipleSeqAlignment
+           alignment : Alignment or MultipleSeqAlignment object
                multiple sequence alignment used to calculate parsimony
                score of different NNI trees.
 
@@ -1112,56 +1136,47 @@ class ParsimonyTreeConstructor(TreeConstructor):
     --------
     We will load an alignment, and then load various trees which have already been computed from it::
 
-        from Bio import AlignIO, Phylo
-        aln = AlignIO.read(open('TreeConstruction/msa.phy'), 'phylip')
-        print(aln)
-
-    Output::
-
-        Alignment with 5 rows and 13 columns
-        AACGTGGCCACAT Alpha
-        AAGGTCGCCACAC Beta
-        CAGTTCGCCACAA Gamma
-        GAGATTTCCGCCT Delta
-        GAGATCTCCGCCC Epsilon
+    >>> from Bio import AlignIO, Phylo
+    >>> aln = AlignIO.read(open('TreeConstruction/msa.phy'), 'phylip')
+    >>> print(aln)
+    Alignment with 5 rows and 13 columns
+    AACGTGGCCACAT Alpha
+    AAGGTCGCCACAC Beta
+    CAGTTCGCCACAA Gamma
+    GAGATTTCCGCCT Delta
+    GAGATCTCCGCCC Epsilon
 
     Load a starting tree::
 
-        starting_tree = Phylo.read('TreeConstruction/nj.tre', 'newick')
-        print(starting_tree)
-
-    Output::
-
-        Tree(rooted=False, weight=1.0)
-            Clade(branch_length=0.0, name='Inner3')
-                Clade(branch_length=0.01421, name='Inner2')
-                    Clade(branch_length=0.23927, name='Inner1')
-                        Clade(branch_length=0.08531, name='Epsilon')
-                        Clade(branch_length=0.13691, name='Delta')
-                    Clade(branch_length=0.2923, name='Alpha')
-                Clade(branch_length=0.07477, name='Beta')
-                Clade(branch_length=0.17523, name='Gamma')
+    >>> starting_tree = Phylo.read('TreeConstruction/nj.tre', 'newick')
+    >>> print(starting_tree)
+    Tree(rooted=False, weight=1.0)
+        Clade(branch_length=0.0, name='Inner3')
+            Clade(branch_length=0.01421, name='Inner2')
+                Clade(branch_length=0.23927, name='Inner1')
+                    Clade(branch_length=0.08531, name='Epsilon')
+                    Clade(branch_length=0.13691, name='Delta')
+                Clade(branch_length=0.2923, name='Alpha')
+            Clade(branch_length=0.07477, name='Beta')
+            Clade(branch_length=0.17523, name='Gamma')
 
     Build the Parsimony tree from the starting tree::
 
-        scorer = Phylo.TreeConstruction.ParsimonyScorer()
-        searcher = Phylo.TreeConstruction.NNITreeSearcher(scorer)
-        constructor = Phylo.TreeConstruction.ParsimonyTreeConstructor(searcher, starting_tree)
-        pars_tree = constructor.build_tree(aln)
-        print(pars_tree)
-
-    Output::
-
-        Tree(rooted=True, weight=1.0)
-            Clade(branch_length=0.0)
-                Clade(branch_length=0.19732999999999998, name='Inner1')
-                    Clade(branch_length=0.13691, name='Delta')
-                    Clade(branch_length=0.08531, name='Epsilon')
-                Clade(branch_length=0.04194000000000003, name='Inner2')
-                    Clade(branch_length=0.01421, name='Inner3')
-                        Clade(branch_length=0.17523, name='Gamma')
-                        Clade(branch_length=0.07477, name='Beta')
-                    Clade(branch_length=0.2923, name='Alpha')
+    >>> scorer = Phylo.TreeConstruction.ParsimonyScorer()
+    >>> searcher = Phylo.TreeConstruction.NNITreeSearcher(scorer)
+    >>> constructor = Phylo.TreeConstruction.ParsimonyTreeConstructor(searcher, starting_tree)
+    >>> pars_tree = constructor.build_tree(aln)
+    >>> print(pars_tree)
+    Tree(rooted=True, weight=1.0)
+        Clade(branch_length=0.0)
+            Clade(branch_length=0.19732999999999998, name='Inner1')
+                Clade(branch_length=0.13691, name='Delta')
+                Clade(branch_length=0.08531, name='Epsilon')
+            Clade(branch_length=0.04194000000000003, name='Inner2')
+                Clade(branch_length=0.01421, name='Inner3')
+                    Clade(branch_length=0.17523, name='Gamma')
+                    Clade(branch_length=0.07477, name='Beta')
+                Clade(branch_length=0.2923, name='Alpha')
 
     """
 
@@ -1184,3 +1199,9 @@ class ParsimonyTreeConstructor(TreeConstructor):
             dtc = DistanceTreeConstructor(DistanceCalculator("identity"), "upgma")
             self.starting_tree = dtc.build_tree(alignment)
         return self.searcher.search(self.starting_tree, alignment)
+
+
+if __name__ == "__main__":
+    from Bio._utils import run_doctest
+
+    run_doctest()

--- a/Tests/test_Consensus.py
+++ b/Tests/test_Consensus.py
@@ -10,6 +10,7 @@ import unittest
 import tempfile
 
 # from io import StringIO
+from Bio import Align
 from Bio import AlignIO
 from Bio import Phylo
 from Bio.Phylo import BaseTree
@@ -135,6 +136,7 @@ class BootstrapTest(unittest.TestCase):
 
     def setUp(self):
         self.msa = AlignIO.read("TreeConstruction/msa.phy", "phylip")
+        self.alignment = Align.read("TreeConstruction/msa.phy", "phylip")
 
     def test_bootstrap(self):
         msa_list = list(Consensus.bootstrap(self.msa, 100))
@@ -142,18 +144,34 @@ class BootstrapTest(unittest.TestCase):
         self.assertEqual(len(msa_list[0]), len(self.msa))
         self.assertEqual(len(msa_list[0][0]), len(self.msa[0]))
 
-    def test_bootstrap_trees(self):
+    def test_bootstrap_trees_msa(self):
         calculator = DistanceCalculator("blosum62")
         constructor = DistanceTreeConstructor(calculator)
         trees = list(Consensus.bootstrap_trees(self.msa, 100, constructor))
         self.assertEqual(len(trees), 100)
         self.assertIsInstance(trees[0], BaseTree.Tree)
 
-    def test_bootstrap_consensus(self):
+    def test_bootstrap_trees(self):
+        calculator = DistanceCalculator("blosum62")
+        constructor = DistanceTreeConstructor(calculator)
+        trees = list(Consensus.bootstrap_trees(self.alignment, 100, constructor))
+        self.assertEqual(len(trees), 100)
+        self.assertIsInstance(trees[0], BaseTree.Tree)
+
+    def test_bootstrap_consensus_msa(self):
         calculator = DistanceCalculator("blosum62")
         constructor = DistanceTreeConstructor(calculator, "nj")
         tree = Consensus.bootstrap_consensus(
             self.msa, 100, constructor, Consensus.majority_consensus
+        )
+        self.assertIsInstance(tree, BaseTree.Tree)
+        Phylo.write(tree, os.path.join(temp_dir, "bootstrap_consensus.tre"), "newick")
+
+    def test_bootstrap_consensus(self):
+        calculator = DistanceCalculator("blosum62")
+        constructor = DistanceTreeConstructor(calculator, "nj")
+        tree = Consensus.bootstrap_consensus(
+            self.alignment, 100, constructor, Consensus.majority_consensus
         )
         self.assertIsInstance(tree, BaseTree.Tree)
         Phylo.write(tree, os.path.join(temp_dir, "bootstrap_consensus.tre"), "newick")

--- a/Tests/test_TreeConstruction.py
+++ b/Tests/test_TreeConstruction.py
@@ -10,6 +10,7 @@ import unittest
 import tempfile
 
 from io import StringIO
+from Bio import Align
 from Bio import AlignIO
 from Bio import Phylo
 from Bio.Phylo import BaseTree
@@ -140,8 +141,27 @@ class DistanceMatrixTest(unittest.TestCase):
 class DistanceCalculatorTest(unittest.TestCase):
     """Test DistanceCalculator."""
 
+    def test_known_matrices_msa(self):
+        msa = AlignIO.read("TreeConstruction/msa.phy", "phylip")
+
+        calculator = DistanceCalculator("identity")
+        dm = calculator.get_distance(msa)
+        self.assertEqual(dm["Alpha", "Beta"], 1 - 10 / 13)
+
+        calculator = DistanceCalculator("blastn")
+        dm = calculator.get_distance(msa)
+        self.assertEqual(dm["Alpha", "Beta"], 1 - 38 / 65)
+
+        calculator = DistanceCalculator("trans")
+        dm = calculator.get_distance(msa)
+        self.assertEqual(dm["Alpha", "Beta"], 1 - 54 / 65)
+
+        calculator = DistanceCalculator("blosum62")
+        dm = calculator.get_distance(msa)
+        self.assertEqual(dm["Alpha", "Beta"], 1 - 53 / 84)
+
     def test_known_matrices(self):
-        aln = AlignIO.read("TreeConstruction/msa.phy", "phylip")
+        aln = Align.read("TreeConstruction/msa.phy", "phylip")
 
         calculator = DistanceCalculator("identity")
         dm = calculator.get_distance(aln)
@@ -159,8 +179,21 @@ class DistanceCalculatorTest(unittest.TestCase):
         dm = calculator.get_distance(aln)
         self.assertEqual(dm["Alpha", "Beta"], 1 - 53 / 84)
 
-    def test_nonmatching_seqs(self):
+    def test_nonmatching_seqs_msa(self):
         aln = AlignIO.read(StringIO(">Alpha\nA-A--\n>Gamma\n-Y-Y-"), "fasta")
+        # With a proper scoring matrix -- no matches
+        dmat = DistanceCalculator("blosum62").get_distance(aln)
+        self.assertEqual(dmat["Alpha", "Alpha"], 0.0)
+        self.assertEqual(dmat["Alpha", "Gamma"], 1.0)
+        # Comparing characters only -- 4 misses, 1 match
+        dmat = DistanceCalculator().get_distance(aln)
+        self.assertEqual(dmat["Alpha", "Alpha"], 0.0)
+        self.assertAlmostEqual(dmat["Alpha", "Gamma"], 4.0 / 5.0)
+
+    def test_nonmatching_seqs(self):
+        aln = Align.read(
+            StringIO(">Alpha\nA-A--\n>Beta\nXXXXX\n>Gamma\n-Y-Y-"), "fasta"
+        )
         # With a proper scoring matrix -- no matches
         dmat = DistanceCalculator("blosum62").get_distance(aln)
         self.assertEqual(dmat["Alpha", "Alpha"], 0.0)
@@ -175,10 +208,23 @@ class DistanceTreeConstructorTest(unittest.TestCase):
     """Test DistanceTreeConstructor."""
 
     def setUp(self):
-        self.aln = AlignIO.read("TreeConstruction/msa.phy", "phylip")
+        self.msa = AlignIO.read("TreeConstruction/msa.phy", "phylip")
         calculator = DistanceCalculator("blosum62")
-        self.dm = calculator.get_distance(self.aln)
+        self.dm_msa = calculator.get_distance(self.msa)
+        self.constructor_msa = DistanceTreeConstructor(calculator)
+        self.alignment = Align.read("TreeConstruction/msa.phy", "phylip")
+        calculator = DistanceCalculator("blosum62")
+        self.dm = calculator.get_distance(self.alignment)
         self.constructor = DistanceTreeConstructor(calculator)
+
+    def test_upgma_msa(self):
+        tree = self.constructor.upgma(self.dm_msa)
+        self.assertIsInstance(tree, BaseTree.Tree)
+        # tree_file = StringIO()
+        # Phylo.write(tree, tree_file, 'newick')
+        ref_tree = Phylo.read("./TreeConstruction/upgma.tre", "newick")
+        self.assertTrue(Consensus._equal_topology(tree, ref_tree))
+        # ref_tree.close()
 
     def test_upgma(self):
         tree = self.constructor.upgma(self.dm)
@@ -188,6 +234,27 @@ class DistanceTreeConstructorTest(unittest.TestCase):
         ref_tree = Phylo.read("./TreeConstruction/upgma.tre", "newick")
         self.assertTrue(Consensus._equal_topology(tree, ref_tree))
         # ref_tree.close()
+
+    def test_nj_msa(self):
+        tree = self.constructor.nj(self.dm_msa)
+        self.assertIsInstance(tree, BaseTree.Tree)
+        # tree_file = StringIO()
+        # Phylo.write(tree, tree_file, 'newick')
+        ref_tree = Phylo.read("./TreeConstruction/nj.tre", "newick")
+        self.assertTrue(Consensus._equal_topology(tree, ref_tree))
+        # ref_tree.close()
+
+        # create a matrix of length 2
+        calculator = DistanceCalculator("blosum62")
+        self.min_dm = calculator.get_distance(self.msa)
+        for i in range(len(self.min_dm) - 2):
+            del self.min_dm[len(self.min_dm) - 1]
+
+        min_tree = self.constructor.nj(self.min_dm)
+        self.assertIsInstance(min_tree, BaseTree.Tree)
+
+        ref_min_tree = Phylo.read("./TreeConstruction/nj_min.tre", "newick")
+        self.assertTrue(Consensus._equal_topology(min_tree, ref_min_tree))
 
     def test_nj(self):
         tree = self.constructor.nj(self.dm)
@@ -200,7 +267,7 @@ class DistanceTreeConstructorTest(unittest.TestCase):
 
         # create a matrix of length 2
         calculator = DistanceCalculator("blosum62")
-        self.min_dm = calculator.get_distance(self.aln)
+        self.min_dm = calculator.get_distance(self.msa)
         for i in range(len(self.min_dm) - 2):
             del self.min_dm[len(self.min_dm) - 1]
 
@@ -210,8 +277,17 @@ class DistanceTreeConstructorTest(unittest.TestCase):
         ref_min_tree = Phylo.read("./TreeConstruction/nj_min.tre", "newick")
         self.assertTrue(Consensus._equal_topology(min_tree, ref_min_tree))
 
+    def test_built_tree_msa(self):
+        tree = self.constructor.build_tree(self.msa)
+        self.assertIsInstance(tree, BaseTree.Tree)
+        # tree_file = StringIO()
+        # Phylo.write(tree, tree_file, 'newick')
+        ref_tree = Phylo.read("./TreeConstruction/nj.tre", "newick")
+        self.assertTrue(Consensus._equal_topology(tree, ref_tree))
+        # ref_tree.close()
+
     def test_built_tree(self):
-        tree = self.constructor.build_tree(self.aln)
+        tree = self.constructor.build_tree(self.alignment)
         self.assertIsInstance(tree, BaseTree.Tree)
         # tree_file = StringIO()
         # Phylo.write(tree, tree_file, 'newick')


### PR DESCRIPTION
This PR generalizes the functions in `Bio.Phylo` to accept the new `Alignnment` objects in addition to the older `MultipleSeqAlignment` objects.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

