### PR TITLE
Add a search method to Seq and MutableSeq

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -793,6 +793,9 @@ class _SeqAbstractBaseClass(ABC):
 
         >>> my_rna.find("AUG", 4)
         15
+
+        See the ``search`` method to find the locations of multiple subsequences
+        at the same time.
         """
         if isinstance(sub, _SeqAbstractBaseClass):
             sub = bytes(sub)
@@ -831,6 +834,9 @@ class _SeqAbstractBaseClass(ABC):
 
         >>> my_rna.rfind("AUG", end=15)
         3
+
+        See the ``search`` method to find the locations of multiple subsequences
+        at the same time.
         """
         if isinstance(sub, _SeqAbstractBaseClass):
             sub = bytes(sub)
@@ -871,7 +877,7 @@ class _SeqAbstractBaseClass(ABC):
         15
 
         This method performs the same search as the ``find`` method.  However,
-        if the subsequence is not found, ``find`` returns -1 which ``index``
+        if the subsequence is not found, ``find`` returns -1 while ``index``
         raises a ValueError:
 
         >>> my_rna.index("T")
@@ -880,6 +886,9 @@ class _SeqAbstractBaseClass(ABC):
         ValueError: ...
         >>> my_rna.find("T")
         -1
+
+        See the ``search`` method to find the locations of multiple subsequences
+        at the same time.
         """
         if isinstance(sub, MutableSeq):
             sub = sub._data
@@ -931,6 +940,9 @@ class _SeqAbstractBaseClass(ABC):
         ValueError: ...
         >>> my_rna.rfind("T")
         -1
+
+        See the ``search`` method to find the locations of multiple subsequences
+        at the same time.
         """
         if isinstance(sub, MutableSeq):
             sub = sub._data

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -17,6 +17,9 @@ and MAST programs, as well as files in the TRANSFAC format.
 
 from urllib.parse import urlencode
 from urllib.request import urlopen, Request
+import warnings
+
+from Bio import BiopythonDeprecationWarning
 
 
 def create(instances, alphabet="ACGT"):
