### PR TITLE
Remove an unused variable in Bio/PDB/ccealignmodule.c 

### DIFF
--- a/Bio/PDB/ccealignmodule.c
+++ b/Bio/PDB/ccealignmodule.c
@@ -513,7 +513,6 @@ findPath(double **S, double **dA, double **dB, int lenA, int lenB,
         Py_INCREF(pathBList);
 
         int j = 0;
-        int it = 0;
         // Grab the current path
         while (j < smaller) {
             if (pathBuffer[o][j].first != -1) {
@@ -527,8 +526,6 @@ findPath(double **S, double **dA, double **dB, int lenA, int lenB,
                     v = Py_BuildValue("i", idxB + k);
                     PyList_Append(pathBList, v);
                     Py_DECREF(v);
-
-                    it++;
                 }
                 j++;
             } else {


### PR DESCRIPTION
The variable `it` is not used and causes a compiler warning.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

