### PR TITLE
Change set_angle to update related angles, fix errors in default internal_coordinate values, make_extended()

### DIFF
--- a/Bio/PDB/PICIO.py
+++ b/Bio/PDB/PICIO.py
@@ -305,6 +305,9 @@ def read_PIC(
         accpt = IC_Residue.accept_atoms
         if not all(ek[i].akl[atmNdx] in accpt for i in range(4)):
             return
+        dangle = float(dangle)
+        dangle = dangle if (dangle <= 180.0) else dangle - 360.0
+        dangle = dangle if (dangle >= -180.0) else dangle + 360.0
         da[ek] = float(dangle)
         sbcic.dihedra[ek] = ric.dihedra[ek] = d = Dihedron(ek)
         d.cic = sbcic
@@ -392,8 +395,6 @@ def read_PIC(
 
             if paKey in da:
                 angl = da[paKey] + dihedra_secondary_defaults[rdclass][1]
-                angl = angl if (angl <= 180.0) else angl - 360.0
-                angl = angl if (angl >= -180.0) else angl + 360.0
                 process_dihedron(
                     str(ek[0]),
                     str(ek[1]),
@@ -431,8 +432,6 @@ def read_PIC(
 
                 if paKey in da:
                     angl = da[paKey] + offset
-                    angl = angl if (angl <= 180.0) else angl - 360.0
-                    angl = angl if (angl >= -180.0) else angl + 360.0
                     process_dihedron(
                         str(ek[0]),
                         str(ek[1]),

--- a/Bio/PDB/PICIO.py
+++ b/Bio/PDB/PICIO.py
@@ -181,7 +181,7 @@ def read_PIC(
         # akstr: full AtomKey string read from .pic file, includes residue info
         try:
             return akc[akstr]
-        except (KeyError):
+        except KeyError:
             ak = akc[akstr] = AtomKey(akstr)
             return ak
 
@@ -391,12 +391,15 @@ def read_PIC(
                 )
 
             if paKey in da:
+                angl = da[paKey] + dihedra_secondary_defaults[rdclass][1]
+                angl = angl if (angl <= 180.0) else angl - 360.0
+                angl = angl if (angl >= -180.0) else angl + 360.0
                 process_dihedron(
                     str(ek[0]),
                     str(ek[1]),
                     str(ek[2]),
                     str(ek[3]),
-                    da[paKey] + dihedra_secondary_defaults[rdclass][1],
+                    angl,
                     ric,
                 )
 
@@ -427,12 +430,15 @@ def read_PIC(
                     )
 
                 if paKey in da:
+                    angl = da[paKey] + offset
+                    angl = angl if (angl <= 180.0) else angl - 360.0
+                    angl = angl if (angl >= -180.0) else angl + 360.0
                     process_dihedron(
                         str(ek[0]),
                         str(ek[1]),
                         str(ek[2]),
                         str(ek[3]),
-                        da[paKey] + offset,
+                        angl,
                         ric,
                     )
 
@@ -588,7 +594,9 @@ def read_PIC(
             sha = {k: ha[k] for k in sorted(ha)}
             shl12 = {k: hl12[k] for k in sorted(hl12)}
             shl23 = {k: hl23[k] for k in sorted(hl23)}
-            sbcic._hedraDict2chain(shl12, sha, shl23, da, bfacs)
+            # da not in order if generated from seq
+            sda = {k: da[k] for k in sorted(da)}
+            sbcic._hedraDict2chain(shl12, sha, shl23, sda, bfacs)
 
     # read_PIC processing starts here:
     with as_handle(file, mode="r") as handle:

--- a/Bio/PDB/ic_data.py
+++ b/Bio/PDB/ic_data.py
@@ -17,6 +17,7 @@ for naming of individual atoms
 """
 
 # Backbone hedra and dihedra - within residue, no next or prev (no psi, phi, omg).
+# Core backbone angles like psi, omega, phi, tau defined in :meth:`_create_edra`.
 ic_data_backbone = (
     ("N", "CA", "C", "O"),  # locate backbone O
     ("O", "C", "CA", "CB"),  # locate CB

--- a/Bio/PDB/internal_coords.py
+++ b/Bio/PDB/internal_coords.py
@@ -3735,7 +3735,14 @@ class IC_Residue:
         If angle is a `Dihedron` and `overlap` is True (default), overlapping
         dihedra are also changed as appropriate.  The overlap is a result of
         protein chain definitions in :mod:`.ic_data` and :meth:`_create_edra`
-        (e.g. psi overlaps N-CA-C-O) so this is probably what you want.
+        (e.g. psi overlaps N-CA-C-O).
+
+        Te default overlap=True is probably what you want for:
+        `set_angle("chi1", val)`
+
+        The default is probably NOT what you want when processing all dihedrals
+        in a chain or residue (such as copying from another structure), as the
+        overlaping dihedra will likely be in the set as well.
 
         N.B. setting e.g. PRO chi2 is permitted without error or warning!
 

--- a/Bio/PDB/internal_coords.py
+++ b/Bio/PDB/internal_coords.py
@@ -2223,6 +2223,10 @@ class IC_Chain:
         chain breaks (otherwise each fragment will start at origin).
 
         Also useful if copying internal coordinates from another chain.
+
+        N.B. :meth:`IC_Residue.set_angle()` and :meth:`IC_Residue.set_length()`
+        invalidate their relevant atoms, so apply them before calling this
+        function.
         """
         ndx = [self.atomArrayIndex[ak] for iNCaC in other.initNCaCs for ak in iNCaC]
         self.atomArray[ndx] = other.atomArray[ndx]

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -28,6 +28,15 @@ Additionally, the amino acids considered were revised as per recent literature.
 The sequence objects now have ``.removeprefix()`` and ``.removesuffix()``
 methods matching that added to strings in Python 3.9.
 
+Calling ``set_angle()`` on a residue dihedral angle previously set only
+the specified angle, now the default behavior is to update overlapping
+angles as well.  For example, setting Psi (N-CA-CN) now updates the
+overlapping angle N-CA-C-O. as most users would probably expect.
+
+Generating a structure with default internal coordinates, e.g. from a
+sequence with ``read_PIC_seq()``,  previously selected wrong default
+values in many cases.  This has been fixed.
+
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite.
 
@@ -43,6 +52,7 @@ possible, especially the following contributors:
 - Peter Cock
 - Ricardas Ralys (first contribution)
 - Vladislav Kuznetsov (first contribution)
+- Rob Miller
 
 12 February 2023: Biopython 1.81
 ================================

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -37,6 +37,10 @@ Generating a structure with default internal coordinates, e.g. from a
 sequence with ``read_PIC_seq()``,  previously selected wrong default
 values in many cases.  This has been fixed.
 
+Added ``make_extended()`` to set a chain to an extended beta strand
+conformation, as the default backbone values reflect the more popular
+alpha helix in most cases.
+
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite.
 

--- a/Tests/test_PDB_internal_coords.py
+++ b/Tests/test_PDB_internal_coords.py
@@ -37,7 +37,8 @@ from Bio.File import as_handle
 from Bio.PDB.internal_coords import IC_Residue, IC_Chain, Dihedron, AtomKey
 
 from Bio.PDB.PDBExceptions import PDBConstructionWarning
-from Bio import SeqIO
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
 
 
 class Rebuild(unittest.TestCase):
@@ -537,20 +538,66 @@ class Rebuild(unittest.TestCase):
         self.assertTrue(np.amax(dpdiff) < 0.000001)
 
     def test_seq_as_PIC(self):
-        """Read protein sequence, generate default PIC data, test various."""
-        seqIter = SeqIO.parse("Fasta/f001", "fasta")
-        for _record in seqIter:
-            break
-        pdb_structure = read_PIC_seq(_record)
-        pdb_structure.internal_to_atom_coordinates()
-        for _chn in pdb_structure.get_chains():
-            break
-        cic = _chn.internal_coord
-        self.assertEqual(
-            len(cic.atomArrayValid), 575, msg="wrong number atoms from Fasta/f001"
+        """Read seq as PIC data, extend chain, set each chi angle, check various."""
+        pdb_structure = read_PIC_seq(
+            SeqRecord(
+                Seq("GAVLIMFPSTCNQYWDEHKR"),
+                id="1RND",
+                description="my 20aa sequence",
+            )
         )
+        chn = next(pdb_structure.get_chains())
+        cic = chn.internal_coord
+        cic.make_extended()
+        for chi in range(1, 6):
+            for ric in chn.internal_coord.ordered_aa_ic_list:
+                targ = "chi" + str(chi)
+                rchi = ric.get_angle(targ)
+                if rchi is not None:
+                    nangl = rchi + 60.0
+                    # nangl = nangl if (nangl <= 180.0) else nangl - 360.0
+                    ric.set_angle(targ, nangl)
+                    # ric.bond_set("chi1", nangl)
+
+        pdb_structure.internal_to_atom_coordinates()
+
+        self.assertEqual(
+            len(cic.atomArrayValid), 168, msg="wrong number atoms from sequence"
+        )
+
+        # test make_extended and each sequential chi rotation places selected
+        # atom from each sidechain where expected.
+        posnDict = {
+            "1_G_CA": [0.000, 0.000, 0.000, 1.000],
+            "2_A_CB": [-0.411, 2.505, 4.035, 1.000],
+            "3_V_CG2": [-2.246, -2.942, 4.865, 1.000],
+            "4_L_CD2": [-4.673, 2.124, 6.060, 1.000],
+            "5_I_CD1": [-4.260, -4.000, 10.546, 1.000],
+            "6_M_CE": [-10.035, 4.220, 12.322, 1.000],
+            "7_F_CE2": [-5.835, -1.076, 15.391, 1.000],
+            "8_P_CD": [-15.060, -2.368, 17.751, 1.000],
+            "9_S_OG": [-12.733, 0.388, 24.504, 1.000],
+            "10_T_CG2": [-19.084, -0.423, 22.650, 1.000],
+            "11_C_SG": [-15.455, 2.166, 27.172, 1.000],
+            "12_N_ND2": [-20.734, -3.990, 27.233, 1.000],
+            "13_Q_NE2": [-19.362, 4.465, 30.847, 1.000],
+            "14_Y_CE2": [-20.685, -3.571, 32.854, 1.000],
+            "15_W_CH2": [-23.295, 1.706, 32.883, 1.000],
+            "16_D_OD2": [-24.285, -3.683, 40.620, 1.000],
+            "17_E_OE2": [-31.719, 2.385, 38.887, 1.000],
+            "18_H_NE2": [-25.763, -0.071, 46.356, 1.000],
+            "19_K_NZ": [-36.073, -0.926, 42.383, 1.000],
+            "20_R_NH2": [-28.792, 3.687, 51.738, 1.000],
+        }
+
+        for k, v in posnDict.items():
+            atm = AtomKey(k)
+            ndx = cic.atomArrayIndex[atm]
+            coord = np.round(cic.atomArray[ndx], 3)
+            self.assertTrue(np.array_equal(coord, v), msg=f"position error on atom {k}")
+
         cic.update_dCoordSpace()
-        rt = cic.ordered_aa_ic_list[10]  # pick a residue
+        rt = cic.ordered_aa_ic_list[5]  # pick a residue
         chi1 = rt.pick_angle("chi1")  # chi1 coord space puts CA at origin
         rt.applyMtx(chi1.cst)
         coord = rt.residue.child_dict["CA"].coord  # Biopython API Atom coords
@@ -558,13 +605,15 @@ class Rebuild(unittest.TestCase):
             np.allclose(coord, [0.0, 0.0, 0.0]), msg="dCoordSpace transform error"
         )
 
+        # test Dihedron repr and all that leads into it
         psi = rt.pick_angle("psi")
 
         self.assertEqual(
             psi.__repr__(),
-            "4-11_M_N:11_M_CA:11_M_C:12_A_N MNMCAMCAN 179.0 ('gi|3318709|pdb|1A91|', 0, 'A', (' ', 11, ' '))",
-            msg="dihedron __repr__ error for M11 psi",
+            "4-6_M_N:6_M_CA:6_M_C:7_F_N MNMCAMCFN 123.0 ('1RND', 0, 'A', (' ', 6, ' '))",
+            msg="dihedron __repr__ error for M6 psi",
         )
+
         m = "Edron rich comparison failed"
         self.assertTrue(chi1 != psi, msg=m)
         self.assertFalse(chi1 == psi, msg=m)
@@ -578,15 +627,20 @@ class Rebuild(unittest.TestCase):
             msg="covalent radii assignment error for chi1",
         )
 
+        # dihedron atomkeys are all in residue atomkeys as expected, including
+        # i+1 N for psi.
         self.assertTrue(all(ak in rt for ak in chi1.atomkeys))
         self.assertFalse(all(ak in rt for ak in psi.atomkeys))
+
+        # test Hedron repr and all that leads into it
         tau = rt.pick_angle("tau")
         self.assertEqual(
             tau.__repr__(),
-            "3-11_M_N:11_M_CA:11_M_C MNMCAMC 1.46091 110.97184 1.52499",
+            "3-6_M_N:6_M_CA:6_M_C MNMCAMC 1.46091 110.97184 1.52499",
             msg="hedron __repr__ error for M11 tau",
         )
-        # some specific AtomKey compsrisons missed in other tests
+
+        # some specific AtomKey comparisons missed in other tests
         a0, a1 = tau.atomkeys[0], tau.atomkeys[1]
         m = "AtomKey rich comparison failed"
         self.assertTrue(a1 > a0, msg=m)


### PR DESCRIPTION
- [X ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X ] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


Closes #4318.

This PR changes the default behaviour of `IC_Residue.set_angle()` to modify overlapping angles by default, as most users would probably expect.   For example, with this change, setting Psi (N-CA-C-N) now updates the overlapping angle N-CA-C-O instead of generating a structure with clashing atoms.  The original behaviour can be restored by setting an optional parameter `overlap=False`.  Probably this was not noticed before because the tests look specifically at the changed angles and not the resulting coordinates; none of the previous tests were affected by this change.

This functionality was previously available only with the poorly named `bond_set()`, which is retained for compatibility.

Thanks to @niccolo93 for detailing the issue and highlighting the `bond_set()` workaround.

Other changes:

- fixes an unidentified issue in `read_PIC()` whereby the wrong default angles were selected in many cases.
- adds `IC_Chain.make_extended()` to change all psi and phi backbone angles of a chain to be those of an extended beta strand.  The default angles stored in `ic_data.py` generate the more popular alpha helix conformation in most cases.
- makes `bond_set()` and related `bond_rotate()` more robust
- more and better comments
- adds testing to check resulting coordinates for a default structure chain after `make_extended()` and sequentially modifying all chi angles 