### PR TITLE
Add missing molecule types in EMBL writer

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -1237,7 +1237,14 @@ class EmblWriter(_InsdcWriter):
         mol_type = record.annotations.get("molecule_type")
         if mol_type is None:
             raise ValueError("missing molecule_type in annotations")
-        if mol_type not in ("DNA", "genomic DNA", "unassigned DNA", "mRNA", "RNA", "protein"):
+        if mol_type not in (
+            "DNA",
+            "genomic DNA",
+            "unassigned DNA",
+            "mRNA",
+            "RNA",
+            "protein",
+        ):
             warnings.warn(f"Non-standard molecule type: {mol_type}", BiopythonWarning)
         mol_type_upper = mol_type.upper()
         if "DNA" in mol_type_upper:

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -1237,7 +1237,7 @@ class EmblWriter(_InsdcWriter):
         mol_type = record.annotations.get("molecule_type")
         if mol_type is None:
             raise ValueError("missing molecule_type in annotations")
-        if mol_type not in ("DNA", "RNA", "protein"):
+        if mol_type not in ("DNA", "genomic DNA", "unassigned DNA", "mRNA", "RNA", "protein"):
             warnings.warn(f"Non-standard molecule type: {mol_type}", BiopythonWarning)
         mol_type_upper = mol_type.upper()
         if "DNA" in mol_type_upper:

--- a/Tests/test_SeqIO_Insdc.py
+++ b/Tests/test_SeqIO_Insdc.py
@@ -4,6 +4,7 @@
 # as part of this package.
 """Tests for SeqIO Insdc module."""
 import unittest
+import warnings
 
 from io import StringIO
 
@@ -90,15 +91,21 @@ class TestEmblRewrite(SeqRecordTestBaseClass):
 
     def test_annotation1(self):
         """Check writing-and-parsing EMBL file (1)."""
-        self.check_rewrite("EMBL/TRBG361.embl")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            self.check_rewrite("EMBL/TRBG361.embl")
 
     def test_annotation2(self):
         """Check writing-and-parsing EMBL file (2)."""
-        self.check_rewrite("EMBL/DD231055_edited.embl")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            self.check_rewrite("EMBL/DD231055_edited.embl")
 
     def test_annotation3(self):
         """Check writing-and-parsing EMBL file (3)."""
-        self.check_rewrite("EMBL/AE017046.embl")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            self.check_rewrite("EMBL/AE017046.embl")
 
 
 class ConvertTestsInsdc(SeqIOConverterTestBaseClass):


### PR DESCRIPTION
Fixes warnings like this while writing:
``` 
BiopythonWarning: Non-standard molecule type: genomic DNA
```

This PR only fixes this for "mRNA", "genomic DNA" and "unassigned DNA".
Possibly this is the complete list: https://www.ebi.ac.uk/ena/WebFeat/qualifiers/mol_type.html

Also changed the EMBL writer tests to fail if there are warnings.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)