### PR TITLE
Fix Bio.Nexus.cnexus import

### DIFF
--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -22,7 +22,7 @@ import warnings
 from Bio import File
 from Bio.Data import IUPACData
 from Bio.Seq import Seq
-from Bio import BiopythonDeprecationWarning
+from Bio import BiopythonDeprecationWarning, BiopythonWarning
 
 
 from Bio.Nexus.StandardData import StandardData
@@ -2133,8 +2133,12 @@ class Nexus:
 
 
 try:
-    import cnexus  # type: ignore
-except ImportError:
+    from . import cnexus  # type: ignore
+except ImportError as ex:
+    warnings.warn(
+        f"Import of C module failed ({ex}). Falling back to slow Python implementation",
+        BiopythonWarning,
+    )
 
     def _get_command_lines(file_contents):
         lines = _kill_comments_and_break_lines(file_contents)


### PR DESCRIPTION
Fix the `Bio.Nexus.cnexus` import and issue a `BiopythonWarning` if the import fails.

----

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)