### PR TITLE
add rate limit for KEGG

### DIFF
--- a/Bio/KEGG/REST.py
+++ b/Bio/KEGG/REST.py
@@ -31,9 +31,21 @@ Nucleic Acids Res. 28, 29-34 (2000).
 
 import io
 from urllib.request import urlopen
+import time
+from Bio._utils import function_with_previous
 
 
+@function_with_previous
 def _q(op, arg1, arg2=None, arg3=None):
+    delay = 0.333333333  # one third of a second
+    current = time.time()
+    wait = _q.previous + delay - current
+    if wait > 0:
+        time.sleep(wait)
+        _q.previous = current + wait
+    else:
+        _q.previous = current
+
     URL = "https://rest.kegg.jp/%s"
     if arg2 and arg3:
         args = f"{op}/{arg1}/{arg2}/{arg3}"
@@ -49,6 +61,9 @@ def _q(op, arg1, arg2=None, arg3=None):
     handle = io.TextIOWrapper(resp, encoding="UTF-8")
     handle.url = resp.url
     return handle
+
+
+_q.previous = 0
 
 
 # https://www.kegg.jp/kegg/rest/keggapi.html


### PR DESCRIPTION
The [KEGG API page](https://www.kegg.jp/kegg/rest/) says this about rate limits:
> Please also limit your API calls up to 3 times per second. Otherwise, your access will be blocked.

Currently, Biopython does not respect this and will send as many requests as it wants as fast as possible. This recently came up in issue #4459. This PR implements [Peter's suggestion](https://github.com/biopython/biopython/issues/4459#issuecomment-1770323053) on that thread.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4459
