### PR TITLE
Allow PDBIO to write to an open IO object without closing it

### DIFF
--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -320,11 +320,9 @@ class PDBIO(StructureIO):
         """
         if isinstance(file, str):
             fhandle = open(file, "w")
-            should_close = True
         else:
             # filehandle, I hope :-)
             fhandle = file
-            should_close = False
 
         get_atom_line = self._get_atom_line
 
@@ -410,5 +408,5 @@ class PDBIO(StructureIO):
         if write_end:
             fhandle.write("END   \n")
 
-        if should_close:
+        if isinstance(file, str):
             fhandle.close()

--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -320,91 +320,95 @@ class PDBIO(StructureIO):
         """
         if isinstance(file, str):
             fhandle = open(file, "w")
+            should_close = True
         else:
             # filehandle, I hope :-)
             fhandle = file
+            should_close = False
 
-        with fhandle:
-            get_atom_line = self._get_atom_line
+        get_atom_line = self._get_atom_line
 
-            # multiple models?
-            if len(self.structure) > 1 or self.use_model_flag:
-                model_flag = 1
-            else:
-                model_flag = 0
+        # multiple models?
+        if len(self.structure) > 1 or self.use_model_flag:
+            model_flag = 1
+        else:
+            model_flag = 0
 
-            for model in self.structure.get_list():
-                if not select.accept_model(model):
+        for model in self.structure.get_list():
+            if not select.accept_model(model):
+                continue
+            # necessary for ENDMDL
+            # do not write ENDMDL if no residues were written
+            # for this model
+            model_residues_written = 0
+            if not preserve_atom_numbering:
+                atom_number = 1
+            if model_flag:
+                fhandle.write(f"MODEL      {model.serial_num}\n")
+
+            for chain in model.get_list():
+                if not select.accept_chain(chain):
                     continue
-                # necessary for ENDMDL
-                # do not write ENDMDL if no residues were written
-                # for this model
-                model_residues_written = 0
-                if not preserve_atom_numbering:
-                    atom_number = 1
-                if model_flag:
-                    fhandle.write(f"MODEL      {model.serial_num}\n")
+                chain_id = chain.id
+                if len(chain_id) > 1:
+                    e = f"Chain id ('{chain_id}') exceeds PDB format limit."
+                    raise PDBIOException(e)
 
-                for chain in model.get_list():
-                    if not select.accept_chain(chain):
+                # necessary for TER
+                # do not write TER if no residues were written
+                # for this chain
+                chain_residues_written = 0
+
+                for residue in chain.get_unpacked_list():
+                    if not select.accept_residue(residue):
                         continue
-                    chain_id = chain.id
-                    if len(chain_id) > 1:
-                        e = f"Chain id ('{chain_id}') exceeds PDB format limit."
+                    hetfield, resseq, icode = residue.id
+                    resname = residue.resname
+                    segid = residue.segid
+                    resid = residue.id[1]
+                    if resid > 9999:
+                        e = f"Residue number ('{resid}') exceeds PDB format limit."
                         raise PDBIOException(e)
 
-                    # necessary for TER
-                    # do not write TER if no residues were written
-                    # for this chain
-                    chain_residues_written = 0
-
-                    for residue in chain.get_unpacked_list():
-                        if not select.accept_residue(residue):
+                    for atom in residue.get_unpacked_list():
+                        if not select.accept_atom(atom):
                             continue
-                        hetfield, resseq, icode = residue.id
-                        resname = residue.resname
-                        segid = residue.segid
-                        resid = residue.id[1]
-                        if resid > 9999:
-                            e = f"Residue number ('{resid}') exceeds PDB format limit."
-                            raise PDBIOException(e)
+                        chain_residues_written = 1
+                        model_residues_written = 1
+                        if preserve_atom_numbering:
+                            atom_number = atom.serial_number
 
