### PR TITLE
Fix failing open file mode is binary check in Bio/bgzf.py

### DIFF
--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -501,7 +501,7 @@ def _is_binary(fileobj):
         # and there doesn't seem to be an equivalent attribute. The following
         # is taken from https://stackoverflow.com/questions/44584829/
         # how-to-determine-if-file-is-opened-in-binary-or-text-mode
-        return isinstance(fileobj, (io.RawIOBase, io.BufferedIOBase)):
+        return isinstance(fileobj, (io.RawIOBase, io.BufferedIOBase))
     else:
         return "b" in fileobj.mode.lower()
 

--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -494,7 +494,7 @@ def _load_bgzf_block(handle, text_mode=False):
 class BgzfReader:
     r"""BGZF reader, acts like a read only handle but seek/tell differ.
 
-    Let's use the BgzfBlocks function to have a peak at the BGZF blocks
+    Let's use the BgzfBlocks function to have a peek at the BGZF blocks
     in an example BAM file,
 
     >>> from builtins import open

--- a/Tests/test_bgzf.py
+++ b/Tests/test_bgzf.py
@@ -13,6 +13,7 @@ import gzip
 import os
 import tempfile
 from random import shuffle
+import io
 
 from Bio import bgzf
 
@@ -464,6 +465,28 @@ class BgzfTests(unittest.TestCase):
             with bgzf.open("GenBank/cor6_6.gb.bgz", mode) as decompressed:
                 with self.assertRaises(TypeError):
                     list(bgzf.BgzfBlocks(decompressed))
+
+    def test_reader_with_binary_fileobj(self):
+        """BgzfReader must accept a binary mode file object"""
+        reader = bgzf.BgzfReader(fileobj=io.BytesIO())
+        self.assertEqual(0, reader.tell())
+
+    def test_reader_with_non_binary_fileobj(self):
+        """BgzfReader must raise ValueError on a non-binary mode file object"""
+        error = r"^fileobj not opened in binary mode$"
+        with self.assertRaisesRegex(ValueError, error):
+            bgzf.BgzfReader(fileobj=io.StringIO())
+
+    def test_writer_with_binary_fileobj(self):
+        """BgzfWriter must accept a binary mode file object"""
+        writer = bgzf.BgzfWriter(fileobj=io.BytesIO())
+        self.assertEqual(0, writer.tell())
+
+    def test_writer_with_non_binary_fileobj(self):
+        """BgzfWriter must raise ValueError on a non-binary mode file object"""
+        error = r"^fileobj not opened in binary mode$"
+        with self.assertRaisesRegex(ValueError, error):
+            bgzf.BgzfWriter(fileobj=io.StringIO())
 
 
 if __name__ == "__main__":

--- a/Tests/test_bgzf.py
+++ b/Tests/test_bgzf.py
@@ -467,24 +467,24 @@ class BgzfTests(unittest.TestCase):
                     list(bgzf.BgzfBlocks(decompressed))
 
     def test_reader_with_binary_fileobj(self):
-        """BgzfReader must accept a binary mode file object"""
+        """A BgzfReader must accept a binary mode file object."""
         reader = bgzf.BgzfReader(fileobj=io.BytesIO())
         self.assertEqual(0, reader.tell())
 
     def test_reader_with_non_binary_fileobj(self):
-        """BgzfReader must raise ValueError on a non-binary mode file object"""
-        error = r"^fileobj not opened in binary mode$"
+        """A BgzfReader must raise ValueError on a non-binary file object."""
+        error = "^fileobj not opened in binary mode$"
         with self.assertRaisesRegex(ValueError, error):
             bgzf.BgzfReader(fileobj=io.StringIO())
 
     def test_writer_with_binary_fileobj(self):
-        """BgzfWriter must accept a binary mode file object"""
+        """A BgzfWriter must accept a binary mode file object."""
         writer = bgzf.BgzfWriter(fileobj=io.BytesIO())
         self.assertEqual(0, writer.tell())
 
     def test_writer_with_non_binary_fileobj(self):
-        """BgzfWriter must raise ValueError on a non-binary mode file object"""
-        error = r"^fileobj not opened in binary mode$"
+        """A BgzfWriter must raise ValueError on a non-binary file object."""
+        error = "^fileobj not opened in binary mode$"
         with self.assertRaisesRegex(ValueError, error):
             bgzf.BgzfWriter(fileobj=io.StringIO())
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [ X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

In running the unit tests of a project of my own, I ran into the following problem (under Python 3.10):

```
self = <Bio.bgzf.BgzfWriter object at 0x19bc18d60>, filename = None, mode = 'w', fileobj = <_io.BytesIO object at 0x19be88d60>, compresslevel = 6

    def __init__(self, filename=None, mode="w", fileobj=None, compresslevel=6):
        """Initilize the class."""
        if filename and fileobj:
            raise ValueError("Supply either filename or fileobj, not both")
        if fileobj:
>           if "b" not in fileobj.mode.lower():
E           AttributeError: '_io.BytesIO' object has no attribute 'mode'

../../miniconda3/envs/310/lib/python3.10/site-packages/Bio/bgzf.py:802: AttributeError
```

I had a look at a `BytesIO` instance, and indeed there is no `mode` attribute:

```
$ python
Python 3.10.9 | packaged by conda-forge | (main, Feb  2 2023, 20:24:27) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import io
>>> i = io.BytesIO()
>>> dir(i)
['__class__', '__del__', '__delattr__', '__dict__', '__dir__', '__doc__', '__enter__', '__eq__', '__exit__', '__format__', '__ge__', '__getattribute__', '__getstate__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__iter__', '__le__', '__lt__', '__ne__', '__new__', '__next__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__setstate__', '__sizeof__', '__str__', '__subclasshook__', '_checkClosed', '_checkReadable', '_checkSeekable', '_checkWritable', 'close', 'closed', 'detach', 'fileno', 'flush', 'getbuffer', 'getvalue', 'isatty', 'read', 'read1', 'readable', 'readinto', 'readinto1', 'readline', 'readlines', 'seek', 'seekable', 'tell', 'truncate', 'writable', 'write', 'writelines']
```

Based on https://stackoverflow.com/questions/44584829/how-to-determine-if-file-is-opened-in-binary-or-text-mode this pull request adds an internal `_is_binary` function to `Bio/bgzy.py` and uses it in two places.

I tried running the tests via `python setup.py build` then `python setup.py test` and got 350 errors:

```
Ran 569 tests in 102.190 seconds

FAILED (failures = 350)
```
