### PR TITLE
Add ruff to pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,8 @@ repos:
     hooks:
     -   id: black
         args: [--check,--target-version,py38]
--   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.118
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.284
     hooks:
     -   id: ruff
         args: ['--extend-ignore=E501,F401,F841']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,9 @@ repos:
     -   id: black
         args: [--check,--target-version,py38]
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.284
+    rev: v0.1.3
     hooks:
+    # Run the Ruff linter.
     -   id: ruff
         args: ['--extend-ignore=E501,F401,F841']
 -   repo: https://github.com/PyCQA/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,11 @@ repos:
     hooks:
     -   id: black
         args: [--check,--target-version,py38]
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.118
+    hooks:
+    -   id: ruff
+        args: ['--extend-ignore=E501,F401,F841']
 -   repo: https://github.com/PyCQA/flake8
     rev: 6.1.0
     hooks:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -2917,10 +2917,10 @@ class Alignment:
             starts = ends
             ends = self.coordinates[:, k]
             for row, start, end, rc in zip(a, starts, ends, rcs):
-                if rc == False and start < end:  # noqa: 712
+                if rc == False and start < end:  # noqa: E712
                     j = i + end - start
                     row[i:j] = range(start, end)
-                elif rc == True and start > end:  # noqa: 712
+                elif rc == True and start > end:  # noqa: E712
                     j = i + start - end
                     row[i:j] = range(start - 1, end - 1, -1)
             i = j
@@ -2999,10 +2999,10 @@ class Alignment:
             starts = self.coordinates[:, k]
             ends = self.coordinates[:, k + 1]
             for row, start, end, rc in zip(a, starts, ends, rcs):
-                if rc == False and start < end:  # noqa: 712
+                if rc == False and start < end:  # noqa: E712
                     j = i + end - start
                     row[start:end] = range(i, j)
-                elif rc == True and start > end:  # noqa: 712
+                elif rc == True and start > end:  # noqa: E712
                     j = i + start - end
                     if end > 0:
                         row[start - 1 : end - 1 : -1] = range(i, j)

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -312,7 +312,7 @@ class _CursorWrapper:
         """Decode any bytestrings present in the row (PRIVATE)."""
         tuple_list = list(tuple_)
         for i, elem in enumerate(tuple_list):
-            if type(elem) is bytes:
+            if isinstance(elem, bytes):
                 tuple_list[i] = elem.decode("utf-8")
         return tuple(tuple_list)
 

--- a/Tests/test_Align_bigbed.py
+++ b/Tests/test_Align_bigbed.py
@@ -2293,7 +2293,7 @@ table bed
             self.assertEqual(alignment.itemRgb, "0,255,0", msg=msg)
         with self.assertRaises(StopIteration) as cm:
             next(alignments)
-            self.fail(f"More than two alignments reported in {filename}")
+            self.fail("More than two alignments reported")
 
     def test_reading(self):
         """Test parsing alignments in file formats BED3 through BED12."""


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Revives work on pull request #4164.

Aims to close #3958 by using ruff as a fast subset of flake8 (which is now too slow to use on the pre-commit.ci service).

~~Also enables ``autofix_prs`` as per https://pre-commit.ci/#configuration-autofix_prs to run ruff and black in fixer mode on pull requests as needed.~~
