### PR TITLE
Bio.motifs: add relative entropy to the Motif class

### DIFF
--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -559,14 +559,24 @@ class Motif:
     @property
     def information_content(self):
         """Return an array with the information content for each column of the motif."""
-        alignment = self.alignment
         background = self.background
-        total = len(alignment)
-        values = np.zeros(alignment.length)
-        for letter, frequencies in alignment.frequencies.items():
-            mask = frequencies > 0
-            frequencies = frequencies[mask] / total
-            values[mask] += frequencies * np.log2(frequencies / background[letter])
+        counts = self.counts
+        length = self.length
+        values = np.zeros(length)
+        if self.alignment is None:
+            total = np.array([sum(counts[c][i] for c in counts) for i in range(length)])
+            for letter, frequencies in counts.items():
+                frequencies = np.array(frequencies)
+                mask = frequencies > 0
+                frequencies = frequencies[mask] / total[mask]
+                values[mask] += frequencies * np.log2(frequencies / background[letter])
+        else:
+            total = len(self.alignment)
+            for letter, frequencies in counts.items():
+                frequencies = np.array(frequencies)
+                mask = frequencies > 0
+                frequencies = frequencies[mask] / total
+                values[mask] += frequencies * np.log2(frequencies / background[letter])
         return values
 
     def weblogo(self, fname, fmt="PNG", version="2.8.2", **kwds):

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -560,20 +560,27 @@ class Motif:
     def information_content(self):
         """Return an array with the information content for each column of the motif."""
         background = self.background
+        pseudocounts = self.pseudocounts
+        alphabet = self.alphabet
         counts = self.counts
         length = self.length
         values = np.zeros(length)
         if self.alignment is None:
-            total = np.array([sum(counts[c][i] for c in counts) for i in range(length)])
+            total = np.array(
+                [
+                    sum(counts[c][i] + pseudocounts[c] for c in alphabet)
+                    for i in range(length)
+                ]
+            )
             for letter, frequencies in counts.items():
-                frequencies = np.array(frequencies)
+                frequencies = np.array(frequencies) + pseudocounts[letter]
                 mask = frequencies > 0
                 frequencies = frequencies[mask] / total[mask]
                 values[mask] += frequencies * np.log2(frequencies / background[letter])
         else:
-            total = len(self.alignment)
+            total = len(self.alignment) + sum(pseudocounts.values())
             for letter, frequencies in counts.items():
-                frequencies = np.array(frequencies)
+                frequencies = np.array(frequencies) + pseudocounts[letter]
                 mask = frequencies > 0
                 frequencies = frequencies[mask] / total
                 values[mask] += frequencies * np.log2(frequencies / background[letter])

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -460,12 +460,12 @@ class Motif:
 
     @property
     def pwm(self):
-        """Compute position weight matrices."""
+        """Calculate and return the position weight matrix for this motif."""
         return self.counts.normalize(self._pseudocounts)
 
     @property
     def pssm(self):
-        """Compute position specific scoring matrices."""
+        """Calculate and return the position specific scoring matrix for this motif."""
         return self.pwm.log_odds(self._background)
 
     @property
@@ -555,6 +555,19 @@ class Motif:
         The same rules are used by TRANSFAC.
         """
         return self.counts.degenerate_consensus
+
+    @property
+    def information_content(self):
+        """Return an array with the information content for each column of the motif."""
+        alignment = self.alignment
+        background = self.background
+        total = len(alignment)
+        values = np.zeros(alignment.length)
+        for letter, frequencies in alignment.frequencies.items():
+            mask = frequencies > 0
+            frequencies = frequencies[mask] / total
+            values[mask] += frequencies * np.log2(frequencies / background[letter])
+        return values
 
     def weblogo(self, fname, fmt="PNG", version="2.8.2", **kwds):
         """Download and save a weblogo using the Berkeley weblogo service.

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -557,8 +557,8 @@ class Motif:
         return self.counts.degenerate_consensus
 
     @property
-    def information_content(self):
-        """Return an array with the information content for each column of the motif."""
+    def relative_entropy(self):
+        """Return an array with the relative entropy for each column of the motif."""
         background = self.background
         pseudocounts = self.pseudocounts
         alphabet = self.alphabet

