### PR TITLE
Avoid reportlab v4 under CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
           command: |
             python --version
             pip install -r .circleci/requirements-sphinx.txt
-            pip install coverage numpy scipy mmtf-python mysqlclient mysql-connector-python rdflib networkx matplotlib reportlab
+            pip install coverage numpy scipy mmtf-python mysqlclient mysql-connector-python rdflib networkx matplotlib
             echo "Python dependencies installed"
       - run:
           name: Installation

--- a/.circleci/requirements-sphinx.txt
+++ b/.circleci/requirements-sphinx.txt
@@ -2,7 +2,7 @@ mmtf-python
 mysql-connector-python-rf
 numpy
 rdflib
-reportlab
+reportlab<4.0
 scipy
 sphinx==4.3.2
 numpydoc==1.3.1


### PR DESCRIPTION
ReportLab v4 uses pycario, which would need to be built from source. We do still install ReportLab under GitHub Actions.

Closes #4304

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
