### PR TITLE
context manager for Bio.Align.parse

### DIFF
--- a/Bio/Align/a2m.py
+++ b/Bio/Align/a2m.py
@@ -66,18 +66,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
     fmt = "A2M"
 
-    def __init__(self, source):
-        """Create an AlignmentIterator object.
-
-        Arguments:
-        - source - input file stream, or path to input file
-        """
-        super().__init__(source)
-        self._done = False
-
     def _read_next_alignment(self, stream):
-        if self._done is True:
-            return
         names = []
         descriptions = []
         lines = []
@@ -98,7 +87,9 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             else:
                 lines[-1] += line.strip()
         if not lines:
-            raise ValueError("Empty file.")
+            if self._stream.tell() == 0:
+                raise ValueError("Empty file.")
+            return
         state = ""
         for c in lines[0]:
             if c == "-" or c.isupper():
@@ -127,10 +118,4 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         alignment = Alignment(records, coordinates)
         alignment.column_annotations = {}
         alignment.column_annotations["state"] = state
-        self._done = True
         return alignment
-
-    def rewind(self):
-        """Rewind the file and loop over the alignments from the beginning."""
-        super().rewind()
-        self._done = False

--- a/Bio/Align/fasta.py
+++ b/Bio/Align/fasta.py
@@ -50,18 +50,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
     fmt = "FASTA"
 
-    def __init__(self, source):
-        """Create an AlignmentIterator object.
-
-        Arguments:
-        - source - input file stream, or path to input file
-        """
-        super().__init__(source)
-        self._done = False
-
     def _read_next_alignment(self, stream):
-        if self._done is True:
-            return
         names = []
         descriptions = []
         lines = []
@@ -82,7 +71,9 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             else:
                 lines[-1] += line.strip()
         if not lines:
-            raise ValueError("Empty file.")
+            if self._stream.tell() == 0:
+                raise ValueError("Empty file.")
+            return
         coordinates = Alignment.infer_coordinates(lines)
         records = []
         for name, description, line in zip(names, descriptions, lines):
@@ -91,10 +82,4 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             record = SeqRecord(sequence, id=name, description=description)
             records.append(record)
         alignment = Alignment(records, coordinates)
-        self._done = True
         return alignment
-
-    def rewind(self):
-        """Rewind the file and loop over the alignments from the beginning."""
-        super().rewind()
-        self._done = False

--- a/Bio/Align/interfaces.py
+++ b/Bio/Align/interfaces.py
@@ -60,11 +60,7 @@ class AlignmentIterator(ABC):
             else:
                 raise ValueError(f"Unknown mode '{self.mode}'") from None
             self._stream = source
-        try:
-            self._read_header(self._stream)
-        except Exception:
-            self._close()
-            raise
+        self._read_header(self._stream)
 
     def __next__(self):
         """Return the next entry."""
@@ -72,11 +68,7 @@ class AlignmentIterator(ABC):
             stream = self._stream
         except AttributeError:
             raise StopIteration from None
-        try:
-            alignment = self._read_next_alignment(stream)
-        except Exception:
-            self._close()
-            raise
+        alignment = self._read_next_alignment(stream)
         if alignment is None:
             raise StopIteration
         return alignment
@@ -92,7 +84,13 @@ class AlignmentIterator(ABC):
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        self._close()
+        try:
+            stream = self._stream
+        except AttributeError:
+            return
+        if stream is not self.source:
+            stream.close()
+        del self._stream
 
     def _read_header(self, stream):
         """Read the file header and store it in metadata."""
@@ -101,15 +99,6 @@ class AlignmentIterator(ABC):
     @abstractmethod
     def _read_next_alignment(self, stream):
         """Read one Alignment from the stream, and return it."""
-
-    def _close(self):
-        try:
-            stream = self._stream
-        except AttributeError:
-            return
-        if stream is not self.source:
-            stream.close()
-        del self._stream
 
     def rewind(self):
         """Rewind the file and loop over the alignments from the beginning."""