--- a/Doc/Tutorial.tex
+++ b/Doc/Tutorial.tex
@@ -216,6 +216,8 @@ V. Matys, E. Fricke, R. Geffers, E. G\"ossling, M. Haubrock, R. Hehl, K. Hornisc
 \bibitem{saldanha2004}
 Alok Saldanha: ``Java Treeview---extensible visualization of microarray data''. \textit{Bioinformatics} {\bf 20} (17): 3246--3248 (2004).
 \url{https://doi.org/10.1093/bioinformatics/bth349}
+\bibitem{schneider1986}
+Thomas D. Schneider, Gary D. Stormo, Larry Gold: ``Information content of binding sites on nucleotide sequences''. \textit{Journal of Molecular Biology} {\bf 188} (3): 415--431 (1986). \url{https://doi.org/10.1016/0022-2836(86)90165-8}
 \bibitem{schneider2005}
 Adrian Schneider, Gina M. Cannarozzi, and Gaston H. Gonnet: ``Empirical codon substitution matrix''. \textit{BMC Bioinformatics} {\bf 6}: 134 (2005).
 \url{https://doi.org/10.1186/1471-2105-6-134}

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -168,47 +168,6 @@ Here, W and R follow the IUPAC nucleotide ambiguity codes: W is either A or T,
 and V is A, C, or G \cite{cornish1985}. The degenerate consensus sequence is
 constructed following the rules specified by Cavener \cite{cavener1987}.
 
-The information content $IC_j$ of column $j$ of the motif is defined as \cite{schneider1986}
-\begin{displaymath}
-IC_{j} = \sum_{i=1}^{M} P_{ij} \mathrm{log}\left(\frac{P_{ij}}{Q_{i}}\right)
-\end{displaymath}
-
-\noindent where:
-
-\begin{itemize}
-  \item $M$ -- The number of letters in the alphabet;
-  \item $P_{ij}$ -- The observed normalized frequency of letter $i$ in the $j$-th column;
-  \item $Q_{i}$ --  The background probability of letter $i$.
-\end{itemize}
-Both $P_{ij}$ and $Q_{i}$ are normalized to 1:
-\begin{displaymath}
-\sum_{i=1}^{M} P_{ij} = 1 \\
-\sum_{i=1}^{M} Q_i = 1
-\end{displaymath}
-The observed normalized frequency $P_{ij}$ is computed as follows:
-\begin{displaymath}
-P_{ij} = \frac{n_{ij} + k\times Q_{i}}{N_{j} + k}
-\end{displaymath}
-\noindent where:
-
-\begin{itemize}
-  \item $n_{ij}$ -- the number of times letter $i$ appears in column $j$ of the alignment;
-  \item $k$ -- the pseudocount;
-  \item $N_{j}$ --  The total number of letters in column $j$: $N_{j} = \sum_{i=1}^{M} n_{ij}$.
-\end{itemize}
-The information content for each column of motif \verb+m+ can be obtained using the \verb+information_content+ property:
-%cont-doctest
-\begin{minted}{pycon}
->>> m.information_content
-array([1.01477186, 2.        , 1.13687943, 0.44334329, 1.40832722])
-\end{minted}
-These values are calculated using the base-2 logarithm, and are therefore in units of bits. The second column (which consists of \verb+A+ nucleotides only) has the highest information content; the fourth column (which consists of \verb+A+, \verb+C+, or \verb+G+ nucleotides) has the lowest information content). The total information content of the motif can be calculated by summing over the columns:
-%cont-doctest
-\begin{minted}{pycon}
->>> sum(m.information_content)
-6.0033218093539675
-\end{minted}
-
 We can also get the reverse complement of a motif:
 %cont-doctest
 \begin{minted}{pycon}
@@ -1012,6 +971,53 @@ G [  0.00   0.00   0.00   0.00   0.00   0.00   0.00   0.00   2.00  50.00]
 T [  7.00  58.00   0.00  55.00  49.00  52.00  21.00  56.00   0.00   2.00]
 \end{minted}
 
+\section{Relative entropy}
+\label{sec:relative_entropy}
+
+The relative entropy (or Kullback-Leibler distance) $H_j$ of column $j$ of the motif is defined as \cite{schneider1986,durbin1998}
+\begin{displaymath}
+H_{j} = \sum_{i=1}^{M} P_{ij} \mathrm{log}\left(\frac{P_{ij}}{Q_{i}}\right)
+\end{displaymath}
+
+\noindent where:
+
+\begin{itemize}
+  \item $M$ -- The number of letters in the alphabet;
+  \item $P_{ij}$ -- The observed normalized frequency of letter $i$ in the $j$-th column;
+  \item $Q_{i}$ --  The background probability of letter $i$.
+\end{itemize}
+Both $P_{ij}$ and $Q_{i}$ are normalized to 1:
+\begin{displaymath}
+\sum_{i=1}^{M} P_{ij} = 1 \\
+\sum_{i=1}^{M} Q_i = 1
+\end{displaymath}
+The observed normalized frequency $P_{ij}$ is computed as follows:
+\begin{displaymath}
+P_{ij} = \frac{n_{ij} + k\times Q_{i}}{N_{j} + k}
+\end{displaymath}
+\noindent where:
+
+\begin{itemize}
+  \item $n_{ij}$ -- the number of times letter $i$ appears in column $j$ of the alignment;
+  \item $k$ -- the pseudocount;
+  \item $N_{j}$ --  The total number of letters in column $j$: $N_{j} = \sum_{i=1}^{M} n_{ij}$.
+\end{itemize}
+The relative entropy is the same as the information content if the background distribution is uniform.
+
+The relative entropy for each column of motif \verb+m+ can be obtained using the \verb+relative_entropy+ property:
+% Don't include this in the doctest, as the exact output can vary.  To ensure
+% that the calculation is correct, we test the sum of these values below.
+\begin{minted}{pycon}
+>>> m.relative_entropy
+array([1.01477186, 2.        , 1.13687943, 0.44334329, 1.40832722])
+\end{minted}
+These values are calculated using the base-2 logarithm, and are therefore in units of bits. The second column (which consists of \verb+A+ nucleotides only) has the highest relative entropy; the fourth column (which consists of \verb+A+, \verb+C+, or \verb+G+ nucleotides) has the lowest relative entropy). The relative entropy of the motif can be calculated by summing over the columns:
+%cont-doctest
+\begin{minted}{pycon}
+>>> sum(m.relative_entropy)  # doctest:+ELLIPSIS
+6.003321...
+\end{minted}
+
 \section{Position-Weight Matrices}
 
 The \verb+.counts+ attribute of a Motif object shows how often each
@@ -1157,11 +1163,7 @@ background are calculated by the \verb+.mean+ and \verb+.std+ methods.
 mean = 3.21, standard deviation = 2.59
 \end{minted}
 A uniform background is used if \verb+background+ is not specified.
-The mean is particularly important, as its value is equal to the
-Kullback-Leibler divergence or relative entropy, and is a measure for the
-information content of the motif compared to the background. As in Biopython
-the base-2 logarithm is used in the calculation of the log-odds scores, the
-information content has units of bits.
+The mean is equal to the Kullback-Leibler divergence or relative entropy described in Section~\ref{sec:relative_entropy}.
 
 The \verb+.reverse_complement+, \verb+.consensus+, \verb+.anticonsensus+, and
 \verb+.degenerate_consensus+ methods can be applied directly to PSSM objects.

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -136,7 +136,10 @@ in the alphabet of the motif:
 >>> m.counts[0, :]
 (3, 7, 0, 2, 1)
 \end{minted}
-The motif has an associated consensus sequence, defined as the sequence of
+
+\subsection{Consensus, anticonsensus, and degenerate consensus  sequence}
+
+The consensus sequence of a motif is defined as the sequence of
 letters along the positions of the motif for which the largest value in the
 corresponding columns of the \verb+.counts+ matrix is obtained:
 
@@ -145,7 +148,7 @@ corresponding columns of the \verb+.counts+ matrix is obtained:
 >>> m.consensus
 Seq('TACGC')
 \end{minted}
-as well as an anticonsensus sequence, corresponding to the smallest values in
+Conversely, the anticonsensus sequence corresponds to the smallest values in
 the columns of the \verb+.counts+ matrix:
 
 %cont-doctest
@@ -155,9 +158,7 @@ Seq('CCATG')
 \end{minted}
 Note that there is some ambiguity in the definition of the consensus and anticonsensus sequence if in some columns multiple nucleotides have the maximum or minimum count.
 
-You can also ask for a degenerate consensus sequence, in which ambiguous
-nucleotides are used for positions where there are multiple nucleotides with
-high counts:
+for DNA sequences, you can also ask for a degenerate consensus sequence, in which ambiguous nucleotides are used for positions where there are multiple nucleotides with high counts:
 
 %cont-doctest
 \begin{minted}{pycon}
@@ -168,7 +169,9 @@ Here, W and R follow the IUPAC nucleotide ambiguity codes: W is either A or T,
 and V is A, C, or G \cite{cornish1985}. The degenerate consensus sequence is
 constructed following the rules specified by Cavener \cite{cavener1987}.
 
-We can also get the reverse complement of a motif:
+\subsection{Reverse-complementing a motif}
+
+We can get the reverse complement of a motif by calling the \verb+reverse_complement+ method on it:
 %cont-doctest
 \begin{minted}{pycon}
 >>> r = m.reverse_complement()
@@ -185,23 +188,75 @@ GGGTT
 GCATT
 GCATT
 \end{minted}
-The reverse complement and the degenerate consensus sequence are
-only defined for DNA motifs.
+The reverse complement is only defined for DNA motifs.
+
+\subsection{Slicing a motif}
 
 You can slice the motif to obtain a new \verb+Motif+ object for the selected positions:
 %cont-doctest
 \begin{minted}{pycon}
->>> m_sub = m[1:-2]
+>>> m_sub = m[2:-1]
 >>> print(m_sub)
-AC
-AC
-AC
-AC
-AC
-AT
-AT
+CA
+CG
+CA
+CC
+CC
+TG
+TG
 >>> m_sub.consensus
-Seq('AC')
+Seq('CG')
+>>> m_sub.degenerate_consensus
+Seq('CV')
+\end{minted}
+
+\subsection{Relative entropy}
+\label{subsec:relative_entropy}
+
+The relative entropy (or Kullback-Leibler distance) $H_j$ of column $j$ of the motif is defined as \cite{schneider1986,durbin1998}
+\begin{displaymath}
+H_{j} = \sum_{i=1}^{M} p_{ij} \log\left(\frac{p_{ij}}{b_{i}}\right)
+\end{displaymath}
+
+\noindent where:
+
+\begin{itemize}
+  \item $M$ -- The number of letters in the alphabet (given by \verb+len(m.alphabet)+);
+  \item $p_{ij}$ -- The observed frequency of letter $i$, normalized, in the $j$-th column (see below);
+  \item $b_{i}$ --  The background probability of letter $i$ (given by \verb+m.background[i]+).
+\end{itemize}
+The observed frequency $p_{ij}$ is computed as follows:
+\begin{displaymath}
+p_{ij} = \frac{c_{ij} + k_i}{C_{j} + k}
+\end{displaymath}
+\noindent where:
+\begin{itemize}
+  \item $c_{ij}$ -- the number of times letter $i$ appears in column $j$ of the alignment (given by \verb+m.counts[i, j]+);
+  \item $C_{j}$ --  The total number of letters in column $j$: $C_{j} = \sum_{i=1}^{M} c_{ij}$ (given by \verb+sum(m.counts[:, j])+).
+  \item $k_i$ -- the pseudocount of letter $i$ (given by \verb+m.pseudocounts[i]+).
+  \item $k$ -- the total pseudocount: $k = \sum_{i=1}^{M} k_i$ (given by \verb+sum(m.pseudocounts.values())+).
+\end{itemize}
+With these definitions, both $p_{ij}$ and $b_{i}$ are normalized to 1:
+\begin{displaymath}
+\sum_{i=1}^{M} p_{ij} = 1
+\end{displaymath}
+\begin{displaymath}
+\sum_{i=1}^{M} b_i = 1
+\end{displaymath}
+The relative entropy is the same as the information content if the background distribution is uniform.
+
+The relative entropy for each column of motif \verb+m+ can be obtained using the \verb+relative_entropy+ property:
+% Don't include this in the doctest, as the exact output can vary.  To ensure
+% that the calculation is correct, we test the sum of these values below.
+\begin{minted}{pycon}
+>>> m.relative_entropy
+array([1.01477186, 2.        , 1.13687943, 0.44334329, 1.40832722])
+\end{minted}
+These values are calculated using the base-2 logarithm, and are therefore in units of bits. The second column (which consists of \verb+A+ nucleotides only) has the highest relative entropy; the fourth column (which consists of \verb+A+, \verb+C+, or \verb+G+ nucleotides) has the lowest relative entropy). The relative entropy of the motif can be calculated by summing over the columns:
+%cont-doctest
+\begin{minted}{pycon}
+>>> sum(m.relative_entropy)  # doctest:+ELLIPSIS
+6.003321...
 \end{minted}
 
 \subsection{Creating a sequence logo}
