### PR TITLE
Create a new-style Alignment object from a MultipleSeqAlignment object

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -955,7 +955,12 @@ class MultipleSeqAlignment:
 
     @property
     def alignment(self):
-        """Return an Alignment object based on the MultipleSeqAlignment object."""
+        """Return an Alignment object based on the MultipleSeqAlignment object.
+
+        This makes a copy of each SeqRecord with a gap-less sequence. Any
+        future changes to the original records in the MultipleSeqAlignment will
+        not affect the new records in the Alignment.
+        """
         records = [copy.copy(record) for record in self._records]
         if records:
             lines = [str(record.seq) for record in records]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -953,6 +953,22 @@ class MultipleSeqAlignment:
 
         return m
 
+    @property
+    def alignment(self):
+        """Return an Alignment object based on the MultipleSeqAlignment object."""
+        records = [copy.copy(record) for record in self._records]
+        if records:
+            lines = [str(record.seq) for record in records]
+            coordinates = Alignment.infer_coordinates(lines)
+            for record in records:
+                record.seq = record.seq.replace("-", "")
+            alignment = Alignment(records, coordinates)
+        else:
+            alignment = Alignment([])
+        alignment.annotations = self.annotations
+        alignment.column_annotations = self.column_annotations
+        return alignment
+
 
 class Alignment:
     """Represents a sequence alignment.

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -17,11 +17,8 @@ Right now we've got tests for:
 
 # standard library
 import os
-import collections
 import unittest
 from io import StringIO
-
-import numpy as np
 
 # biopython
 from Bio.Seq import Seq


### PR DESCRIPTION
This PR adds an `alignment` property to `MultipleSeqAlignment` in `Bio.Align` that creates and returns a new-style `Alignment` object based on the information stored in the `MultipleSeqAlignment`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