@@ -229,6 +232,10 @@ class Instances(list):
         This is a generator function, returning found positions of motif
         instances in a given sequence.
         """
+        warnings.warn(
+            """instances.search(sequence) has been deprecated. Please use sequence.search(instances) instead, where sequence is a Seq object.""",
+            BiopythonDeprecationWarning,
+        )
         for pos in range(0, len(sequence) - self.length + 1):
             for instance in self:
                 if instance == sequence[pos : pos + self.length]:

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -100,6 +100,11 @@ release 1.74. Also affects ``Bio.motifs.read`` and ``Bio.motifs.parse`` for the
 The ``format`` method of the ``Motif`` class in ``Bio.motifs`` was deprecated
 in release 1.77, in favor of a ``__format__`` method that can be used from the
 ``format`` built-in function. This decision was reversed in release 1.79.
+The ``search`` method of the ``Instances`` class in ``Bio.motifs`` was
+deprecated in release 1.82. Instead of ``instances.search(sequence)``,
+``sequence.search(instances)`` can be used, where sequence is a Seq object.
+This allows instances to have different lengths.
+
 
 Bio.Restriction.RanaConfig
 --------------------------

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -1129,7 +1129,7 @@ the true instances of the motif:
 
 %cont-doctest
 \begin{minted}{pycon}
->>> for pos, seq in m.instances.search(test_seq):
+>>> for pos, seq in test_seq.search(m.instances):
 ...     print("%i %s" % (pos, seq))
 ...
 0 TACAC
@@ -1140,7 +1140,7 @@ We can do the same with the reverse complement (to find instances on the complem
 
 %cont-doctest
 \begin{minted}{pycon}
->>> for pos, seq in r.instances.search(test_seq):
+>>> for pos, seq in test_seq.search(r.instances):
 ...     print("%i %s" % (pos, seq))
 ...
 6 GCATT

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -669,68 +669,6 @@ Partially defined sequences can also be created by appending sequences, if at le
 Seq({0: 'ACGT', 14: 'ACGT'}, length=18)
 \end{minted}
 
-\section{Finding subsequences}
-
-Sequence objects have ``find``, ``rfind``, ``index``, and ``rindex`` methods
-that perform the same function as the corresponding methods on plain string
-objects. The only difference is that the subsequence can be a string, ``bytes``,
-``bytearray``, ``Seq``, or ``MutableSeq`` object:
-
-%doctest
-\begin{minted}{pycon}
->>> from Bio.Seq import Seq
->>> seq = Seq("GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA")
->>> seq.index("ATGGGCCGC")
-9
->>> seq.index(b"ATGGGCCGC")
-9
->>> seq.index(bytearray(b"ATGGGCCGC"))
-9
->>> seq.index(Seq("ATGGGCCGC"))
-9
->>> seq.index(MutableSeq("ATGGGCCGC"))
-9
-\end{minted}
-A ``ValueError`` is raised if the subsequence is not found:
-%cont-doctest
-\begin{minted}{pycon}
->>> seq.index("ACTG")  # doctest:+ELLIPSIS
-Traceback (most recent call last):
-...
-ValueError: subsection not found
-\end{pycon}
-while the ``find`` method returns -1 if the subsequence is not found:
-%cont-doctest
-\begin{minted}{pycon}
->>> seq.find("ACTG")
--1
-\end{pycon}
-The methods ``rfind`` and ``rindex`` search for the subsequence starting from
-the right hand side of the sequence:
-%cont-doctest
-\begin{minted}{pycon}
->>> seq.find("CC")
-1
->>> seq.rfind("CC")
-29
-\end{pycon}
-
-Use the ``search`` method to search for multiple subsequences at the same time.
-This method returns an iterator:
-%cont-doctest
-\begin{minted}{pycon}
->>> for index, sub in seq.search(["CC", "GGG", "CC"]):
-...     print(index, sub)
-...
-1 CC
-11 GGG
-14 CC
-23 GGG
-28 CC
-29 CC
-\end{pycon}
-The ``search`` method also takes plain strings, `bytes`, `bytearray`, `Seq`, and `MutableSeq` objects as subsequences; identical subsequences are reported only once, as in the example above.
-
 \section{MutableSeq objects}
 \label{sec:mutable-seq}
 
@@ -801,6 +739,68 @@ Seq('AGCCCGTGGGAAAGTCGCCGGGTAATGCACCG')
 \end{minted}
 
 You can also get a string from a \verb|MutableSeq| object just like from a \verb|Seq| object (Section~\ref{sec:seq-to-string}).
+
+\section{Finding subsequences}
+
+Sequence objects have ``find``, ``rfind``, ``index``, and ``rindex`` methods
+that perform the same function as the corresponding methods on plain string
+objects. The only difference is that the subsequence can be a string, ``bytes``,
+``bytearray``, ``Seq``, or ``MutableSeq`` object:
+
+%doctest
+\begin{minted}{pycon}
+>>> from Bio.Seq import Seq, MutableSeq
+>>> seq = Seq("GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA")
+>>> seq.index("ATGGGCCGC")
+9
+>>> seq.index(b"ATGGGCCGC")
+9
+>>> seq.index(bytearray(b"ATGGGCCGC"))
+9
+>>> seq.index(Seq("ATGGGCCGC"))
+9
+>>> seq.index(MutableSeq("ATGGGCCGC"))
+9
+\end{minted}
+A ``ValueError`` is raised if the subsequence is not found:
+%cont-doctest
+\begin{minted}{pycon}
+>>> seq.index("ACTG")  # doctest:+ELLIPSIS
+Traceback (most recent call last):
+...
+ValueError: subsection not found
+\end{minted}
+while the ``find`` method returns -1 if the subsequence is not found:
+%cont-doctest
+\begin{minted}{pycon}
+>>> seq.find("ACTG")
+-1
+\end{minted}
+The methods ``rfind`` and ``rindex`` search for the subsequence starting from
+the right hand side of the sequence:
+%cont-doctest
+\begin{minted}{pycon}
+>>> seq.find("CC")
+1
+>>> seq.rfind("CC")
+29
+\end{minted}
+
+Use the ``search`` method to search for multiple subsequences at the same time.
+This method returns an iterator:
+%cont-doctest
+\begin{minted}{pycon}
+>>> for index, sub in seq.search(["CC", "GGG", "CC"]):
+...     print(index, sub)
+...
+1 CC
+11 GGG
+14 CC
+23 GGG
+28 CC
+29 CC
+\end{minted}
+The ``search`` method also takes plain strings, `bytes`, `bytearray`, `Seq`, and `MutableSeq` objects as subsequences; identical subsequences are reported only once, as in the example above.
 
 \section{Working with strings directly}
 \label{sec:seq-module-functions}

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -669,6 +669,68 @@ Partially defined sequences can also be created by appending sequences, if at le
 Seq({0: 'ACGT', 14: 'ACGT'}, length=18)
 \end{minted}
 
+\section{Finding subsequences}
+
+Sequence objects have ``find``, ``rfind``, ``index``, and ``rindex`` methods
+that perform the same function as the corresponding methods on plain string
+objects. The only difference is that the subsequence can be a string, ``bytes``,
+``bytearray``, ``Seq``, or ``MutableSeq`` object:
+
+%doctest
+\begin{minted}{pycon}
+>>> from Bio.Seq import Seq
+>>> seq = Seq("GCCATTGTAATGGGCCGCTGAAAGGGTGCCCGA")
+>>> seq.index("ATGGGCCGC")
+9
+>>> seq.index(b"ATGGGCCGC")
+9
+>>> seq.index(bytearray(b"ATGGGCCGC"))
+9
+>>> seq.index(Seq("ATGGGCCGC"))
+9
+>>> seq.index(MutableSeq("ATGGGCCGC"))
+9
+\end{minted}
+A ``ValueError`` is raised if the subsequence is not found:
+%cont-doctest
+\begin{minted}{pycon}
+>>> seq.index("ACTG")  # doctest:+ELLIPSIS
+Traceback (most recent call last):
+...
+ValueError: subsection not found
+\end{pycon}
+while the ``find`` method returns -1 if the subsequence is not found:
+%cont-doctest
+\begin{minted}{pycon}
+>>> seq.find("ACTG")
+-1
+\end{pycon}
+The methods ``rfind`` and ``rindex`` search for the subsequence starting from
+the right hand side of the sequence:
+%cont-doctest
+\begin{minted}{pycon}
+>>> seq.find("CC")
+1
+>>> seq.rfind("CC")
+29
+\end{pycon}
+
+Use the ``search`` method to search for multiple subsequences at the same time.
+This method returns an iterator:
+%cont-doctest
+\begin{minted}{pycon}
+>>> for index, sub in seq.search(["CC", "GGG", "CC"]):
+...     print(index, sub)
+...
+1 CC
+11 GGG
+14 CC
+23 GGG
+28 CC
+29 CC
+\end{pycon}
+The ``search`` method also takes plain strings, `bytes`, `bytearray`, `Seq`, and `MutableSeq` objects as subsequences; identical subsequences are reported only once, as in the example above.
+
 \section{MutableSeq objects}
 \label{sec:mutable-seq}
 

--- a/Doc/Tutorial/chapter_seq_objects.tex
+++ b/Doc/Tutorial/chapter_seq_objects.tex
@@ -763,12 +763,15 @@ objects. The only difference is that the subsequence can be a string, ``bytes``,
 9
 \end{minted}
 A ``ValueError`` is raised if the subsequence is not found:
+% The error message on CPython is "subsection not found";
+% on PyPy it is "substring not found".
+
 %cont-doctest
 \begin{minted}{pycon}
 >>> seq.index("ACTG")  # doctest:+ELLIPSIS
 Traceback (most recent call last):
 ...
-ValueError: subsection not found
+ValueError: ...
 \end{minted}
 while the ``find`` method returns -1 if the subsequence is not found:
 %cont-doctest

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -41,6 +41,9 @@ Added ``make_extended()`` to set a chain to an extended beta strand
 conformation, as the default backbone values reflect the more popular
 alpha helix in most cases.
 
+Added a ``search`` method to ``Seq`` and ``MultipleSeq`` object to search for
+multiple subsequences at the same time.
+
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite.
 

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -611,6 +611,29 @@ class StringMethodTests(unittest.TestCase):
         u = Seq(None, length=0)
         self.assertEqual(u, "")
 
+    def test_search(self):
+        """Check the search method of Seq objects."""
+        s = Seq("ACGTACGT")
+        matches = s.search(["CGT", Seq("CG"), b"ACGT", bytearray(b"GTA")])
+        self.assertEqual(next(matches), (0, "ACGT"))
+        self.assertEqual(next(matches), (1, "CGT"))
+        self.assertEqual(next(matches), (1, "CG"))
+        self.assertEqual(next(matches), (2, "GTA"))
+        self.assertEqual(next(matches), (4, "ACGT"))
+        self.assertEqual(next(matches), (5, "CGT"))
+        self.assertEqual(next(matches), (5, "CG"))
+        self.assertRaises(StopIteration, next, matches)
+        s = MutableSeq("ACGTACGT")
+        matches = s.search(["CGT", Seq("CG"), b"ACGT", bytearray(b"GTA")])
+        self.assertEqual(next(matches), (0, "ACGT"))
+        self.assertEqual(next(matches), (1, "CGT"))
+        self.assertEqual(next(matches), (1, "CG"))
+        self.assertEqual(next(matches), (2, "GTA"))
+        self.assertEqual(next(matches), (4, "ACGT"))
+        self.assertEqual(next(matches), (5, "CGT"))
+        self.assertEqual(next(matches), (5, "CG"))
+        self.assertRaises(StopIteration, next, matches)
+
     def test_MutableSeq_setitem(self):
         """Check setting sequence contents of a MutableSeq object."""
         m = MutableSeq("ABCD")


### PR DESCRIPTION
This PR deprecates the `search` method of the `Instances` class in `Bio.motifs`. Instead, a new method `search` on `Seq` and `MutableSeq` is introduced to provide the same functionality. Code like
```python
>>> seq = Seq("ACGT")
>>> instances = Instances([Seq("ACG"), Seq("CGT")])
>>> matches = instances.search(seq)
>>> for index, sub in matches:
...     print(index, sub)
... 
0 ACG
1 CGT
```
should be replaced by
```python
>>> seq = Seq("ACGT")
>>> instances = [Seq("ACG"), Seq("CGT")]
>>> matches = seq.search(instances)
>>> for index, sub in matches:
...     print(index, sub)
... 
0 ACG
1 CGT
```
This has three advantages:
 - The order `seq.search(instances)` is consistent with `seq.find(instance)` and  `seq.index(instance)`.
 - The `Instances` class in `Bio.motifs` is not really needed any more, and can be deprecated (in a separate PR).
 - The instances to be searched for can now have different lengths:
```python
>>> seq = Seq("ACGT")
>>> instances = [Seq("ACG"), Seq("GT")]
>>> matches = seq.search(instances)
>>> for index, sub in matches:
...     print(index, sub)
... 
0 ACG
2 GT
```
whereas the `Instances` class requires all instances to have the same sequence length:
```python
>>> instances = Instances([Seq("ACG"), Seq("GT")])
Traceback (most recent call last):
...
ValueError: All instances should have the same length (2 found, 3 expected)
```

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