@@ -971,53 +1026,6 @@ G [  0.00   0.00   0.00   0.00   0.00   0.00   0.00   0.00   2.00  50.00]
 T [  7.00  58.00   0.00  55.00  49.00  52.00  21.00  56.00   0.00   2.00]
 \end{minted}
 
-\section{Relative entropy}
-\label{sec:relative_entropy}
-
-The relative entropy (or Kullback-Leibler distance) $H_j$ of column $j$ of the motif is defined as \cite{schneider1986,durbin1998}
-\begin{displaymath}
-H_{j} = \sum_{i=1}^{M} P_{ij} \mathrm{log}\left(\frac{P_{ij}}{Q_{i}}\right)
-\end{displaymath}
-
-\noindent where:
-
-\begin{itemize}
-  \item $M$ -- The number of letters in the alphabet;
-  \item $P_{ij}$ -- The observed normalized frequency of letter $i$ in the $j$-th column;
-  \item $Q_{i}$ --  The background probability of letter $i$.
-\end{itemize}
-Both $P_{ij}$ and $Q_{i}$ are normalized to 1:
-\begin{displaymath}
-\sum_{i=1}^{M} P_{ij} = 1 \\
-\sum_{i=1}^{M} Q_i = 1
-\end{displaymath}
-The observed normalized frequency $P_{ij}$ is computed as follows:
-\begin{displaymath}
-P_{ij} = \frac{n_{ij} + k\times Q_{i}}{N_{j} + k}
-\end{displaymath}
-\noindent where:
-
-\begin{itemize}
-  \item $n_{ij}$ -- the number of times letter $i$ appears in column $j$ of the alignment;
-  \item $k$ -- the pseudocount;
-  \item $N_{j}$ --  The total number of letters in column $j$: $N_{j} = \sum_{i=1}^{M} n_{ij}$.
-\end{itemize}
-The relative entropy is the same as the information content if the background distribution is uniform.
-
-The relative entropy for each column of motif \verb+m+ can be obtained using the \verb+relative_entropy+ property:
-% Don't include this in the doctest, as the exact output can vary.  To ensure
-% that the calculation is correct, we test the sum of these values below.
-\begin{minted}{pycon}
->>> m.relative_entropy
-array([1.01477186, 2.        , 1.13687943, 0.44334329, 1.40832722])
-\end{minted}
-These values are calculated using the base-2 logarithm, and are therefore in units of bits. The second column (which consists of \verb+A+ nucleotides only) has the highest relative entropy; the fourth column (which consists of \verb+A+, \verb+C+, or \verb+G+ nucleotides) has the lowest relative entropy). The relative entropy of the motif can be calculated by summing over the columns:
-%cont-doctest
-\begin{minted}{pycon}
->>> sum(m.relative_entropy)  # doctest:+ELLIPSIS
-6.003321...
-\end{minted}
-
 \section{Position-Weight Matrices}
 
 The \verb+.counts+ attribute of a Motif object shows how often each
