### PR TITLE
Alignments iterator

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1290,6 +1290,7 @@ class Alignment:
             "containing the same values as the path attributes, after "
             "transposition.",
             BiopythonDeprecationWarning,
+            stacklevel=2,
         )
         return tuple(tuple(row) for row in self.coordinates.transpose())
 
@@ -1301,6 +1302,7 @@ class Alignment:
             "containing the same values as the path attributes, after "
             "transposition.",
             BiopythonDeprecationWarning,
+            stacklevel=2,
         )
         self.coordinates = numpy.array(value).transpose()
 
@@ -3176,8 +3178,6 @@ class PairwiseAlignments:
         return alignment
 
     def __iter__(self):
-        self._paths.reset()
-        self._index = -1
         return self
 
     def __next__(self):
@@ -3188,6 +3188,11 @@ class PairwiseAlignments:
         alignment.score = self.score
         self._alignment = alignment
         return alignment
+
+    def rewind(self):
+        """Rewind the iterator to let it loop over the alignments from the beginning.."""
+        self._paths.reset()
+        self._index = -1
 
 
 class PairwiseAligner(_aligners.PairwiseAligner):
@@ -3481,6 +3486,7 @@ class PairwiseAlignment(Alignment):
             "an Alignment object is a numpy array and the transpose of the "
             "path attribute of a PairwiseAlignment object.",
             BiopythonDeprecationWarning,
+            stacklevel=2,
         )
         sequences = [target, query]
         coordinates = numpy.array(path).transpose()

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1943,7 +1943,7 @@ query             0 AA- 2
 ...     print(alignment)
 ...
 \end{minted}
-Note that \verb+alignments+ can be reused, i.e. you can iterate over alignments multiple times:
+By calling \verb+alignments.rewind+, you can rewind the \verb+alignments+ iterator to the first alignment and iterate over the alignments from the beginning:
 
 %doctest
 \begin{minted}{pycon}
@@ -1965,6 +1965,7 @@ target            0 AAA 3
                   0 -|| 3
 query             0 -AA 2
 <BLANKLINE>
+>>> alignments.rewind()
 >>> for alignment in alignments:
 ...     print(alignment)
 ...

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -11,6 +11,12 @@ The latest news is at the top of this file.
 (In progress, not yet released): Biopython 1.82
 ===============================================
 
+Calling ``iter`` on a ``PairwiseAlignments`` object returned by a
+``PairwiseAigner`` previously reset the iterator such that it will start from
+the first alignment when iterating. As a side effect, this will cause all other
+iterators of the alignments to reset as well, which is bug prone. Instead,
+calling ``iter`` on a ``PairwiseAlignments`` object will now return itself. The
+iterator can be reset by calling the ``rewind`` method.
 
 12 February 2023: Biopython 1.81
 ===============================================

--- a/Tests/test_Align_Alignment.py
+++ b/Tests/test_Align_Alignment.py
@@ -2534,10 +2534,11 @@ class TestAlignment_pairwise_format(unittest.TestCase):
         self.assertEqual(len(alignments), 2)
         self.seq_alignments = list(alignments)
         alignments = aligner.align(seqA, seqB)
+        alignments = list(alignments)
         for alignment in alignments:
             alignment.sequences[0] = SeqRecord(seqA, id="A", description="sequence A")
             alignment.sequences[1] = SeqRecord(seqB, id="B", description="sequence B")
-        self.seqrecord_alignments = list(alignments)
+        self.seqrecord_alignments = alignments
 
     def test_a2m(self):
         for alignment in self.plain_alignments:


### PR DESCRIPTION
The `__iter__` method of the `PairwiseAlignments` class resets the iterator so that it iterates starting from the first alignment. This will also cause the iterator to have a side effect of implicitly resetting any existing iterator of these alignments, which is bug prone. This PR changes the `__iter__` such that it will simply return itself, and a `rewind` method to reset the alignments explicitly. This is consistent with the behavior of e.g. `gzip` in the standard library:
```python
>>> import gzip
>>> stream = gzip.open("text.gz")
>>> next(stream)
b'line1\n'
>>> next(stream)
b'line2\n'
>>> stream.rewind()
>>> next(stream)
b'line1\n'
>>> stream
<gzip _io.BufferedReader name='text.gz' 0x10cfbfa30>
>>> iter(stream)
<gzip _io.BufferedReader name='text.gz' 0x10cfbfa30>
>>> iter(stream) is stream
True
```

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
