### PR TITLE
Update calculation of secondary structure fraction

### DIFF
--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -323,7 +323,7 @@ class ProteinAnalysis:
         Amino acids in Turn: N, P, G, S, D.
         Amino acids in sheet: V, I, Y, F, W, L, T.
 
-        Note that, prior to v1.8.2, this method wrongly returned
+        Note that, prior to v1.82, this method wrongly returned
         (Sheet, Turn, Helix) while claiming to return (Helix, Turn, Sheet).
 
         Returns a tuple of three floats (Helix, Turn, Sheet).

--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -315,17 +315,17 @@ class ProteinAnalysis:
         Returns a list of the fraction of amino acids which tend
         to be in Helix, Turn or Sheet.
 
-        Amino acids in helix: V, I, Y, F, W, L.
-        Amino acids in Turn: N, P, G, S.
-        Amino acids in sheet: E, M, A, L.
+        Amino acids in helix: E, M, A, L, K.
+        Amino acids in Turn: N, P, G, S, D.
+        Amino acids in sheet: V, I, Y, F, W, L, T.
 
         Returns a tuple of three floats (Helix, Turn, Sheet).
         """
         aa_percentages = self.get_amino_acids_percent()
 
-        helix = sum(aa_percentages[r] for r in "VIYFWL")
-        turn = sum(aa_percentages[r] for r in "NPGS")
-        sheet = sum(aa_percentages[r] for r in "EMAL")
+        helix = sum(aa_percentages[r] for r in "EMALK")
+        turn = sum(aa_percentages[r] for r in "NPGSD")
+        sheet = sum(aa_percentages[r] for r in "VIYFWLT")
 
         return helix, turn, sheet
 

--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -317,10 +317,11 @@ class ProteinAnalysis:
         """Calculate fraction of helix, turn and sheet.
 
         Returns a list of the fraction of amino acids which tend
-        to be in Helix, Turn or Sheet.
+        to be in Helix, Turn or Sheet, according to Haimov and Srebnik, 2016;
+        Hutchinson and Thornton, 1994; and Kim and Berg, 1993, respectively.
 
         Amino acids in helix: E, M, A, L, K.
-        Amino acids in Turn: N, P, G, S, D.
+        Amino acids in turn: N, P, G, S, D.
         Amino acids in sheet: V, I, Y, F, W, L, T.
 
         Note that, prior to v1.82, this method wrongly returned

--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -30,7 +30,11 @@ Examples
 7.72
 >>> sec_struc = X.secondary_structure_fraction()  # [helix, turn, sheet]
 >>> print("%0.2f" % sec_struc[0])  # helix
-0.28
+0.33
+>>> print("%0.2f" % sec_struc[1])  # turn
+0.29
+>>> print("%0.2f" % sec_struc[2])  # sheet
+0.37
 >>> epsilon_prot = X.molar_extinction_coefficient()  # [reduced, oxidized]
 >>> print(epsilon_prot[0])  # with reduced cysteines
 17420
@@ -318,6 +322,9 @@ class ProteinAnalysis:
         Amino acids in helix: E, M, A, L, K.
         Amino acids in Turn: N, P, G, S, D.
         Amino acids in sheet: V, I, Y, F, W, L, T.
+
+        Note that, prior to v1.8.2, this method wrongly returned
+        (Sheet, Turn, Helix) while claiming to return (Helix, Turn, Sheet).
 
         Returns a tuple of three floats (Helix, Turn, Sheet).
         """

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -42,6 +42,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Antony Lee <https://github.com/anntzer>
 - Anuj Sharma <https://github.com/xulesc>
 - Ariel Aptekmann <https://github.com/aralap>
+- Arpan Sahoo <https://github.com/arpansahoo>
 - Artemi Bendandi <https://github.com/artbendandi>
 - Arup Ghosh <https://github.com/arupgsh>
 - Austin Varela <https://github.com/austinv11>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -24,6 +24,7 @@ to the test suite.
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
+- Arpan Sahoo
 - Cam McMenamie
 - Ricardas Ralys
 - Vladislav Kuznetsov

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -18,6 +18,10 @@ iterators of the alignments to reset as well, which is bug prone. Instead,
 calling ``iter`` on a ``PairwiseAlignments`` object will now return itself. The
 iterator can be reset by calling the ``rewind`` method.
 
+Calling `secondary_structure_fraction` on a ``ProtParam.ProteinAnalysis``
+object historically returned (sheet, turn, helix) while claiming to return
+(helix, turn, sheet). This was fixed to correctly return (helix, turn, sheet).
+
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite.
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -21,6 +21,7 @@ iterator can be reset by calling the ``rewind`` method.
 Calling `secondary_structure_fraction` on a ``ProtParam.ProteinAnalysis``
 object historically returned (sheet, turn, helix) while claiming to return
 (helix, turn, sheet). This was fixed to correctly return (helix, turn, sheet).
+Additionally, the amino acids considered were revised as per recent literature.
 
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite.

--- a/Tests/test_ProtParam.py
+++ b/Tests/test_ProtParam.py
@@ -165,9 +165,9 @@ class ProtParamTest(unittest.TestCase):
         for analysis in self.analyses:
             helix, turn, sheet = analysis.secondary_structure_fraction()
             # Old test used numbers rounded to two digits, so use the same
-            self.assertAlmostEqual(helix, 0.28, 2)
-            self.assertAlmostEqual(turn, 0.26, 2)
-            self.assertAlmostEqual(sheet, 0.25, 2)
+            self.assertAlmostEqual(helix, 0.33, 2)
+            self.assertAlmostEqual(turn, 0.29, 2)
+            self.assertAlmostEqual(sheet, 0.37, 2)
 
     def test_protein_scale(self):
         """Calculate the Kite Doolittle scale."""


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

I believe there is a mistake in secondary_structure_fraction() method in ProtParam. "V, I, Y, F, W, L" and "E, M, A, L" are listed as the amino acids that tend to be in helix and sheet respectively, but it is actually the opposite.

I have fixed this mistake, and I also updated the amino acid list for each secondary structure based on information found in the scientific articles below:

For beta turn: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2142776/pdf/7756980.pdf (Table 2)
- Added D (aspartic acid) to the list

For alpha helix: https://www.nature.com/articles/srep38341
- Added K (lysine)

For beta sheet: https://www.nature.com/articles/362267a0 (Table 1)
- Added T (threonine)