@@ -1163,7 +1171,7 @@ background are calculated by the \verb+.mean+ and \verb+.std+ methods.
 mean = 3.21, standard deviation = 2.59
 \end{minted}
 A uniform background is used if \verb+background+ is not specified.
-The mean is equal to the Kullback-Leibler divergence or relative entropy described in Section~\ref{sec:relative_entropy}.
+The mean is equal to the Kullback-Leibler divergence or relative entropy described in Section~\ref{subsec:relative_entropy}.
 
 The \verb+.reverse_complement+, \verb+.consensus+, \verb+.anticonsensus+, and
 \verb+.degenerate_consensus+ methods can be applied directly to PSSM objects.

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -60,9 +60,13 @@ then we can create a Motif object as follows:
 \begin{minted}{pycon}
 >>> m = motifs.create(instances)
 \end{minted}
-The instances are saved in an attribute \verb+m.instances+, which is essentially a Python list with some added functionality, as described below.
-Printing out the Motif object shows the instances from which it was constructed:
-
+The instances from which this motif was created is stored in the \verb+.alignment+ property:
+%cont-doctest
+\begin{minted}{pycon}
+>>> print(m.alignment.sequences)
+[Seq('TACAA'), Seq('TACGC'), Seq('TACAC'), Seq('TACCC'), Seq('AACCC'), Seq('AATGC'), Seq('AATGC')]
+\end{minted}
+Printing the Motif object shows the instances from which it was constructed:
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(m)
@@ -164,8 +168,48 @@ Here, W and R follow the IUPAC nucleotide ambiguity codes: W is either A or T,
 and V is A, C, or G \cite{cornish1985}. The degenerate consensus sequence is
 constructed following the rules specified by Cavener \cite{cavener1987}.
 
-We can also get the reverse complement of a motif:
+The information content $IC_j$ of column $j$ of the motif is defined as \cite{schneider1986}
+\begin{displaymath}
+IC_{j} = \sum_{i=1}^{M} P_{ij} \mathrm{log}\left(\frac{P_{ij}}{Q_{i}}\right)
+\end{displaymath}
 
+\noindent where:
+
+\begin{itemize}
+  \item $M$ -- The number of letters in the alphabet;
+  \item $P_{ij}$ -- The observed normalized frequency of letter $i$ in the $j$-th column;
+  \item $Q_{i}$ --  The background probability of letter $i$.
+\end{itemize}
+Both $P_{ij}$ and $Q_{i}$ are normalized to 1:
+\begin{displaymath}
+\sum_{i=1}^{M} P_{ij} = 1 \\
+\sum_{i=1}^{M} Q_i = 1
+\end{displaymath}
+The observed normalized frequency $P_{ij}$ is computed as follows:
+\begin{displaymath}
+P_{ij} = \frac{n_{ij} + k\times Q_{i}}{N_{j} + k}
+\end{displaymath}
+\noindent where:
+
+\begin{itemize}
+  \item $n_{ij}$ -- the number of times letter $i$ appears in column $j$ of the alignment;
+  \item $k$ -- the pseudocount;
+  \item $N_{j}$ --  The total number of letters in column $j$: $N_{j} = \sum_{i=1}^{M} n_{ij}$.
+\end{itemize}
+The information content for each column of motif \verb+m+ can be obtained using the \verb+information_content+ property:
+%cont-doctest
+\begin{minted}{pycon}
+>>> m.information_content
+array([1.01477186, 2.        , 1.13687943, 0.44334329, 1.40832722])
+\end{minted}
+These values are calculated using the base-2 logarithm, and are therefore in units of bits. The second column (which consists of \verb+A+ nucleotides only) has the highest information content; the fourth column (which consists of \verb+A+, \verb+C+, or \verb+G+ nucleotides) has the lowest information content). The total information content of the motif can be calculated by summing over the columns:
+%cont-doctest
+\begin{minted}{pycon}
+>>> sum(m.information_content)
+6.0033218093539675
+\end{minted}
+
+We can also get the reverse complement of a motif:
 %cont-doctest
 \begin{minted}{pycon}
 >>> r = m.reverse_complement()
@@ -182,7 +226,6 @@ GGGTT
 GCATT
 GCATT
 \end{minted}
-
 The reverse complement and the degenerate consensus sequence are
 only defined for DNA motifs.
 

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -61,21 +61,21 @@ XX
         self.assertEqual(s3, expected_transfac)
         self.assertRaises(ValueError, format, m, "foo_bar")
 
