### PR TITLE
4203 numpy types

### DIFF
--- a/Bio/PDB/SASA.py
+++ b/Bio/PDB/SASA.py
@@ -203,7 +203,7 @@ class ShrakeRupley:
         twice_maxradii = np.max(radii) * 2
 
         # Calculate ASAs
-        asa_array = np.zeros((n_atoms, 1), dtype=np.int)
+        asa_array = np.zeros((n_atoms, 1), dtype=np.int64)
         ptset = set(range(self.n_points))
         for i in range(n_atoms):
 

--- a/Bio/PDB/internal_coords.py
+++ b/Bio/PDB/internal_coords.py
@@ -749,7 +749,7 @@ class IC_Chain:
         self.dCoordSpace: np.ndarray = np.empty(
             (2, self.dihedraLen, 4, 4), dtype=np.float64
         )
-        self.dcsValid: np.ndarray = np.zeros((self.dihedraLen), dtype=np.bool)
+        self.dcsValid: np.ndarray = np.zeros((self.dihedraLen), dtype=bool)
 
         # hedra atoms
         self.hAtoms: np.ndarray = np.zeros((self.hedraLen, 3, 4), dtype=np.float64)
@@ -786,10 +786,10 @@ class IC_Chain:
         # dihedra forward/reverse data
         a2da_map = {}
         a2d_map = [[[], []] for _ in range(self.AAsiz)]
-        self.dRev: np.ndarray = np.zeros((self.dihedraLen), dtype=np.bool)
+        self.dRev: np.ndarray = np.zeros((self.dihedraLen), dtype=bool)
 
-        self.dH1ndx = np.empty(self.dihedraLen, dtype=np.int)
-        self.dH2ndx = np.empty(self.dihedraLen, dtype=np.int)
+        self.dH1ndx = np.empty(self.dihedraLen, dtype=np.int64)
+        self.dH2ndx = np.empty(self.dihedraLen, dtype=np.int64)
         self.h1d_map = [[] for _ in range(self.hedraLen)]
 
         self.id3_dh_index = {k[0:3]: [] for k in self.dihedraNdx.keys()}

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -15,6 +15,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Aaron Rosenfeld <https://github.com/arosenfeld>
 - Adam Kurkiewicz <adam@kurkiewicz.pl>
 - Adam Novak <https://github.com/AdamNovak>
+- Adam Vandergriff <https://github.com/acvander>
 - Adhemar Zerlotini <https://github.com/azneto>
 - Adil Iqbal <https://github.com/Adil-Iqbal>
 - Adrian Altenhoff <https://github.com/alpae>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -17,6 +17,7 @@ also been tested on PyPy3.7 v7.3.5. We intend to drop Python 3.7 support.
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
+- Adam Vandergriff
 - Michiel de Hoon
 - Peter Cock
 - Robert Miller

--- a/Tests/test_Cluster.py
+++ b/Tests/test_Cluster.py
@@ -251,7 +251,7 @@ class TestCluster(unittest.TestCase):
                 [4.1, 2.2, 0.6, 5.5, 0.6],
                 [2.7, 2.5, 0.4, 5.7, 0.2],
             ],
-            numpy.float,
+            numpy.float64,
         )
         try:
             treecluster(data, mask1)

--- a/Tests/test_Cluster.py
+++ b/Tests/test_Cluster.py
@@ -251,7 +251,7 @@ class TestCluster(unittest.TestCase):
                 [4.1, 2.2, 0.6, 5.5, 0.6],
                 [2.7, 2.5, 0.4, 5.7, 0.2],
             ],
-            numpy.float64,
+            float,
         )
         try:
             treecluster(data, mask1)


### PR DESCRIPTION
- replaced `np.int` with `np.int64`
- replaced `np.bool` with `bool`

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4203.

This PR fixes issues related to some NumPy type deprecations that affects platforms or users of NumPy v1.24
