### PR TITLE
Update secondary_structure_fraction calculation

### DIFF
--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -315,17 +315,17 @@ class ProteinAnalysis:
         Returns a list of the fraction of amino acids which tend
         to be in Helix, Turn or Sheet.
 
-        Amino acids in helix: V, I, Y, F, W, L.
-        Amino acids in Turn: N, P, G, S.
-        Amino acids in sheet: E, M, A, L.
+        Amino acids in helix: E, M, A, L, K, Q, R.
+        Amino acids in Turn: N, P, G, S, D.
+        Amino acids in sheet: V, I, Y, F, W, C, T.
 
         Returns a tuple of three floats (Helix, Turn, Sheet).
         """
         aa_percentages = self.get_amino_acids_percent()
 
-        helix = sum(aa_percentages[r] for r in "VIYFWL")
-        turn = sum(aa_percentages[r] for r in "NPGS")
-        sheet = sum(aa_percentages[r] for r in "EMAL")
+        helix = sum(aa_percentages[r] for r in "EMALKQR")
+        turn = sum(aa_percentages[r] for r in "NPGSD")
+        sheet = sum(aa_percentages[r] for r in "VIYFWCT")
 
         return helix, turn, sheet
 

--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -317,7 +317,7 @@ class ProteinAnalysis:
 
         Amino acids in helix: E, M, A, L, K, Q, R.
         Amino acids in Turn: N, P, G, S, D.
-        Amino acids in sheet: V, I, Y, F, W, C, T.
+        Amino acids in sheet: V, I, Y, F, W, L, C, T.
 
         Returns a tuple of three floats (Helix, Turn, Sheet).
         """
@@ -325,7 +325,7 @@ class ProteinAnalysis:
 
         helix = sum(aa_percentages[r] for r in "EMALKQR")
         turn = sum(aa_percentages[r] for r in "NPGSD")
-        sheet = sum(aa_percentages[r] for r in "VIYFWCT")
+        sheet = sum(aa_percentages[r] for r in "VIYFWLCT")
 
         return helix, turn, sheet
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -42,6 +42,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Antony Lee <https://github.com/anntzer>
 - Anuj Sharma <https://github.com/xulesc>
 - Ariel Aptekmann <https://github.com/aralap>
+- Arpan Sahoo <https://github.com/arpansahoo>
 - Artemi Bendandi <https://github.com/artbendandi>
 - Arup Ghosh <https://github.com/arupgsh>
 - Austin Varela <https://github.com/austinv11>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -24,6 +24,7 @@ to the test suite.
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
+- Arpan Sahoo
 - Cam McMenamie
 - Ricardas Ralys
 - Vladislav Kuznetsov


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

I believe there was a mistake in secondary_structure_fraction() method in ProtParam. Before, "V, I, Y, F, W, L" and "E, M, A, L" were listed as the amino acids that tend to be in helix and sheet respectively, but it is actually the opposite.

I have also updated the amino acid list for each secondary structure based on information found in the scientific articles below:
- For beta turn: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2142776/pdf/7756980.pdf (Table 2)
- For beta sheet and alpha helix: https://doi.org/10.1016/j.bbrc.2006.01.159 (first paragraph of the Results section)