-    def test_information_content(self):
+    def test_relative_entropy(self):
         m = motifs.create([Seq("ATATA"), Seq("ATCTA"), Seq("TTGTA")])
         self.assertEqual(len(m.alignment), 3)
         self.assertEqual(m.background, {"A": 0.25, "C": 0.25, "G": 0.25, "T": 0.25})
         self.assertEqual(m.pseudocounts, {"A": 0.0, "C": 0.0, "G": 0.0, "T": 0.0})
         self.assertTrue(
             numpy.array_equal(
-                m.information_content,
+                m.relative_entropy,
                 numpy.array([1.0817041659455104, 2.0, 0.4150374992788437, 2.0, 2.0]),
             )
         )
         m.background = {"A": 0.3, "C": 0.2, "G": 0.2, "T": 0.3}
         self.assertTrue(
             numpy.array_equal(
-                m.information_content,
+                m.relative_entropy,
                 numpy.array(
                     [
                         0.8186697601117167,
@@ -95,7 +95,7 @@ XX
         }
         self.assertTrue(
             numpy.array_equal(
-                m.information_content,
+                m.relative_entropy,
                 numpy.array(
                     [
                         0.3532586861097656,
@@ -110,7 +110,7 @@ XX
         m.background = {"A": 0.3, "C": 0.2, "G": 0.2, "T": 0.3}
         self.assertTrue(
             numpy.array_equal(
-                m.information_content,
+                m.relative_entropy,
                 numpy.array(
                     [
                         0.19727984803857979,
@@ -1601,7 +1601,7 @@ class TestClusterBuster(unittest.TestCase):
             self.assertEqual(motif.degenerate_consensus, "CACGTG")
             self.assertTrue(
                 numpy.array_equal(
-                    motif.information_content,
+                    motif.relative_entropy,
                     numpy.array(
                         [1.278071905112638, 1.7136030428840439, 2.0, 2.0, 2.0, 2.0]
                     ),
@@ -1640,7 +1640,7 @@ class TestClusterBuster(unittest.TestCase):
             self.assertEqual(motif.degenerate_consensus, "YGCGTG")
             self.assertTrue(
                 numpy.array_equal(
-                    motif.information_content,
+                    motif.relative_entropy,
                     numpy.array(
                         [
                             0.28206397041108283,
@@ -1686,7 +1686,7 @@ class TestClusterBuster(unittest.TestCase):
             self.assertEqual(motif.degenerate_consensus, "CAATTATT")
             self.assertTrue(
                 numpy.array_equal(
-                    motif.information_content,
+                    motif.relative_entropy,
                     numpy.array(
                         [
                             0.2549535827226545,
@@ -1814,7 +1814,7 @@ class TestXMS(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "NSNTTTATGGCNNN")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         0.09689283163718865,
@@ -1839,7 +1839,7 @@ class TestXMS(unittest.TestCase):
         self.assertEqual(motif[3::2].degenerate_consensus, "TTTGNN")
         self.assertTrue(
             numpy.array_equal(
-                motif[3::2].information_content,
+                motif[3::2].relative_entropy,
                 numpy.array(
                     [
                         1.1150033950025815,
@@ -1908,7 +1908,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "TTATCACT")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         1.765707971839016,
@@ -2012,7 +2012,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "WNRWNMGGATTANGAGGACA")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         0.1946677220077018,
@@ -2092,7 +2092,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "TAAACTARNNN")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         0.4489017067534855,
@@ -2147,7 +2147,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "TTAATKA")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         1.0555114658337947,
@@ -2213,7 +2213,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "NTGASTCAKN")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         0.30427230622817475,
@@ -2275,7 +2275,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "NTNGCGTGN")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         0.09662409645348236,
@@ -2332,7 +2332,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "ATGACTCA")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         0.889358068874075,
@@ -2400,7 +2400,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "BCMAAMNRMTT")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         0.43314504855176084,
@@ -2457,7 +2457,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "GAAAKY")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         1.349977578351646,
@@ -2539,7 +2539,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "MGCNNNNNNNNNMGC")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         1.0,
@@ -2630,7 +2630,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "NKWTCGAGGAATNNN")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         0.13892143832881046,
@@ -2685,7 +2685,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "TCTAGA")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         1.0042727863947818,
@@ -2731,7 +2731,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "TCTAGA")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         1.0042727863947818,
@@ -2785,7 +2785,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "NYAATTAA")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         0.2005361303021225,
@@ -2849,7 +2849,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "CCAWAWATAG")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         1.7725753233561499,
@@ -2915,7 +2915,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "CCAWAWATAG")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         1.7725753233561499,
@@ -2987,7 +2987,7 @@ class TestJASPAR(unittest.TestCase):
         self.assertEqual(m.degenerate_consensus, "CACGTG")
         self.assertTrue(
             numpy.array_equal(
-                m.information_content,
+                m.relative_entropy,
                 numpy.array(
                     [1.278071905112638, 1.7136030428840439, 2.0, 2.0, 2.0, 2.0]
                 ),
@@ -3129,7 +3129,7 @@ class TestMEME(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "GSKGCATGTGAAA")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         1.4083272214176723,
@@ -3248,7 +3248,7 @@ class TestMEME(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "TTGACWCYTGCYCNG")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         2.0,
@@ -4867,7 +4867,7 @@ class TestMEME(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "TGTGANNNWGNTCACAYWW")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         1.1684297174927525,
@@ -4910,7 +4910,7 @@ class TestMEME(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "TACTGTATATAHAWMCAG")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         0.9632889858595118,
@@ -5555,7 +5555,7 @@ class TestTransfac(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "SRACAGGTGKYG")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         0.4780719051126377,
@@ -5577,7 +5577,7 @@ class TestTransfac(unittest.TestCase):
         self.assertEqual(motif[1:-2].degenerate_consensus, "RACAGGTGK")
         self.assertTrue(
             numpy.array_equal(
-                motif[1:-2].information_content,
+                motif[1:-2].relative_entropy,
                 numpy.array(
                     [
                         0.4780719051126377,
@@ -5640,7 +5640,7 @@ class TestTransfac(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "RSCAGAGGTY")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         0.4780719051126377,
@@ -5660,7 +5660,7 @@ class TestTransfac(unittest.TestCase):
         self.assertEqual(motif[::2].degenerate_consensus, "RCGGT")
         self.assertTrue(
             numpy.array_equal(
-                motif[::2].information_content,
+                motif[::2].relative_entropy,
                 numpy.array(
                     [0.4780719051126377, 2.0, 1.278071905112638, 1.278071905112638, 2.0]
                 ),
@@ -5714,7 +5714,7 @@ class TestTransfac(unittest.TestCase):
         self.assertEqual(motif.degenerate_consensus, "NGGGGA")
         self.assertTrue(
             numpy.array_equal(
-                motif.information_content,
+                motif.relative_entropy,
                 numpy.array(
                     [
                         0.09629830394265171,
@@ -5730,7 +5730,7 @@ class TestTransfac(unittest.TestCase):
         self.assertEqual(motif[1:-3].degenerate_consensus, "GG")
         self.assertTrue(
             numpy.array_equal(
-                motif[1:-3].information_content,
+                motif[1:-3].relative_entropy,
                 numpy.array([1.7136030428840439, 1.5310044064107189]),
             )
         )

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -1437,6 +1437,14 @@ CCTCCAGGTCGCATG""",
             self.assertEqual(motif.alphabet, "GATC")
             self.assertEqual(motif.consensus, "CACGTG")
             self.assertEqual(motif.degenerate_consensus, "CACGTG")
+            self.assertTrue(
+                numpy.array_equal(
+                    motif.information_content,
+                    numpy.array(
+                        [1.278071905112638, 1.7136030428840439, 2.0, 2.0, 2.0, 2.0]
+                    ),
+                )
+            )
             self.assertEqual(motif[1:-2].consensus, "ACG")
             self.assertEqual(motif.length, 6)
             self.assertAlmostEqual(motif.counts["G", 0], 0.0)
@@ -1468,6 +1476,21 @@ CCTCCAGGTCGCATG""",
             self.assertEqual(motif.alphabet, "GATC")
             self.assertEqual(motif.consensus, "TGCGTG")
             self.assertEqual(motif.degenerate_consensus, "YGCGTG")
+            self.assertTrue(
+                numpy.array_equal(
+                    motif.information_content,
+                    numpy.array(
+                        [
+                            0.28206397041108283,
+                            1.7501177071668148,
+                            1.7501177071668148,
+                            1.7501177071668148,
+                            2.0,
+                            2.0,
+                        ]
+                    ),
+                )
+            )
             self.assertEqual(motif[1:-2].consensus, "GCG")
             self.assertEqual(motif.length, 6)
             self.assertAlmostEqual(motif.counts["G", 0], 2.0)
@@ -1499,6 +1522,23 @@ CCTCCAGGTCGCATG""",
             self.assertEqual(motif.alphabet, "GATC")
             self.assertEqual(motif.consensus, "CAATTATT")
             self.assertEqual(motif.degenerate_consensus, "CAATTATT")
+            self.assertTrue(
+                numpy.array_equal(
+                    motif.information_content,
+                    numpy.array(
+                        [
+                            0.2549535827226545,
+                            1.2358859454459725,
+                            2.0,
+                            2.0,
+                            1.278071905112638,
+                            1.7577078109175852,
+                            1.7577078109175852,
+                            1.5978208097977271,
+                        ]
+                    ),
+                )
+            )
             self.assertEqual(motif[1:-2].consensus, "AATTA")
             self.assertEqual(motif.length, 8)
             self.assertAlmostEqual(motif.counts["G", 0], 4.0)
@@ -1606,8 +1646,46 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 13], 0.333333333)
         self.assertEqual(motif.consensus, "GCGTTTATGGCGAC")
         self.assertEqual(motif.degenerate_consensus, "NSNTTTATGGCNNN")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        0.09689283163718865,
+                        0.26557323997556864,
+                        0.007815379142180268,
+                        1.1150033950025815,
+                        0.78848108520697,
+                        0.3768768552773923,
+                        1.125231003810913,
+                        0.7023990165752877,
+                        0.7536432192801433,
+                        0.3995487907017483,
+                        1.0658162802208113,
+                        0.022422587676774776,
+                        0.07979555429087543,
+                        0.03400971806422712,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[3::2].consensus, "TTTGGC")
         self.assertEqual(motif[3::2].degenerate_consensus, "TTTGNN")
+        self.assertTrue(
+            numpy.array_equal(
+                motif[3::2].information_content,
+                numpy.array(
+                    [
+                        1.1150033950025815,
+                        0.3768768552773923,
+                        0.7023990165752877,
+                        0.3995487907017483,
+                        0.022422587676774776,
+                        0.03400971806422712,
+                    ]
+                ),
+            )
+        )
 
     def test_pfm_parsing(self):
         """Test if Bio.motifs can parse JASPAR-style pfm files."""
@@ -1658,6 +1736,23 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 7], 0.009615385)
         self.assertEqual(motif.consensus, "TTATCACT")
         self.assertEqual(motif.degenerate_consensus, "TTATCACT")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        1.765707971839016,
+                        1.765707971839016,
+                        1.7657079718390165,
+                        1.765707971839016,
+                        1.7657079718390158,
+                        1.7657079718390165,
+                        1.7657079718390158,
+                        1.765707971839016,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[1:-2].consensus, "TATCA")
         motif = record[1]
         self.assertEqual(motif.name, "ENSG00000197372")
@@ -1745,6 +1840,35 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 19], 0.000000000)
         self.assertEqual(motif.consensus, "TGAACCGGATTAAGAGGACA")
         self.assertEqual(motif.degenerate_consensus, "WNRWNMGGATTANGAGGACA")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        0.1946677220077018,
+                        0.1566211351816578,
+                        0.31728135119311995,
+                        0.3086747573287918,
+                        0.053393542701508756,
+                        0.381471417197324,
+                        1.5505596169174871,
+                        1.8558501430757017,
+                        1.6274200195132635,
+                        1.8972899364737197,
+                        1.809312450637467,
+                        1.7709547585539227,
+                        0.2549373240046801,
+                        2.0,
+                        2.0,
+                        2.0,
+                        2.0,
+                        2.0,
+                        2.0,
+                        2.0,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[1:-2].consensus, "GAACCGGATTAAGAGGA")
         motif = record[2]
         self.assertAlmostEqual(motif.counts["G", 0], 0.083333300)
@@ -1796,6 +1920,26 @@ CCTCCAGGTCGCATG""",
         self.assertEqual(motif.alphabet, "GATC")
         self.assertEqual(motif.consensus, "TAAACTAAAAG")
         self.assertEqual(motif.degenerate_consensus, "TAAACTARNNN")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        0.4489017067534855,
+                        0.9591474871280075,
+                        1.3499768043761913,
+                        2.0,
+                        1.1833109116849791,
+                        1.0817044992792044,
+                        1.3499768043761913,
+                        0.5408517496401433,
+                        0.2704258182036411,
+                        0.04085174964014324,
+                        0.1120812409282564,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[1:-2].consensus, "AAACTAAA")
         motif = record[3]
         self.assertEqual(motif.name, "AbdA_Cell_FBgn0000014")
@@ -1831,6 +1975,22 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 6], 1.000000000)
         self.assertEqual(motif.consensus, "TTAATTA")
         self.assertEqual(motif.degenerate_consensus, "TTAATKA")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        1.0555114658337947,
+                        2.0,
+                        1.4967416652243541,
+                        2.0,
+                        1.6904565708496748,
+                        1.0817041659455104,
+                        1.1969282726758976,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[1:-2].consensus, "TAAT")
         motif = record[4]
         self.assertEqual(
@@ -1881,6 +2041,25 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 9], 0.444000000)
         self.assertEqual(motif.consensus, "ATGACTCATC")
         self.assertEqual(motif.degenerate_consensus, "NTGASTCAKN")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        0.30427230622817475,
+                        1.9657810606529142,
+                        1.7408585738061,
+                        1.8654244261025423,
+                        0.5449286810918202,
+                        1.8033449015144003,
+                        1.639502374827662,
+                        1.8370335049436752,
+                        0.3124728907316759,
+                        0.13671828556764112,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[1:-2].consensus, "TGACTCA")
         motif = record[5]
         self.assertEqual(motif.name, "AHR_si")
@@ -1924,6 +2103,24 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 8], 66.875582269)
         self.assertEqual(motif.consensus, "GTTGCGTGC")
         self.assertEqual(motif.degenerate_consensus, "NTNGCGTGN")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        0.09662409645348236,
+                        0.5383413903068038,
+                        0.17471270188228985,
+                        1.6270151623731723,
+                        1.8170663607301638,
+                        1.7760800937680195,
+                        1.803660112630464,
+                        2.0,
+                        0.17577786614573548,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[1:-2].consensus, "TTGCGT")
         motif = record[6]
         self.assertIsNone(motif.name)
@@ -1963,6 +2160,23 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 7], 0.019497000)
         self.assertEqual(motif.consensus, "ATGACTCA")
         self.assertEqual(motif.degenerate_consensus, "ATGACTCA")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        0.889358068874075,
+                        1.6123293058245811,
+                        1.471654165929799,
+                        1.4693092198124151,
+                        0.8764628815119266,
+                        1.5686388858173408,
+                        1.37357038822754,
+                        1.6369796776980579,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[1:-2].consensus, "TGACT")
         motif = record[7]
         self.assertIsNone(motif.name)
@@ -2014,6 +2228,26 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 10], 0.0)
         self.assertEqual(motif.consensus, "CCAAAAAACTT")
         self.assertEqual(motif.degenerate_consensus, "BCMAAMNRMTT")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        0.43314504855176084,
+                        2.0,
+                        0.6114044621231828,
+                        2.0,
+                        1.2699833698542062,
+                        0.7139129756130338,
+                        0.1909607288346033,
+                        1.0366644543273158,
+                        1.0817041659455104,
+                        1.180735028768561,
+                        2.0,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[1:-2].consensus, "CAAAAAAC")
 
     def test_pfm_four_rows_parsing(self):
@@ -2051,6 +2285,21 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 5], 4.0)
         self.assertEqual(motif.consensus, "GAAAGC")
         self.assertEqual(motif.degenerate_consensus, "GAAAKY")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        1.349977578351646,
+                        1.349977578351646,
+                        2.0,
+                        1.349977578351646,
+                        0.5408520829727552,
+                        1.0817041659455104,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[:-2].consensus, "GAAA")
         motif = record[1]
         self.assertEqual(motif.name, "")
@@ -2118,6 +2367,30 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 14], 0.583333333)
         self.assertEqual(motif.consensus, "AGCGGGGGGGGGAGC")
         self.assertEqual(motif.degenerate_consensus, "MGCNNNNNNNNNMGC")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        1.0,
+                        2.0,
+                        2.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0,
+                        2.0,
+                        0.44890182844369547,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[:-2].consensus, "AGCGGGGGGGGGA")
         motif = record[2]
         self.assertEqual(motif.name, "")
