### PR TITLE
Allow string-like objects as filenames in SeqIO

### DIFF
--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -844,8 +844,12 @@ def index(filename, format, alphabet=None, key_function=None):
 
     """
     # Try and give helpful error messages:
-    if not isinstance(filename, str):
-        raise TypeError("Need a filename (not a handle)")
+    if type(filename).__str__ is object.__str__:
+        raise TypeError("Need string for the filename (not a handle)")
+    elif not isinstance(filename, str):
+        # if filename is not a string, but can be converted to one, then
+        # convert it. Makes the API a bit nicer.
+        filename = str(filename)
     if not isinstance(format, str):
         raise TypeError("Need a string for the file format (lower case)")
     if not format:
@@ -924,14 +928,19 @@ def index_db(
 
     """
     # Try and give helpful error messages:
-    if not isinstance(index_filename, str):
-        raise TypeError("Need a string for the index filename")
-    if isinstance(filenames, str):
+    if type(index_filename).__str__ is object.__str__:
+        raise TypeError("Need a string for the index filename (not a handle)")
+    elif not isinstance(index_filename, str):
+        # if index_filename is not a string, but can be converted to one, then
+        # convert it. Makes the API a bit nicer.
+        index_filename = str(index_filename)
+    if type(filenames).__str__ is not object.__str__:
         # Make the API a little more friendly, and more similar
         # to Bio.SeqIO.index(...) for indexing just one file.
-        filenames = [filenames]
+        filenames = [str(filenames)]
     if filenames is not None and not isinstance(filenames, list):
-        raise TypeError("Need a list of filenames (as strings), or one filename")
+        # raise TypeError("Need a list of filenames (as strings), or one filename")
+        raise TypeError(str(type(filenames)))
     if format is not None and not isinstance(format, str):
         raise TypeError("Need a string for the file format (lower case)")
     if format and not format.islower():

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -872,7 +872,7 @@ def index(filename, format, alphabet=None, key_function=None):
         random_access_proxy = proxy_class(filename, format)
     except TypeError:
         raise TypeError(
-            "Need a string or path-like object for the filename (not a handle)"
+            "Need a string or path-like objects for the filename (not a handle)"
         ) from None
 
     return _IndexedSeqFileDict(random_access_proxy, key_function, repr, "SeqRecord")
@@ -947,7 +947,7 @@ def index_db(
     if filenames is not None and not isinstance(filenames, list):
         raise TypeError(
             "Need a list of filenames (as strings or path-like "
-            "object), or one filename"
+            "objects), or one filename"
         )
     if format is not None and not isinstance(format, str):
         raise TypeError("Need a string for the file format (lower case)")

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -873,7 +873,7 @@ def index(filename, format, alphabet=None, key_function=None):
     except TypeError:
         raise TypeError(
             "Need a string or path-like object for the filename (not a handle)"
-        )
+        ) from None
 
     return _IndexedSeqFileDict(random_access_proxy, key_function, repr, "SeqRecord")
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -872,7 +872,7 @@ def index(filename, format, alphabet=None, key_function=None):
         random_access_proxy = proxy_class(filename, format)
     except TypeError:
         raise TypeError(
-            "Need a string or path-like objects for the filename (not a handle)"
+            "Need a string or path-like object for the filename (not a handle)"
         ) from None
 
     return _IndexedSeqFileDict(random_access_proxy, key_function, repr, "SeqRecord")

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -18,6 +18,7 @@ import gzip
 import warnings
 from io import BytesIO
 from io import StringIO
+from pathlib import Path
 
 from Bio.SeqRecord import SeqRecord
 from Bio import SeqIO
@@ -82,6 +83,11 @@ if sqlite3:
             d = SeqIO.index_db("Roche/triple_sff.idx")
             self.assertEqual(54, len(d))
             self.assertRaises(FileNotFoundError, d.get_raw, "alpha")
+
+        def test_pathobj(self):
+            """Load existing index from a pathlib.Path object."""
+            d = SeqIO.index_db(Path("Roche/triple_sff.idx"))
+            self.assertEqual(54, len(d))
 
         def test_old_check_same_thread(self):
             """Setting check_same_thread to False doesn't raise an exception."""
@@ -441,7 +447,7 @@ class IndexDictTests(SeqRecordTestBaseClass, SeqIOTestBaseClass):
             id_list = [rec.id for rec in SeqIO.parse(filename, fmt)]
 
         with warnings.catch_warnings():
-            if "_alt_index_" in filename:
+            if "_alt_index_" in str(filename):
                 # BiopythonParserWarning: Could not parse the SFF index:
                 # Unknown magic number b'.diy' in SFF index header:
                 # b'.diy1.00'
@@ -516,7 +522,7 @@ class IndexDictTests(SeqRecordTestBaseClass, SeqIOTestBaseClass):
         key_list = [self.add_prefix(id) for id in id_list]
 
         with warnings.catch_warnings():
-            if "_alt_index_" in filename:
+            if "_alt_index_" in str(filename):
                 # BiopythonParserWarning: Could not parse the SFF index:
                 # Unknown magic number b'.diy' in SFF index header:
                 # b'.diy1.00'
