### PR TITLE
Fix file extensions in PDBList.py

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -275,7 +275,7 @@ class PDBList:
         archive_fn = archive[file_format]
 
         if file_format not in archive.keys():
-            raise (
+            raise Exception(
                 f"Specified file_format {file_format} doesn't exists or is not supported. Maybe a "
                 "typo. Please, use one of the following: mmCif, pdb, xml, mmtf, bundle"
             )
@@ -384,14 +384,14 @@ class PDBList:
         # and index of which files we have efficiently (or glob them).
         for pdb_code in obsolete:
             if self.flat_tree:
-                old_file = os.path.join(self.local_pdb, f"pdb{pdb_code}.ent")
+                old_file = os.path.join(self.local_pdb, f"pdb{pdb_code}.{file_format}")
                 new_dir = self.obsolete_pdb
             else:
                 old_file = os.path.join(
-                    self.local_pdb, pdb_code[1:3], f"pdb{pdb_code}.ent"
+                    self.local_pdb, pdb_code[1:3], f"pdb{pdb_code}.{file_format}"
                 )
                 new_dir = os.path.join(self.obsolete_pdb, pdb_code[1:3])
-            new_file = os.path.join(new_dir, f"pdb{pdb_code}.ent")
+            new_file = os.path.join(new_dir, f"pdb{pdb_code}.{file_format}")
             if os.path.isfile(old_file):
                 if not os.path.isdir(new_dir):
                     os.mkdir(new_dir)
@@ -537,7 +537,7 @@ class PDBList:
         file_format = self._print_default_format_warning(file_format)
         file_format = file_format.lower()  # we should standardize this.
         if file_format not in archive:
-            raise (
+            raise Exception(
                 f"Specified file_format '{file_format}' is not supported. Use one of the "
                 "following: 'mmcif' or 'pdb'."
             )

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -38,6 +38,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Andrey Raspopov <https://github.com/Andrey-Raspopov>
 - Andrius Merkys <https://github.com/merkys>
 - Anne Pajon <ap one two at sanger ac uk>
+- Antonio Jesús Gálvez Muñoz <https://github.com/PyCreatine>
 - Anthony Bradley <https://github.com/abradle>
 - Antony Lee <https://github.com/anntzer>
 - Anuj Sharma <https://github.com/xulesc>


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This pull request changes the `.ent` file extensions in `PBDList.py` to `.{file_format}` to fix issue [#1691](https://github.com/biopython/biopython/issues/1691) whereby the code that moves the old and obsolete pdb files only accepted files with `.ent` extension rather than using the variable passed to the function. Also fixed some literals being raised to comply with `pre-commit` needs.