@@ -2185,6 +2458,30 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 14], 148.0)
         self.assertEqual(motif.consensus, "TGTTCGAGGAATTTT")
         self.assertEqual(motif.degenerate_consensus, "NKWTCGAGGAATNNN")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        0.13892143832881046,
+                        0.2692660952911542,
+                        0.27915566353819243,
+                        0.2665840150038887,
+                        1.8371160692433293,
+                        1.3354706334248059,
+                        1.8856611660889357,
+                        1.6600123906824402,
+                        1.7329826640509962,
+                        1.3601399752384014,
+                        1.5978925123167893,
+                        0.8698961051280728,
+                        0.19290147849975406,
+                        0.11003972948477392,
+                        0.08469189143040626,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[:-2].consensus, "TGTTCGAGGAATT")
         motif = record[3]
         self.assertEqual(motif.name, "")
@@ -2216,6 +2513,21 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 5], 2.0)
         self.assertEqual(motif.consensus, "TCTAGA")
         self.assertEqual(motif.degenerate_consensus, "TCTAGA")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        1.0042727863947818,
+                        1.758059267146789,
+                        1.7580592671467892,
+                        1.7580592671467892,
+                        1.7580592671467892,
+                        1.5774573308022544,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[:-2].consensus, "TCTA")
         motif = record[4]
         self.assertEqual(motif.name, "")
