### PR TITLE
fix reverse_complement

### DIFF
--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -18,6 +18,8 @@ and MAST programs, as well as files in the TRANSFAC format.
 from urllib.parse import urlencode
 from urllib.request import urlopen, Request
 
+from Bio.Seq import reverse_complement
+
 
 def create(instances, alphabet="ACGT"):
     """Create a Motif object."""
@@ -246,8 +248,10 @@ class Instances(list):
             # TODO: remove inplace=False
             if isinstance(instance, (Seq, MutableSeq)):
                 instance = instance.reverse_complement(inplace=False)
-            elif isinstance(instance, (str, SeqRecord)):
+            elif isinstance(instance, SeqRecord):
                 instance = instance.reverse_complement()
+            elif isinstance(instance, str):
+                instance = reverse_complement(instance)
             else:
                 raise RuntimeError("instance has unexpected type %s" % type(instance))
             instances.append(instance)


### PR DESCRIPTION
Fix `reverse_complement` for strings in `Bio.motifs`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
