### PR TITLE
Test UniProt parsing Tutorial example (offline)

### DIFF
--- a/Doc/Tutorial/chapter_uniprot.tex
+++ b/Doc/Tutorial/chapter_uniprot.tex
@@ -15,8 +15,9 @@ To parse a Swiss-Prot record, we first get a handle to a Swiss-Prot record. Ther
 \begin{itemize}
 
 \item Open a Swiss-Prot file locally:
+%doctest ../Tests
 \begin{minted}{pycon}
->>> handle = open("myswissprotfile.dat")
+>>> handle = open("SwissProt/F2CXE6.txt")
 \end{minted}
 
 \item Open a gzipped Swiss-Prot file:
@@ -37,7 +38,7 @@ to open the file stored on the Internet before calling \verb|read|.
 (see section \ref{sec:expasy_swissprot}):
 \begin{minted}{pycon}
 >>> from Bio import ExPASy
->>> handle = ExPASy.get_sprot_raw(myaccessionnumber)
+>>> handle = ExPASy.get_sprot_raw("F2CXE6")
 \end{minted}
 \end{itemize}
 The key point is that for the parser, it doesn't matter how the handle was created, as long as it points to data in the Swiss-Prot format. The parser will automatically decode the data as ASCII (the encoding used by Swiss-Prot) if the handle was opened in binary mode.
@@ -45,7 +46,7 @@ The key point is that for the parser, it doesn't matter how the handle was creat
 We can use \verb+Bio.SeqIO+ as described in Section~\ref{sec:SeqIO_ExPASy_and_SwissProt} to get file format agnostic \verb|SeqRecord| objects.  Alternatively, we can use \verb+Bio.SwissProt+ get \verb|Bio.SwissProt.Record| objects, which are a much closer match to the underlying file format.
 
 To read one Swiss-Prot record from the handle, we use the function \verb|read()|:
-%--cont-doctest
+%cont-doctest
 \begin{minted}{pycon}
 >>> from Bio import SwissProt
 >>> record = SwissProt.read(handle)
@@ -53,8 +54,7 @@ To read one Swiss-Prot record from the handle, we use the function \verb|read()|
 This function should be used if the handle points to exactly one Swiss-Prot record. It raises a \verb|ValueError| if no Swiss-Prot record was found, and also if more than one record was found.
 
 We can now print out some information about this record:
-%TODO - Check the single quotes when printing record.description here:
-%--cont-doctest
+%cont-doctest
 \begin{minted}{pycon}
 >>> print(record.description)
 SubName: Full=Plasma membrane intrinsic protein {ECO:0000313|EMBL:BAN04711.1}; SubName: Full=Predicted protein {ECO:0000313|EMBL:BAJ87517.1};


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Follow on from 8345c7e430204bc4f47559aaaea176ffbd0833da to actually test this example.

Note the third reference really does have no title (which gives a trailing space in the expected output, something doc8 grumbles about when converted to RST)