@@ -2247,6 +2559,21 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 5], 0.02)
         self.assertEqual(motif.consensus, "TCTAGA")
         self.assertEqual(motif.degenerate_consensus, "TCTAGA")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        1.0042727863947818,
+                        1.758059267146789,
+                        1.7580592671467892,
+                        1.7580592671467892,
+                        1.7580592671467892,
+                        1.5774573308022544,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[:-2].consensus, "TCTA")
         motif = record[5]
         self.assertEqual(motif.name, "abd-A")
@@ -2286,6 +2613,23 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 7], 0.033934252)
         self.assertEqual(motif.consensus, "GTAATTAA")
         self.assertEqual(motif.degenerate_consensus, "NYAATTAA")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        0.2005361303021225,
+                        0.6336277209668335,
+                        0.933405467206956,
+                        1.3704286046679186,
+                        1.2873833086962072,
+                        1.0187720746919493,
+                        0.975022432438911,
+                        0.547109562258496,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[:-2].consensus, "GTAATT")
         motif = record[6]
         self.assertEqual(motif.name, "MA0001.1 AGL3")
@@ -2333,6 +2677,25 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 9], 3.0)
         self.assertEqual(motif.consensus, "CCATAAATAG")
         self.assertEqual(motif.degenerate_consensus, "CCAWAWATAG")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        1.7725753233561499,
+                        1.0972718180683638,
+                        1.0578945228970464,
+                        0.6353945886004412,
+                        0.9651537633423314,
+                        0.8757972203228152,
+                        0.6864859661195083,
+                        1.1561334005018244,
+                        0.8724039945822116,
+                        1.4691041160249607,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[:-2].consensus, "CCATAAAT")
         motif = record[7]
         self.assertEqual(motif.name, "MA0001.1 AGL3")
@@ -2380,6 +2743,25 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(motif.counts["C", 9], 3.0)
         self.assertEqual(motif.consensus, "CCATAAATAG")
         self.assertEqual(motif.degenerate_consensus, "CCAWAWATAG")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        1.7725753233561499,
+                        1.0972718180683638,
+                        1.0578945228970464,
+                        0.6353945886004412,
+                        0.9651537633423314,
+                        0.8757972203228152,
+                        0.6864859661195083,
+                        1.1561334005018244,
+                        0.8724039945822116,
+                        1.4691041160249607,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[:-2].consensus, "CCATAAAT")
 
     def test_sites_parsing(self):