-                        for atom in residue.get_unpacked_list():
-                            if not select.accept_atom(atom):
-                                continue
-                            chain_residues_written = 1
-                            model_residues_written = 1
-                            if preserve_atom_numbering:
-                                atom_number = atom.serial_number
+                        try:
+                            s = get_atom_line(
+                                atom,
+                                hetfield,
+                                segid,
+                                atom_number,
+                                resname,
+                                resseq,
+                                icode,
+                                chain_id,
+                            )
+                        except Exception as err:
+                            # catch and re-raise with more information
+                            raise PDBIOException(
+                                f"Error when writing atom {atom.full_id}"
+                            ) from err
+                        else:
+                            fhandle.write(s)
+                            # inconsequential if preserve_atom_numbering is True
+                            atom_number += 1
 
-                            try:
-                                s = get_atom_line(
-                                    atom,
-                                    hetfield,
-                                    segid,
-                                    atom_number,
-                                    resname,
-                                    resseq,
-                                    icode,
-                                    chain_id,
-                                )
-                            except Exception as err:
-                                # catch and re-raise with more information
-                                raise PDBIOException(
-                                    f"Error when writing atom {atom.full_id}"
-                                ) from err
-                            else:
-                                fhandle.write(s)
-                                # inconsequential if preserve_atom_numbering is True
-                                atom_number += 1
+                if chain_residues_written:
+                    fhandle.write(
+                        _TER_FORMAT_STRING
+                        % (atom_number, resname, chain_id, resseq, icode)
+                    )
 
-                    if chain_residues_written:
-                        fhandle.write(
-                            _TER_FORMAT_STRING
-                            % (atom_number, resname, chain_id, resseq, icode)
-                        )
+            if model_flag and model_residues_written:
+                fhandle.write("ENDMDL\n")
+        if write_end:
+            fhandle.write("END   \n")
 
-                if model_flag and model_residues_written:
-                    fhandle.write("ENDMDL\n")
-            if write_end:
-                fhandle.write("END   \n")
+        if should_close:
+            fhandle.close()

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -19,6 +19,7 @@ possible, especially the following contributors:
 
 - Michiel de Hoon
 - Peter Cock
+- Joe Greener
 - Robert Miller
 
 18 November 2022: Biopython 1.80


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Recent changes to `PDBIO` in https://github.com/biopython/biopython/commit/be77131200821bb01254c87fb14ee1bf6c81dd4b switched to using a `with fhandle` block for the open file handle. This is fine in the case of the file being opened by `PDBIO`, but another useful situation is having an open file handle or string object that you can read from or write to again.

This PR only closes the file handle if `PDBIO` opened it, allowing for example:
```python
from Bio.PDB import *
from io import StringIO

parser = PDBParser()
structure = parser.get_structure("6YYT", "6YYT.pdb")
res = structure[0]["A"][31]

io_pdb = PDBIO()
io_pdb.set_structure(res)
io_str = StringIO()
io_pdb.save(io_str)
print(io_str.getvalue())
```
```
ATOM      1  N   VAL A  31     125.110  92.109  68.636  1.00 52.46           N  
ATOM      2  CA  VAL A  31     124.229  91.412  69.563  1.00 52.46           C  
ATOM      3  C   VAL A  31     122.990  92.264  69.821  1.00 52.46           C  
ATOM      4  O   VAL A  31     122.766  93.266  69.142  1.00 52.46           O  
ATOM      5  CB  VAL A  31     124.958  91.076  70.879  1.00 52.46           C  
ATOM      6  CG1 VAL A  31     126.011  90.005  70.641  1.00 52.46           C  
ATOM      7  CG2 VAL A  31     125.585  92.327  71.479  1.00 52.46           C  
TER       8      VAL A  31                                                       
END   
```
whereas on Biopython 1.79 the last line errors as `io_str` has been closed by `save`:
```
ValueError: I/O operation on closed file
```
Most of the code change is white space, it just adds a flag that closes the handle depending on whether `open` was called.

This initially came to my attention due to a downstream error in NGLView (https://bioinformatics.stackexchange.com/questions/20151/file-i-o-error-using-nglview-show-biopythonstructure) which uses this behaviour to access the string of a written PDB file without writing a file (https://github.com/nglviewer/nglview/blob/master/nglview/adaptor.py#L193-L200).