### PR TITLE
File.as_handle_and_flag

### DIFF
--- a/Bio/SeqIO/AceIO.py
+++ b/Bio/SeqIO/AceIO.py
@@ -11,11 +11,11 @@ See also the Bio.Sequencing.Ace module which offers more than just accessing
 the contig consensus sequences in an ACE file as SeqRecord objects.
 """
 
+from Bio.File import _TextIOSource
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Sequencing import Ace
 
-from .Interfaces import _TextIOSource
 from .Interfaces import SequenceIterator
 
 

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -13,6 +13,7 @@
 You are expected to use this module via the Bio.SeqIO functions.
 """
 
+from Bio.File import _TextIOSource
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio import BiopythonDeprecationWarning
@@ -20,7 +21,6 @@ from Bio import BiopythonDeprecationWarning
 
 from .Interfaces import _clean
 from .Interfaces import _get_seq_string
-from .Interfaces import _TextIOSource
 from .Interfaces import SequenceIterator
 from .Interfaces import SequenceWriter
 

--- a/Bio/SeqIO/PhdIO.py
+++ b/Bio/SeqIO/PhdIO.py
@@ -54,11 +54,11 @@ Note these examples only show the first 50 bases to keep the output short.
 
 from collections.abc import Iterator
 
+from Bio.File import _IOSource
+from Bio.File import _TextIOSource
 from Bio.SeqRecord import SeqRecord
 from Bio.Sequencing import Phd
 
-from .Interfaces import _IOSource
-from .Interfaces import _TextIOSource
 from .Interfaces import SequenceWriter
 from .QualityIO import _get_phred_quality
 

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -362,7 +362,6 @@ are approximately equal.
 import warnings
 from math import log
 from typing import Callable
-from typing import IO
 from collections.abc import Iterator
 from collections.abc import Mapping
 from typing import Optional
@@ -371,14 +370,14 @@ from typing import Union
 
 from Bio import BiopythonParserWarning
 from Bio import BiopythonWarning
-from Bio import StreamModeError
 from Bio.File import as_handle
+from Bio.File import check_handle_mode
+from Bio.File import _TextIOSource
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
 from .Interfaces import _clean
 from .Interfaces import _get_seq_string
-from .Interfaces import _TextIOSource
 from .Interfaces import SequenceIterator
 from .Interfaces import SequenceWriter
 
@@ -923,8 +922,7 @@ def FastqGeneralIterator(source: _TextIOSource) -> Iterator[tuple[str, str, str]
     would prevent the above problem with the "@" character.
     """
     with as_handle(source) as handle:
-        if handle.read(0) != "":
-            raise StreamModeError("Fastq files must be opened in text mode") from None
+        check_handle_mode(handle, "r", fmt="Fastq")
         try:
             line = next(handle)
         except StopIteration:

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -381,6 +381,7 @@ from collections.abc import Iterable
 from typing import Union
 
 from Bio.File import as_handle
+from Bio.File import _TextIOSource
 from Bio.SeqIO import AbiIO
 from Bio.SeqIO import AceIO
 from Bio.SeqIO import FastaIO
@@ -402,8 +403,6 @@ from Bio.SeqIO import TwoBitIO
 from Bio.SeqIO import UniprotIO
 from Bio.SeqIO import XdnaIO
 from Bio.SeqRecord import SeqRecord
-
-from .Interfaces import _TextIOSource
 
 # Convention for format names is "mainname-subtype" in lower case.
 # Please use the same names as BioPerl or EMBOSS where possible.

--- a/Bio/Sequencing/Ace.py
+++ b/Bio/Sequencing/Ace.py
@@ -57,6 +57,8 @@ Thus an ace file does not entirerly suit the concept of iterating. If WA, CT, RT
 are needed, the 'read' function rather than the 'parse' function might be more appropriate.
 """
 
+from Bio import File
+
 
 class rd:
     """RD (reads), store a read with its name, sequence etc.
@@ -300,14 +302,8 @@ def parse(source):
 
     where each record is a Contig object.
     """
-    try:
-        handle = open(source)
-    except TypeError:
-        handle = source
-        if handle.read(0) != "":
-            raise ValueError("Ace files must be opened in text mode.") from None
-
-    try:
+    with File.as_handle(source) as handle:
+        File.check_handle_mode(handle, "r", fmt="Ace")
         line = ""
         while True:
             # at beginning, skip the AS and look for first CO command
@@ -498,10 +494,6 @@ def parse(source):
                     break
 
             yield record
-
-    finally:
-        if handle is not source:
-            handle.close()
 
 
 class ACEFileRecord:

--- a/Tests/test_SeqIO.py
+++ b/Tests/test_SeqIO.py
@@ -235,7 +235,7 @@ class TestZipped(unittest.TestCase):
             self.assertEqual(6, len(list(SeqIO.parse(handle, "gb"))))
         with gzip.open("GenBank/cor6_6.gb.bgz") as handle:
             with self.assertRaisesRegex(
-                ValueError, "GenBank files must be opened in text mode."
+                ValueError, "GenBank files must be opened in text mode"
             ):
                 list(SeqIO.parse(handle, "gb"))
 


### PR DESCRIPTION
Follow-up on https://github.com/biopython/biopython/pull/4377 ("mypy pre-commit hook").

- New function `as_handle_and_flag`
- New function `check_handle_mode`
- Use `as_handle` or `as_handle_and_flag` where appropriate
- Move `_PathLikeTypes`, `_IOSource` and `_TextIOSource` to `Bio.File` module

----

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)