### PR TITLE
Add missing references to Cluster chapter

### DIFF
--- a/Doc/Tutorial.tex
+++ b/Doc/Tutorial.tex
@@ -179,7 +179,7 @@ Gene H. Golub, Christian Reinsch: ``Singular value decomposition and least squar
 \bibitem{golub1989}
 Gene H. Golub, Charles F. Van Loan: \textit{Matrix computations}, 2nd edition (1989).
 \bibitem{hamelryck2003a}
-Thomas Hamelryck and  Bernard Manderick: 11PDB parser and structure class
+Thomas Hamelryck and  Bernard Manderick: ``PDB parser and structure class
 implemented in Python''. \textit{Bioinformatics}, \textbf{19} (17): 2308--2310 (2003) \url{https://doi.org/10.1093/bioinformatics/btg299}. 
 \bibitem{hamelryck2003b}
 Thomas Hamelryck: ``Efficient identification of side-chain patterns using a multidimensional index tree''. \textit{Proteins} {\bf 51} (1): 96--108 (2003).

--- a/Doc/Tutorial/chapter_cluster.tex
+++ b/Doc/Tutorial/chapter_cluster.tex
@@ -410,7 +410,7 @@ In pairwise centroid-linkage clustering, the distance between two nodes is defin
 
 For pairwise single-, complete-, and average-linkage clustering, the distance between two nodes can be found directly from the distances between the individual items. Therefore, the clustering algorithm does not need access to the original gene expression data, once the distance matrix is known. For pairwise centroid-linkage clustering, however, the centroids of newly formed subnodes can only be calculated from the original data and not from the distance matrix.
 
-The implementation of pairwise single-linkage hierarchical clustering is based on the SLINK algorithm (R. Sibson, 1973), which is much faster and more memory-efficient than a straightforward implementation of pairwise single-linkage clustering. The clustering result produced by this algorithm is identical to the clustering solution found by the conventional single-linkage algorithm. The single-linkage hierarchical clustering algorithm implemented in this library can be used to cluster large gene expression data sets, for which conventional hierarchical clustering algorithms fail due to excessive memory requirements and running time.
+The implementation of pairwise single-linkage hierarchical clustering is based on the SLINK algorithm \cite{sibson1973}, which is much faster and more memory-efficient than a straightforward implementation of pairwise single-linkage clustering. The clustering result produced by this algorithm is identical to the clustering solution found by the conventional single-linkage algorithm. The single-linkage hierarchical clustering algorithm implemented in this library can be used to cluster large gene expression data sets, for which conventional hierarchical clustering algorithms fail due to excessive memory requirements and running time.
 
 \subsection*{Representing a hierarchical clustering solution}
 
@@ -687,7 +687,7 @@ The original matrix \verb|data| can be recreated by calculating \verb|columnmean
 
 \section{Handling Cluster/TreeView-type files}
 
-Cluster/TreeView are GUI-based codes for clustering gene expression data. They were originally written by \href{http://rana.lbl.gov}{Michael Eisen} while at Stanford University. \verb|Bio.Cluster| contains functions for reading and writing data files that correspond to the format specified for Cluster/TreeView. In particular, by saving a clustering result in that format, TreeView can be used to visualize the clustering results. We recommend using Alok Saldanha's \url{http://jtreeview.sourceforge.net/}{Java TreeView program}, which can display hierarchical as well as $k$-means clustering results.
+Cluster/TreeView are GUI-based codes for clustering gene expression data. They were originally written by \href{http://rana.lbl.gov}{Michael Eisen} while at Stanford University \cite{eisen1998}. \verb|Bio.Cluster| contains functions for reading and writing data files that correspond to the format specified for Cluster/TreeView. In particular, by saving a clustering result in that format, TreeView can be used to visualize the clustering results. We recommend using Alok Saldanha's \url{http://jtreeview.sourceforge.net/}{Java TreeView program} \cite{saldanha2004}, which can display hierarchical as well as $k$-means clustering results.
 
 An object of the class \verb|Record| contains all information stored in a Cluster/TreeView-type data file. To store the information contained in the data file in a \verb|Record| object, we first open the file and then read it:
 


### PR DESCRIPTION
This PR fixes the references to sibson1973, eisen1998, and saldanha2004 in the chapter on clustering in the tutorial.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