@@ -544,9 +550,14 @@ class IndexDictTests(SeqRecordTestBaseClass, SeqIOTestBaseClass):
             rec_dict.close()
 
             # Saving to file...
-            index_tmp = filename + ".key.idx"
-            if os.path.isfile(index_tmp):
-                os.remove(index_tmp)
+            index_tmp = None
+            if isinstance(filename, str):
+                index_tmp = filename + ".key.idx"
+            elif isinstance(filename, Path):
+                index_tmp = Path(str(filename) + ".key.idx")
+
+            if os.path.isfile(str(index_tmp)):
+                os.remove(str(index_tmp))
             rec_dict = SeqIO.index_db(
                 index_tmp, [filename], fmt, key_function=self.add_prefix
             )
@@ -567,7 +578,7 @@ class IndexDictTests(SeqRecordTestBaseClass, SeqIOTestBaseClass):
             self.check_dict_methods(rec_dict, key_list, id_list, msg=msg)
             rec_dict.close()
             rec_dict._con.close()  # hack for PyPy
-            os.remove(index_tmp)
+            os.remove(str(index_tmp))
             # Done
 
     def get_raw_check(self, filename, fmt, comp):
@@ -715,6 +726,15 @@ class IndexDictTests(SeqRecordTestBaseClass, SeqIOTestBaseClass):
             for filename2, comp in tasks:
                 self.simple_check(filename2, fmt, comp)
 
+    def test_simple_checks_with_pathobj(self):
+        for filename1, fmt in self.tests:
+            assert fmt in _FormatToRandomAccess
+            tasks = [(filename1, None)]
+            if os.path.isfile(filename1 + ".bgz"):
+                tasks.append((filename1 + ".bgz", "bgzf"))
+            for filename2, comp in tasks:
+                self.simple_check(Path(filename2), fmt, comp)
+
     def test_key_checks(self):
         for filename1, fmt in self.tests:
             assert fmt in _FormatToRandomAccess
@@ -724,6 +744,15 @@ class IndexDictTests(SeqRecordTestBaseClass, SeqIOTestBaseClass):
             for filename2, comp in tasks:
                 self.key_check(filename2, fmt, comp)
 
+    def test_key_checks_with_pathobj(self):
+        for filename1, fmt in self.tests:
+            assert fmt in _FormatToRandomAccess
+            tasks = [(filename1, None)]
+            if os.path.isfile(filename1 + ".bgz"):
+                tasks.append((filename1 + ".bgz", "bgzf"))
+            for filename2, comp in tasks:
+                self.key_check(Path(filename2), fmt, comp)
+
     def test_raw_checks(self):
         for filename1, fmt in self.tests:
             assert fmt in _FormatToRandomAccess
@@ -732,6 +761,15 @@ class IndexDictTests(SeqRecordTestBaseClass, SeqIOTestBaseClass):
                 tasks.append((filename1 + ".bgz", "bgzf"))
             for filename2, comp in tasks:
                 self.get_raw_check(filename2, fmt, comp)
+
+    def test_raw_checks_with_pathobj(self):
+        for filename1, fmt in self.tests:
+            assert fmt in _FormatToRandomAccess
+            tasks = [(filename1, None)]
+            if os.path.isfile(filename1 + ".bgz"):
+                tasks.append((filename1 + ".bgz", "bgzf"))
+            for filename2, comp in tasks:
+                self.get_raw_check(Path(filename2), fmt, comp)
 
 
 class IndexOrderingSingleFile(unittest.TestCase):

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -552,7 +552,7 @@ class IndexDictTests(SeqRecordTestBaseClass, SeqIOTestBaseClass):
             # Saving to file...
             index_tmp = None
             if isinstance(filename, str):
-                index_tmp = filename + ".key.idx"
+                index_tmp = filename.with_suffix(".key.idx")
             elif isinstance(filename, Path):
                 index_tmp = Path(str(filename) + ".key.idx")
 

--- a/Tests/test_SeqIO_index.py
+++ b/Tests/test_SeqIO_index.py
@@ -552,9 +552,9 @@ class IndexDictTests(SeqRecordTestBaseClass, SeqIOTestBaseClass):
             # Saving to file...
             index_tmp = None
             if isinstance(filename, str):
-                index_tmp = filename.with_suffix(".key.idx")
+                index_tmp = filename + ".key.idx"
             elif isinstance(filename, Path):
-                index_tmp = Path(str(filename) + ".key.idx")
+                index_tmp = filename.with_suffix(".key.idx")
 
             if os.path.isfile(str(index_tmp)):
                 os.remove(str(index_tmp))


### PR DESCRIPTION
Rather than forcing the filename parameters to SeqIO.index and SeqIO.index_db to be of type str, allow them to be any object that implements the __str__ method for itself (ie: doesn't use the default object.__str__). This allows pathlib.Path objects to be passed to those functions and bascially anything else you'd want to represent a path. See issue #4325.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4325 
