### PR TITLE
Remove unused references from bibliography

### DIFF
--- a/Doc/Tutorial.tex
+++ b/Doc/Tutorial.tex
@@ -148,8 +148,6 @@ Florian Jupe, Leighton Pritchard, Graham J. Etherington, Katrin MacKenzie, Peter
 \url{https://doi.org/10.1186/1471-2164-13-75}
 \bibitem{cock2010}
 Peter J. A. Cock, Christopher J. Fields, Naohisa Goto, Michael L. Heuer, Peter M. Rice: ``The Sanger FASTQ file format for sequences with quality scores, and the Solexa/Illumina FASTQ variants''.  \textit{Nucleic Acids Research} {\bf 38} (6): 1767--1771 (2010). \url{https://doi.org/10.1093/nar/gkp1137}
-\bibitem{brown1999}
-Patrick O. Brown, David Botstein: ``Exploring the new world of the genome with DNA microarrays''. \textit{Nature Genetics} {\bf 21} (Supplement 1), 33--37 (1999). \url{https://doi.org/10.1038/4462}
 \bibitem{talevich2012}
 Eric Talevich, Brandon M. Invergo, Peter J.A. Cock, Brad A. Chapman: ``Bio.Phylo: A unified toolkit for processing, analyzing and visualizing phylogenetic trees in Biopython''.  \textit{BMC Bioinformatics} {\bf 13}: 209 (2012).
 \url{https://doi.org/10.1186/1471-2105-13-209}
@@ -187,16 +185,12 @@ Thomas Hamelryck: ``Efficient identification of side-chain patterns using a mult
 \bibitem{hamelryck2005}
 Thomas Hamelryck: ``An amino acid has two sides; A new 2D measure provides a different view of solvent exposure''. \textit{Proteins} {\bf 59} (1): 29--48 (2005).
 \url{https://doi.org/10.1002/prot.20379}.
-\bibitem{hartigan1975}
-John A. Hartiga. \textit{Clustering algorithms}. New York: Wiley (1975).
 \bibitem{henikoff1992}
 Steven Henikoff, Jorja G. Henikoff: ``Amino acid substitution matrices from protein blocks.'' \textit{Proceedings of the National Academy of Sciences USA} {\bf 89} (2): 10915--10919 (1992). \url{https://doi.org/10.1073/pnas.89.22.10915}.
 \bibitem{hihara2001}
 Yukako Hihara, Ayako Kamei, Minoru Kanehisa, Aaron Kaplan and Masahiko Ikeuchi: ``DNA microarray analysis of cyanobacterial gene expression during acclimation to high light''. \textit{Plant Cell} {\bf 13} (4): 793--806 (2001). \url{https://doi.org/10.1105/tpc.13.4.793}.
 \bibitem{altschul1990}
 Stephen F. Altschul, Warren Gish, Webb Miller, Eugene W. Myers, David J. Lipman: ``Basic Local Alignment Search Tool''.  \textit{Journal of Molecular Biology} {\bf 215} (3): 403--410 (1990). \url{https://doi.org/10.1016/S0022-2836%2805%2980360-2}.
-\bibitem{jain1988}
-Anil L. Jain, Richard C. Dubes: \textit{Algorithms for clustering data}. Englewood Cliffs, N.J.: Prentice Hall (1988).
 \bibitem{kachitvichyanukul1988}
 Voratas Kachitvichyanukul, Bruce W. Schmeiser: Binomial Random Variate Generation. \textit{Communications of the ACM} {\bf 31} (2): 216--222 (1988). \url{https://doi.org/10.1145/42372.42381}
 \bibitem{kent2002}
@@ -231,8 +225,6 @@ Robin Sibson: ``SLINK: An optimally efficient algorithm for the single-link clus
 George W. Snedecor, William G. Cochran: \textit{Statistical methods}. Ames, Iowa: Iowa State University Press (1989).
 \bibitem{tamayo1999}
 Pablo Tamayo, Donna Slonim, Jill Mesirov, Qing Zhu, Sutisak Kitareewan, Ethan Dmitrovsky, Eric S. Lander, Todd R. Golub: ``Interpreting patterns of gene expression with self-organizing maps: Methods and application to hematopoietic differentiation''. \textit{Proceedings of the National Academy of Science USA} {\bf 96} (6): 2907--2912 (1999). \url{https://doi.org/10.1073/pnas.96.6.2907}
-\bibitem{tryon1970}
-Robert C. Tryon, Daniel E. Bailey: \textit{Cluster analysis}. New York: McGraw-Hill (1970).
 \bibitem{tukey1977}
 John W. Tukey: ``Exploratory data analysis''. Reading, Mass.: Addison-Wesley Pub. Co. (1977).
 \bibitem{waterman1987}


### PR DESCRIPTION
Spotted via Sphinx warnings after converting the LaTeX tutorial to RST as part of #4371 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This first batch were all added in Biopython 1.61 commit b928630f14dbd9513df86b7f286909604c7eb047 but never cited. They look to be clustering related - so perhaps worth citing rather than dropping @mdehoon?

(There are a few more which I need to trace the history of first)