### PR TITLE
A relaxed and sequential PHYLIP format for `Bio.AlignIO.write()`

### DIFF
--- a/Bio/AlignIO/PhylipIO.py
+++ b/Bio/AlignIO/PhylipIO.py
@@ -438,6 +438,33 @@ class SequentialPhylipIterator(PhylipIterator):
         return MultipleSeqAlignment(records)
 
 
+# Relaxed, sequential phylip
+
+class RelaxedSequentialPhylipWriter(SequentialPhylipWriter):
+    """Relaxed Sequential Phylip format writer."""
+
+    def write_alignment(self, alignment):
+        """Write a relaxed phylip alignment."""
+        # Check inputs
+        for name in (s.id.strip() for s in alignment):
+            if any(c in name for c in string.whitespace):
+                raise ValueError(f"Whitespace not allowed in identifier: {name}")
+
+        # Calculate a truncation length - maximum length of sequence ID plus a
+        # single character for padding
+        # If no sequences, set id_width to 1. super(...) call will raise a
+        # ValueError
+        if len(alignment) == 0:
+            id_width = 1
+        else:
+            id_width = max(len(s.id.strip()) for s in alignment) + 1
+        super().write_alignment(alignment, id_width)
+
+class RelaxedSequentialPhylipIterator(RelaxedPhylipIterator, SequentialPhylipIterator):
+
+    pass
+    
+
 def sanitize_name(name, width=None):
     """Sanitise sequence identifier for output.
 

--- a/Bio/AlignIO/__init__.py
+++ b/Bio/AlignIO/__init__.py
@@ -114,6 +114,7 @@ names are also used in Bio.SeqIO and include the following:
   - phylip    - Interlaced PHYLIP, as used by the PHYLIP tools.
   - phylip-sequential - Sequential PHYLIP.
   - phylip-relaxed - PHYLIP like format allowing longer names.
+  - phylip-relaxed-sequential - Sequential PHYLIP like format allowing longer names.
   - stockholm - A richly annotated alignment file format used by PFAM.
   - mauve - Output from progressiveMauve/Mauve
 
@@ -164,6 +165,7 @@ _FormatToIterator = {  # "fasta" is done via Bio.SeqIO
     "phylip": PhylipIO.PhylipIterator,
     "phylip-sequential": PhylipIO.SequentialPhylipIterator,
     "phylip-relaxed": PhylipIO.RelaxedPhylipIterator,
+    "phylip-relaxed-sequential": PhylipIO.RelaxedSequentialPhylipIterator,
     "stockholm": StockholmIO.StockholmIterator,
 }
 
@@ -175,6 +177,7 @@ _FormatToWriter = {  # "fasta" is done via Bio.SeqIO
     "phylip": PhylipIO.PhylipWriter,
     "phylip-sequential": PhylipIO.SequentialPhylipWriter,
     "phylip-relaxed": PhylipIO.RelaxedPhylipWriter,
+    "phylip-relaxed-sequential": PhylipIO.RelaxedSequentialPhylipWriter,
     "stockholm": StockholmIO.StockholmWriter,
 }
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -120,6 +120,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Erik Cederstrand <https://github.com/ecederstrand>
 - Erik Weßels <https://github.com/BioNij>
 - Erik Whiting <https://github.com/erik-whiting>
+- Etka Yapar <https://github.com/etkayapar>
 - Fabian Egli <https://github.com/fabianegli>
 - Fei Qi <https://github.com/qifei9>
 - Foen Peng <https://github.com/foenpeng>


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...

I implemented the writer and the iterator for this new format. It basically combines the behaviour of the writers and iterators for "phylip-relaxed" and "phylip-sequential". 

Aims to fix issue #4440 
