### PR TITLE
Fix auth_residues=False for MMCIFParser

### DIFF
--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -215,8 +215,7 @@ class MMCIFParser:
             except ValueError:
                 serial = atom_serial_list[i]
                 warnings.warn(
-                    "PDBConstructionWarning: "
-                    "Some atom serial numbers are not numerical",
+                    "PDBConstructionWarning: Some atom serial numbers are not numerical",
                     PDBConstructionWarning,
                 )
 
@@ -239,8 +238,7 @@ class MMCIFParser:
                 except (KeyError, IndexError):
                     msg = f"Non-existing residue ID in chain '{chainid}'"
                 warnings.warn(
-                    "PDBConstructionWarning: ",
-                    msg,
+                    "PDBConstructionWarning: " + msg,
                     PDBConstructionWarning,
                 )
                 continue
@@ -530,8 +528,7 @@ class FastMMCIFParser:
                 except (KeyError, IndexError):
                     msg = f"Non-existing residue ID in chain '{chainid}'"
                 warnings.warn(
-                    "PDBConstructionWarning: ",
-                    msg,
+                    "PDBConstructionWarning: " + msg,
                     PDBConstructionWarning,
                 )
                 continue

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -27,6 +27,7 @@ possible, especially the following contributors:
 - Cam McMenamie
 - Ricardas Ralys
 - Vladislav Kuznetsov
+- Joe Greener
 
 12 February 2023: Biopython 1.81
 ===============================================

--- a/Tests/test_PDB_MMCIFParser.py
+++ b/Tests/test_PDB_MMCIFParser.py
@@ -54,15 +54,15 @@ class ParseReal(unittest.TestCase):
         self.assertEqual(len(structure), 1)
         self.assertEqual(len(f_structure), 1)
 
-        parser_label_res = MMCIFParser(auth_residues=False, QUIET=True)
-        fast_parser_label_res = FastMMCIFParser(auth_residues=False, QUIET=True)
-        parser_label_chain = MMCIFParser(auth_chains=False, QUIET=True)
-        fast_parser_label_chain = FastMMCIFParser(auth_chains=False, QUIET=True)
+        parser_lab_res = MMCIFParser(auth_residues=False, QUIET=True)
+        fast_parser_lab_res = FastMMCIFParser(auth_residues=False, QUIET=True)
+        parser_lab_chain = MMCIFParser(auth_chains=False, QUIET=True)
+        fast_parser_lab_chain = FastMMCIFParser(auth_chains=False, QUIET=True)
 
-        structure_lr = parser_label_res.get_structure("example", "PDB/1A8O.cif")
-        f_structure_lr = fast_parser_label_res.get_structure("example", "PDB/1A8O.cif")
-        structure_lc = parser_label_chain.get_structure("example", "PDB/1A8O.cif")
-        f_structure_lc = fast_parser_label_chain.get_structure("example", "PDB/1A8O.cif")
+        structure_lr = parser_lab_res.get_structure("example", "PDB/1A8O.cif")
+        f_structure_lr = fast_parser_lab_res.get_structure("example", "PDB/1A8O.cif")
+        structure_lc = parser_lab_chain.get_structure("example", "PDB/1A8O.cif")
+        f_structure_lc = fast_parser_lab_chain.get_structure("example", "PDB/1A8O.cif")
 
         self.assertEqual(len(list(structure_lr.get_atoms())), 556)
         self.assertEqual(len(list(f_structure_lr.get_atoms())), 556)

--- a/Tests/test_PDB_MMCIFParser.py
+++ b/Tests/test_PDB_MMCIFParser.py
@@ -54,6 +54,21 @@ class ParseReal(unittest.TestCase):
         self.assertEqual(len(structure), 1)
         self.assertEqual(len(f_structure), 1)
 
+        parser_label_res = MMCIFParser(auth_residues=False, QUIET=True)
+        fast_parser_label_res = FastMMCIFParser(auth_residues=False, QUIET=True)
+        parser_label_chain = MMCIFParser(auth_chains=False, QUIET=True)
+        fast_parser_label_chain = FastMMCIFParser(auth_chains=False, QUIET=True)
+
+        structure_lr = parser_label_res.get_structure("example", "PDB/1A8O.cif")
+        f_structure_lr = fast_parser_label_res.get_structure("example", "PDB/1A8O.cif")
+        structure_lc = parser_label_chain.get_structure("example", "PDB/1A8O.cif")
+        f_structure_lc = fast_parser_label_chain.get_structure("example", "PDB/1A8O.cif")
+
+        self.assertEqual(len(list(structure_lr.get_atoms())), 556)
+        self.assertEqual(len(list(f_structure_lr.get_atoms())), 556)
+        self.assertEqual(len(list(structure_lc.get_atoms())), 644)
+        self.assertEqual(len(list(f_structure_lc.get_atoms())), 644)
+
         for ppbuild in [PPBuilder(), CaPPBuilder()]:
             # ==========================================================
             # Check that serial_num (model column) is stored properly


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4216, closes #4276.

Fix `warnings.warn` calls to have two arguments. The three argument form presumably arose from converting code such as
```python
            warnings.warn(
                "WARNING: Chain %s is discontinuous at line %i."
                % (chain_id, self.line_counter),
                PDBConstructionWarning,
            )
```
which is just two arguments.