### PR TITLE
Added MultipleSeqAlignment del method for removing sequences by index or slice

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -791,6 +791,13 @@ class MultipleSeqAlignment:
                     new.column_annotations[k] = v[col_index]
             return new
 
+    def __delitem__(self, index):
+        """Delete SeqRecord by index or multiple SeqRecords by slice."""
+        if not isinstance(index, int) and not isinstance(index, slice):
+            raise TypeError("Invalid index type.")
+
+        del self._records[index]
+
     def sort(self, key=None, reverse=False):
         """Sort the rows (SeqRecord objects) of the alignment in place.
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -286,6 +286,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Shoichiro Kawauchi <https://github.com/lacrosse91>
 - Shuichiro MAKIGAKI <https://github.com/shuichiro-makigaki>
 - Shyam Saladi <https://github.com/smsaladi>
+- Siddharta Morion <https://github.com/siddhartasr10>
 - Siong Kong <https://github.com/siongkong>
 - Sjoerd de Vries <https://github.com/sjdv1982>
 - Soroush Saffari <https://github.com/sorsaffari>

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -176,6 +176,8 @@ class TestBasics(unittest.TestCase):
         alignment.append(SeqRecord(Seq(letters), id="mixed"))
         alignment.append(SeqRecord(Seq(letters.lower()), id="lower"))
         alignment.append(SeqRecord(Seq(letters.upper()), id="upper"))
+        alignment.append(SeqRecord(Seq(letters), id="duplicate"))
+        del alignment[3]
         self.assertEqual(alignment.get_alignment_length(), 26)
         self.assertEqual(len(alignment), 3)
         self.assertEqual(alignment[0].seq, letters)


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4137

Added support for deleting sequences from MultipleSeqAlignment objects, using the format requested in the issue. Added test that basically extends a basic test of an alignment of 3 sequences. 
