### PR TITLE
Remove obsolete import workarounds

### DIFF
--- a/Bio/MarkovModel.py
+++ b/Bio/MarkovModel.py
@@ -24,29 +24,7 @@ MarkovModel     Holds the description of a markov model
 
 import numpy as np
 
-
-try:
-    logaddexp = np.logaddexp
-except AttributeError:
-    # Numpy versions older than 1.3 do not contain logaddexp.
-    # Once we require Numpy version 1.3 or later, we should revisit this
-    # module to see if we can simplify some of the other functions in
-    # this module.
-    import warnings
-
-    warnings.warn(
-        "For optimal speed, please update to NumPy version 1.3 or later (current version is %s)"
-        % np.__version__
-    )
-
-    def logaddexp(logx, logy):
-        """Implement logaddexp method if NumPy version is older than 1.3."""
-        if logy - logx > 100:
-            return logy
-        elif logx - logy > 100:
-            return logx
-        minxy = min(logx, logy)
-        return minxy + np.log(np.exp(logx - minxy) + np.exp(logy - minxy))
+logaddexp = np.logaddexp
 
 
 def itemindex(values):

--- a/Bio/Phylo/NeXMLIO.py
+++ b/Bio/Phylo/NeXMLIO.py
@@ -33,20 +33,7 @@ DEFAULT_NAMESPACE = NAMESPACES["nex"]
 VERSION = "0.9"
 SCHEMA = "http://www.nexml.org/2009/nexml/xsd/nexml.xsd"
 
-
-try:
-    register_namespace = ElementTree.register_namespace
-except AttributeError:
-    if not hasattr(ElementTree, "_namespace_map"):
-        # cElementTree needs the pure-Python xml.etree.ElementTree
-        from xml.etree import ElementTree as ET_py
-
-        ElementTree._namespace_map = ET_py._namespace_map
-
-    def register_namespace(prefix, uri):
-        """Set NameSpace map."""
-        ElementTree._namespace_map[uri] = prefix
-
+register_namespace = ElementTree.register_namespace
 
 for prefix, uri in NAMESPACES.items():
     register_namespace(prefix, uri)

--- a/Bio/Phylo/PhyloXMLIO.py
+++ b/Bio/Phylo/PhyloXMLIO.py
@@ -28,19 +28,7 @@ from Bio.Phylo import PhyloXML as PX
 # See http://effbot.org/zone/element-namespaces.htm
 NAMESPACES = {"phy": "http://www.phyloxml.org"}
 
-try:
-    register_namespace = ElementTree.register_namespace
-except AttributeError:
-    if not hasattr(ElementTree, "_namespace_map"):
-        # cElementTree needs the pure-Python xml.etree.ElementTree
-        from xml.etree import ElementTree as ET_py
-
-        ElementTree._namespace_map = ET_py._namespace_map
-
-    def register_namespace(prefix, uri):
-        """Set the namespace for ElementTree."""
-        ElementTree._namespace_map[uri] = prefix
-
+register_namespace = ElementTree.register_namespace
 
 for prefix, uri in NAMESPACES.items():
     register_namespace(prefix, uri)


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Biopython currently supports Python 3.8+

The oldest supported numpy version for Python 3.8 is 1.17, according to https://github.com/scipy/oldest-supported-numpy/

- `ElementTree.register_namespace` workaround obsolete since Python 3.2
- `numpy.logaddexp` workaround obsolete since numpy 1.3