### PR TITLE
update substitution matrix reading to ensure files are closed

### DIFF
--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -11,6 +11,8 @@ import os
 import string
 import numpy as np
 
+from Bio.File import as_handle
+
 
 class Array(np.ndarray):
     """numpy array subclass indexed by integers and by letters."""
@@ -455,12 +457,7 @@ class Array(np.ndarray):
 
 def read(handle, dtype=float):
     """Parse the file and return an Array object."""
-    try:
-        fp = open(handle)
-    except TypeError:
-        fp = handle
-
-    with fp:
+    with as_handle(handle) as fp:
         lines = fp.readlines()
 
     header = []

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -455,17 +455,15 @@ class Array(np.ndarray):
 
 def read(handle, dtype=float):
     """Parse the file and return an Array object."""
+
     try:
         fp = open(handle)
-        lines = fp.readlines()
     except TypeError:
         fp = handle
-        try:
-            lines = fp.readlines()
-        except Exception as e:
-            raise e from None
-        finally:
-            fp.close()
+
+    with fp:
+        lines = fp.readlines()
+
     header = []
     for i, line in enumerate(lines):
         if not line.startswith("#"):

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -455,7 +455,6 @@ class Array(np.ndarray):
 
 def read(handle, dtype=float):
     """Parse the file and return an Array object."""
-
     try:
         fp = open(handle)
     except TypeError:

--- a/Tests/test_align_substitution_matrices.py
+++ b/Tests/test_align_substitution_matrices.py
@@ -2423,14 +2423,15 @@ class TestLoading(unittest.TestCase):
         matrix_path = os.path.join(sub_mx_dir, matrix_name)
 
         fname_matrix = substitution_matrices.read(matrix_path)
-        self.assertEqual(fname_matrix["A"]["A"], 4.0)
+        self.assertAlmostEqual(fname_matrix["A"]["A"], 4.0)
         self.assertEqual(len(fname_matrix), 24)
         self.assertEqual(len(fname_matrix[0]), 24)
 
         with open(matrix_path, "r") as handle:
             handle_matrix = substitution_matrices.read(handle)
+            self.assertFalse(handle.closed)
         self.assertTrue(handle.closed)
-        self.assertEqual(handle_matrix["A"]["A"], 4.0)
+        self.assertAlmostEqual(handle_matrix["A"]["A"], 4.0)
         self.assertEqual(len(handle_matrix), 24)
         self.assertEqual(len(handle_matrix[0]), 24)
 

--- a/Tests/test_align_substitution_matrices.py
+++ b/Tests/test_align_substitution_matrices.py
@@ -2412,6 +2412,28 @@ class TestLoading(unittest.TestCase):
             except Exception:
                 self.fail(f"Failed to load subsitution matrix '{name}'")
 
+    def test_reading(self):
+        """Confirm matrix reading works with filename or handle."""
+        matrix_name = "BLOSUM62"
+        test_path = os.path.dirname(__file__)
+        parent_dir = os.path.dirname(test_path)
+        sub_mx_dir = os.path.join(
+            parent_dir, "Bio", "Align", "substitution_matrices", "data"
+        )
+        matrix_path = os.path.join(sub_mx_dir, matrix_name)
+
+        fname_matrix = substitution_matrices.read(matrix_path)
+        assert fname_matrix["A"]["A"] == 4.0
+        assert len(fname_matrix) == 24
+        assert len(fname_matrix[0]) == 24
+
+        with open(matrix_path, "r") as handle:
+            handle_matrix = substitution_matrices.read(handle)
+        assert handle.closed
+        assert handle_matrix["A"]["A"] == 4.0
+        assert len(handle_matrix) == 24
+        assert len(handle_matrix[0]) == 24
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)

--- a/Tests/test_align_substitution_matrices.py
+++ b/Tests/test_align_substitution_matrices.py
@@ -2423,16 +2423,16 @@ class TestLoading(unittest.TestCase):
         matrix_path = os.path.join(sub_mx_dir, matrix_name)
 
         fname_matrix = substitution_matrices.read(matrix_path)
-        assert fname_matrix["A"]["A"] == 4.0
-        assert len(fname_matrix) == 24
-        assert len(fname_matrix[0]) == 24
+        self.assertEqual(fname_matrix["A"]["A"], 4.0)
+        self.assertEqual(len(fname_matrix), 24)
+        self.assertEqual(len(fname_matrix[0]), 24)
 
         with open(matrix_path, "r") as handle:
             handle_matrix = substitution_matrices.read(handle)
-        assert handle.closed
-        assert handle_matrix["A"]["A"] == 4.0
-        assert len(handle_matrix) == 24
-        assert len(handle_matrix[0]) == 24
+        self.assertTrue(handle.closed)
+        self.assertEqual(handle_matrix["A"]["A"], 4.0)
+        self.assertEqual(len(handle_matrix), 24)
+        self.assertEqual(len(handle_matrix[0]), 24)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4475

Reworked file reading in `substitution_matrices.__init__.read` to ensure file is closed, which clears up the `ResourceWarning`, but is also a little nicer to read
