### PR TITLE
fix formatting for .pic file seq line in Tutorial

### DIFF
--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -1133,7 +1133,7 @@ io.save("myChain2.pdb")
 
 A file format is defined in the \texttt{PICIO} module to describe protein chains as hedra and
 dihedra relative to initial coordinates.  All parts of the file other than the residue sequence
-information (e.g. \texttt{\('1A8O', 0, 'A', \(' ', 153, ' '\)\) ILE}) are optional, and will be
+information (e.g. \texttt{('1A8O', 0, 'A', (' ', 153, ' ')) ILE}) are optional, and will be
 filled in with default values if not specified and \texttt{read\_PIC\(\)} is called with the
 \texttt{defaults=True} option.  Default values are calculated from Sep 2019 Dunbrack
 cullpdb\_pc20\_res2.2\_R1.0.


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4229
The issue is trying to escape the parens inside the `\texttt`, the `\`'s are not needed and not correct.  Wrapping with `\verb` doesn't allow a linebreak that's needed here.
