### PR TITLE
Bio.motifs format

### DIFF
--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -670,18 +670,6 @@ class Motif:
          - transfac : TRANSFAC like files
 
         """
-        return self.format(format_spec)
-
-    def format(self, format_spec):
-        """Return a string representation of the Motif in the given format.
-
-        Currently supported formats:
-         - clusterbuster: Cluster Buster position frequency matrix format
-         - pfm : JASPAR single Position Frequency Matrix
-         - jaspar : JASPAR multiple Position Frequency Matrix
-         - transfac : TRANSFAC like files
-
-        """
         if format_spec in ("pfm", "jaspar"):
             from Bio.motifs import jaspar
 
@@ -699,6 +687,19 @@ class Motif:
             return clusterbuster.write(motifs)
         else:
             raise ValueError("Unknown format type %s" % format_spec)
+
+    def format(self, format_spec):
+        """Return a string representation of the Motif in the given format.
+
+        Currently supported formats:
+         - clusterbuster: Cluster Buster position frequency matrix format
+         - pfm : JASPAR single Position Frequency Matrix
+         - jaspar : JASPAR multiple Position Frequency Matrix
+         - transfac : TRANSFAC like files
+
+        """
+        raise Exception
+        return self.__format__(format_spec)
 
 
 def write(motifs, fmt):

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -887,7 +887,7 @@ Speaking of exporting, let's look at export functions in general.
 We can use the \verb+format+ built-in function to write the motif in the simple JASPAR \verb+pfm+ format:
 %the tabs in the output confuse doctest; don't test
 \begin{minted}{pycon}
->>> print(arnt.format("pfm"))
+>>> print(format(arnt, "pfm"))
   4.00  19.00   0.00   0.00   0.00   0.00
  16.00   0.00  20.00   0.00   0.00   0.00
   0.00   1.00   0.00  20.00   0.00  20.00
@@ -895,7 +895,7 @@ We can use the \verb+format+ built-in function to write the motif in the simple 
 \end{minted}
 Similarly, we can use \verb+format+ to write the motif in the JASPAR \verb+jaspar+ format:
 \begin{minted}{pycon}
->>> print(arnt.format("jaspar"))
+>>> print(format(arnt, "jaspar"))
 >MA0004.1  Arnt
 A [  4.00  19.00   0.00   0.00   0.00   0.00]
 C [ 16.00   0.00  20.00   0.00   0.00   0.00]
@@ -907,7 +907,7 @@ To write the motif in a TRANSFAC-like matrix format, use
 
 %cont-doctest
 \begin{minted}{pycon}
->>> print(m.format("transfac"))
+>>> print(format(m, "transfac"))
 P0      A      C      G      T
 01      3      0      0      4      W
 02      7      0      0      0      A

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -2439,18 +2439,18 @@ CCTCCAGGTCGCATG""",
         """Ensure that we can write proper TransFac output files."""
         m = motifs.create([Seq("ATATA")])
         with tempfile.TemporaryFile("w") as stream:
-            stream.write(m.format("transfac"))
+            stream.write(format(m, "transfac"))
 
     def test_format(self):
         m = motifs.create([Seq("ATATA")])
         m.name = "Foo"
-        s1 = m.format("pfm")
+        s1 = format(m, "pfm")
         expected_pfm = """  1.00   0.00   1.00   0.00  1.00
   0.00   0.00   0.00   0.00  0.00
   0.00   0.00   0.00   0.00  0.00
   0.00   1.00   0.00   1.00  0.00
 """
-        s2 = m.format("jaspar")
+        s2 = format(m, "jaspar")
         expected_jaspar = """>None Foo
 A [  1.00   0.00   1.00   0.00   1.00]
 C [  0.00   0.00   0.00   0.00   0.00]
@@ -2458,7 +2458,7 @@ G [  0.00   0.00   0.00   0.00   0.00]
 T [  0.00   1.00   0.00   1.00   0.00]
 """
         self.assertEqual(s2, expected_jaspar)
-        s3 = m.format("transfac")
+        s3 = format(m, "transfac")
         expected_transfac = """P0      A      C      G      T
 01      1      0      0      0      A
 02      0      0      0      1      T
@@ -2469,7 +2469,7 @@ XX
 //
 """
         self.assertEqual(s3, expected_transfac)
-        self.assertRaises(ValueError, m.format, "foo_bar")
+        self.assertRaises(ValueError, format, m, "foo_bar")
 
     def test_reverse_complement(self):
         """Test if motifs can be reverse-complemented."""
@@ -2478,7 +2478,7 @@ XX
         m = motifs.create([Seq("ATATA")])
         m.background = background
         m.pseudocounts = pseudocounts
-        received_forward = m.format("transfac")
+        received_forward = format(m, "transfac")
         expected_forward = """\
 P0      A      C      G      T
 01      1      0      0      0      A
@@ -2499,7 +2499,7 @@ T:   0.17   0.50   0.17   0.50   0.17
 """
         self.assertEqual(str(m.pwm), expected_forward_pwm)
         m = m.reverse_complement()
-        received_reverse = m.format("transfac")
+        received_reverse = format(m, "transfac")
         expected_reverse = """\
 P0      A      C      G      T
 01      0      0      0      1      T
@@ -2525,11 +2525,11 @@ T:   0.50   0.17   0.50   0.17   0.50
         m = motifs.Motif(counts=counts)
         m.background = background
         m.pseudocounts = pseudocounts
-        received_forward = m.format("transfac")
+        received_forward = format(m, "transfac")
         self.assertEqual(received_forward, expected_forward)
         self.assertEqual(str(m.pwm), expected_forward_pwm)
         m = m.reverse_complement()
-        received_reverse = m.format("transfac")
+        received_reverse = format(m, "transfac")
         self.assertEqual(received_reverse, expected_reverse)
         self.assertEqual(str(m.pwm), expected_reverse_pwm)
 


### PR DESCRIPTION
In Bio.motifs, use the `format` built-in function instead of the `format` method where possible.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #...
