### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -116,7 +116,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
 
@@ -215,7 +215,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -253,7 +253,7 @@ jobs:
       matrix:
         # TODO - Try Python 3.11 again, was Python 3.11.0 was
         # failing when trying to delete SQlite databases.
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [pypy-3.7]
+        python-version: [pypy-3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -253,7 +253,7 @@ jobs:
       matrix:
         # TODO - Try Python 3.11 again, was Python 3.11.0 was
         # failing when trying to delete SQlite databases.
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -16,7 +16,7 @@ First supported in release 1.75.
 
 Python 3.7
 ----------
-First supported in release 1.73.
+No longer supported as of Release 1.82. First supported in release 1.73.
 
 Python 3.6
 ----------

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ with just one terminal command::
     pip uninstall biopython
 
 Since Biopython 1.70 we have provided pre-compiled binary wheel packages on
-PyPI for Linux, Mac OS X and Windows. This means pip install should be quick,
+PyPI for Linux, macOS and Windows. This means pip install should be quick,
 and not require a compiler.
 
 As a developer or potential contributor, you may wish to download, build and
@@ -83,14 +83,14 @@ install Biopython yourself. This is described below.
 Python Requirements
 ===================
 
-We currently recommend using Python 3.10 from http://www.python.org
+We currently recommend using Python 3.11 from http://www.python.org
 
 Biopython is currently supported and tested on the following Python
 implementations:
 
-- Python 3.7, 3.8, 3.9, 3.10 and 3.11 -- see http://www.python.org
+- Python 3.8, 3.9, 3.10 and 3.11 -- see http://www.python.org
 
-- PyPy3.7 v7.3.5 -- or later, see http://www.pypy.org
+- PyPy3.8 v7.3.11 -- or later, see http://www.pypy.org
 
 
 Optional Dependencies

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ if "bdist_wheel" in sys.argv:
 
 
 # Make sure we have the right Python version.
-MIN_PY_VER = (3, 7)
+MIN_PY_VER = (3, 8)
 if sys.version_info[:2] < MIN_PY_VER:
     sys.stderr.write(
         ("ERROR: Biopython requires Python %i.%i or later. " % MIN_PY_VER)
@@ -243,10 +243,10 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
         "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Quoting the Biopython 1.81 news entry, "We intend to drop Python 3.7 support."

Note that PyPy now offers Python 3.8 and 3.9 support.

Cross reference https://mailman.open-bio.org/pipermail/biopython/2023-May/016976.html