### PR TITLE
fix `Bio.Align._aligners` for Python 3.12

### DIFF
--- a/Bio/Align/_aligners.c
+++ b/Bio/Align/_aligners.c
@@ -1771,7 +1771,6 @@ set_alphabet(Aligner* self, PyObject* alphabet)
                                 * is 0x10ffff = 1114111 */
                 break;
             }
-            case PyUnicode_WCHAR_KIND:
             default:
                 PyErr_SetString(PyExc_ValueError, "could not interpret alphabet");
                 return -1;
@@ -6656,7 +6655,6 @@ sequence_converter(PyObject* argument, void* pointer)
                 indices = convert_4bytes_to_ints(mapping, n, s);
                 break;
             }
-            case PyUnicode_WCHAR_KIND:
             default:
                 PyErr_SetString(PyExc_ValueError, "could not interpret unicode data");
                 return 0;


### PR DESCRIPTION
Remove the deprecated `PyUnicode_WCHAR_KIND` from `Bio/Align/_aligners.c`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

