### PR TITLE
Special case single entry GenBank lineage

### DIFF
--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -576,7 +576,7 @@ class InsdcScanner:
                         # sub features...
                         annotations["raw_location"] = location_string.replace(" ", "")
 
-                        for (qualifier_name, qualifier_data) in qualifiers:
+                        for qualifier_name, qualifier_data in qualifiers:
                             if (
                                 qualifier_data is not None
                                 and qualifier_data[0] == '"'
@@ -1710,7 +1710,16 @@ class GenBankScanner(InsdcScanner):
                                 lineage_data
                                 or ";" in line
                                 or line[self.GENBANK_INDENT :].strip()
-                                in ("Bacteria.", "Archaea.", "Eukaryota.")
+                                in (
+                                    "Bacteria.",
+                                    "Archaea.",
+                                    "Eukaryota.",
+                                    "Unclassified.",
+                                    "Viruses.",
+                                    "cellular organisms.",
+                                    "other sequences.",
+                                    "unclassified sequences.",
+                                )
                             ):
                                 lineage_data += " " + line[self.GENBANK_INDENT :]
                             elif line[self.GENBANK_INDENT :].strip() == ".":

--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1706,7 +1706,12 @@ class GenBankScanner(InsdcScanner):
                     while True:
                         line = next(line_iter)
                         if line[0 : self.GENBANK_INDENT] == self.GENBANK_SPACER:
-                            if lineage_data or ";" in line:
+                            if (
+                                lineage_data
+                                or ";" in line
+                                or line[self.GENBANK_INDENT :].strip()
+                                in ("Bacteria.", "Archaea.", "Eukaryota.")
+                            ):
                                 lineage_data += " " + line[self.GENBANK_INDENT :]
                             elif line[self.GENBANK_INDENT :].strip() == ".":
                                 # No lineage data, just . place holder


### PR DESCRIPTION
Closes #4210 where 'Bacteria.' was treated as a continuation of the organism name due to lacking any semi-colons.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
