### PR TITLE
No insertion codes with auth_residues=False

### DIFF
--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -191,6 +191,8 @@ class MMCIFParser:
                 seq_id_list = mmcif_dict["_atom_site.label_seq_id"]
         else:
             seq_id_list = mmcif_dict["_atom_site.label_seq_id"]
+            icode_list = ["."] * len(icode_list)
+
         # Now loop over atoms and build the structure
         current_chain_id = None
         current_residue_id = None
@@ -488,6 +490,7 @@ class FastMMCIFParser:
                 seq_id_list = mmcif_dict["_atom_site.label_seq_id"]
         else:
             seq_id_list = mmcif_dict["_atom_site.label_seq_id"]
+            icode_list = ["."] * len(icode_list)
 
         # Now loop over atoms and build the structure
         current_chain_id = None

--- a/Tests/test_PDB_MMCIFParser.py
+++ b/Tests/test_PDB_MMCIFParser.py
@@ -247,17 +247,23 @@ class ParseReal(unittest.TestCase):
     def test_insertions(self):
         """Test file with residue insertion codes."""
         parser = MMCIFParser(QUIET=1)
+        parser_lab_res = MMCIFParser(auth_residues=False, QUIET=True)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", PDBConstructionWarning)
             structure = parser.get_structure("example", "PDB/4ZHL.cif")
+            structure_lr = parser_lab_res.get_structure("example", "PDB/4ZHL.cif")
         for ppbuild in [PPBuilder(), CaPPBuilder()]:
             # First try allowing non-standard amino acids,
             polypeptides = ppbuild.build_peptides(structure[0], False)
+            polypeptides_lr = ppbuild.build_peptides(structure_lr[0], False)
             self.assertEqual(len(polypeptides), 2)
             pp = polypeptides[0]
+            pp_lr = polypeptides_lr[0]
             # Check the start and end positions (first segment only)
             self.assertEqual(pp[0].get_id()[1], 16)
             self.assertEqual(pp[-1].get_id()[1], 244)
+            self.assertEqual(pp[22].get_id(), (" ", 37, "A"))
+            self.assertEqual(pp_lr[22].get_id(), (" ", 23, " "))
             # Check the sequence
             refseq = (
                 "IIGGEFTTIENQPWFAAIYRRHRGGSVTYVCGGSLISPCWVISATHCFIDYPKKEDYIVYLGR"


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

When passing `auth_residues=False` to `MMCIFParser` or `FastMMCIFParser`, then ignore insertion codes.

Closes https://github.com/biopython/biopython/issues/4335