### PR TITLE
Re-enable CircleCI Orb for codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,5 +50,5 @@ jobs:
             coverage run run_tests.py --offline
             echo "Tests run"
             coverage xml
-      #- codecov/upload:
-      #    file: biopython-*/Tests/coverage.xml
+      - codecov/upload:
+          file: biopython-*/Tests/coverage.xml


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Follow up for #4282 which removed too much (CircleCI was already using orb, with legacy PyPI package also being installed).