### PR TITLE
Check sorting of CONTRIB.rst vis pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,6 +90,13 @@ repos:
         entry: '(?i)(doi:|dx\.doi\.org|http://doi\.org)'
         language: pygrep
         files: \.(rst|tex)$
+    -   id: contrib-sort
+        name: Contributor sorting
+        description: Confirms alphabetical sorting of the CONTRIB.rst file
+        entry: bash -c 'for n in $(seq 0 "$#"); do grep "^- " "${!n}" | LC_ALL=C sort -u -c -f; done'
+        #entry: 'grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f'
+        language: system
+        files: ^CONTRIB\.rst$
 ci:
     # Settings for the https://pre-commit.ci/ continuous integration service
     autofix_prs: true


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

We used to run ``grep "^- " CONTRIB.rst | LC_ALL=C sort -u -c -f``  as part of the TravisCI setup (as documented at the start of that file), but appear not to be under GitHub Actions or AppVeyor.

Cross reference 99cbeb58a0d07ffc5a2fc55f11ae0dfad208fb56

This solution via pre-commit is not that elegant, perhaps there is an easier way - e.g. an entry in the GitHub actions directly?