--- a/Bio/Align/interfaces.py
+++ b/Bio/Align/interfaces.py
@@ -88,6 +88,12 @@ class AlignmentIterator(ABC):
         """
         return self
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self._close()
+
     def _read_header(self, stream):
         """Read the file header and store it in metadata."""
         return

--- a/Bio/Align/phylip.py
+++ b/Bio/Align/phylip.py
@@ -75,15 +75,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
     fmt = "PHYLIP"
 
-    def __init__(self, source):
-        """Create an AlignmentIterator object.
-
-        Arguments:
-        - source - input file stream, or path to input file
-        """
-        super().__init__(source)
-        self._done = False
-
     def _read_header(self, stream):
         try:
             line = next(stream)
@@ -162,7 +153,9 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         return names, seqs
 
     def _read_next_alignment(self, stream):
-        if self._done is True:
+        try:
+            self._number_of_seqs
+        except AttributeError:
             return
         names, seqs = self._read_file(stream)
 
@@ -190,10 +183,4 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         alignment = Alignment(records, coordinates)
         del self._number_of_seqs
         del self._length_of_seqs
-        self._done = True
         return alignment
-
-    def rewind(self):
-        """Rewind the file and loop over the alignments from the beginning."""
-        super().rewind()
-        self._done = False

--- a/Tests/test_Align_a2m.py
+++ b/Tests/test_Align_a2m.py
@@ -619,8 +619,9 @@ numpy.array([['D', '-', 'V', 'L', 'L', 'G', 'A', 'N', 'G', 'G', 'V', 'L', 'V',
         """Checking empty file."""
         stream = StringIO()
         alignments = Align.parse(stream, "a2m")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as cm:
             next(alignments)
+        self.assertEqual(str(cm.exception), "Empty file.")
 
 
 if __name__ == "__main__":

--- a/Tests/test_Align_a2m.py
+++ b/Tests/test_Align_a2m.py
@@ -47,6 +47,15 @@ class TestA2MReadingWriting(unittest.TestCase):
             with self.assertRaises(StopIteration):
                 next(alignments)
             self.check_clustalw(alignment)
+        with Align.parse(path, "a2m") as alignments:
+            alignment = next(alignments)
+            self.check_clustalw(alignment)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "a2m") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
         self.check_reading_writing(path)
 
     def check_clustalw(self, alignment):

--- a/Tests/test_Align_bed.py
+++ b/Tests/test_Align_bed.py
@@ -1178,6 +1178,14 @@ chr3	42530895	42532606	NR_046654.1_modified	978	-	42530895	42532606	0	5	27,36,17
         self.check_alignments(alignments)
         alignments.rewind()
         self.check_alignments(alignments)
+        with Align.parse(path, "bed") as alignments:
+            self.check_alignments(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "bed") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
     def test_writing(self):
         """Test writing the alignments in dna_rna.bed."""

--- a/Tests/test_Align_bigbed.py
+++ b/Tests/test_Align_bigbed.py
@@ -60,6 +60,14 @@ class TestAlign_dna_rna(unittest.TestCase):
         self.check_alignments(alignments)
         alignments.rewind()
         self.check_alignments(alignments)
+        with Align.parse(path, "bigbed") as alignments:
+            self.check_alignments(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "bigbed") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
     def check_alignments(self, alignments):
         self.assertEqual(

--- a/Tests/test_Align_bigmaf.py
+++ b/Tests/test_Align_bigmaf.py
@@ -9706,6 +9706,14 @@ numpy.array([['T', 'G', 'T', 'T', 'T', 'A', 'G', 'T', 'A', 'C', 'C', '-', '-',
         self.check_reading_ucsc_test(alignments)
         alignments.rewind()
         self.check_reading_ucsc_test(alignments)
+        with Align.parse(path, "bigmaf") as alignments:
+            self.check_reading_ucsc_test(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "bigmaf") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
     def check_reading_ucsc_test(self, alignments):
         self.assertEqual(

--- a/Tests/test_Align_bigpsl.py
+++ b/Tests/test_Align_bigpsl.py
@@ -53,6 +53,14 @@ class TestAlign_dna_rna(unittest.TestCase):
         self.check_alignments(alignments)
         alignments.rewind()
         self.check_alignments(alignments)
+        with Align.parse(path, "bigpsl") as alignments:
+            self.check_alignments(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "bigpsl") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
     def check_alignments(self, alignments):
         self.assertEqual(

--- a/Tests/test_Align_clustal.py
+++ b/Tests/test_Align_clustal.py
@@ -42,6 +42,14 @@ class TestClustalReadingWriting(unittest.TestCase):
             self.check_clustalw(alignments)
             alignments.rewind()
             self.check_clustalw(alignments)
+        with Align.parse(path, "clustal") as alignments:
+            self.check_clustalw(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "clustal") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
         self.check_reading_writing(path)
 
     def check_clustalw(self, alignments):

--- a/Tests/test_Align_emboss.py
+++ b/Tests/test_Align_emboss.py
@@ -250,6 +250,14 @@ numpy.array([['G', 'P', 'P', 'P', 'Q', 'S', 'P', 'D', 'E', 'N', 'R', 'A', 'G',
         self.check_matcher_pair(alignments)
         alignments.rewind()
         self.check_matcher_pair(alignments)
+        with Align.parse(path, "emboss") as alignments:
+            self.check_matcher_pair(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "emboss") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
     def check_matcher_pair(self, alignments):
         self.assertEqual(alignments.metadata["Program"], "matcher")

--- a/Tests/test_Align_exonerate.py
+++ b/Tests/test_Align_exonerate.py
@@ -44,6 +44,14 @@ class Exonerate_est2genome(unittest.TestCase):
         stream.seek(0)
         alignments = Align.parse(stream, "exonerate")
         self.check_cigar(alignments)
+        with Align.parse(exn_file, "exonerate") as alignments:
+            self.check_cigar(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(exn_file, "exonerate") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
     def check_cigar(self, alignments):
         self.assertEqual(alignments.metadata["Program"], "exonerate")
@@ -3815,6 +3823,14 @@ class Exonerate_none(unittest.TestCase):
         self.assertRaises(StopIteration, next, alignments)
         alignments.rewind()
         self.assertRaises(StopIteration, next, alignments)
+        with Align.parse(exn_file, "exonerate") as alignments:
+            self.assertRaises(StopIteration, next, alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(exn_file, "exonerate") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
 
 if __name__ == "__main__":

--- a/Tests/test_Align_fasta.py
+++ b/Tests/test_Align_fasta.py
@@ -41,6 +41,14 @@ class TestFASTAReadingWriting(unittest.TestCase):
             self.check_clustalw(alignments)
             alignments.rewind()
             self.check_clustalw(alignments)
+        with Align.parse(path, "fasta") as alignments:
+            self.check_clustalw(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "fasta") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
         self.check_reading_writing(path)
 
     def check_clustalw(self, alignments):

--- a/Tests/test_Align_fasta.py
+++ b/Tests/test_Align_fasta.py
@@ -596,8 +596,9 @@ VHMLNKGKDGAMVFEPASLKVAPGDTVTFIPTDK-GHNVETIKGMIPDG-AE-A-------FKSKINENYKVTFTA---P
         """Checking empty file."""
         stream = StringIO()
         alignments = Align.parse(stream, "fasta")
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as cm:
             next(alignments)
+        self.assertEqual(str(cm.exception), "Empty file.")
 
 
 if __name__ == "__main__":

--- a/Tests/test_Align_hhr.py
+++ b/Tests/test_Align_hhr.py
@@ -20,6 +20,14 @@ class Align_hhr_2uvo_hhblits(unittest.TestCase):
         self.check_alignments(alignments)
         alignments.rewind()
         self.check_alignments(alignments)
+        with Align.parse(self.path, "hhr") as alignments:
+            self.check_alignments(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(self.path, "hhr") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
     def check_alignments(self, alignments):
         self.assertEqual(alignments.metadata["No_of_seqs"], (1560, 4005))

--- a/Tests/test_Align_maf.py
+++ b/Tests/test_Align_maf.py
@@ -11005,6 +11005,15 @@ i oryCun1.scaffold_133159 N 0 N 0
         alignments.rewind()
         self.check_header(alignments)
         self.check_alignments(alignments)
+        with Align.parse(path, "maf") as alignments:
+            self.check_header(alignments)
+            self.check_alignments(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "maf") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
     def check_header(self, alignments):
         self.assertEqual(len(alignments.metadata), 9)

--- a/Tests/test_Align_mauve.py
+++ b/Tests/test_Align_mauve.py
@@ -40,6 +40,14 @@ class TestCombinedFile(unittest.TestCase):
             self.check_alignments(alignments)
             alignments.rewind()
             self.check_alignments(alignments)
+        with Align.parse(path, "mauve") as alignments:
+            self.check_alignments(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "mauve") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
     def check_alignments(self, alignments):
         saved_alignments = []

--- a/Tests/test_Align_msf.py
+++ b/Tests/test_Align_msf.py
@@ -29,6 +29,14 @@ class TestMSF(unittest.TestCase):
         self.check_alignments(alignments)
         alignments.rewind()
         self.check_alignments(alignments)
+        with Align.parse(path, "msf") as alignments:
+            self.check_alignments(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "msf") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
     def check_alignments(self, alignments):
         alignment = next(alignments)

--- a/Tests/test_Align_msf.py
+++ b/Tests/test_Align_msf.py
@@ -6,7 +6,7 @@
 """Tests for Bio.Align.msf module."""
 import unittest
 import warnings
-
+from io import StringIO
 
 from Bio import BiopythonParserWarning
 from Bio import Align
@@ -397,6 +397,14 @@ DOA*01:04        62 ----------  62
         )
         with self.assertRaises(StopIteration):
             next(alignments)
+
+    def test_empty(self):
+        """Checking empty file."""
+        stream = StringIO()
+        alignments = Align.parse(stream, "msf")
+        with self.assertRaises(ValueError) as cm:
+            next(alignments)
+        self.assertEqual(str(cm.exception), "Empty file.")
 
 
 if __name__ == "__main__":

--- a/Tests/test_Align_nexus.py
+++ b/Tests/test_Align_nexus.py
@@ -51,6 +51,14 @@ class TestNexusReading(unittest.TestCase):
         self.check_nexus1(alignments)
         alignments.rewind()
         self.check_nexus1(alignments)
+        with Align.parse(path, "nexus") as alignments:
+            self.check_nexus1(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "nexus") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
         self.check_reading_writing(path)
 
     def check_nexus1(self, alignments):

--- a/Tests/test_Align_phylip.py
+++ b/Tests/test_Align_phylip.py
@@ -52,6 +52,14 @@ class TestPhylipReading(unittest.TestCase):
             self.check_one(alignments)
             alignments.rewind()
             self.check_one(alignments)
+        with Align.parse(path, "phylip") as alignments:
+            self.check_one(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "phylip") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
         self.check_reading_writing(path)
 
     def check_one(self, alignments):

--- a/Tests/test_Align_psl.py
+++ b/Tests/test_Align_psl.py
@@ -53,6 +53,14 @@ class TestAlign_dna_rna(unittest.TestCase):
         self.check_alignments(alignments)
         alignments.rewind()
         self.check_alignments(alignments)
+        with Align.parse(path, "psl") as alignments:
+            self.check_alignments(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "psl") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
     def check_alignments(self, alignments):
         self.assertEqual(alignments.metadata["psLayout version"], "3")

--- a/Tests/test_Align_sam.py
+++ b/Tests/test_Align_sam.py
@@ -1512,6 +1512,14 @@ NR_046654.1_modified	16	chr3	42530896	0	5S27M3I36M1062N17M2D56M468N43M3S	*	0	0	A
         self.check_alignments(alignments)
         alignments.rewind()
         self.check_alignments(alignments)
+        with Align.parse(path, "sam") as alignments:
+            self.check_alignments(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "sam") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
     def test_reading_psl_comparison(self):
         """Test parsing dna_rna.sam and comparing to dna_rna.psl."""

--- a/Tests/test_Align_stockholm.py
+++ b/Tests/test_Align_stockholm.py
@@ -5913,6 +5913,15 @@ G4FEQ2/2-92                     VERYSLSPMKDLWTEEAKYRRWLEVELAVTRAYEELGMIPKGVTERIR
         alignments.rewind()
         alignment = next(alignments)
         self.assertRaises(StopIteration, next, alignments)
+        with Align.parse(path, "stockholm") as alignments:
+            alignment = next(alignments)
+            self.check_alignment_globins45(alignment)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "stockholm") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
         self.check_alignment_globins45(alignment)
         stream = StringIO()
         n = Align.write(alignment, stream, "stockholm")

--- a/Tests/test_Align_tabular.py
+++ b/Tests/test_Align_tabular.py
@@ -41,6 +41,14 @@ class TestFastaProtein(unittest.TestCase):
         self.check_m8CB(alignments)
         alignments.rewind()
         self.check_m8CB(alignments)
+        with Align.parse(path, "tabular") as alignments:
+            self.check_m8CB(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "tabular") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
 
     def check_m8CB(self, alignments):
         self.assertEqual(


### PR DESCRIPTION
Since `rewind` was added to `AlignmentIterator`, the file stream must stay open until the iterator goes out of scope. This PR adds`__enter__`, `__exit__` to `AlignmentIterator` to allow it to be used in a `with ... ` statement to automatically close the file at the end of the `with` block.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