@@ -2433,6 +2815,14 @@ CCTCCAGGTCGCATG""",
         self.assertAlmostEqual(m.counts["T", 5], 0)
         self.assertEqual(m.consensus, "CACGTG")
         self.assertEqual(m.degenerate_consensus, "CACGTG")
+        self.assertTrue(
+            numpy.array_equal(
+                m.information_content,
+                numpy.array(
+                    [1.278071905112638, 1.7136030428840439, 2.0, 2.0, 2.0, 2.0]
+                ),
+            )
+        )
         self.assertEqual(m[::2].consensus, "CCT")
 
     def test_TFoutput(self):
@@ -2665,6 +3055,28 @@ class TestMEME(unittest.TestCase):
         self.assertEqual(motif.alignment.sequences[6], "AGTGCATGTGGAA")
         self.assertEqual(motif.consensus, "GCGGCATGTGAAA")
         self.assertEqual(motif.degenerate_consensus, "GSKGCATGTGAAA")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        1.4083272214176723,
+                        0.5511843642748154,
+                        0.6212165065138244,
+                        1.136879431433369,
+                        2.0,
+                        2.0,
+                        2.0,
+                        2.0,
+                        1.4083272214176723,
+                        2.0,
+                        1.4083272214176723,
+                        2.0,
+                        1.136879431433369,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[1::2].consensus, "CGAGGA")
         motif = record[1]
         self.assertEqual(motif.name, "TTGACWCYTGCYCWG")
@@ -2762,6 +3174,30 @@ class TestMEME(unittest.TestCase):
         self.assertEqual(motif.alignment.sequences[6], "TTCACGCTTGCTACG")
         self.assertEqual(motif.consensus, "TTGACACCTGCTCTG")
         self.assertEqual(motif.degenerate_consensus, "TTGACWCYTGCYCNG")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        2.0,
+                        2.0,
+                        1.136879431433369,
+                        1.4083272214176723,
+                        2.0,
+                        0.6212165065138244,
+                        1.136879431433369,
+                        1.0147718639657484,
+                        1.4083272214176723,
+                        0.8511651457190834,
+                        1.4083272214176723,
+                        1.0147718639657484,
+                        0.8511651457190834,
+                        0.15762900682289133,
+                        2.0,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[1::2].consensus, "TAACGTT")
 
     def test_meme_parser_2(self):
@@ -4357,6 +4793,34 @@ class TestMEME(unittest.TestCase):
             self.assertIsNone(motif.instances)
         self.assertEqual(motif.consensus, "TGTGATCGAGGTCACACTT")
         self.assertEqual(motif.degenerate_consensus, "TGTGANNNWGNTCACAYWW")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        1.1684297174927525,
+                        0.9432809925744818,
+                        1.4307101633876265,
+                        1.1549413780465179,
+                        0.9308256303218774,
+                        0.009164393966550805,
+                        0.20124190687894253,
+                        0.17618542656995528,
+                        0.36777933103380855,
+                        0.6635834532368525,
+                        0.07729943368061855,
+                        0.9838293592717438,
+                        1.72489868427398,
+                        0.8397561713453014,
+                        1.72489868427398,
+                        0.8455332015343343,
+                        0.3106481207768122,
+                        0.7382733641762232,
+                        0.537435993300495,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[2:9].consensus, "TGATCGA")
         motif = record[1]
         self.assertEqual(motif.name, "IFXA")
@@ -4372,6 +4836,33 @@ class TestMEME(unittest.TestCase):
         self.assertIsNone(motif.alignment)
         self.assertEqual(motif.consensus, "TACTGTATATATATCCAG")
         self.assertEqual(motif.degenerate_consensus, "TACTGTATATAHAWMCAG")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        0.9632889858595118,
+                        1.02677956765017,
+                        2.451526420551951,
+                        1.7098384161433415,
+                        2.2598671267551107,
+                        1.7098384161433415,
+                        1.02677956765017,
+                        1.391583804103081,
+                        1.02677956765017,
+                        1.1201961888781142,
+                        0.27822438781180836,
+                        0.36915366971717867,
+                        1.7240522753630425,
+                        0.3802185945622609,
+                        0.790937683007783,
+                        2.451526420551951,
+                        1.7240522753630425,
+                        1.3924085743645374,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[2:9].consensus, "CTGTATA")
         # using the old instances property:
         with self.assertWarns(BiopythonDeprecationWarning):
@@ -4990,7 +5481,46 @@ class TestTransfac(unittest.TestCase):
         self.assertEqual(motif.counts["T", 10], 3)
         self.assertEqual(motif.counts["T", 11], 1)
         self.assertEqual(motif.degenerate_consensus, "SRACAGGTGKYG")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        0.4780719051126377,
+                        0.4780719051126377,
+                        0.6290494055453314,
+                        2.0,
+                        2.0,
+                        1.278071905112638,
+                        1.278071905112638,
+                        2.0,
+                        2.0,
+                        0.4780719051126377,
+                        1.0290494055453312,
+                        0.6290494055453314,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[1:-2].degenerate_consensus, "RACAGGTGK")
+        self.assertTrue(
+            numpy.array_equal(
+                motif[1:-2].information_content,
+                numpy.array(
+                    [
+                        0.4780719051126377,
+                        0.6290494055453314,
+                        2.0,
+                        2.0,
+                        1.278071905112638,
+                        1.278071905112638,
+                        2.0,
+                        2.0,
+                        0.4780719051126377,
+                    ]
+                ),
+            )
+        )
         motif = record[1]
         self.assertEqual(motif["ID"], "motif2")
         self.assertEqual(len(motif.counts), 4)
@@ -5036,7 +5566,34 @@ class TestTransfac(unittest.TestCase):
         self.assertEqual(motif.counts["T", 8], 5)
         self.assertEqual(motif.counts["T", 9], 3)
         self.assertEqual(motif.degenerate_consensus, "RSCAGAGGTY")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        0.4780719051126377,
+                        0.4780719051126377,
+                        2.0,
+                        0.6290494055453314,
+                        1.278071905112638,
+                        2.0,
+                        1.278071905112638,
+                        2.0,
+                        2.0,
+                        1.0290494055453312,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[::2].degenerate_consensus, "RCGGT")
+        self.assertTrue(
+            numpy.array_equal(
+                motif[::2].information_content,
+                numpy.array(
+                    [0.4780719051126377, 2.0, 1.278071905112638, 1.278071905112638, 2.0]
+                ),
+            )
+        )
 
     def test_permissive_transfac_parser(self):
         """Parse the TRANSFAC-like file motifs/MA0056.1.transfac."""
@@ -5083,7 +5640,28 @@ class TestTransfac(unittest.TestCase):
         self.assertEqual(motif.counts["T", 5], 0.0)
         self.assertEqual(motif.consensus, "TGGGGA")
         self.assertEqual(motif.degenerate_consensus, "NGGGGA")
+        self.assertTrue(
+            numpy.array_equal(
+                motif.information_content,
+                numpy.array(
+                    [
+                        0.09629830394265171,
+                        1.7136030428840439,
+                        1.5310044064107189,
+                        1.7136030428840439,
+                        2.0,
+                        1.5310044064107189,
+                    ]
+                ),
+            )
+        )
         self.assertEqual(motif[1:-3].degenerate_consensus, "GG")
+        self.assertTrue(
+            numpy.array_equal(
+                motif[1:-3].information_content,
+                numpy.array([1.7136030428840439, 1.5310044064107189]),
+            )
+        )
 
 
 class MotifTestPWM(unittest.TestCase):


### PR DESCRIPTION
Add a property`relative_entropy` to the `Motif` class in `Bio.motifs`. This property returns the relative entropy, otherwise known as the Kullback-Leibler distance and equal to the information content if the background is uniform.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

