### PR TITLE
Generalize Bio.CAPS to accept both Alignment and MultipleSeqAlignment objects

### DIFF
--- a/Bio/CAPS/__init__.py
+++ b/Bio/CAPS/__init__.py
@@ -13,6 +13,9 @@ be found in the paper `Konieczny and Ausubel (1993)`_ (PMID 8106085).
 
 """
 
+from Bio.Align import MultipleSeqAlignment
+from Bio.Seq import Seq
+
 
 class DifferentialCutsite:
     """Differential enzyme cutsite in an alignment.
@@ -71,12 +74,16 @@ class CAPSMap:
         """
         if enzymes is None:
             enzymes = []
-        self.sequences = [rec.seq for rec in alignment]
-        self.size = len(self.sequences)
-        self.length = len(self.sequences[0])
-        for seq in self.sequences:
-            if len(seq) != self.length:
-                raise AlignmentHasDifferentLengthsError
+        if isinstance(alignment, MultipleSeqAlignment):
+            self.sequences = [rec.seq for rec in alignment]
+            self.size = len(self.sequences)
+            self.length = len(self.sequences[0])
+            for seq in self.sequences:
+                if len(seq) != self.length:
+                    raise AlignmentHasDifferentLengthsError
+        else:  # Alignment object
+            self.sequences = [Seq(s) for s in alignment]
+            self.size, self.length = alignment.shape
 
         self.alignment = alignment
         self.enzymes = enzymes
@@ -86,42 +93,32 @@ class CAPSMap:
 
     def _digest_with(self, enzyme):
         cuts = []  # list of lists, one per sequence
-        all = []
+        all_seq_cuts = []
 
         # go through each sequence
         for seq in self.sequences:
             # grab all the cuts in the sequence
             seq_cuts = [cut - enzyme.fst5 for cut in enzyme.search(seq)]
             # maintain a list of all cuts in all sequences
-            all.extend(seq_cuts)
+            all_seq_cuts.extend(seq_cuts)
             cuts.append(seq_cuts)
 
         # we sort the all list and remove duplicates
-        all.sort()
+        all_seq_cuts = sorted(set(all_seq_cuts))
 
-        last = -999
-        new = []
-        for cut in all:
-            if cut != last:
-                new.append(cut)
-            last = cut
-        all = new
-        # all now has indices for all sequences in the alignment
-
-        for cut in all:
+        for cut in all_seq_cuts:
             # test for dcuts
 
             cuts_in = []
             blocked_in = []
 
-            for i in range(0, self.size):
-                seq = self.sequences[i]
+            for i, seq in enumerate(self.sequences):
                 if cut in cuts[i]:
                     cuts_in.append(i)
                 else:
                     blocked_in.append(i)
 
-            if cuts_in != [] and blocked_in != []:
+            if cuts_in and blocked_in:
                 self.dcuts.append(
                     DifferentialCutsite(
                         start=cut, enzyme=enzyme, cuts_in=cuts_in, blocked_in=blocked_in

--- a/Tests/test_CAPS.py
+++ b/Tests/test_CAPS.py
@@ -11,11 +11,21 @@ from Bio import CAPS
 from Bio.Restriction import EcoRI, AluI
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.Align import MultipleSeqAlignment
+from Bio.Align import Alignment, MultipleSeqAlignment
 
 
 def createAlignment(sequences):
     """Create an Alignment object from a list of sequences."""
+    return Alignment(
+        [
+            SeqRecord(Seq(s), id="sequence%i" % (i + 1))
+            for (i, s) in enumerate(sequences)
+        ]
+    )
+
+
+def createMultipleSeqAlignment(sequences):
+    """Create a MultipleSeqAlignment object from a list of sequences."""
     return MultipleSeqAlignment(
         SeqRecord(Seq(s), id="sequence%i" % (i + 1)) for (i, s) in enumerate(sequences)
     )
@@ -26,13 +36,25 @@ class TestCAPS(unittest.TestCase):
         enzymes = [EcoRI]
         alignment = ["gaattc", "gaactc"]
         align = createAlignment(alignment)
-        map = CAPS.CAPSMap(align, enzymes)
+        capsmap = CAPS.CAPSMap(align, enzymes)
 
-        self.assertEqual(len(map.dcuts), 1)
-        self.assertEqual(map.dcuts[0].enzyme, EcoRI)
-        self.assertEqual(map.dcuts[0].start, 1)
-        self.assertEqual(map.dcuts[0].cuts_in, [0])
-        self.assertEqual(map.dcuts[0].blocked_in, [1])
+        self.assertEqual(len(capsmap.dcuts), 1)
+        self.assertEqual(capsmap.dcuts[0].enzyme, EcoRI)
+        self.assertEqual(capsmap.dcuts[0].start, 1)
+        self.assertEqual(capsmap.dcuts[0].cuts_in, [0])
+        self.assertEqual(capsmap.dcuts[0].blocked_in, [1])
+
+    def test_trivial_msa(self):
+        enzymes = [EcoRI]
+        alignment = ["gaattc", "gaactc"]
+        align = createMultipleSeqAlignment(alignment)
+        capsmap = CAPS.CAPSMap(align, enzymes)
+
+        self.assertEqual(len(capsmap.dcuts), 1)
+        self.assertEqual(capsmap.dcuts[0].enzyme, EcoRI)
+        self.assertEqual(capsmap.dcuts[0].start, 1)
+        self.assertEqual(capsmap.dcuts[0].cuts_in, [0])
+        self.assertEqual(capsmap.dcuts[0].blocked_in, [1])
 
     def test(self):
         alignment = [
@@ -55,24 +77,64 @@ class TestCAPS(unittest.TestCase):
         self.assertEqual(len(alignment), 3)
         enzymes = [EcoRI, AluI]
         align = createAlignment(alignment)
-        map = CAPS.CAPSMap(align, enzymes)
+        capsmap = CAPS.CAPSMap(align, enzymes)
 
-        self.assertEqual(len(map.dcuts), 2)
-        self.assertEqual(map.dcuts[0].enzyme, EcoRI)
-        self.assertEqual(map.dcuts[0].start, 5)
-        self.assertEqual(map.dcuts[0].cuts_in, [0])
-        self.assertEqual(map.dcuts[0].blocked_in, [1, 2])
-        self.assertEqual(map.dcuts[1].enzyme, AluI)
-        self.assertEqual(map.dcuts[1].start, 144)
-        self.assertEqual(map.dcuts[1].cuts_in, [1, 2])
-        self.assertEqual(map.dcuts[1].blocked_in, [0])
+        self.assertEqual(len(capsmap.dcuts), 2)
+        self.assertEqual(capsmap.dcuts[0].enzyme, EcoRI)
+        self.assertEqual(capsmap.dcuts[0].start, 5)
+        self.assertEqual(capsmap.dcuts[0].cuts_in, [0])
+        self.assertEqual(capsmap.dcuts[0].blocked_in, [1, 2])
+        self.assertEqual(capsmap.dcuts[1].enzyme, AluI)
+        self.assertEqual(capsmap.dcuts[1].start, 144)
+        self.assertEqual(capsmap.dcuts[1].cuts_in, [1, 2])
+        self.assertEqual(capsmap.dcuts[1].blocked_in, [0])
+
+    def test_msa(self):
+        alignment = [
+            "AAAagaattcTAGATATACCAAACCAGAGAAAACAAATACATAATCGGAGAAATACAGAT"
+            "AGAGAGCGAGAGAGATCGACGGCGAAGCTCTTTACCCGGAAACCATTGAAATCGGACGGT"
+            "TTAGTGAAAATGGAGGATCAAGTagAtTTTGGGTTCCGTCCGAACGACGAGGAGCTCGTT"
+            "GGTCACTATCTCCGTAACAAAATCGAAGGAAACACTAGCCGCGACGTTGAAGTAGCCATC"
+            "AGCGAGGTCAACATCTGTAGCTACGATCCTTGGAACTTGCGCTGTAAGTTCCGAATTTTC",
+            "AAAagaTttcTAGATATACCAAACCAGAGAAAACAAATACATAATCGGAGAAATACAGAT"
+            "AGAGAGCGAGAGAGATCGACGGCGAAGCTCTTTACCCGGAAACCATTGAAATCGGACGGT"
+            "TTAGTGAAAATGGAGGATCAAGTagctTTTGGGTTCCGTCCGAACGACGAGGAGCTCGTT"
+            "GGTCACTATCTCCGTAACAAAATCGAAGGAAACACTAGCCGCGACGTTGAAGTAGCCATC"
+            "AGCGAGGTCAACATCTGTAGCTACGATCCTTGGAACTTGCGCTGTAAGTTCCGAATTTTC",
+            "AAAagaTttcTAGATATACCAAACCAGAGAAAACAAATACATAATCGGAGAAATACAGAT"
+            "AGAGAGCGAGAGAGATCGACGGCGAAGCTCTTTACCCGGAAACCATTGAAATCGGACGGT"
+            "TTAGTGAAAATGGAGGATCAAGTagctTTTGGGTTCCGTCCGAACGACGAGGAGCTCGTT"
+            "GGTCACTATCTCCGTAACAAAATCGAAGGAAACACTAGCCGCGACGTTGAAGTAGCCATC"
+            "AGCGAGGTCAACATCTGTAGCTACGATCCTTGGAACTTGCGCTGTAAGTTCCGAATTTTC",
+        ]
+        self.assertEqual(len(alignment), 3)
+        enzymes = [EcoRI, AluI]
+        align = createMultipleSeqAlignment(alignment)
+        capsmap = CAPS.CAPSMap(align, enzymes)
+
+        self.assertEqual(len(capsmap.dcuts), 2)
+        self.assertEqual(capsmap.dcuts[0].enzyme, EcoRI)
+        self.assertEqual(capsmap.dcuts[0].start, 5)
+        self.assertEqual(capsmap.dcuts[0].cuts_in, [0])
+        self.assertEqual(capsmap.dcuts[0].blocked_in, [1, 2])
+        self.assertEqual(capsmap.dcuts[1].enzyme, AluI)
+        self.assertEqual(capsmap.dcuts[1].start, 144)
+        self.assertEqual(capsmap.dcuts[1].cuts_in, [1, 2])
+        self.assertEqual(capsmap.dcuts[1].blocked_in, [0])
 
     def testNoCAPS(self):
         alignment = ["aaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaa"]
         enzymes = []
         align = createAlignment(alignment)
-        map = CAPS.CAPSMap(align, enzymes)
-        self.assertEqual(map.dcuts, [])
+        capsmap = CAPS.CAPSMap(align, enzymes)
+        self.assertEqual(capsmap.dcuts, [])
+
+    def testNoCAPS_msa(self):
+        alignment = ["aaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaa"]
+        enzymes = []
+        align = createMultipleSeqAlignment(alignment)
+        capsmap = CAPS.CAPSMap(align, enzymes)
+        self.assertEqual(capsmap.dcuts, [])
 
     def test_uneven(self):
         alignment = [
@@ -80,7 +142,7 @@ class TestCAPS(unittest.TestCase):
             "aaaaaaaaaaaaaa",  # we'll change this below
             "aaaaaaaaaaaaaa",
         ]
-        align = createAlignment(alignment)
+        align = createMultipleSeqAlignment(alignment)
         align[1].seq = align[1].seq[:8]  # evil
         self.assertRaises(CAPS.AlignmentHasDifferentLengthsError, CAPS.CAPSMap, align)
 


### PR DESCRIPTION
This PR modifies Bio.CAPS to accept both the newer `Alignment` object and the older `MultipleSeqAlignment` objects

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
