### PR TITLE
fix misleading comment in CompoundLocation.end documentation.

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1846,8 +1846,7 @@ class CompoundLocation(Location):
         position.
 
         For the special case of a CompoundLocation wrapping the origin of
-        a circular genome this will match the genome length (minus one
-        given how Python counts from zero).
+        a circular genome this will match the genome length.
         """
         return max(loc.end for loc in self.parts)
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Deleted a sentence in documentation.
Closes #4260 
