### PR TITLE
Bio.Align alignment object frequencies

### DIFF
--- a/Bio/Align/clustal.py
+++ b/Bio/Align/clustal.py
@@ -244,7 +244,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         coordinates = Alignment.infer_coordinates(aligned_seqs)
         alignment = Alignment(records, coordinates)
         if consensus:
-            rows, columns = alignment.shape
+            columns = alignment.length
             if len(consensus) != columns:
                 raise ValueError(
                     "Alignment has %i columns, consensus length is %i, '%s'"

--- a/Bio/Align/msf.py
+++ b/Bio/Align/msf.py
@@ -237,7 +237,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
         alignment = Alignment(records, coordinates)
         # This will check alignment lengths are self-consistent:
-        rows, columns = alignment.shape
+        columns = alignment.length
         if columns != aln_length:
             raise ValueError(
                 "GCG MSF headers said alignment length %i, but found %i"

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -328,15 +328,14 @@ class Motif:
             self.counts = matrix.FrequencyPositionMatrix(alphabet, counts)
             self.length = self.counts.length
         elif alignment is not None:
+            length = alignment.length
+            frequencies = alignment.frequencies
+            for letter in alphabet:
+                if letter not in frequencies:
+                    frequencies[letter] = np.zeros(length, int)
+            self.counts = matrix.FrequencyPositionMatrix(alphabet, frequencies)
             self.alignment = alignment
-            block = np.array(alignment, dtype="U")
-            self.length = block.shape[1]
-            counts = {letter: [0] * self.length for letter in alphabet}
-            for row in block:
-                for position, letter in enumerate(row):
-                    counts[letter][position] += 1
-            self.counts = matrix.FrequencyPositionMatrix(alphabet, counts)
-            self.length = self.counts.length
+            self.length = length
         else:
             self.counts = None
             self.alignment = None

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2056,13 +2056,23 @@ Here, the two rows refer to the target and query sequence. These coordinates sho
 \item \verb+target[4:5]+ aligned to \verb+query[2:3]+.
 \end{itemize}
 
-The length of the alignment is defined as the number of aligned sequences,
-which is always 2 for a pairwise alignment:
+The number of aligned sequences is returned by \verb+len(alignment)+; this is
+always 2 for a pairwise alignment:
 
 %cont-doctest
 \begin{minted}{pycon}
 >>> len(alignment)
 2
+\end{minted}
+
+The alignment length is defined as the number of columns in the alignment as
+printed. This is equal to the sum of the number of matches, number of
+mismatches, and the total length of gaps in the target and query:
+
+%cont-doctest
+\begin{minted}{pycon}
+>>> alignment.length
+5
 \end{minted}
 
 The \verb+shape+ property returns a tuple consisting of the length of the

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -2211,12 +2211,11 @@ query             1 GAAC 5
 <BLANKLINE>
 \end{minted}
 
-Use the \verb+substitutions+ method to find the number of substitutions between each pair of nucleotides:
+The \verb+frequencies+ method calculates how often each letter appears in each column of the alignment:
 %cont-doctest
 \begin{minted}{pycon}
 >>> target = "AAAAAAAACCCCCCCCGGGGGGGGTTTTTTTT"
 >>> query = "AAAAAAACCCTCCCCGGCCGGGGTTTAGTTT"
->>> alignments = aligner.align(target, query)
 >>> aligner.mismatch_score = -1
 >>> aligner.gap_score = -1
 >>> alignments = aligner.align(target, query)
@@ -2227,6 +2226,15 @@ target            0 AAAAAAAACCCCCCCCGGGGGGGGTTTTTTTT 32
                   0 |||||||-|||.||||||..|||||||..||| 32
 query             0 AAAAAAA-CCCTCCCCGGCCGGGGTTTAGTTT 31
 <BLANKLINE>
+>>> alignments[0].frequencies  # doctest: +NORMALIZE_WHITESPACE
+{'A': array([2, 2, 2, 2, 2, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0]),
+ 'C': array([0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 1, 2, 2, 2, 2, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+ 'G': array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 1, 1, 2, 2, 2, 2, 0, 0, 0, 0, 1, 0, 0, 0]),
+ 'T': array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 1, 1, 2, 2, 2])}
+\end{minted}
+Use the \verb+substitutions+ method to find the number of substitutions between each pair of nucleotides:
+%cont-doctest
+\begin{minted}{pycon}
 >>> m = alignments[0].substitutions
 >>> print(m)
     A   C   G   T

--- a/Tests/test_Align_Alignment.py
+++ b/Tests/test_Align_Alignment.py
@@ -74,6 +74,23 @@ query             7 A-C-GG-AAC--  0
 """,
                 msg=msg,
             )
+        frequencies = alignment.frequencies
+        self.assertEqual(list(frequencies.keys()), ["A", "C", "G"])
+        self.assertTrue(
+            numpy.array_equal(
+                frequencies["A"], numpy.array([2, 1, 0, 0, 0, 0, 0, 2, 1, 0, 0, 0])
+            )
+        )
+        self.assertTrue(
+            numpy.array_equal(
+                frequencies["C"], numpy.array([0, 0, 2, 1, 0, 0, 0, 0, 0, 2, 1, 0])
+            )
+        )
+        self.assertTrue(
+            numpy.array_equal(
+                frequencies["G"], numpy.array([0, 0, 0, 0, 2, 2, 1, 0, 0, 0, 0, 1])
+            )
+        )
         self.assertAlmostEqual(alignment.score, 6.0)
         self.assertEqual(len(alignment), 2)
         self.assertEqual(alignment.shape, (2, 12))
@@ -587,6 +604,23 @@ query             0 -AG 2
                 numpy.array([[0, 1, 2, 3, 4, 6, 7, 8, 8, 9, 11]]),
             )
         )
+        frequencies = subalignment.frequencies
+        self.assertEqual(list(frequencies.keys()), ["A", "C", "G"])
+        self.assertTrue(
+            numpy.array_equal(
+                frequencies["A"], numpy.array([1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0])
+            )
+        )
+        self.assertTrue(
+            numpy.array_equal(
+                frequencies["C"], numpy.array([0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0])
+            )
+        )
+        self.assertTrue(
+            numpy.array_equal(
+                frequencies["G"], numpy.array([0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1])
+            )
+        )
         subalignment = alignment[:1, :]
         self.assertEqual(len(subalignment.sequences), 1)
         sequence = subalignment.sequences[0]
@@ -600,6 +634,23 @@ query             0 -AG 2
             numpy.array_equal(
                 subalignment.coordinates,
                 numpy.array([[0, 1, 2, 3, 4, 6, 7, 8, 8, 9, 11]]),
+            )
+        )
+        frequencies = subalignment.frequencies
+        self.assertEqual(list(frequencies.keys()), ["A", "C", "G"])
+        self.assertTrue(
+            numpy.array_equal(
+                frequencies["A"], numpy.array([1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0])
+            )
+        )
+        self.assertTrue(
+            numpy.array_equal(
+                frequencies["C"], numpy.array([0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0])
+            )
+        )
+        self.assertTrue(
+            numpy.array_equal(
+                frequencies["G"], numpy.array([0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 1])
             )
         )
         subalignment = alignment[:]


### PR DESCRIPTION
Add a `.frequencies` property to the `Alignment` object in `Bio.Align`. This method calculates how often each letter occurs for each column in the alignment.

Also, add a `.length` property to the `Alignment` object, returning the number of columns in the printed alignment. This number can also be found from the `.shape` property, but if the number of aligned sequences is not needed, then the `.length` property is more convenient. This property's name is consistent with the `.length` property in the `Motif` class in `Bio.motifs`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
