### PR TITLE
renderPM now optional in ReportLab v4

### DIFF
--- a/Tests/test_GraphicsBitmaps.py
+++ b/Tests/test_GraphicsBitmaps.py
@@ -111,9 +111,12 @@ def real_test():
                 "Check the fonts needed by ReportLab if you want "
                 "bitmaps from Bio.Graphics\n" + str(err)
             ) from None
+        elif str(err).startswith("cannot import desired renderPM backend rlPyCairo"):
+            raise MissingExternalDependencyError(
+                "Reportlab module rlPyCairo unavailable\n" + str(err)
+            ) from None
         else:
             raise
-
     return True
 
 


### PR DESCRIPTION
See discussion on #4305 (originally about CircleCI where installing ReportLab v4 is problematic and thus we are sticking with v3.6), the GitHub actions tests on the master branch have started to fail with ReportLab v4:

```
======================================================================
ERROR: test_GraphicsBitmaps
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/reportlab/graphics/renderPM.py", line 43, in _getPMBackend
    import rlPyCairo as M
ModuleNotFoundError: No module named 'rlPyCairo'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/reportlab/graphics/renderPM.py", line 46, in _getPMBackend
    import _rl_renderPM as M
ModuleNotFoundError: No module named '_rl_renderPM'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "run_tests.py", line 258, in runTest
    suite = loader.loadTestsFromName(name)
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/home/runner/work/biopython/biopython/Tests/test_GraphicsBitmaps.py", line 121, in <module>
    real_test()
  File "/home/runner/work/biopython/biopython/Tests/test_GraphicsBitmaps.py", line 92, in real_test
    compare_plot.draw_to_file(output_file, "Testing Scatter Plots")
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/Bio/Graphics/Comparative.py", line 96, in draw_to_file
    return _write(cur_drawing, output_file, self.output_format)
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/Bio/Graphics/__init__.py", line 88, in _write
    return drawmethod.drawToFile(drawing, output_file, format, dpi=dpi)
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/reportlab/graphics/renderPM.py", line 716, in drawToFile
    c = drawToPMCanvas(d, dpi=dpi, bg=bg, configPIL=configPIL, showBoundary=showBoundary,backend=backend)
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/reportlab/graphics/renderPM.py", line 701, in drawToPMCanvas
    c = PMCanvas(d.width, d.height, dpi=dpi, bg=bg, configPIL=configPIL, backend=backend)
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/reportlab/graphics/renderPM.py", line 304, in __init__
    self.__dict__['_gs'] = self._getGState(w,h,bg,backend)
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/reportlab/graphics/renderPM.py", line 317, in _getGState
    mod = _getPMBackend(backend)
  File "/opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages/reportlab/graphics/renderPM.py", line 48, in _getPMBackend
    raise RenderPMError(f"""cannot import desired renderPM backend {backend}
reportlab.graphics.utils.RenderPMError: cannot import desired renderPM backend rlPyCairo
Seek advice at the users list see
https://pairlist2.pair.net/mailman/listinfo/reportlab-users
----------------------------------------------------------------------
```

It appears under GitHub Actions we can install reportlab v4 (the headers etc for pycairo must be present), but one of our tests tries to use the now optional legacy renderPM module [*Update - not exactly. It was attempting to use renderPM when it could not use pycairo.*]

If this works it will at least fix the failing CI test on the master branch. [*Update - attempting to install renderPM did not work*]

However, it is not ideal as a long term fix since most end users will also not have the renderPM module installed.

i.e. Any test using renderPM ought to be skipped gracefully. [*Update: now done*]

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
