### PR TITLE
Stop using flake8 to check whitespace - just trust black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -80,12 +80,12 @@ ignore =
 # ========================
 per-file-ignores =
     Bio/*:F401,F841,D105,B009,B010
-    Tests/*:F401,F841,D101,D102,D103,W504,B009,B010,B015
+    Tests/*:F401,F841,D101,D102,D103,W291,B009,B010,B015
 
     # Due to a bug in flake8, we need the following lines for running the
     # pre-commit hook. If you made edits above, please change also here!
     /Bio/*:F401,F841,D105,B009,B010
-    /Tests/*:F401,F841,D101,D102,D103,B009,B010,B015
+    /Tests/*:F401,F841,D101,D102,D103,W291,B009,B010,B015
 
 #Explanation of the codes being ignored in Bio/ and Tests/:
 #
@@ -100,6 +100,7 @@ per-file-ignores =
 #        D101 missing docstring in public class (244 occurrences)
 #        D102 missing docstring in public method (1368 occurrences)
 #        D103 missing docstring in public functions (20 occurrences)
+#        W291 trailing whitespace (due to alignment tests)
 #        B009 do not call getattr with a constant attribute value (10 occurrences),
 #             it is not any safer than normal property access
 #        B010 do not call setattr with a constant attribute value (7 occurrences),

--- a/.flake8
+++ b/.flake8
@@ -41,6 +41,17 @@ ignore =
     # whitespace before ':'
     # gives false positives after running black, see
     # https://github.com/PyCQA/pycodestyle/issues/373
+    E122,E131,E124,E126,E127,E128,E201,E241,
+    # E112 continuation line missing indentation or outdented
+    # E131 continuation line unaligned for hanging indent
+    # E124 closing bracket does not match visual indentation
+    # E126 continuation line over-indented for hanging indent
+    # E127 continuation line over-indented for visual indent
+    # E128 continuation line under-indented for visual indent
+    # E201 whitespace after '['
+    # E241 multiple spaces after ','
+    # ignoring as using black for layout (if this is triggered,
+    # it would be in a snippet explicitly excluded from black)
     E501,
     # line too long
     # Maybe we find a sensible limit, e.g. 88 (black) and enforce it

--- a/Tests/test_Align_Alignment.py
+++ b/Tests/test_Align_Alignment.py
@@ -705,7 +705,6 @@ query             0 A-C-GG-AAC--  7
             np.array_equal(
                 alignment.aligned,
                 # fmt: off
-# flake8: noqa
                 np.array([[[0, 1],
                               [2, 3],
                               [4, 6],
@@ -726,7 +725,6 @@ query             0 A-C-GG-AAC--  7
                 np.array(
                     [
                         # fmt: off
-# flake8: noqa
                         [0,  1, 2,  3, 4, 5,  6, 7, -1, 8,  9, 10],
                         [0, -1, 1, -1, 2, 3, -1, 4,  5, 6, -1, -1],
                         # fmt: on
@@ -738,7 +736,6 @@ query             0 A-C-GG-AAC--  7
         self.assertEqual(len(inverse_indices), 2)
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[0],
                 np.array([0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11])
@@ -747,7 +744,6 @@ query             0 A-C-GG-AAC--  7
         )
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[1],
                 np.array([0, 2, 4, 5, 7, 8, 9])
@@ -767,7 +763,6 @@ query             1 -C-GG-AAC--  7
             np.array_equal(
                 alignment.aligned,
                 # fmt: off
-# flake8: noqa
                 np.array([[[2, 3],
                               [4, 6],
                               [7, 8],
@@ -786,7 +781,6 @@ query             1 -C-GG-AAC--  7
                 np.array(
                     [
                         # fmt: off
-# flake8: noqa
                         [ 1, 2,  3, 4, 5,  6, 7, -1, 8,  9, 10],
                         [-1, 1, -1, 2, 3, -1, 4,  5, 6, -1, -1],
                         # fmt: on
@@ -798,7 +792,6 @@ query             1 -C-GG-AAC--  7
         self.assertEqual(len(inverse_indices), 2)
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[0],
                 np.array([-1, 0, 1, 2, 3, 4, 5, 6, 8, 9, 10])
@@ -807,7 +800,6 @@ query             1 -C-GG-AAC--  7
         )
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[1],
                 np.array([-1, 1, 3, 4, 6, 7, 8])
@@ -827,7 +819,6 @@ query             0 A-C-GG-AAC  7
             np.array_equal(
                 alignment.aligned,
                 # fmt: off
-# flake8: noqa
                 np.array([[[0, 1],
                               [2, 3],
                               [4, 6],
@@ -848,7 +839,6 @@ query             0 A-C-GG-AAC  7
                 np.array(
                     [
                         # fmt: off
-# flake8: noqa
                         [0,  1, 2,  3, 4, 5,  6, 7, -1, 8],
                         [0, -1, 1, -1, 2, 3, -1, 4,  5, 6],
                         # fmt: on
@@ -860,7 +850,6 @@ query             0 A-C-GG-AAC  7
         self.assertEqual(len(inverse_indices), 2)
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[0],
                 np.array([0, 1, 2, 3, 4, 5, 6, 7, 9, -1, -1])
@@ -869,7 +858,6 @@ query             0 A-C-GG-AAC  7
         )
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[1],
                 np.array([0, 2, 4, 5, 7, 8, 9])
@@ -889,7 +877,6 @@ query             1 -C-GG-AAC 7
             np.array_equal(
                 alignment.aligned,
                 # fmt: off
-# flake8: noqa
                 np.array([[[2, 3],
                               [4, 6],
                               [7, 8],
@@ -908,7 +895,6 @@ query             1 -C-GG-AAC 7
                 np.array(
                     [
                         # fmt: off
-# flake8: noqa
                         [ 1, 2,  3, 4, 5,  6, 7, -1, 8],
                         [-1, 1, -1, 2, 3, -1, 4,  5, 6],
                         # fmt: on
@@ -920,7 +906,6 @@ query             1 -C-GG-AAC 7
         self.assertEqual(len(inverse_indices), 2)
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[0],
                 np.array([-1, 0, 1, 2, 3, 4, 5, 6, 8, -1, -1])
@@ -929,7 +914,6 @@ query             1 -C-GG-AAC 7
         )
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[1],
                 np.array([-1, 1, 3, 4, 6, 7, 8])
@@ -942,7 +926,6 @@ query             1 -C-GG-AAC 7
             np.array_equal(
                 alignment.aligned,
                 # fmt: off
-# flake8: noqa
                 np.array([[[0, 1],
                               [2, 3],
                               [4, 6],
@@ -971,7 +954,6 @@ query             7 A-C-GG-AAC--  0
                 np.array(
                     [
                         # fmt: off
-# flake8: noqa
                         [0,  1, 2,  3, 4, 5,  6, 7, -1, 8,  9, 10],
                         [6, -1, 5, -1, 4, 3, -1, 2,  1, 0, -1, -1],
                         # fmt: on
@@ -983,7 +965,6 @@ query             7 A-C-GG-AAC--  0
         self.assertEqual(len(inverse_indices), 2)
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[0],
                 np.array([0, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11])
@@ -992,7 +973,6 @@ query             7 A-C-GG-AAC--  0
         )
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[1],
                 np.array([9, 8, 7, 5, 4, 2, 0])
@@ -1004,7 +984,6 @@ query             7 A-C-GG-AAC--  0
             np.array_equal(
                 alignment.aligned,
                 # fmt: off
-# flake8: noqa
                 np.array([[[2, 3],
                               [4, 6],
                               [7, 8],
@@ -1031,7 +1010,6 @@ query             6 -C-GG-AAC--  0
                 np.array(
                     [
                         # fmt: off
-# flake8: noqa
                         [ 1, 2,  3, 4, 5,  6, 7, -1, 8,  9, 10],
                         [-1, 5, -1, 4, 3, -1, 2,  1, 0, -1, -1],
                         # fmt: on
@@ -1043,7 +1021,6 @@ query             6 -C-GG-AAC--  0
         self.assertEqual(len(inverse_indices), 2)
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[0],
                 np.array([-1, 0, 1, 2, 3, 4, 5, 6, 8, 9, 10])
@@ -1052,7 +1029,6 @@ query             6 -C-GG-AAC--  0
         )
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[1],
                 np.array([8, 7, 6, 4, 3, 1, -1])
@@ -1064,7 +1040,6 @@ query             6 -C-GG-AAC--  0
             np.array_equal(
                 alignment.aligned,
                 # fmt: off
-# flake8: noqa
                 np.array([[[0, 1],
                               [2, 3],
                               [4, 6],
@@ -1093,7 +1068,6 @@ query             7 A-C-GG-AAC  0
                 np.array(
                     [
                         # fmt: off
-# flake8: noqa
                         [0,  1, 2,  3, 4, 5,  6, 7, -1, 8],
                         [6, -1, 5, -1, 4, 3, -1, 2,  1, 0],
                         # fmt: on
@@ -1105,7 +1079,6 @@ query             7 A-C-GG-AAC  0
         self.assertEqual(len(inverse_indices), 2)
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[0],
                 np.array([0, 1, 2, 3, 4, 5, 6, 7, 9, -1, -1])
@@ -1114,7 +1087,6 @@ query             7 A-C-GG-AAC  0
         )
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[1],
                 np.array([9, 8, 7, 5, 4, 2, 0])
@@ -1126,7 +1098,6 @@ query             7 A-C-GG-AAC  0
             np.array_equal(
                 alignment.aligned,
                 # fmt: off
-# flake8: noqa
                 np.array([[[2, 3],
                               [4, 6],
                               [7, 8],
@@ -1153,7 +1124,6 @@ query             6 -C-GG-AAC 0
                 np.array(
                     [
                         # fmt: off
-# flake8: noqa
                         [ 1, 2,  3, 4, 5,  6, 7, -1, 8],
                         [-1, 5, -1, 4, 3, -1, 2,  1, 0],
                         # fmt: on
@@ -1165,7 +1135,6 @@ query             6 -C-GG-AAC 0
         self.assertEqual(len(inverse_indices), 2)
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[0],
                 np.array([-1, 0, 1, 2, 3, 4, 5, 6, 8, -1, -1])
@@ -1174,7 +1143,6 @@ query             6 -C-GG-AAC 0
         )
         self.assertTrue(
             # fmt: off
-# flake8: noqa
             np.array_equal(
                 inverse_indices[1],
                 np.array([8, 7, 6, 4, 3, 1, -1])
@@ -1262,7 +1230,6 @@ seq1              0 ACTT 4
         query = record.seq
         coordinates = np.array(
             # fmt: off
-# flake8: noqa
             [
                 [
                      503,  744,  744,  747,  748,  820,  820,  822,  822,  823,
@@ -2806,7 +2773,6 @@ class TestAlign_out_of_order(unittest.TestCase):
                 np.array_equal(
                     a,
                     # fmt: off
-# flake8: noqa
 np.array([['T', 'T', 'T', 'A', 'A', 'A', 'T', 'T', 'T', 'T', 'C', 'C', 'C', 'A', 'A', 'A', 'A', 'C', 'C'],
              ['T', 'G', 'T', '-', '-', '-', 'T', 'T', 'T', 'T', 'C', 'C', 'C', '-', '-', '-', '-', 'C', 'C']],
             dtype='U')
@@ -2818,7 +2784,6 @@ np.array([['T', 'T', 'T', 'A', 'A', 'A', 'T', 'T', 'T', 'T', 'C', 'C', 'C', 'A',
             np.array_equal(
                 self.multiple_array,
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'T', 'T', 'A', 'A', 'A', 'T', 'T', 'T', 'T', 'C', 'C', 'C', 'A', 'A', 'A', 'A', 'C', 'C'],
              ['T', 'T', 'T', 'A', 'A', 'A', 'T', 'T', 'T', 'T', 'C', 'C', 'C', 'A', 'A', 'A', 'A', 'C', 'C'],
              ['T', 'G', 'T', '-', '-', '-', 'T', 'T', 'T', 'T', 'C', 'C', 'C', '-', '-', '-', '-', 'C', 'C']],
@@ -3025,7 +2990,6 @@ query             7 CCC---- 10
             np.array_equal(
                 self.forward_alignment.aligned,
                 # fmt: off
-# flake8: noqa
                 np.array([[[16, 19],
                               [22, 26],
                               [ 2,  5],
@@ -3042,7 +3006,6 @@ query             7 CCC---- 10
             np.array_equal(
                 self.reverse_alignment.aligned,
                 # fmt: off
-# flake8: noqa
                 np.array([[[13, 10],
                               [ 7,  3],
                               [27, 24],
@@ -3062,7 +3025,6 @@ query             7 CCC---- 10
             np.array_equal(
                 indices,
                 # fmt: off
-# flake8: noqa
                 np.array([[16, 17, 18, 19, 20, 21, 22, 23, 24, 25,  2,  3,  4,  5,  6,  7, 8,  9, 10],
                              [ 0,  1,  2, -1, -1, -1,  3,  4,  5,  6,  7,  8,  9, -1, -1, -1, -1, 10, 11]])
                 # fmt: on
@@ -3089,7 +3051,6 @@ query             7 CCC---- 10
             np.array_equal(
                 indices,
                 # fmt: off
-# flake8: noqa
                 np.array([[12, 11, 10,  9,  8,  7,  6,  5,  4,  3, 26, 25, 24, 23, 22, 21, 20, 19, 18],
                              [ 0,  1,  2, -1, -1, -1,  3,  4,  5,  6,  7,  8,  9, -1, -1, -1, -1, 10, 11]])
                 # fmt: on
@@ -3116,7 +3077,6 @@ query             7 CCC---- 10
             np.array_equal(
                 indices,
                 # fmt: off
-# flake8: noqa
                 np.array([[16, 17, 18, 19, 20, 21, 22, 23, 24, 25,  2,  3,  4,  5,  6,  7,  8,  9, 10],
                              [12, 11, 10,  9,  8,  7,  6,  5,  4,  3, 26, 25, 24, 23, 22, 21, 20, 19, 18],
                              [ 0,  1,  2, -1, -1, -1,  3,  4,  5,  6,  7,  8,  9, -1, -1, -1, -1, 10, 11]])

--- a/Tests/test_Align_a2m.py
+++ b/Tests/test_Align_a2m.py
@@ -468,7 +468,6 @@ GCTGGGGATGGAGAGGGAACAGAGTaG
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'C', 'T', 'G', 'G', 'G', 'G', 'A', 'T', 'G', 'G', 'A', 'G', 'A',
            'G', 'G', 'G', 'A', 'A', 'C', 'A', 'G', 'A', 'G', 'T', '-', 'T'],
           ['G', 'C', 'T', 'G', 'G', 'G', 'G', 'A', 'T', 'G', 'G', 'A', 'G', 'A',
@@ -577,7 +576,6 @@ VhMLNKGKDGAMVFEPASLKVAPGDTVTFIPTDK-GHNVETIKGMIPDG.AE.A-------FKSKINENYKVTFTA...P
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['D', '-', 'V', 'L', 'L', 'G', 'A', 'N', 'G', 'G', 'V', 'L', 'V',
            'F', 'E', 'P', 'N', 'D', 'F', 'S', 'V', 'K', 'A', 'G', 'E', 'T',
            'I', 'T', 'F', 'K', 'N', 'N', 'A', 'G', 'Y', 'P', 'H', 'N', 'V',

--- a/Tests/test_Align_bed.py
+++ b/Tests/test_Align_bed.py
@@ -54,7 +54,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42530895, 42530958, 42532020,
                            42532095, 42532563, 42532606],
                           [     181,      118,      118,
@@ -68,7 +67,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[36.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0., 40.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  0., 57.,  0.,  0.,  0.,  0.,  0.],
@@ -221,7 +219,6 @@ chr3	42530895	42532606	NR_046654.1	1000	-	42530895	42532606	0	3	63,75,43,	0,1125
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42530895, 42530922, 42530958, 42532020, 42532037,
                            42532039, 42532095, 42532563, 42532606],
                           [     179,      152,      116,      116,       99,
@@ -369,7 +366,6 @@ chr3	42530895	42532606	NR_046654.1_modified	978	-	42530895	42532606	0	5	27,36,17
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48663767, 48663813, 48665640,
                            48665722, 48669098, 48669174],
                           [       0,       46,       46,
@@ -383,7 +379,6 @@ chr3	42530895	42532606	NR_046654.1_modified	978	-	42530895	42532606	0	5	27,36,17
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[53.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0., 35.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  0., 50.,  0.,  0.,  0.,  0.,  0.],
@@ -784,7 +779,6 @@ chr3	48663767	48669174	NR_111921.1	1000	+	48663767	48669174	0	3	46,82,76,	0,1873
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48663767, 48663795, 48663796, 48663813, 48665640,
                            48665716, 48665722, 48669098, 48669174],
                           [       0,       28,       28,       45,       45,
@@ -1220,7 +1214,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [       0,       16]]),
                 # fmt: on
@@ -1254,7 +1247,6 @@ chr4	61646095	61646111	hg19_dna	1000	+	61646095	61646111	0	1	16,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -1288,7 +1280,6 @@ chr1	10271783	10271816	hg19_dna	1000	+	10271783	10271816	0	1	33,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      17,        0]]),
                 # fmt: on
@@ -1322,7 +1313,6 @@ chr2	53575980	53575997	hg19_dna	1000	-	53575980	53575997	0	1	17,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       0,       41]]),
                 # fmt: on
@@ -1356,7 +1346,6 @@ chr9	85737865	85737906	hg19_dna	854	+	85737865	85737906	0	1	41,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       0,       41]]),
                 # fmt: on
@@ -1390,7 +1379,6 @@ chr8	95160479	95160520	hg19_dna	1000	+	95160479	95160520	0	1	41,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [       0,       36]]),
                 # fmt: on
@@ -1424,7 +1412,6 @@ chr22	42144400	42144436	hg19_dna	834	+	42144400	42144436	0	1	36,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183926028],
                           [        0,         6,        44]]),
                 # fmt: on
@@ -1458,7 +1445,6 @@ chr2	183925984	183926028	hg19_dna	682	+	183925984	183926028	0	2	6,38,	0,6,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [       0,       25,       25,       36]]),
                 # fmt: on
@@ -1500,7 +1486,6 @@ chr19	35483340	35483510	hg19_dna	890	+	35483340	35483510	0	2	25,11,	0,159,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [       0,       39]]),
                 # fmt: on
@@ -1534,7 +1519,6 @@ chr18	23891310	23891349	hg19_dna	1000	+	23891310	23891349	0	1	39,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [       0,       28]]),
                 # fmt: on
@@ -1568,7 +1552,6 @@ chr18	43252217	43252245	hg19_dna	930	+	43252217	43252245	0	1	28,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759198],
                           [       0,        7,        7,       45]]),
                 # fmt: on
@@ -1602,7 +1585,6 @@ chr13	52759147	52759198	hg19_dna	912	+	52759147	52759198	0	2	7,38,	0,13,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -1636,7 +1618,6 @@ chr1	1207056	1207106	hg19_dna	1000	+	1207056	1207106	0	1	50,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       0,       34]]),
                 # fmt: on
@@ -1670,7 +1651,6 @@ chr1	61700837	61700871	hg19_dna	824	+	61700837	61700871	0	1	34,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558191],
                           [      28,       18,       18,        0]]),
                 # fmt: on
@@ -1704,7 +1684,6 @@ chr4	37558157	37558191	hg19_dna	572	-	37558157	37558191	0	2	10,18,	0,16,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      37,        0]]),
                 # fmt: on
@@ -1738,7 +1717,6 @@ chr22	48997405	48997442	hg19_dna	892	-	48997405	48997442	0	1	37,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       36,         0]]),
                 # fmt: on
@@ -1772,7 +1750,6 @@ chr2	120641740	120641776	hg19_dna	946	-	120641740	120641776	0	1	36,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      39,        0]]),
                 # fmt: on
@@ -1806,7 +1783,6 @@ chr19	54017130	54017169	hg19_dna	1000	-	54017130	54017169	0	1	39,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    39,      0]]),
                 # fmt: on
@@ -1840,7 +1816,6 @@ chr19	553742	553781	hg19_dna	848	-	553742	553781	0	1	39,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      36,        0]]),
                 # fmt: on
@@ -1874,7 +1849,6 @@ chr10	99388555	99388591	hg19_dna	834	-	99388555	99388591	0	1	36,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       25,         0]]),
                 # fmt: on
@@ -1908,7 +1882,6 @@ chr10	112178171	112178196	hg19_dna	920	-	112178171	112178196	0	1	25,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[39368490, 39368526],
                           [      36,        0]]),
                 # fmt: on
@@ -1942,7 +1915,6 @@ chr1	39368490	39368526	hg19_dna	946	-	39368490	39368526	0	1	36,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       34,         0]]),
                 # fmt: on
@@ -1996,7 +1968,6 @@ chr1	220325687	220325721	hg19_dna	942	-	220325687	220325721	0	1	34,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [       0,       16]]),
                 # fmt: on
@@ -2030,7 +2001,6 @@ chr4	61646095	61646111	hg18_dna	1000	+	61646095	61646111	0	1	16,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -2064,7 +2034,6 @@ chr1	10271783	10271816	hg18_dna	1000	+	10271783	10271816	0	1	33,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      17,        0]]),
                 # fmt: on
@@ -2118,7 +2087,6 @@ chr2	53575980	53575997	hg18_dna	1000	-	53575980	53575997	0	1	17,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       0,       41]]),
                 # fmt: on
@@ -2152,7 +2120,6 @@ chr9	85737865	85737906	hg19_dna	854	+	85737865	85737906	0	1	41,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       0,       41]]),
                 # fmt: on
@@ -2186,7 +2153,6 @@ chr8	95160479	95160520	hg19_dna	1000	+	95160479	95160520	0	1	41,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [       0,       36]]),
                 # fmt: on
@@ -2220,7 +2186,6 @@ chr22	42144400	42144436	hg19_dna	834	+	42144400	42144436	0	1	36,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183926028],
                           [        0,         6,        44]]),
                 # fmt: on
@@ -2254,7 +2219,6 @@ chr2	183925984	183926028	hg19_dna	682	+	183925984	183926028	0	2	6,38,	0,6,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [       0,       25,       25,       36]]),
                 # fmt: on
@@ -2296,7 +2260,6 @@ chr19	35483340	35483510	hg19_dna	890	+	35483340	35483510	0	2	25,11,	0,159,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [       0,       39]]),
                 # fmt: on
@@ -2330,7 +2293,6 @@ chr18	23891310	23891349	hg19_dna	1000	+	23891310	23891349	0	1	39,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [       0,       28]]),
                 # fmt: on
@@ -2364,7 +2326,6 @@ chr18	43252217	43252245	hg19_dna	930	+	43252217	43252245	0	1	28,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759198],
                           [       0,        7,        7,       45]]),
                 # fmt: on
@@ -2398,7 +2359,6 @@ chr13	52759147	52759198	hg19_dna	912	+	52759147	52759198	0	2	7,38,	0,13,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -2432,7 +2392,6 @@ chr1	1207056	1207106	hg19_dna	1000	+	1207056	1207106	0	1	50,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       0,       34]]),
                 # fmt: on
@@ -2466,7 +2425,6 @@ chr1	61700837	61700871	hg19_dna	824	+	61700837	61700871	0	1	34,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558191],
                           [      28,       18,       18,        0]]),
                 # fmt: on
@@ -2500,7 +2458,6 @@ chr4	37558157	37558191	hg19_dna	572	-	37558157	37558191	0	2	10,18,	0,16,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      37,        0]]),
                 # fmt: on
@@ -2534,7 +2491,6 @@ chr22	48997405	48997442	hg19_dna	892	-	48997405	48997442	0	1	37,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       36,         0]]),
                 # fmt: on
@@ -2568,7 +2524,6 @@ chr2	120641740	120641776	hg19_dna	946	-	120641740	120641776	0	1	36,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      39,        0]]),
                 # fmt: on
@@ -2602,7 +2557,6 @@ chr19	54017130	54017169	hg19_dna	1000	-	54017130	54017169	0	1	39,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    39,      0]]),
                 # fmt: on
@@ -2636,7 +2590,6 @@ chr19	553742	553781	hg19_dna	848	-	553742	553781	0	1	39,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      36,        0]]),
                 # fmt: on
@@ -2670,7 +2623,6 @@ chr10	99388555	99388591	hg19_dna	834	-	99388555	99388591	0	1	36,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       25,         0]]),
                 # fmt: on
@@ -2704,7 +2656,6 @@ chr10	112178171	112178196	hg19_dna	920	-	112178171	112178196	0	1	25,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[39368490, 39368526],
                           [      36,        0]]),
                 # fmt: on
@@ -2738,7 +2689,6 @@ chr1	39368490	39368526	hg19_dna	946	-	39368490	39368526	0	1	36,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       34,         0]]),
                 # fmt: on
@@ -2792,7 +2742,6 @@ chr1	220325687	220325721	hg19_dna	942	-	220325687	220325721	0	1	34,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [       0,       16]]),
                 # fmt: on
@@ -2826,7 +2775,6 @@ chr4	61646095	61646111	hg19_dna	1000	+	61646095	61646111	0	1	16,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -2860,7 +2808,6 @@ chr1	10271783	10271816	hg19_dna	1000	+	10271783	10271816	0	1	33,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      17,        0]]),
                 # fmt: on
@@ -2894,7 +2841,6 @@ chr2	53575980	53575997	hg19_dna	1000	-	53575980	53575997	0	1	17,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       0,       41]]),
                 # fmt: on
@@ -2928,7 +2874,6 @@ chr9	85737865	85737906	hg19_dna	854	+	85737865	85737906	0	1	41,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       0,       41]]),
                 # fmt: on
@@ -2962,7 +2907,6 @@ chr8	95160479	95160520	hg19_dna	1000	+	95160479	95160520	0	1	41,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [       0,       36]]),
                 # fmt: on
@@ -2996,7 +2940,6 @@ chr22	42144400	42144436	hg19_dna	834	+	42144400	42144436	0	1	36,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183926028],
                           [        0,         6,        44]]),
                 # fmt: on
@@ -3030,7 +2973,6 @@ chr2	183925984	183926028	hg19_dna	682	+	183925984	183926028	0	2	6,38,	0,6,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [       0,       25,       25,       36]]),
                 # fmt: on
@@ -3072,7 +3014,6 @@ chr19	35483340	35483510	hg19_dna	890	+	35483340	35483510	0	2	25,11,	0,159,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [       0,       39]]),
                 # fmt: on
@@ -3106,7 +3047,6 @@ chr18	23891310	23891349	hg19_dna	1000	+	23891310	23891349	0	1	39,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [       0,       28]]),
                 # fmt: on
@@ -3140,7 +3080,6 @@ chr18	43252217	43252245	hg19_dna	930	+	43252217	43252245	0	1	28,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759198],
                           [       0,        7,        7,       45]]),
                 # fmt: on
@@ -3174,7 +3113,6 @@ chr13	52759147	52759198	hg19_dna	912	+	52759147	52759198	0	2	7,38,	0,13,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -3208,7 +3146,6 @@ chr1	1207056	1207106	hg19_dna	1000	+	1207056	1207106	0	1	50,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       0,       34]]),
                 # fmt: on
@@ -3242,7 +3179,6 @@ chr1	61700837	61700871	hg19_dna	824	+	61700837	61700871	0	1	34,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558191],
                           [      28,       18,       18,        0]]),
                 # fmt: on
@@ -3276,7 +3212,6 @@ chr4	37558157	37558191	hg19_dna	572	-	37558157	37558191	0	2	10,18,	0,16,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      37,        0]]),
                 # fmt: on
@@ -3310,7 +3245,6 @@ chr22	48997405	48997442	hg19_dna	892	-	48997405	48997442	0	1	37,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       36,         0]]),
                 # fmt: on
@@ -3344,7 +3278,6 @@ chr2	120641740	120641776	hg19_dna	946	-	120641740	120641776	0	1	36,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      39,        0]]),
                 # fmt: on
@@ -3378,7 +3311,6 @@ chr19	54017130	54017169	hg19_dna	1000	-	54017130	54017169	0	1	39,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    39,      0]]),
                 # fmt: on
@@ -3412,7 +3344,6 @@ chr19	553742	553781	hg19_dna	848	-	553742	553781	0	1	39,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      36,        0]]),
                 # fmt: on
@@ -3446,7 +3377,6 @@ chr10	99388555	99388591	hg19_dna	834	-	99388555	99388591	0	1	36,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       25,         0]]),
                 # fmt: on
@@ -3513,7 +3443,6 @@ chr1	39368490	39368526	hg19_dna	946	-	39368490	39368526	0	1	36,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       34,         0]]),
                 # fmt: on
@@ -3568,7 +3497,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75566694, 75566850],
                           [       0,      156]]),
                 # fmt: on
@@ -3609,7 +3537,6 @@ chr13	75566694	75566850	CAG33136.1	1000	+	75566694	75566850	0	1	156,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75560749, 75560881],
                           [       0,      132]]),
                 # fmt: on
@@ -3650,7 +3577,6 @@ chr13	75560749	75560881	CAG33136.1	1000	+	75560749	75560881	0	1	132,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75549820, 75549865, 75567225, 75567312],
                           [       0,       45,       45,      132]]),
                 # fmt: on
@@ -4847,7 +4773,6 @@ chr13	75549820	75567312	CAG33136.1	986	+	75549820	75567312	0	2	45,87,	0,17405,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75604767, 75604827, 75605728, 75605809],
                           [       0,       60,       60,      141]]),
                 # fmt: on
@@ -4948,7 +4873,6 @@ chr13	75604767	75605809	CAG33136.1	1000	+	75604767	75605809	0	2	60,81,	0,961,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75594914, 75594989],
                           [       0,       75]]),
                 # fmt: on
@@ -4985,7 +4909,6 @@ chr13	75594914	75594989	CAG33136.1	1000	+	75594914	75594989	0	1	75,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75569459, 75569507],
                           [       0,       48]]),
                 # fmt: on
@@ -5018,7 +4941,6 @@ chr13	75569459	75569507	CAG33136.1	1000	+	75569459	75569507	0	1	48,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[41260685, 41260787],
                           [       0,      102]]),
                 # fmt: on
@@ -5055,7 +4977,6 @@ chr4	41260685	41260787	CAG33136.1	530	+	41260685	41260787	0	1	102,	0,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[41257605, 41257731, 41263227, 41263290],
                           [       0,      126,      126,      189]]),
                 # fmt: on
@@ -5484,7 +5405,6 @@ chr4	41257605	41263290	CAG33136.1	166	+	41257605	41263290	0	2	126,63,	0,5622,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[9712654, 9712786, 9715941, 9716097, 9716445, 9716532, 9718374,
                            9718422, 9739264, 9739339, 9743706, 9743766, 9744511, 9744592],
                           [      0,     132,     132,     288,     288,     375,     375,
@@ -7647,7 +7567,6 @@ KI537979	9712654	9744592	CAG33136.1	972	+	9712654	9744592	0	7	132,156,87,48,75,6
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[2103463, 2103523, 2103522, 2104149],
                           [      0,      60,      60,     687]]),
                 # fmt: on
@@ -7728,7 +7647,6 @@ KI538594	2103463	2104149	CAG33136.1	792	+	2103463	2104149	0	2	60,627,	0,59,
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[20872390, 20872471, 20872472, 20873021],
                           [     630,      549,      549,        0]]),
                 # fmt: on
@@ -7835,7 +7753,6 @@ class TestAlign_bed12(unittest.TestCase):
                     np.array_equal(
                         alignment.coordinates,
                         # fmt: off
-# flake8: noqa
                         np.array([[1000, 1567, 4512, 5000],
                                   [   0,  567,  567, 1055]]),
                         # fmt: on
@@ -7905,7 +7822,6 @@ class TestAlign_bed12(unittest.TestCase):
                     np.array_equal(
                         alignment.coordinates,
                         # fmt: off
-# flake8: noqa
                         np.array([[2000, 2433, 5601, 6000],
                                   [ 832,  399,  399,    0]])
                         # fmt: on

--- a/Tests/test_Align_bigbed.py
+++ b/Tests/test_Align_bigbed.py
@@ -1934,7 +1934,6 @@ table bed
 
     def test_reading_psl_35_001(self):
         """Test parsing psl_35_001.bb."""
-
         alignments = Align.parse(self.path, "bigbed")
         self.check_alignments(alignments)
 

--- a/Tests/test_Align_bigbed.py
+++ b/Tests/test_Align_bigbed.py
@@ -125,7 +125,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42530895, 42530958, 42532020,
                            42532095, 42532563, 42532606],
                           [     181,      118,      118,
@@ -139,7 +138,6 @@ table bed
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[36.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0., 40.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  0., 57.,  0.,  0.,  0.,  0.,  0.],
@@ -168,7 +166,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42530895, 42530922, 42530958, 42532020, 42532037,
                            42532039, 42532095, 42532563, 42532606],
                           [     179,      152,      116,      116,       99,
@@ -190,7 +187,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48663767, 48663813, 48665640,
                            48665722, 48669098, 48669174],
                           [       0,       46,       46,
@@ -204,7 +200,6 @@ table bed
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[53.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0., 35.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  0., 50.,  0.,  0.,  0.,  0.,  0.],
@@ -231,7 +226,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48663767, 48663795, 48663796, 48663813, 48665640,
                            48665716, 48665722, 48669098, 48669174],
                           [       0,       28,       28,       45,       45,
@@ -321,7 +315,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -341,7 +334,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -361,7 +353,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[39368490, 39368526],
                           [      36,        0]]),
                 # fmt: on
@@ -381,7 +372,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       0,       34]]),
                 # fmt: on
@@ -401,7 +391,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       34,         0]]),
                 # fmt: on
@@ -421,7 +410,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      36,        0]]),
                 # fmt: on
@@ -441,7 +429,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       25,         0]]),
                 # fmt: on
@@ -461,7 +448,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759198],
                           [       0,        7,        7,       45]]),
                 # fmt: on
@@ -481,7 +467,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [       0,       39]]),
                 # fmt: on
@@ -501,7 +486,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [       0,       28]]),
                 # fmt: on
@@ -521,7 +505,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    39,      0]]),
                 # fmt: on
@@ -541,7 +524,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [       0,       25,       25,       36]]),
                 # fmt: on
@@ -561,7 +543,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      39,        0]]),
                 # fmt: on
@@ -581,7 +562,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      17,        0]]),
                 # fmt: on
@@ -601,7 +581,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       36,         0]]),
                 # fmt: on
@@ -621,7 +600,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183926028],
                           [        0,         6,        44]]),
                 # fmt: on
@@ -641,7 +619,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [       0,       36]]),
                 # fmt: on
@@ -661,7 +638,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      37,        0]]),
                 # fmt: on
@@ -681,7 +657,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558191],
                           [      28,       18,       18,        0]]),
                 # fmt: on
@@ -701,7 +676,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [       0,       16]]),
                 # fmt: on
@@ -721,7 +695,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       0,       41]]),
                 # fmt: on
@@ -741,7 +714,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       0,       41]]),
                 # fmt: on
@@ -810,7 +782,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -830,7 +801,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      17,        0]]),
                 # fmt: on
@@ -850,7 +820,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [       0,       16]]),
                 # fmt: on
@@ -933,7 +902,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -953,7 +921,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[39368490, 39368526],
                           [      36,        0]]),
                 # fmt: on
@@ -973,7 +940,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       0,       34]]),
                 # fmt: on
@@ -993,7 +959,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       34,         0]]),
                 # fmt: on
@@ -1013,7 +978,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      36,        0]]),
                 # fmt: on
@@ -1033,7 +997,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       25,         0]]),
                 # fmt: on
@@ -1053,7 +1016,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759198],
                           [       0,        7,        7,       45]]),
                 # fmt: on
@@ -1073,7 +1035,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [       0,       39]]),
                 # fmt: on
@@ -1093,7 +1054,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [       0,       28]]),
                 # fmt: on
@@ -1113,7 +1073,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    39,      0]]),
                 # fmt: on
@@ -1133,7 +1092,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [       0,       25,       25,       36]]),
                 # fmt: on
@@ -1153,7 +1111,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      39,        0]]),
                 # fmt: on
@@ -1173,7 +1130,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       36,         0]]),
                 # fmt: on
@@ -1193,7 +1149,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183926028],
                           [        0,         6,        44]]),
                 # fmt: on
@@ -1213,7 +1168,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [       0,       36]]),
                 # fmt: on
@@ -1233,7 +1187,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      37,        0]]),
                 # fmt: on
@@ -1253,7 +1206,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558191],
                           [      28,       18,       18,        0]]),
                 # fmt: on
@@ -1273,7 +1225,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       0,       41]]),
                 # fmt: on
@@ -1293,7 +1244,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       0,       41]]),
                 # fmt: on
@@ -1376,7 +1326,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -1396,7 +1345,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -1435,7 +1383,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       0,       34]]),
                 # fmt: on
@@ -1455,7 +1402,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       34,         0]]),
                 # fmt: on
@@ -1475,7 +1421,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      36,        0]]),
                 # fmt: on
@@ -1495,7 +1440,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       25,         0]]),
                 # fmt: on
@@ -1515,7 +1459,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759198],
                           [       0,        7,        7,       45]]),
                 # fmt: on
@@ -1535,7 +1478,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [       0,       39]]),
                 # fmt: on
@@ -1555,7 +1497,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [       0,       28]]),
                 # fmt: on
@@ -1575,7 +1516,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    39,      0]]),
                 # fmt: on
@@ -1595,7 +1535,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [       0,       25,       25,       36]]),
                 # fmt: on
@@ -1615,7 +1554,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      39,        0]]),
                 # fmt: on
@@ -1635,7 +1573,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      17,        0]]),
                 # fmt: on
@@ -1655,7 +1592,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       36,         0]]),
                 # fmt: on
@@ -1675,7 +1611,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183926028],
                           [        0,         6,        44]]),
                 # fmt: on
@@ -1695,7 +1630,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [       0,       36]]),
                 # fmt: on
@@ -1715,7 +1649,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      37,        0]]),
                 # fmt: on
@@ -1735,7 +1668,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558191],
                           [      28,       18,       18,        0]]),
                 # fmt: on
@@ -1755,7 +1687,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [       0,       16]]),
                 # fmt: on
@@ -1775,7 +1706,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       0,       41]]),
                 # fmt: on
@@ -1795,7 +1725,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       0,       41]]),
                 # fmt: on
@@ -1870,7 +1799,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75549820, 75549865, 75567225, 75567312],
                           [       0,       45,       45,      132]]),
                 # fmt: on
@@ -1889,7 +1817,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75560749, 75560881],
                           [       0,      132]]),
                 # fmt: on
@@ -1908,7 +1835,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75566694, 75566850],
                           [       0,      156]]),
                 # fmt: on
@@ -1927,7 +1853,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75569459, 75569507],
                           [       0,       48]]),
                 # fmt: on
@@ -1946,7 +1871,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75594914, 75594989],
                           [       0,       75]]),
                 # fmt: on
@@ -1965,7 +1889,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75604767, 75604827, 75605728, 75605809],
                           [       0,       60,       60,      141]]),
                 # fmt: on
@@ -1984,7 +1907,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[41257605, 41257731, 41263227, 41263290],
                           [       0,      126,      126,      189]]),
                 # fmt: on
@@ -2003,7 +1925,6 @@ table bed
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[41260685, 41260787],
                           [       0,      102]]),
                 # fmt: on
@@ -2209,7 +2130,6 @@ table bed
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[1000, 1567, 4512, 5000],
                               [   0,  567,  567, 1055]]),
                     # fmt: on
@@ -2262,7 +2182,6 @@ table bed
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[2000, 2433, 5601, 6000],
                               [ 832,  399,  399,    0]])
                     # fmt: on

--- a/Tests/test_Align_bigmaf.py
+++ b/Tests/test_Align_bigmaf.py
@@ -140,7 +140,6 @@ rn3.chr4   81344243 -AA-GGGGATGCTAAGCCAATGAGTTGTTGTCTCTCAATGTG 81344283
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'A', 'A', '-', 'G', 'G', 'G', 'A', 'A', 'T', 'G', 'T', 'T',
            'A', 'A', 'C', 'C', 'A', 'A', 'A', 'T', 'G', 'A', '-', '-', '-',
            'A', 'T', 'T', 'G', 'T', 'C', 'T', 'C', 'T', 'T', 'A', 'C', 'G',
@@ -217,7 +216,6 @@ rn3.chr4   81444246 taagga 81444252
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'A', 'A', 'A', 'G', 'A'],
           ['T', 'A', 'A', 'A', 'G', 'A'],
           ['T', 'A', 'A', 'A', 'G', 'A'],
@@ -281,7 +279,6 @@ mm4.chr6   53310102 ACAGCTGAAAATA 53310115
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['g', 'c', 'a', 'g', 'c', 't', 'g', 'a', 'a', 'a', 'a', 'c', 'a'],
           ['g', 'c', 'a', 'g', 'c', 't', 'g', 'a', 'a', 'a', 'a', 'c', 'a'],
           ['g', 'c', 'a', 'g', 'c', 't', 'g', 'a', 'a', 'a', 'a', 'c', 'a'],
@@ -350,7 +347,6 @@ table bedMaf
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'C', 'A', 'T', 'A', 'G', 'G', 'T', 'A', 'T', 'T', 'T', 'A',
            'T', 'T', 'T', 'T', 'T', 'A', 'A', 'A', 'T', 'A', 'T', 'G', 'G',
            'T', 'T', 'T', 'G', 'C', 'T', 'T', 'T', 'A', 'T', 'G', 'G', 'C',
@@ -431,7 +427,6 @@ oryCun1.s     11207 TGTTTTCTCCATGGAAACTGATGTCAAATACTTTCCCTTTGGTT   11251
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[3009319, 3009392, 3009392, 3009481],
                           [  11087,   11160,   11162,   11251],
                          ])
@@ -544,7 +539,6 @@ oryCun1.s     11207 TGTTTTCTCCATGGAAACTGATGTCAAATACTTTCCCTTTGGTT   11251
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'C', 'A', 'T', 'A', 'G', 'G', 'T', 'A', 'T', 'T', 'T', 'A',
            'T', 'T', 'T', 'T', 'T', 'A', 'A', 'A', 'T', 'A', 'T', 'G', 'G',
            'T', 'T', 'T', 'G', 'C', 'T', 'T', 'T', 'A', 'T', 'G', 'G', 'C',
@@ -840,7 +834,6 @@ otoGar1.s    178845 GGGAAGC    178838
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'G', 'G', 'G', 'T', 'C', 'C', 'C', 'C', 'T', 'T', 'G', 'G',
            'C', 'A', 'C', 'A', 'T', 'C', 'C', 'A', 'G', 'A', 'T', 'C', 'T',
            'C', 'C', 'C', 'C', 'A', 'G', 'T', 'T', 'A', 'A', 'C', 'C', 'T',
@@ -1549,7 +1542,6 @@ mm9.chr10   3013398 AAAATAAAAAACCCAACCTAAACCAAATAACAAAACACT 3013437
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['a', 'g', 'c', 'c', 'a', 'g', 'g', 'c', 'g', 't', 'g', 'g', 't',
            'g', 'g', 'c', 'a', 'c', 'a', 'c', 'a', 'c', 'c', 't', 't', 't',
            'a', 'c', 't', 'c', 'c', 'c', 'a', 'g', 'c', 'a', 't', 't', 't',
@@ -1685,7 +1677,6 @@ ponAbe2.c 158049029 TCCTATTTTATGGGTGTATCGTTTTGCATTCATGGGCTGTTTGATA 158048983
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'C', 'C', 'A', 'A', 'A', 'A', 'T', 'G', 'G', 'T', 'T', 'A',
            'G', 'C', 'T', 'A', 'T', 'G', 'C', 'C', 'C', 'A', 'A', 'C', 'T',
            'C', 'C', 'T', 'T', 'T', 'C', 'A', 'C', 'T', 'C', 'C', 'A', 'A',
@@ -1965,7 +1956,6 @@ loxAfr1.s      9407 ------------TTTGGTTAGAA-TTATGCTTTAATTCAAAAC-TTCC      9373
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'T', 'G', 'T', 'A', 'C', 'C', '-', '-', '-', 'C', 'T',
            'T', 'T', 'G', 'G', 'T', 'G', 'A', 'G', 'A', 'A', 'T', 'T', 'T',
            'T', 'T', 'G', 'T', 'T', 'T', 'C', 'A', 'G', 'T', 'G', 'T', 'T',
@@ -2135,7 +2125,6 @@ loxAfr1.s      9319
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'G', 'G', 'A', 'G', 'C', 'A', 'T', 'A', 'A', 'A', 'A', 'C', 'T',
            'C', 'T', 'A', 'A', 'A', 'T', 'C', 'T', 'G', 'C', 'T', 'A', 'A', 'A',
            'T', 'G', 'T', 'C', 'T', 'T', 'G', 'T', 'C', 'C', 'C', 'T', '-', 'T',
@@ -2270,7 +2259,6 @@ loxAfr1.s      9317 AGGCTTA-----TG----CCACCCCCCACCCCCACA    9290
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'A', 'G', 'T', 'T', 'C', 'C', 'C', 'T', 'C', 'C', 'A', 'T',
            'A', 'A', 'T', 'T', 'C', 'C', 'T', 'T', 'C', 'C', 'T', 'C', 'C',
            'C', 'A', 'C', 'C', 'C', 'C', 'C', 'A', 'C', 'A'],
@@ -2357,7 +2345,6 @@ mm9.chr10   3014778 TCCCATGTCCACCCTGA 3014795
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'C', 'C', 'C', 'A', 'T', 'G', 'T', 'C', 'C', 'A', 'C', 'C',
            'C', 'T', 'G', 'A']], dtype='U')
                 # fmt: on
@@ -2576,7 +2563,6 @@ loxAfr1.s      9207 CTCt      9203
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'T', 'T', 'T', 'C', 'A', 'G', 'G', 'G', 'G', 'C', 'A', 'G',
            'C', 'T', 'C', 'G', 'C', 'T', 'G', '-', '-', '-', '-', '-', '-',
            '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'T', 'T', 'A',
@@ -3120,7 +3106,6 @@ otoGar1.s    174889 ------------    174889
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['c', 'c', 'a', 't', 't', 't', 't', '-', '-', '-', '-', '-', '-',
            '-', '-', '-', '-', 't', 't', 'a', 't', 't', 'a', 'g', 'g', 't',
            'a', 't', 't', 't', 'a', 'g', 'c', 't', 'c', 'a', 't', 't', 't',
@@ -3444,7 +3429,6 @@ panTro2.c 157518516 TTGCCTTTTCCCAAATCTCCACTTCCACC 157518487
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'T', 'T', 'T', 'T', 'A', 'T', 'T', 'T', 'G', 'C', 'A', 'G',
            'G', 'T', 'T', 'T', 'C', 'T', 'T', 'T', 'A', 'C', '-', '-', '-',
            '-', 'A', 'G', 'T', 'T', 'C', 'T', 'C', 'T', 'T', 'T', 'C', 'A',
@@ -3565,7 +3549,6 @@ mm9.chr10   3018161
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'C', 'C', 'A', 'C', 'A', 'G', 'A', 'C', 'C', 'T', 'T', 'C',
            'T', 'G', 'T', 'T', 'T', 'A', 'G', 'T', 'C', 'C', 'A', 'A', 'A',
            'G', 'G', 'A', 'C', 'G', 'C', 'A', 'A', 'A', 'T', 'T', 'A', 'T',
@@ -3730,7 +3713,6 @@ ponAbe2.c 158040566 TTTTATTTTATTGA 158040552
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'T', 'C', 'C', 'A', 'C', 'A', 'A', 'A', 'A', 'G', 'A', 'G',
            'A', 'C', '-', '-', '-', '-', '-', 'A', 'A', 'A', 'G', 'A', 'A',
            'G', 'A', 'A', 'A', 'A', 'C', 'C', 'A', 'A', 'A', 'A', 'G', 'A',
@@ -3882,7 +3864,6 @@ panTro2.c 157518285 ttaggtatatg 157518274
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'G', 'G', 'A', '-', 'C', 'A', 'A', 'A', 'A', 'T', 'A', 'A', 'T',
            'A', 'C', 'A', 'G', 'A', 't', 't', 't', 't', 't', 't', 't', 't', 't',
            't', 't', 't', 't', 't', 't', 't', 't', 't', 't', 't', 't', 'G', 'C',
@@ -4075,7 +4056,6 @@ ponAbe2.c 158040338 ATCCTTTTCTTT-- 158040326
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'T', '-', 'C', 'A', 'A', 'A', 'C', 'A', 'T', 'G', 'C', 'A', 'T',
            'A', 'C', 'A', 'T', 'G', 'C', 'A', 'T', 'T', 'C', 'A', 'T', 'G', 'T',
            'C', 'T', 'C', 'A', 'T', 'A', 'A', '-', 'T', 'A', 'A', 'T', 'T', 'A',
@@ -4208,7 +4188,6 @@ mm9.chr10   3018602 agaggaggaaaggaggagaggggaggagaggaggggagGTAT 3018644
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['t', 'c', 't', 't', 'c', 'a', 't', 'c', 't', 'c', 'c', 't', 'c',
            't', 't', 't', 't', 'c', 'c', 't', 'c', 'c', 't', 't', 't', 't',
            't', 't', 't', 't', 't', 't', 'c', 't', 'c', 'a', 't', 't', 't',
@@ -4351,7 +4330,6 @@ canFam2.c  47545665 TATGAAATATAAAATTTCCCTATTGAAGAATTT 47545632
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'G', 'G', 'G', 'T', 'A', 'G', 'G', 'C', 'C', 'A', 'A', 'G',
            'T', 'G', 'C', 'C', 'T', 'T', 'G', 'G', 'G', 'A', 'A', 'G', 'T',
            'A', 'G', 'T', 'T', 'G', 'T', 'T', 'G', 'G', 'T', 'A', 'G', 'A',
@@ -4509,7 +4487,6 @@ canFam2.c  47545353
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'T', 'G', 'C', 'C', 'T', 'T', 'C', 'C', 'A', 'T', 'T', 'A',
            'C', 'G', 'A', 'T', 'T', 'T', 'A', 'C', 'T', 'G', 'A', 'T', 'C',
            'A', 'C', 'T', 'T', 'A', 'C', 'A', 'A', 'C', 'C', 'C', 'T', 'C',
@@ -4630,7 +4607,6 @@ mm9.chr10   3019232 tggcaccactcctggtccaagaatatacaaaccatgaca 3019271
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['g', 't', 'c', 't', 'g', 'a', 'g', 't', 't', 'a', 'g', 'g', 'g',
            't', 't', 't', 't', 'a', 'c', 't', 'g', 'c', 't', 'g', 't', 'g',
            'a', 'a', 'c', 'a', 'g', 'a', 'c', 'a', 'c', 'c', 'a', 't', 'g',
@@ -4781,7 +4757,6 @@ canFam2.c  47545247
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'A', 'G', 'A', 'C', 'C', 'A', 'A', 'A', 'T', 'G', '-', '-',
            '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'T', 'G', 'G',
            'C', 'G', 'C', 'T', 'C', 'A', 'C', 'G', '-', 'T', 'G', 'A', 'G',
@@ -4941,7 +4916,6 @@ canFam2.c  47545187 tgacctagaatctcagaggatg---ggactc 47545159
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'C', 'C', 'A', 'G', 'C', 'A', 'T', 'T', 'C', 'T', 'G',
            'G', 'C', 'A', 'G', 'A', 'C', 'A', 'C', 'A', 'G', 'T', 'G', '-',
            'A', 'A', 'A', 'A', 'G', 'A', 'G', 'A', 'C', 'A', 'G', 'A', 'T',
@@ -5124,7 +5098,6 @@ felCat3.s     46757 ---ACGTGTTTTTAAAAATAG-TTTTCATGTTGTTCTGATGTGTGTT     46714
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'A', 'G', 'A', 'T', 'A', 'G', 'A', 'T', 'A', 'T', 'T', 'T',
            'A', 'G', 'A', 'A', 'G', 'T', 'A', 'G', 'C', 'T', 'T', 'T', 'T',
            'T', 'A', 'T', 'G', 'T', 'T', 'T', 'T', 'T', 'C', 'T', 'G', 'A',
@@ -5323,7 +5296,6 @@ canFam2.c  47545018
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'G', 'C', 'A', 'T', 'C', 'A', 'T', 'T', 'A', 'A', 'G', 'A', 'C',
            'T', 'A', 'G', 'A', 'G', 'T', 'T', 'C', 'C', 'T', '-', '-', '-', '-',
            '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'T', 'T', 'C',
@@ -5467,7 +5439,6 @@ mm9.chr10   3019664 actcactttgtagaccagactggccttgaactcagaaa 3019702
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['t', 't', 't', 'g', 'g', 't', 't', 't', 'g', 'g', 't', 't', 't',
            'g', 'g', 't', 't', 't', 't', 't', 't', 'c', 'a', 'a', 'g', 'a',
            'c', 'a', 'g', 'g', 'g', 't', 't', 't', 'c', 't', 't', 't', 'g',
@@ -5597,7 +5568,6 @@ felCat3.s     46461 TTCTTAAAGGTTTA   46447
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['t', 'c', 't', 'g', 'c', 'c', 't', 'g', 'c', 'c', 't', 'c', 't',
            'g', 'c', 'c', 't', 'c', 'c', 'c', 'a', 'a', 'g', '-', '-', '-',
            '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',
@@ -5800,7 +5770,6 @@ felCat3.s     46387 GA     46385
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',
            '-', '-', '-', '-', 'c', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c',
            't', 'g', 'c', 'c', 'c', 't', 'g', 'c', 'C', 'T', '-', '-', '-',
@@ -6272,7 +6241,6 @@ mm9.chr10   3020680 gaacatttgaaatgtaaataaataaaataataaaaaa 3020717
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['a', 'c', 't', 'a', 'g', 'g', 'g', 'a', 't', 'g', 'g', 'g', 'a',
            'g', 'a', 'g', 'g', 'c', 't', 'c', 'c', 'c', 'a', 'g', 'a', 'a',
            'c', 'c', 'c', 'a', 'g', 't', 'a', 'a', 't', 'g', 'a', 't', 'g',
@@ -6472,7 +6440,6 @@ hg18.chr6 155025365 ----AAAAAT---TTTAAATATACTAGAGGGGTCCATGAATTTTA 155025327
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'G', 'T', 'C', 'A', 'A', 'A', 'C', 'A', 'T', 'G', 'C', 'A',
            'T', 'A', 'A', 'A', 'G', 'A', 'T', 'A', 'T', 'A', 'C', 'T', '-',
            'G', 'A', 'G', 'G', 'A', 'G', 'C', 'C', 'C', 'A', 'T', 'G', 'A',
@@ -6595,7 +6562,6 @@ mm9.chr10   3020881 gtgctgagatcatacctctgcaccatcctgcccACCT 3020918
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'A', 'T', 'A', 'T', 'A', 'T', 'G', 'C', 'T', 'A', 'T', 'C',
            'C', 'G', 'T', 'G', 'T', 'G', 'C', 'T', 'G', 'T', 'G', 'A', 'T',
            'T', 'T', 'T', 'T', 'G', 'T', 'T', 'T', 'T', 'A', 'A', 'A', 'T',
@@ -6847,7 +6813,6 @@ ponAbe2.c 158037510 AGCTTTTAAGGAAAAACGTGTTTGACTTATTAATTATTTAGGACAA 158037464
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'A', 'G', 'G', 'T', 'T', 'T', 'G', 'T', 'G', 'A', 'C', 'T', 'T',           'T', 'T', 'A', 'A', 'T', 'A', '-', '-', '-', '-', '-', '-', '-', '-',           '-', '-', 'C', 'T', 'G', 'A', 'T', 'T', 'G', 'T', 'T', 'A', 'T', 'C',           'T', 'A', 'A', 'C', 'A', 'T', 'C', 'A', 'C', 'A', 'G', 'A', 'A', 'T',           'T', 'C', 'T', 'C', 'A', 'G', 'T', 'T', 'C', 'T', 'T', 'A', 'A', 'G',           'G', 'A', 'A', 'A', 'C', 'A', 'A', 'T', 'T', 'G', 'T', 'T', 'C', 'T',           'G', 'T', 'G', 'T', 'G', 'T', 'T', 'A', 'T', 'T', 'T', 'G', 'T', 'C',           'T', 'A', 'G', 'G', 'A', 'G', 'G', 'A'],
           ['-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',           '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',           '-', '-', '-', '-', '-', 'A', 'T', 'G', 'G', 'T', 'T', 'A', 'T', 'T',           'T', 'A', 'A', 'T', 'A', 'C', 'T', 'G', 'C', 'A', 'C', 'A', 'A', 'T',           'C', 'C', 'T', 'C', 'A', 'G', 'C', 'T', 'T', 'T', 'T', 'A', 'A', 'G',           'G', 'A', 'A', 'A', 'A', 'A', 'C', 'A', 'T', 'G', 'T', 'T', 'T', 'G',           'A', 'C', 'T', 'T', 'A', 'T', 'T', 'A', 'A', 'T', 'T', 'A', 'T', 'T',           'T', 'A', 'G', 'G', 'A', 'C', 'A', 'A'],
           ['-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',           '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',           '-', '-', '-', '-', '-', 'A', 'T', 'G', 'G', 'T', 'T', 'A', 'T', 'T',           'T', 'A', 'A', 'T', 'A', 'C', 'T', 'G', 'C', 'A', 'C', 'A', 'A', 'T',           'C', 'C', 'T', 'C', 'A', 'G', 'C', 'T', 'T', 'T', 'T', 'A', 'A', 'G',           'G', 'A', 'A', 'A', 'A', 'A', 'C', 'A', 'T', 'G', 'T', 'T', 'T', 'G',           'A', 'C', 'T', 'T', 'A', 'T', 'T', 'A', 'A', 'T', 'T', 'A', 'T', 'T',           'T', 'A', 'G', 'G', 'A', 'C', 'A', 'A'],
@@ -7054,7 +7019,6 @@ dasNov1.s      7354 ACATCAGTGAAATCATTCCGACTCGTATGACTGAGCGATG      7314
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'C', 'C', 'T', 'T', 'G', 'G', 'T', 'G', 'A', 'C', 'G', 'C', 'C',
            'A', 'C', 'T', 'G', 'G', 'A', 'T', 'T', 'T', 'T', 'G', 'T', 'A', 'T',
            'G', 'A', 'C', 'T', 'G', 'A', 'A', 'T', 'A', 'C', 'T', 'G'],
@@ -7350,7 +7314,6 @@ dasNov1.s      7254 CTATAAGTAT      7244
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'T', 'C', 'A', 'T', 'T', 'T', 'G', 'G', 'G', 'A', 'A', 'C',
            'T', 'T', 'A', 'C', 'A', 'G', 'G', 'T', 'C', 'A', 'G', 'C', 'A',
            'A', 'A', 'G', 'G', 'C', 'T', 'T', 'C', 'C', 'A', 'G', '-', '-',
@@ -7644,7 +7607,6 @@ echTel1.s     95225 CTGTTAATG--CTCTG------------TTTTATG     95246
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'T', 'G', 'T', 'T', 'A', 'G', 'T', 'G', 'C', 'T', 'G', 'T',
            'T', 'T', 'T', '-', '-', '-', 'A', 'A', 'T', 'G', 'T', 'A', 'C',
            'C', 'T', 'C', 'G', 'C', 'A', 'G', 'T', 'A'],
@@ -8012,7 +7974,6 @@ echTel1.s     95296 -------G--     95297
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'G', 'G', 'C', 'A', 'A', 'A', 'T', 'G', 'A', 'G', 'G', 'T',
            'G', 'A', 'T', 'A', 'A', 'G', 'A', '-', '-', '-', '-', '-', '-',
            '-', 'T', 'T', 'G', 'T', 'G', 'T', 'T', '-', '-', '-', '-', '-',
@@ -8387,7 +8348,6 @@ echTel1.s     95345
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',
            '-', '-', '-', '-', '-', '-', 'T', 'C', 'C', 'C', '-', '-', '-',
            '-', '-', '-', '-', 'A', 'G', 'A', 'G', 'A', 'G', 'T', 'C', 'T',
@@ -9691,7 +9651,6 @@ ornAna1.c  40040173
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'C', 'T', '-', '-', 'A', 'C', 'A', 'C', 'T', 'G', 'T', 'C',
            '-', '-', '-', '-', 'A', 'A', 'G', 'T', 'G', 'G', 'G', 'A', 'G', 'G',
            'A', 'G', 'A', 'C', 'A', 'G', 'T', '-', '-', '-', '-', '-', '-', '-',
@@ -9871,7 +9830,6 @@ ornAna1.c  40040173 TGTTTAAAATG----ATTGCTAGAACTTCTA--CTCACTGGA----  40040137
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'G', 'T', 'T', 'T', 'A', 'G', 'T', 'A', 'C', 'C', '-', '-',
            '-', '-', 'A', 'T', 'G', 'C', 'T', 'T', 'A', 'G', 'G', 'A', 'A',
            'T', 'G', 'A', 'T', 'A', 'A', 'A', 'C', 'T', 'C', 'A', 'C', 'T',
@@ -9952,7 +9910,6 @@ mm4.chr6   53310102 ACAGCTGAAAATA 53310115
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['g', 'c', 'a', 'g', 'c', 't', 'g', 'a', 'a', 'a', 'a', 'c', 'a'],
           ['g', 'c', 'a', 'g', 'c', 't', 'g', 'a', 'a', 'a', 'a', 'c', 'a'],
           ['g', 'c', 'a', 'g', 'c', 't', 'g', 'a', 'a', 'a', 'a', 'c', 'a'],

--- a/Tests/test_Align_bigmaf.py
+++ b/Tests/test_Align_bigmaf.py
@@ -25,11 +25,9 @@ class TestAlign_ucsc_test(unittest.TestCase):
 
     def test_reading(self):
         """Test reading ucsc_test.bb."""
-
         # BigMaf file ucsc_test.bb was created using the commands
         # tail -n +2 ucsc_test.maf | mafToBigMaf hg16 stdin stdout | sort -k1,1 -k2,2n > ucsc_test.txt
         # bedToBigBed -type=bed3+1 -as=bigMaf.as -tab ucsc_test.txt hg16.chrom.sizes ucsc_test.bb
-
         alignments = Align.parse(self.path, "bigmaf")
         self.check_alignments(alignments)
         alignments.rewind()
@@ -295,11 +293,9 @@ class TestAlign_bundle_without_target(unittest.TestCase):
 
     def test_reading(self):
         """Test parsing bundle_without_target.bb."""
-
         # BigMaf file bundle_without_target.bb was created using the commands
         # mafToBigMaf mm8 bundle_without_target.maf stdout | sort -k1,1 -k2,2n > bundle_without_target.txt
         # bedToBigBed -type=bed3+1 -as=bigMaf.as -tab bundle_without_target.txt mm8.chrom.sizes bundle_without_target.bb
-
         alignments = Align.parse(self.path, "bigmaf")
         self.check_alignments(alignments)
         alignments.rewind()
@@ -440,7 +436,6 @@ class TestAlign_ucsc_mm9_chr10(unittest.TestCase):
 
     def test_reading(self):
         """Test parsing file ucsc_mm9_chr10.bb."""
-
         # BigMaf file ucsc_mm9_chr10.bb was created using the commands
         # mafToBigMaf mm9 ucsc_mm9_chr10.maf stdout | sort -k1,1 -k2,2n > ucsc_mm9_chr10.txt
         # bedToBigBed -type=bed3+1 -as=bigMaf.as -tab ucsc_mm9_chr10.txt mm9.chrom.sizes ucsc_mm9_chr10.bb

--- a/Tests/test_Align_bigpsl.py
+++ b/Tests/test_Align_bigpsl.py
@@ -108,7 +108,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42530895, 42530958, 42532020, 42532095, 42532563, 42532606],
                           [     181,      118,      118,       43,       43,        0]])
                 # fmt: on
@@ -121,7 +120,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[36.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0., 40.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  0., 57.,  0.,  0.,  0.,  0.,  0.],
@@ -166,7 +164,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42530895, 42530922, 42530922, 42530958, 42532020,
                            42532037, 42532039, 42532095, 42532563, 42532606],
                           [     185,      158,      155,      119,      119,
@@ -182,7 +179,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[34.,  0.,  0.,  1.,  0.,  0.,  0.,  0.],
                       [ 0., 40.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  0., 57.,  0.,  0.,  0.,  0.,  0.],
@@ -228,7 +224,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array( [[48663767, 48663813, 48665640, 48665722, 48669098, 48669174],
                            [       0,        46,      46,      128,      128,      204]]),
                 # fmt: on
@@ -241,7 +236,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[53.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0., 35.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  0., 50.,  0.,  0.,  0.,  0.,  0.],
@@ -286,7 +280,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48663767, 48663795, 48663796, 48663813, 48665640,
                            48665716, 48665716, 48665722, 48669098, 48669174],
                           [       3,       31,       31,       48,       48,
@@ -302,7 +295,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[53.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0., 34.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  2., 48.,  0.,  0.,  0.,  0.,  0.],
@@ -403,7 +395,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -433,7 +424,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -463,7 +453,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[39368490, 39368526],
                           [      49,       13]]),
                 # fmt: on
@@ -493,7 +482,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       1,       35]]),
                 # fmt: on
@@ -523,7 +511,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       47,        13]]),
                 # fmt: on
@@ -553,7 +540,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      49,       13]]),
                 # fmt: on
@@ -583,7 +569,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       35,        10]]),
                 # fmt: on
@@ -613,7 +598,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759160, 52759198],
                           [       1,        8,        8,       11,       49]]),
                 # fmt: on
@@ -643,7 +627,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [      10,       49]]),
                 # fmt: on
@@ -673,7 +656,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [      21,       49]]),
                 # fmt: on
@@ -703,7 +685,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    49,     10]]),
                 # fmt: on
@@ -733,7 +714,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [      10,       35,       35,       46]]),
                 # fmt: on
@@ -763,7 +743,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      49,       10]]),
                 # fmt: on
@@ -793,7 +772,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      25,        8]]),
                 # fmt: on
@@ -823,7 +801,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       49,        13]]),
                 # fmt: on
@@ -853,7 +830,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183925990, 183926028],
                           [        1,         7,        11,        49]]),
                 # fmt: on
@@ -883,7 +859,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [      11,       47]]),
                 # fmt: on
@@ -913,7 +888,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      49,       12]]),
                 # fmt: on
@@ -943,7 +917,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558173, 37558191],
                           [      49,       39,       39,       29,       11]]),
                 # fmt: on
@@ -973,7 +946,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [      11,       27]]),
                 # fmt: on
@@ -1003,7 +975,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       8,       49]]),
                 # fmt: on
@@ -1033,7 +1004,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       9,       50]]),
                 # fmt: on
@@ -1097,7 +1067,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -1127,7 +1096,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      25,        8]]),
                 # fmt: on
@@ -1157,7 +1125,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [      11,       27]]),
                 # fmt: on
@@ -1235,7 +1202,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -1265,7 +1231,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[39368490, 39368526],
                           [      49,       13]]),
                 # fmt: on
@@ -1295,7 +1260,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       1,       35]]),
                 # fmt: on
@@ -1325,7 +1289,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       47,        13]]),
                 # fmt: on
@@ -1355,7 +1318,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      49,       13]]),
                 # fmt: on
@@ -1385,7 +1347,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       35,        10]]),
                 # fmt: on
@@ -1415,7 +1376,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759160, 52759198],
                           [       1,        8,        8,       11,       49]]),
                 # fmt: on
@@ -1445,7 +1405,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [      10,       49]]),
                 # fmt: on
@@ -1475,7 +1434,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [      21,       49]]),
                 # fmt: on
@@ -1505,7 +1463,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    49,     10]]),
                 # fmt: on
@@ -1535,7 +1492,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [      10,       35,       35,       46]]),
                 # fmt: on
@@ -1565,7 +1521,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      49,       10]]),
                 # fmt: on
@@ -1595,7 +1550,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       49,        13]]),
                 # fmt: on
@@ -1625,7 +1579,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183925990, 183926028],
                           [        1,         7,        11,        49]]),
                 # fmt: on
@@ -1655,7 +1608,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [      11,       47]]),
                 # fmt: on
@@ -1685,7 +1637,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      49,       12]]),
                 # fmt: on
@@ -1715,7 +1666,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558173, 37558191],
                           [      49,       39,       39,       29,       11]]),
                 # fmt: on
@@ -1745,7 +1695,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       8,       49]]),
                 # fmt: on
@@ -1775,7 +1724,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       9,       50]]),
                 # fmt: on
@@ -1853,7 +1801,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -1883,7 +1830,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -1942,7 +1888,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       1,       35]]),
                 # fmt: on
@@ -1972,7 +1917,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       47,        13]]),
                 # fmt: on
@@ -2002,7 +1946,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      49,       13]]),
                 # fmt: on
@@ -2032,7 +1975,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       35,        10]]),
                 # fmt: on
@@ -2062,7 +2004,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759160, 52759198],
                           [       1,        8,        8,       11,       49]]),
                 # fmt: on
@@ -2092,7 +2033,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [      10,       49]]),
                 # fmt: on
@@ -2122,7 +2062,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [      21,       49]]),
                 # fmt: on
@@ -2152,7 +2091,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    49,     10]]),
                 # fmt: on
@@ -2182,7 +2120,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [      10,       35,       35,       46]]),
                 # fmt: on
@@ -2212,7 +2149,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      49,       10]]),
                 # fmt: on
@@ -2242,7 +2178,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      25,        8]]),
                 # fmt: on
@@ -2272,7 +2207,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       49,        13]]),
                 # fmt: on
@@ -2302,7 +2236,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183925990, 183926028],
                           [        1,         7,        11,        49]]),
                 # fmt: on
@@ -2332,7 +2265,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [      11,       47]]),
                 # fmt: on
@@ -2362,7 +2294,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      49,       12]]),
                 # fmt: on
@@ -2392,7 +2323,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558173, 37558191],
                           [      49,       39,       39,       29,       11]]),
                 # fmt: on
@@ -2422,7 +2352,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [      11,       27]]),
                 # fmt: on
@@ -2452,7 +2381,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       8,       49]]),
                 # fmt: on
@@ -2482,7 +2410,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       9,       50]]),
                 # fmt: on
@@ -2550,7 +2477,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75549820, 75549865, 75567225, 75567225, 75567312],
                           [       0,       15,       15,      113,      142]]),
                 # fmt: on
@@ -2579,7 +2505,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75560749, 75560881],
                           [      17,       61]]),
                 # fmt: on
@@ -2608,7 +2533,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75566694, 75566850],
                           [      61,      113]]),
                 # fmt: on
@@ -2637,7 +2561,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75569459, 75569507],
                           [     142,      158]]),
                 # fmt: on
@@ -2666,7 +2589,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75594914, 75594989],
                           [     158,      183]]),
                 # fmt: on
@@ -2695,7 +2617,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75604767, 75604827, 75605728, 75605809],
                           [     183,      203,      203,      230]]),
                 # fmt: on
@@ -2724,7 +2645,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[41257605, 41257731, 41263227, 41263227, 41263290],
                           [      17,       59,       59,      162,      183]]),
                 # fmt: on
@@ -2753,7 +2673,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[41260685, 41260787],
                           [      76,      110]]),
                 # fmt: on
@@ -2791,7 +2710,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[20873021, 20872472, 20872471, 20872471, 20872390],
                           [       0,      183,      183,      203,      230]]),
                 # fmt: on
@@ -2819,7 +2737,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[9712654, 9712786, 9715941, 9716097, 9716445, 9716532,
                            9718374, 9718422, 9739264, 9739339, 9743706, 9743766,
                            9744511, 9744592],
@@ -2917,7 +2834,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[11873, 12227, 12612, 12721, 13220, 14361],
                           [    0,   354,   354,   463,   463,  1604]])
                 # fmt: on
@@ -2937,7 +2853,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[11873, 12227, 12594, 12721, 13402, 14361],
                               [0,   354,   354,   481,   481,  1440]])
                 # fmt: on
@@ -2957,7 +2872,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[11873, 12227, 12645, 12697, 13220, 13656, 13658,
                            13957, 13958, 14362],
                           [    0,   354,   354,   406,   406,   842,   842,
@@ -2979,7 +2893,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[11873, 12227, 12612, 12721, 13220, 14362],
                           [    0,   354,   354,   463,   463,  1605]])
                 # fmt: on
@@ -2999,7 +2912,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[11873, 12227, 12612, 12721, 13220, 14409],
                           [    0,   354,   354,   463,   463,  1652]])
                 # fmt: on
@@ -3019,7 +2931,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[11873, 12227, 12612, 12721, 13220, 14409],
                           [    0,   354,   354,   463,   463,  1652]])
                 # fmt: on
@@ -3039,7 +2950,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[11873, 12227, 12612, 12721, 13220, 14409],
                           [    0,   354,   354,   463,   463,  1652]])
                 # fmt: on
@@ -3059,7 +2969,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[11873, 12227, 12594, 12721, 13402, 14409],
                           [    0,   354,   354,   481,   481,  1488]])
                 # fmt: on
@@ -3072,7 +2981,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[11873, 12227, 12612, 12721, 13220, 13957, 13958,
                            14258, 14270, 14409],
                           [    0,   354,   354,   463,   463,  1200,  1200,
@@ -3094,7 +3002,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[12612, 12721, 13220, 13656, 13658, 13957, 13958, 14362],
                           [    0,   109,   109,   545,   545,   844,   844,  1248]])
                 # fmt: on
@@ -3131,7 +3038,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[13420, 13957, 13958, 14259, 14271, 14407],
                           [    0,   537,   537,   838,   838,   974]])
                 # fmt: on
@@ -3198,7 +3104,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14404, 14455, 14455, 14829, 14969, 15038, 15795,
                            15905, 15906, 15906, 15947, 16606, 16765, 16857,
                            17055, 17232, 17742, 17914, 18061, 18267, 18369,
@@ -3217,7 +3122,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14404, 14511, 14513, 14829, 14969, 15038, 15795,
                            15903, 15903, 15947, 16606, 16765, 16857, 17055,
                            17232, 17358, 17361, 17742, 17914, 18061, 18267,
@@ -3236,7 +3140,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14404, 14455, 14455, 14829, 14969, 15038, 15795,
                            15905, 15906, 15906, 15947, 16606, 16765, 16857,
                            17055, 17232, 17368, 17605, 17742, 17914, 18061,
@@ -3278,7 +3181,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 14404,  14511,  14513,  14829,  14969,  15250, 185765,
                            186064, 186064, 186623, 186626, 187287, 187379, 187577,
                            187754, 188266, 188438, 188485, 188485, 188584, 188790,
@@ -3297,7 +3199,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14404, 14455, 14455, 14829, 14969, 15038, 15795, 15905,
                            15906, 15906, 15947, 16606, 16722, 16722, 16768, 16856,
                            17055, 17232, 17368, 17605, 17742, 17914, 18061, 18267,
@@ -3316,7 +3217,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14404, 14455, 14455, 14829, 15795, 15905, 15906,
                            15906, 15947, 16606, 16765, 16857, 17055, 17605,
                            18061, 24737, 24891, 29320, 29346],
@@ -3353,7 +3253,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14404, 14495, 14559, 14571, 15004, 15038, 15795, 15903,
                            15903, 15947, 16606, 16765, 16857, 17055, 17232, 17368,
                            17605, 17742, 17914, 18061, 18267, 18366, 24737, 24891,
@@ -3379,7 +3278,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14406, 15905, 15906, 15906, 16765, 16857, 18733],
                           [ 4236,  2737,  2737,  2735,  1876,  1876,     0]])
                 # fmt: on
@@ -3392,7 +3290,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 14406,  14829,  14969,  15038,  15795,  15903,  15903,
                             15947,  16606,  16768,  16856,  17055,  17232,  17368,
                             17605,  17745,  18036,  18061,  18267,  18366,  24737,
@@ -3420,7 +3317,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14406, 14455, 14455, 15905, 15906, 15906, 16765,
                            16857, 17055, 17232, 17368, 17605, 17742, 17914,
                            18061, 24737, 24891, 29320, 29344],
@@ -3437,7 +3333,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14406, 14455, 14455, 15905, 15906, 15906, 16765,
                            16857, 17055, 17232, 17368, 17605, 17742, 17914,
                            18061, 24737, 24891, 29320, 29344],
@@ -3454,7 +3349,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14406, 14455, 14455, 14829, 14969, 15038, 15795,
                            15905, 15906, 15906, 15947, 16606, 16768, 16856,
                            17055, 17232, 17368, 17605, 17742, 17914, 18061,
@@ -3475,7 +3369,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14407, 14455, 14455, 14829, 14969, 15038, 15795,
                            15905, 15906, 15906, 15947, 16606, 16765, 16857,
                            17055, 17232, 17742, 17914, 18061, 18267, 19108],
@@ -3492,7 +3385,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14407, 14455, 14455, 14829, 14969, 15038, 15795,
                            15905, 15906, 15906, 15947, 16606, 16722, 16731,
                            16768, 16856, 17055, 17232, 17368, 17605, 17742,
@@ -3520,7 +3412,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14407, 14455, 14455, 14829, 14969, 15038, 15795,
                            15905, 15906, 15906, 15947, 16606, 16722, 16731,
                            16768, 16856, 17055, 17232, 17368, 17605, 17742,
@@ -3582,7 +3473,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14570, 14829, 14969, 15038, 15795, 15905, 15906,
                            15906, 15947, 16606, 16722, 16722, 16768, 16856,
                            17055, 17232, 17368, 17605, 17742, 17914, 18061,
@@ -3856,7 +3746,6 @@ class TestAlign_bigpsl(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[15870, 15903, 15903, 16027, 16606, 16765, 16857,
                            17055, 17232, 17364, 17521, 17742, 17914, 18061,
                            18267, 18366, 29320, 29359],

--- a/Tests/test_Align_bigpsl.py
+++ b/Tests/test_Align_bigpsl.py
@@ -327,7 +327,6 @@ class TestAlign_dna(unittest.TestCase):
 
     def test_reading_psl_34_001(self):
         """Test parsing psl_34_001.psl.bb."""
-
         # The bigPsl file psl_34_001.psl.bb was generated using these commands:
         # pslToBigPsl -fa=fasta_34.fa psl_34_001.psl stdout | sort -k1,1 -k2,2n > psl_34_001.bigPslInput
         # bedToBigBed -type=bed12+13 -tab -as=bigPsl.as psl_34_001.bigPslInput hg19.chrom.sizes psl_34_001.psl.bb
@@ -1013,7 +1012,6 @@ class TestAlign_dna(unittest.TestCase):
 
     def test_reading_psl_34_003(self):
         """Test parsing psl_34_003.psl.bb."""
-
         # The bigPsl file psl_34_003.psl.bb was generated using these commands:
         # pslToBigPsl -fa=fasta_34.fa psl_34_003.psl stdout | sort -k1,1 -k2,2n > psl_34_003.bigPslInput
         # bedToBigBed -type=bed12+13 -tab -as=bigPsl.as psl_34_003.bigPslInput hg19.chrom.sizes psl_34_003.psl.bb
@@ -1134,11 +1132,9 @@ class TestAlign_dna(unittest.TestCase):
 
     def test_reading_psl_34_004(self):
         """Test parsing psl_34_004.psl.bb."""
-
         # The bigPsl file psl_34_004.psl.bb was generated using these commands:
         # pslToBigPsl -fa=fasta_34.fa psl_34_004.psl stdout | sort -k1,1 -k2,2n > psl_34_004.bigPslInput
         # bedToBigBed -type=bed12+13 -tab -as=bigPsl.as psl_34_004.bigPslInput hg19.chrom.sizes psl_34_004.psl.bb
-
         path = "Blat/psl_34_004.psl.bb"
         alignments = Align.parse(path, "bigpsl")
         self.check_psl_34_004(alignments)
@@ -1733,7 +1729,6 @@ class TestAlign_dna(unittest.TestCase):
 
     def test_reading_psl_34_005(self):
         """Test parsing psl_34_005.psl.bb."""
-
         # The bigPsl file psl_34_005.psl.bb was generated using these commands:
         # pslToBigPsl -fa=fasta_34.fa psl_34_005.psl stdout | sort -k1,1 -k2,2n > psl_34_005.bigPslInput
         # bedToBigBed -type=bed12+13 -tab -as=bigPsl.as psl_34_005.bigPslInput hg19.chrom.sizes psl_34_005.psl.bb
@@ -2426,7 +2421,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
 
     def test_reading_psl_35_001(self):
         """Test parsing psl_35_001.psl.bb."""
-
         # The bigPsl file psl_35_001.psl.bb was generated using these commands:
         # pslToBigPsl -fa=CAG33136.1.fasta psl_35_001.psl stdout | sort -k1,1 -k2,2n > psl_35_001.bigPslInput
         # bedToBigBed -type=bed12+13 -tab -as=bigPsl.as psl_35_001.bigPslInput hg38.chrom.sizes psl_35_001.psl.bb
@@ -2750,7 +2744,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
 
     def test_reading_psl_35_002(self):
         """Test parsing psl_35_002.psl.bb."""
-
         # The bigPsl file psl_35_002.psl.bb was generated using these commands:
         # pslToBigPsl -fa=CAG33136.1.fasta psl_35_002.psl stdout | grep -v KI538594 | sort -k1,1 -k2,2n > psl_35_002.bigPslInput
         # (where we excluded KI538594 because its alignment has a negative gap)

--- a/Tests/test_Align_chain.py
+++ b/Tests/test_Align_chain.py
@@ -76,7 +76,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42530895, 42530958, 42532020, 42532095, 42532563, 42532606],
                           [     181,      118,      118,       43,       43,        0]])
                 # fmt: on
@@ -89,7 +88,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[36.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0., 40.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  0., 57.,  0.,  0.,  0.,  0.,  0.],
@@ -246,7 +244,6 @@ chain 176 chr3 198295559 + 42530895 42532606 NR_046654.1 181 - 0 181 1
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42530895, 42530922, 42530922, 42530958, 42532020,
                            42532037, 42532039, 42532095, 42532563, 42532606],
                           [     185,      158,      155,      119,      119,
@@ -262,7 +259,6 @@ chain 176 chr3 198295559 + 42530895 42532606 NR_046654.1 181 - 0 181 1
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[34.,  0.,  0.,  1.,  0.,  0.,  0.,  0.],
                       [ 0., 40.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  0., 57.,  0.,  0.,  0.,  0.,  0.],
@@ -421,7 +417,6 @@ chain 170 chr3 198295559 + 42530895 42532606 NR_046654.1_modified 190 - 5 187 2
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array( [[48663767, 48663813, 48665640, 48665722, 48669098, 48669174],
                               [       0,        46,      46,      128,      128,      204]]),
                 # fmt: on
@@ -434,7 +429,6 @@ chain 170 chr3 198295559 + 42530895 42532606 NR_046654.1_modified 190 - 5 187 2
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[53.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0., 35.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  0., 50.,  0.,  0.,  0.,  0.,  0.],
@@ -839,7 +833,6 @@ chain 182 chr3 198295559 + 48663767 48669174 NR_111921.1 216 + 0 204 3
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48663767, 48663795, 48663796, 48663813, 48665640,
                            48665716, 48665716, 48665722, 48669098, 48669174],
                           [       3,       31,       31,       48,       48,
@@ -855,7 +848,6 @@ chain 182 chr3 198295559 + 48663767 48669174 NR_111921.1 216 + 0 204 3
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[53.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0., 34.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  2., 48.,  0.,  0.,  0.,  0.,  0.],
@@ -1300,7 +1292,6 @@ hg18_dna         11 ????????????????       27
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [      11,       27]]),
                 # fmt: on
@@ -1335,7 +1326,6 @@ hg18_dna          0 ?????????????????????????????????       33
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -1370,7 +1360,6 @@ hg18_dna         25 ?????????????????        8
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      25,        8]]),
                 # fmt: on
@@ -1405,7 +1394,6 @@ hg19_dna          9 ?????????????????????????????????????????       50
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       9,       50]]),
                 # fmt: on
@@ -1440,7 +1428,6 @@ hg19_dna          8 ?????????????????????????????????????????       49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       8,       49]]),
                 # fmt: on
@@ -1475,7 +1462,6 @@ hg19_dna         11 ????????????????????????????????????       47
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [      11,       47]]),
                 # fmt: on
@@ -1510,7 +1496,6 @@ hg19_dna          1 ????????????????????????????????????????????????        49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183925990, 183926028],
                           [        1,         7,        11,        49]]),
                 # fmt: on
@@ -1554,7 +1539,6 @@ hg19_dna         35 ---------------------------------------???????????       46
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [      10,       35,       35,       46]]),
                 # fmt: on
@@ -1590,7 +1574,6 @@ hg19_dna         10 ???????????????????????????????????????       49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [      10,       49]]),
                 # fmt: on
@@ -1625,7 +1608,6 @@ hg19_dna         21 ????????????????????????????       49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [      21,       49]]),
                 # fmt: on
@@ -1664,7 +1646,6 @@ hg19_dna         49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759160, 52759198],
                           [       1,        8,        8,       11,       49]]),
                 # fmt: on
@@ -1700,7 +1681,6 @@ hg19_dna          0 ??????????????????????????????????????????????????      50
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -1735,7 +1715,6 @@ hg19_dna          1 ??????????????????????????????????       35
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       1,       35]]),
                 # fmt: on
@@ -1770,7 +1749,6 @@ hg19_dna         49 ??????????------????????????????????????????       11
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558173, 37558191],
                           [      49,       39,       39,       29,       11]]),
                 # fmt: on
@@ -1803,7 +1781,6 @@ hg19_dna         49 ?????????????????????????????????????       12
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      49,       12]]),
                 # fmt: on
@@ -1838,7 +1815,6 @@ hg19_dna         49 ????????????????????????????????????        13
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       49,        13]]),
                 # fmt: on
@@ -1873,7 +1849,6 @@ hg19_dna         49 ???????????????????????????????????????       10
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      49,       10]]),
                 # fmt: on
@@ -1908,7 +1883,6 @@ hg19_dna         49 ???????????????????????????????????????     10
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    49,     10]]),
                 # fmt: on
@@ -1943,7 +1917,6 @@ hg19_dna         49 ????????????????????????????????????       13
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      49,       13]]),
                 # fmt: on
@@ -1978,7 +1951,6 @@ hg19_dna         35 ?????????????????????????        10
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       35,        10]]),
                 # fmt: on
@@ -2013,7 +1985,6 @@ hg19_dna         49 ????????????????????????????????????       13
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[39368490, 39368526],
                           [      49,       13]]),
                 # fmt: on
@@ -2048,7 +2019,6 @@ hg19_dna         47 ??????????????????????????????????        13
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       47,        13]]),
                 # fmt: on
@@ -2127,7 +2097,6 @@ hg18_dna         11 ????????????????       27
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [      11,       27]]),
                 # fmt: on
@@ -2162,7 +2131,6 @@ hg18_dna          0 ?????????????????????????????????       33
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -2197,7 +2165,6 @@ hg18_dna         25 ?????????????????        8
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      25,        8]]),
                 # fmt: on
@@ -2255,7 +2222,6 @@ hg19_dna          9 ?????????????????????????????????????????       50
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       9,       50]]),
                 # fmt: on
@@ -2290,7 +2256,6 @@ hg19_dna          8 ?????????????????????????????????????????       49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       8,       49]]),
                 # fmt: on
@@ -2325,7 +2290,6 @@ hg19_dna         11 ????????????????????????????????????       47
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [      11,       47]]),
                 # fmt: on
@@ -2360,7 +2324,6 @@ hg19_dna          1 ????????????????????????????????????????????????        49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183925990, 183926028],
                           [        1,         7,        11,        49]]),
                 # fmt: on
@@ -2404,7 +2367,6 @@ hg19_dna         35 ---------------------------------------???????????       46
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [      10,       35,       35,       46]]),
                 # fmt: on
@@ -2440,7 +2402,6 @@ hg19_dna         10 ???????????????????????????????????????       49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [      10,       49]]),
                 # fmt: on
@@ -2475,7 +2436,6 @@ hg19_dna         21 ????????????????????????????       49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [      21,       49]]),
                 # fmt: on
@@ -2514,7 +2474,6 @@ hg19_dna         49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759160, 52759198],
                           [       1,        8,        8,       11,       49]]),
                 # fmt: on
@@ -2550,7 +2509,6 @@ hg19_dna          0 ??????????????????????????????????????????????????      50
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -2585,7 +2543,6 @@ hg19_dna          1 ??????????????????????????????????       35
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       1,       35]]),
                 # fmt: on
@@ -2620,7 +2577,6 @@ hg19_dna         49 ??????????------????????????????????????????       11
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558173, 37558191],
                           [      49,       39,       39,       29,       11]]),
                 # fmt: on
@@ -2656,7 +2612,6 @@ hg19_dna         49 ?????????????????????????????????????       12
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      49,       12]]),
                 # fmt: on
@@ -2691,7 +2646,6 @@ hg19_dna         49 ????????????????????????????????????        13
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       49,        13]]),
                 # fmt: on
@@ -2726,7 +2680,6 @@ hg19_dna         49 ???????????????????????????????????????       10
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      49,       10]]),
                 # fmt: on
@@ -2761,7 +2714,6 @@ hg19_dna         49 ???????????????????????????????????????     10
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    49,     10]]),
                 # fmt: on
@@ -2796,7 +2748,6 @@ hg19_dna         49 ????????????????????????????????????       13
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      49,       13]]),
                 # fmt: on
@@ -2831,7 +2782,6 @@ hg19_dna         35 ?????????????????????????        10
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       35,        10]]),
                 # fmt: on
@@ -2866,7 +2816,6 @@ hg19_dna         49 ????????????????????????????????????       13
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[39368490, 39368526],
                           [      49,       13]]),
                 # fmt: on
@@ -2901,7 +2850,6 @@ hg19_dna         47 ??????????????????????????????????        13
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       47,        13]]),
                 # fmt: on
@@ -2961,7 +2909,6 @@ hg18_dna         11 ????????????????       27
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [      11,       27]]),
                 # fmt: on
@@ -2996,7 +2943,6 @@ hg18_dna          0 ?????????????????????????????????       33
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -3031,7 +2977,6 @@ hg18_dna         25 ?????????????????        8
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      25,        8]]),
                 # fmt: on
@@ -3066,7 +3011,6 @@ hg19_dna          9 ?????????????????????????????????????????       50
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       9,       50]]),
                 # fmt: on
@@ -3101,7 +3045,6 @@ hg19_dna          8 ?????????????????????????????????????????       49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       8,       49]]),
                 # fmt: on
@@ -3136,7 +3079,6 @@ hg19_dna         11 ????????????????????????????????????       47
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [      11,       47]]),
                 # fmt: on
@@ -3171,7 +3113,6 @@ hg19_dna          1 ????????????????????????????????????????????????        49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183925990, 183926028],
                           [        1,         7,        11,        49]]),
                 # fmt: on
@@ -3215,7 +3156,6 @@ hg19_dna         35 ---------------------------------------???????????       46
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [      10,       35,       35,       46]]),
                 # fmt: on
@@ -3251,7 +3191,6 @@ hg19_dna         10 ???????????????????????????????????????       49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [      10,       49]]),
                 # fmt: on
@@ -3286,7 +3225,6 @@ hg19_dna         21 ????????????????????????????       49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [      21,       49]]),
                 # fmt: on
@@ -3325,7 +3263,6 @@ hg19_dna         49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759160, 52759198],
                           [       1,        8,        8,       11,       49]]),
                 # fmt: on
@@ -3361,7 +3298,6 @@ hg19_dna          0 ??????????????????????????????????????????????????      50
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -3396,7 +3332,6 @@ hg19_dna          1 ??????????????????????????????????       35
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       1,       35]]),
                 # fmt: on
@@ -3431,7 +3366,6 @@ hg19_dna         49 ??????????------????????????????????????????       11
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558173, 37558191],
                           [      49,       39,       39,       29,       11]]),
                 # fmt: on
@@ -3467,7 +3401,6 @@ hg19_dna         49 ?????????????????????????????????????       12
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      49,       12]]),
                 # fmt: on
@@ -3502,7 +3435,6 @@ hg19_dna         49 ????????????????????????????????????        13
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       49,        13]]),
                 # fmt: on
@@ -3537,7 +3469,6 @@ hg19_dna         49 ???????????????????????????????????????       10
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      49,       10]]),
                 # fmt: on
@@ -3572,7 +3503,6 @@ hg19_dna         49 ???????????????????????????????????????     10
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    49,     10]]),
                 # fmt: on
@@ -3607,7 +3537,6 @@ hg19_dna         49 ????????????????????????????????????       13
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      49,       13]]),
                 # fmt: on
@@ -3642,7 +3571,6 @@ hg19_dna         35 ?????????????????????????        10
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       35,        10]]),
                 # fmt: on
@@ -3711,7 +3639,6 @@ hg19_dna         47 ??????????????????????????????????        13
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       47,        13]]),
                 # fmt: on

--- a/Tests/test_Align_clustal.py
+++ b/Tests/test_Align_clustal.py
@@ -597,7 +597,6 @@ AT3G20900.1-CDS                     CAGCACCGCTGCTGGGGATGGAGAGGGAACAGAGTAG
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'C', 'T', 'G', 'G', 'G', 'G', 'A', 'T', 'G', 'G', 'A', 'G', 'A',
            'G', 'G', 'G', 'A', 'A', 'C', 'A', 'G', 'A', 'G', 'T', '-', 'T'],
           ['G', 'C', 'T', 'G', 'G', 'G', 'G', 'A', 'T', 'G', 'G', 'A', 'G', 'A',
@@ -650,7 +649,6 @@ AT3G20900                           GCTGGGGATGGAGAGGGAACAGAGTAG
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['D', '-', 'V', 'L', 'L', 'G', 'A', 'N', 'G', 'G', 'V', 'L', 'V',
            'F', 'E', 'P', 'N', 'D', 'F', 'S', 'V', 'K', 'A', 'G', 'E', 'T',
            'I', 'T', 'F', 'K', 'N', 'N', 'A', 'G', 'Y', 'P', 'H', 'N', 'V',

--- a/Tests/test_Align_clustal.py
+++ b/Tests/test_Align_clustal.py
@@ -185,7 +185,7 @@ gi|671626|emb|CAA85685.1|           -
                                      
 
 
-""",
+""",  # noqa: W293
         )
 
     def test_msaprobs(self):
@@ -579,7 +579,7 @@ AT3G20900.1-CDS                     CAGCACCGCTGCTGGGGATGGAGAGGGAACAGAGTAG
                                     ***********************************  
 
 
-""",
+""",  # noqa: W293
         )
         self.check_reading_writing(path)
 

--- a/Tests/test_Align_codonalign.py
+++ b/Tests/test_Align_codonalign.py
@@ -428,7 +428,6 @@ ENSG00000       306
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[0, 42, 126, 126, 231, 333, 549],
                           [0,  0,  84,  90, 195, 195, 195],
                           [9,  9,  93,  99, 204, 306, 306]])
@@ -942,7 +941,6 @@ ENSG00000      1257
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[   0,   72,  255,  255,  603,  606, 1317, 1530,
                            1530, 1737, 1737, 1902, 1902, 1926, 1926, 2031,
                            2088, 2343, 2346, 2418, 2442, 2556, 2562, 2763,
@@ -2643,7 +2641,6 @@ isotig125      2340 GTACTTCAGGGTGACCGGGATTCAAGAGAAGACCAGAATCAGGCCTCA 2388
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[   0,    0,    0,    0,    0,    0,    0,    0,
                               0,    0,    0,    0,   36,   36,   63,   63,
                             213,  222,  240,  240,  330,  330,  330,  405,
@@ -4914,7 +4911,6 @@ isotig125      2340 GTACTTCAGGGTGACCGGGATTCAAGAGAAGACCAGAATCAGGCCTCA 2388
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[   0,    0,    0,    0,    0,    0,    0,    0,
                               0,    0,    0,    0,   36,   36,   63,   63,
                             213,  222,  240,  240,  330,  330,  330,  405,
@@ -5897,7 +5893,6 @@ ENSG00000       306
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[0, 42, 126, 126, 231, 333, 549],
                           [0,  0,  84,  90, 195, 195, 195],
                           [9,  9,  93,  99, 204, 306, 306]])
@@ -7540,7 +7535,6 @@ gi|647886      3753 CCGCCAAGCAGTGAGTTTAGTGGAGCA 3780
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
             np.array([[  84,  105,  114,  129,  171,  183,  198,  198,  210,
                         234,  366,  369,  492,  507,  531,  531,  741,  741,
                         807,  810, 1038, 1038, 1089, 1089, 1107, 1107, 1161,

--- a/Tests/test_Align_emboss.py
+++ b/Tests/test_Align_emboss.py
@@ -88,7 +88,6 @@ IXI_235         101 PPAWAGDRSHE 112
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'S', 'P', 'A', 'S', 'I', 'R', 'P', 'P', 'A', 'G', 'P', 'S', 'S',
            'R', 'P', 'A', 'M', 'V', 'S', 'S', 'R', 'R', 'T', 'R', 'P', 'S', 'P',
            'P', 'G', 'P', 'R', 'R', 'P', 'T', 'G', 'R', 'P', 'C', 'C', 'S', 'A',
@@ -167,7 +166,6 @@ asis              0 CGTTTGAGTACTGGGATG 18
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'G', 'T', 'T', 'T', 'G', 'A', 'G', 'T', '-', 'C', 'T', 'G',
            'G', 'G', 'A', 'T', 'G'],
           ['C', 'G', 'T', 'T', 'T', 'G', 'A', 'G', 'T', 'A', 'C', 'T', 'G',
@@ -231,7 +229,6 @@ CAA85685.        46 GVPPEEAGAAVAAESS 62
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'P', 'P', 'P', 'Q', 'S', 'P', 'D', 'E', 'N', 'R', 'A', 'G',
            'E', 'S', 'S'],
           ['G', 'V', 'P', 'P', 'E', 'E', 'A', 'G', 'A', 'A', 'V', 'A', 'A',
@@ -334,7 +331,6 @@ HBB_HUMAN       121 EFTPPVQAAYQKVVAGVANALAHKY 146
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'S', 'P', 'A', 'D', 'K', 'T', 'N', 'V', 'K', 'A', 'A', 'W',
            'G', 'K', 'V', 'G', 'A', 'H', 'A', 'G', 'E', 'Y', 'G', 'A', 'E',
            'A', 'L', 'E', 'R', 'M', 'F', 'L', 'S', 'F', 'P', 'T', 'T', 'K',
@@ -404,7 +400,6 @@ HBB_HUMAN       131 QKVVAGVANALAH 144
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'K', 'V', 'A', 'D', 'A', 'L', 'T', 'N', 'A', 'V', 'A', 'H'],
           ['Q', 'K', 'V', 'V', 'A', 'G', 'V', 'A', 'N', 'A', 'L', 'A', 'H']],
          dtype='U')
@@ -453,7 +448,6 @@ HBB_HUMAN        17 KVNVDEVGGEALGRLLVV  35
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'L', 'R', 'V', 'D', 'P', 'V', 'N', 'F', 'K', 'L', 'L', 'S',
            'H', 'C', 'L', 'L', 'V'],
           ['K', 'V', 'N', 'V', 'D', 'E', 'V', 'G', 'G', 'E', 'A', 'L', 'G',
@@ -501,7 +495,6 @@ HBB_HUMAN        68 LGAFSDGLAH 78
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'S', 'A', 'L', 'S', 'D', 'L', 'H', 'A', 'H'],
           ['L', 'G', 'A', 'F', 'S', 'D', 'G', 'L', 'A', 'H']], dtype='U')
                 # fmt: on
@@ -547,7 +540,6 @@ HBB_HUMAN       126 VQAAYQKVVA 136
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['V', 'K', 'A', 'A', 'W', 'G', 'K', 'V', 'G', 'A'],
           ['V', 'Q', 'A', 'A', 'Y', 'Q', 'K', 'V', 'V', 'A']], dtype='U')
                 # fmt: on
@@ -633,7 +625,6 @@ IXI_235         101 PPAWAGDRSHE 112
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'S', 'P', 'A', 'S', 'I', 'R', 'P', 'P', 'A', 'G', 'P', 'S',
            'S', 'R', 'P', 'A', 'M', 'V', 'S', 'S', 'R', 'R', 'T', 'R', 'P',
            'S', 'P', 'P', 'G', 'P', 'R', 'R', 'P', 'T', 'G', 'R', 'P', 'C',
@@ -721,7 +712,6 @@ IXI_236         116 PPPPAGDRSHE 127
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'S', 'P', 'A', 'S', 'I', 'R', 'P', 'P', 'A', 'G', 'P', 'S',
            'S', 'R', 'P', 'A', 'M', 'V', 'S', 'S', 'R', 'R', 'T', 'R', 'P',
            'S', 'P', 'P', 'G', 'P', 'R', 'R', 'P', 'T', 'G', 'R', 'P', 'C',
@@ -811,7 +801,6 @@ IXI_237         113 PPAYAGDRSHE 124
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'S', 'P', 'A', 'S', 'I', 'R', 'P', 'P', 'A', 'G', 'P', 'S',
            'S', 'R', 'P', 'A', 'M', 'V', 'S', 'S', 'R', 'R', 'T', 'R', 'P',
            'S', 'P', 'P', 'G', 'P', 'R', 'R', 'P', 'T', 'G', 'R', 'P', 'C',
@@ -914,7 +903,6 @@ gi|949687       116 NGET 120
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'I', 'L', 'I', 'V', 'D', 'D', '-', '-', '-', '-', 'Q', 'Y',
            'G', 'I', 'R', 'I', 'L', 'L', 'N', 'E', 'V', 'F', 'N', 'K', 'E',
            'G', 'Y', 'Q', 'T', 'F', 'Q', 'A', 'A', 'N', 'G', 'L', 'Q', 'A',
@@ -995,7 +983,6 @@ gi|949687       118
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'I', 'L', 'I', 'V', 'D', 'D', 'Q', 'Y', 'G', 'I', 'R', 'I',
            'L', 'L', 'N', 'E', 'V', 'F', 'N', 'K', 'E', 'G', 'Y', 'Q', 'T',
            'F', 'Q', 'A', 'A', 'N', 'G', 'L', 'Q', 'A', 'L', 'D', 'I', 'V',
@@ -1076,7 +1063,6 @@ gi|949675       120
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['-', 'K', 'I', 'L', 'I', 'V', 'D', 'D', 'Q', 'Y', 'G', 'I', 'R',
            'I', 'L', 'L', 'N', 'E', 'V', 'F', 'N', 'K', 'E', 'G', 'Y', 'Q',
            'T', 'F', 'Q', 'A', 'A', 'N', 'G', 'L', 'Q', 'A', 'L', 'D', 'I',
@@ -1163,7 +1149,6 @@ gi|949700       116
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'I', 'L', 'I', 'V', 'D', 'D', 'Q', 'Y', 'G', 'I', 'R', 'I',
            'L', 'L', 'N', 'E', 'V', 'F', 'N', 'K', 'E', 'G', 'Y', 'Q', 'T',
            'F', 'Q', 'A', 'A', 'N', 'G', 'L', 'Q', 'A', 'L', 'D', 'I', 'V',
@@ -1250,7 +1235,6 @@ gi|949700       116 LQKRQ 121
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'I', 'L', 'I', 'V', 'D', 'D', 'Q', 'Y', 'G', 'I', 'R', 'I',
            'L', 'L', 'N', 'E', 'V', 'F', 'N', 'K', 'E', 'G', 'Y', 'Q', 'T',
            'F', 'Q', 'A', 'A', 'N', 'G', 'L', 'Q', 'A', 'L', 'D', 'I', 'V',
@@ -1312,7 +1296,6 @@ np.array([['K', 'I', 'L', 'I', 'V', 'D', 'D', 'Q', 'Y', 'G', 'I', 'R', 'I',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  0, 162, 169, 201, 210, 210, 220, 222, 236, 240,
                            244, 253, 277, 277, 278, 279, 300, 300, 310, 310,
                            314, 320, 334, 351, 357, 357, 379, 379, 390, 403,
@@ -1428,7 +1411,6 @@ asis            311 ------- 311
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[   0,  958,  965,  997, 1006, 1006, 1016, 1018,
                            1032, 1036, 1040, 1049, 1073, 1073, 1074, 1075,
                            1096, 1096, 1106, 1106, 1110, 1116, 1130, 1147,
@@ -1766,7 +1748,6 @@ asis           2507 CTTAATTTTAGAGG--ATGTTTATTTTTATTCTAATAAAAAGGATCCGTTGAA 2558
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[121, 102, 13,  0],
                           [  0,  19, 19, 32]])
                 # fmt: on
@@ -1912,7 +1893,6 @@ seqB              1 C   0
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[20, 13, 11, 10, 10,  2],
                           [ 2,  9,  9, 10, 11, 19]])
                 # fmt: on
@@ -1971,7 +1951,6 @@ seqB              2 TTTTTTT--ACCCGGGCCC 19
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 2, 10, 12, 12, 20],
                           [19, 11, 11, 10,  2]])
                 # fmt: on
@@ -2033,7 +2012,6 @@ seqB             19 GGGCCCGG--GTAAAAAAA  2
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[   0,    1,   27,   45,   49,   54,   61,   68,
                              79,   91,   93,  101,  105,  113,  133,  145,
                             157,  163,  168,  174,  180,  199,  224,  236,

--- a/Tests/test_Align_exonerate.py
+++ b/Tests/test_Align_exonerate.py
@@ -87,7 +87,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10| 
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 85010,  85021,  85021,  85036,  85036,  85040,
                             85040,  85041,  85041,  85049,  85049,  85066,
                            253974, 253978, 253979, 253987, 253987, 253990,
@@ -123,7 +122,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 0 346 + gi|330443688|ref|NC_001145.3| 85
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[130198, 130184, 130183, 130179, 130179, 130154,
                            130153, 130144, 130138, 130096, 130096, 130080,
                            130078, 130071, 130070, 130067, 130067, 130044,
@@ -210,7 +208,6 @@ vulgar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10|
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 85010,  85021,  85021,  85036,  85036,  85040,
                             85040,  85041,  85041,  85049,  85049,  85066,
                             85068, 253972, 253974, 253978, 253979, 253987,
@@ -253,7 +250,6 @@ vulgar: gi|296143771|ref|NM_001180731.1| 0 346 + gi|330443688|ref|NC_001145.3| 8
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[130198, 130184, 130183, 130179, 130179, 130154,
                            130153, 130144, 130138, 130096, 130096, 130080,
                            130078, 130071, 130070, 130067, 130067, 130044,
@@ -343,7 +339,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10| 
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[253990, 254024, 254025, 254031, 254033, 254134,
                            254136, 254142, 254142, 254145, 254145, 254157,
                            254158, 254167, 254167, 254193, 254194, 254228,
@@ -383,7 +378,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 83 552 + gi|330443688|ref|NC_001145.3| 2
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[454073, 454087, 454087, 454094, 454094, 454097,
                            454097, 454109, 454110, 454133, 454134, 454150,
                            454150, 454167, 454169, 454175, 454176, 454183,
@@ -468,7 +462,6 @@ vulgar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10|
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[253990, 254024, 254025, 254031, 254033, 254134,
                            254136, 254142, 254142, 254145, 254145, 254157,
                            254158, 254167, 254167, 254193, 254194, 254228,
@@ -515,7 +508,6 @@ vulgar: gi|296143771|ref|NM_001180731.1| 83 552 + gi|330443688|ref|NC_001145.3| 
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[454073, 454087, 454087, 454094, 454094, 454097,
                            454097, 454109, 454110, 454133, 454134, 454150,
                            454150, 454167, 454169, 454175, 454176, 454183,
@@ -593,7 +585,6 @@ class Exonerate_cdna2genome(unittest.TestCase):
         self.assertTrue(
             np.array_equal(
                 # fmt: off
-# flake8: noqa
                 alignment.coordinates,
                 np.array([[1319275, 1319274, 1319271, 1318045],
                           [      0,       1,       4,    1230]])
@@ -616,7 +607,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10| 
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1318045, 1318174, 1318177, 1319275],
                           [   1230,    1101,    1098,       0]])
                 # fmt: on
@@ -638,7 +628,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 1230 0 - gi|330443520|ref|NC_001136.10| 
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 85010,  85021,  85021,  85036,  85036,  85040,
                             85040,  85041,  85041,  85049,  85049,  85066,
                            253974, 253978, 253979, 253987, 253987, 253990,
@@ -710,7 +699,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 0 516 + gi|330443688|ref|NC_001145.3| 85
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1319275, 1319274, 1319271, 1318045],
                           [      0,       1,       4,    1230]])
                 # fmt: on
@@ -734,7 +722,6 @@ vulgar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10|
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1318045, 1318174, 1318177, 1319275],
                           [   1230,    1101,    1098,       0]])
                 # fmt: on
@@ -758,7 +745,6 @@ vulgar: gi|296143771|ref|NM_001180731.1| 1230 0 - gi|330443520|ref|NC_001136.10|
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 85010,  85021,  85021,  85036,  85036,  85040,
                             85040,  85041,  85041,  85049,  85049,  85066,
                             85068, 253972, 253974, 253978, 253979, 253987,
@@ -877,7 +863,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10| 
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[255638, 255743, 255743, 255794],
                           [  1065,   1170,   1173,   1224]])
                 # fmt: on
@@ -967,7 +952,6 @@ vulgar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10|
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[255638, 255743, 255743, 255794],
                           [  1065,   1170,   1173,   1224]])
                 # fmt: on
@@ -1022,7 +1006,6 @@ class Exonerate_coding2genome(unittest.TestCase):
         self.assertTrue(
             np.array_equal(
                 # fmt: off
-# flake8: noqa
                 alignment.coordinates, np.array([[1318047, 1319274], [1228, 1]])
                 # fmt: on
             )
@@ -1060,7 +1043,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10| 
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[255638, 255743, 255743, 255794],
                           [  1065,   1170,   1173,   1224]])
                 # fmt: on
@@ -1111,7 +1093,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 1065 1224 + gi|330443688|ref|NC_001145.3
         self.assertTrue(
             np.array_equal(
                 # fmt: off
-# flake8: noqa
                 alignment.coordinates, np.array([[1318047, 1319274], [1228, 1]])
                 # fmt: on
             )
@@ -1153,7 +1134,6 @@ vulgar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10|
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[255638, 255743, 255743, 255794],
                           [  1065,   1170,   1173,   1224]])
                 # fmt: on
@@ -1304,7 +1284,6 @@ class Exonerate_genome2genome(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1319997, 1319971, 1319968, 1319468],
                           [    529,     503,     500,       0]])
                 # fmt: on
@@ -1326,7 +1305,6 @@ cigar: sacCer3_dna 529 0 - gi|330443520|ref|NC_001136.10| 1319997 1319468 - 2641
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1319997, 1319971, 1319968, 1319468],
                           [    529,     503,     500,       0]])
                 # fmt: on
@@ -1350,7 +1328,6 @@ cigar: sacCer3_dna 529 0 - gi|330443520|ref|NC_001136.10| 1319997 1319468 - 2641
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1319468, 1319558, 1319561, 1319997],
                           [      0,      90,      93,     529]])
                 # fmt: on
@@ -1372,7 +1349,6 @@ cigar: sacCer3_dna 0 529 + gi|330443520|ref|NC_001136.10| 1319468 1319997 + 2641
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1319468, 1319558, 1319561, 1319997],
                           [      0,      90,      93,     529]])
                 # fmt: on
@@ -1396,7 +1372,6 @@ cigar: sacCer3_dna 0 529 + gi|330443520|ref|NC_001136.10| 1319468 1319997 + 2641
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 23668,  23697,  32680,  32712,  32714,  32716,
                             32717,  32732,  42287,  42290,  42290,  42295,
                             42297,  42300,  42301,  42305,  42306,  42324,
@@ -1432,7 +1407,6 @@ cigar: sacCer3_dna 491 162 - gi|330443489|ref|NC_001135.5| 23668 115569 + 267 M 
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 23668,  23697,  23699,  32678,  32680,  32712,
                             32714,  32716,  32717,  32732,  32734,  42285,
                             42287,  42290,  42290,  42295,  42297,  42300,
@@ -1475,7 +1449,6 @@ cigar: sacCer3_dna 491 162 - gi|330443489|ref|NC_001135.5| 23668 115569 + 267 M 
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[641760, 641729, 641729, 641725, 641725, 641706,
                            641703, 641694, 641693, 641687, 641687, 641680,
                            487436, 487436, 487389, 487362, 487362, 487358,
@@ -1521,7 +1494,6 @@ cigar: sacCer3_dna 529 78 - gi|330443667|ref|NC_001143.9| 641760 71883 - 267 M 3
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[641760, 641729, 641729, 641725, 641725, 641706,
                            641703, 641694, 641693, 641687, 641687, 641682,
                            641680, 487436, 487436, 487389, 487387, 487362,
@@ -1601,7 +1573,6 @@ cigar: sacCer3_dna 529 78 - gi|330443667|ref|NC_001143.9| 641760 71883 - 267 M 3
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1319997, 1319971, 1319968, 1319468],
                           [    529,     503,     500,       0]])
                 # fmt: on
@@ -1645,7 +1616,6 @@ vulgar: sacCer3_dna 0 529 + gi|330443520|ref|NC_001136.10| 1319468 1319997 + 264
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 23668,  23697,  23699,  32678,  32680,  32712,
                             32714,  32716,  32717,  32732,  32734,  42285,
                             42287,  42290,  42290,  42295,  42297,  42300,
@@ -1688,7 +1658,6 @@ vulgar: sacCer3_dna 491 162 - gi|330443489|ref|NC_001135.5| 23668 115569 + 267 M
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[641760, 641729, 641729, 641725, 641725, 641706,
                            641703, 641694, 641693, 641687, 641687, 641682,
                            641680, 487436, 487436, 487389, 487387, 487362,
@@ -2134,7 +2103,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10| 
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[297910, 297918, 297946, 297946, 297958, 297970,
                            297970, 297984, 297992, 297992, 297997, 297997,
                            298005, 298016, 298016, 298019, 298023, 298024,
@@ -2202,7 +2170,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 110 1230 + gi|330443681|ref|NC_001144.5|
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183946, 183952, 183960, 183960, 183977, 183988,
                            183995, 183995, 184002, 184031, 184039, 184039,
                            184044, 184055, 184059, 184059, 184060, 184060,
@@ -2315,7 +2282,6 @@ vulgar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10|
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[297910, 297917, 297946, 297946, 297957, 297970,
                            297970, 297983, 297992, 297992, 297997, 297997,
                            298004, 298019, 298019, 298023, 298024, 298031,
@@ -2384,7 +2350,6 @@ vulgar: gi|296143771|ref|NM_001180731.1| 110 1230 + gi|330443681|ref|NC_001144.5
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183946, 183951, 183977, 183977, 183987, 184002,
                            184002, 184030, 184044, 184044, 184054, 184066,
                            184066, 184080, 184092, 184092, 184107, 184111,
@@ -2494,7 +2459,6 @@ cigar: gi|296142823|ref|NM_001178508.1| 0 897 + gi|330443482|ref|NC_001134.8| 56
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[492933, 492929, 492929, 492908, 492908, 492857,
                            492857, 492851, 492851, 492840, 492840, 492839,
                            492839, 492813, 492813, 492711, 492711, 492710,
@@ -2538,7 +2502,6 @@ cigar: gi|296142823|ref|NM_001178508.1| 2 896 + gi|330443753|ref|NC_001148.4| 49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[267809, 267843, 267843, 267851, 267851, 267852,
                            267852, 267859, 267863, 267867, 267867, 267870,
                            267870, 267880, 267880, 267908, 267908, 267942,
@@ -2601,7 +2564,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10| 
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 85010,  85021,  85021,  85036,  85036,  85040,
                             85040,  85041,  85041,  85049,  85049,  85066,
                            253974, 253978, 253979, 253987, 253987, 253990,
@@ -2637,7 +2599,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 0 346 + gi|330443688|ref|NC_001145.3| 85
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[130198, 130184, 130183, 130179, 130179, 130154,
                            130153, 130144, 130138, 130096, 130096, 130080,
                            130078, 130071, 130070, 130067, 130067, 130044,
@@ -2724,7 +2685,6 @@ vulgar: gi|296142823|ref|NM_001178508.1| 0 897 + gi|330443482|ref|NC_001134.8| 5
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[492933, 492929, 492929, 492908, 492908, 492857,
                            492857, 492851, 492851, 492840, 492840, 492839,
                            492839, 492813, 492813, 492711, 492711, 492710,
@@ -2775,7 +2735,6 @@ vulgar: gi|296142823|ref|NM_001178508.1| 2 896 + gi|330443753|ref|NC_001148.4| 4
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[267809, 267843, 267843, 267851, 267851, 267852,
                            267852, 267859, 267863, 267867, 267867, 267870,
                            267870, 267880, 267880, 267908, 267908, 267942,
@@ -2849,7 +2808,6 @@ vulgar: gi|296143771|ref|NM_001180731.1| 0 1230 + gi|330443520|ref|NC_001136.10|
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 85010,  85021,  85021,  85036,  85036,  85040,
                             85040,  85041,  85041,  85049,  85049,  85066,
                             85068, 253972, 253974, 253978, 253979, 253987,
@@ -2892,7 +2850,6 @@ vulgar: gi|296143771|ref|NM_001180731.1| 0 346 + gi|330443688|ref|NC_001145.3| 8
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[130198, 130184, 130183, 130179, 130179, 130154,
                            130153, 130144, 130138, 130096, 130096, 130080,
                            130078, 130071, 130070, 130067, 130067, 130044,
@@ -2969,7 +2926,6 @@ class Exonerate_coding2coding_fshifts(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[465, 558, 558, 591, 593, 605, 609, 630],
                           [  0,  93,  94, 127, 127, 139, 139, 160]])
                 # fmt: on
@@ -2991,7 +2947,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 0 160 + gi|296143771|ref|NM_001180731.1|
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[628, 604, 598, 559, 559, 466],
                           [158, 134, 134,  95,  94,   1]])
                 # fmt: on
@@ -3043,7 +2998,6 @@ cigar: gi|296143771|ref|NM_001180731.1| 158 1 - gi|296143771|ref|NM_001180731.1|
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[465, 558, 558, 591, 593, 605, 609, 630],
                           [  0,  93,  94, 127, 127, 139, 139, 160]])
                 # fmt: on
@@ -3067,7 +3021,6 @@ vulgar: gi|296143771|ref|NM_001180731.1| 0 160 + gi|296143771|ref|NM_001180731.1
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[628, 604, 598, 559, 559, 466],
                           [158, 134, 134,  95,  94,   1]])
                 # fmt: on
@@ -3225,7 +3178,6 @@ vulgar: sp|P24813|YAP2_YEAST 0 409 . gi|330443520|ref|NC_001136.10| 1319275 1318
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[253991, 254027, 254030, 254270],
                           [    28,     40,     40,    120]])
                 # fmt: on
@@ -3249,7 +3201,6 @@ vulgar: sp|P24813|YAP2_YEAST 28 120 . gi|330443688|ref|NC_001145.3| 253991 25427
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[255638, 255743, 255743, 255794],
                           [   355,    390,    391,    408]])
                 # fmt: on
@@ -3454,7 +3405,6 @@ cigar: sp|P24813|YAP2_YEAST 0 409 . gi|330443520|ref|NC_001136.10| 1319275 13180
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[253991, 254027, 254030, 254270],
                           [    28,     40,     40,    120]])
                 # fmt: on
@@ -3476,7 +3426,6 @@ cigar: sp|P24813|YAP2_YEAST 28 120 . gi|330443688|ref|NC_001145.3| 253991 254270
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[84646, 84535, 68601, 68450],
                           [   37,    74,    74,   125]])
                 # fmt: on
@@ -3538,7 +3487,6 @@ vulgar: sp|P24813|YAP2_YEAST 0 409 . gi|330443520|ref|NC_001136.10| 1319275 1318
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[253991, 254027, 254030, 254270],
                           [    28,     40,     40,    120]])
                 # fmt: on
@@ -3562,7 +3510,6 @@ vulgar: sp|P24813|YAP2_YEAST 28 120 . gi|330443688|ref|NC_001145.3| 253991 25427
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[84646, 84535, 84533, 84531, 68603, 68601,
                            68600, 68450],
                           [   37,    74,    74,    74,    74,    74,
@@ -3622,7 +3569,6 @@ class Exonerate_protein2genome_revcomp_fshifts(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1416, 1380, 1374, 1125, 1125, 1047, 1047,  744,
                             744,  450,  450,  448,  331],
                           [  69,   81,   81,  164,  169,  195,  196,  297,
@@ -3678,7 +3624,6 @@ cigar: Morus-gene026 69 441 . NODE_2_length_1708_cov_48.590765 1416 331 - 1308 M
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1416, 1380, 1374, 1125, 1125, 1047, 1047,  744,
                             744,  450,  450, 448,  331],
                           [  69,   81,   81,  164,  169,  195,  196,  297,
@@ -3738,7 +3683,6 @@ class Exonerate_protein2genome_met_intron(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[2392, 2281, 2129, 2030, 1921, 1810, 1724, 1421,
                            1198, 1058,  925,  388],
                           [  48,   85,   85,  118,  118,  155,  155,  256,
@@ -3785,7 +3729,6 @@ class Exonerate_protein2genome_met_intron(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[2392, 2281, 2279, 2131, 2129, 2030, 2028, 1923,
                            1921, 1810, 1808, 1726, 1724, 1421, 1420, 1418,
                            1200, 1198, 1196, 1058, 1056,  927,  925,  388],

--- a/Tests/test_Align_fasta.py
+++ b/Tests/test_Align_fasta.py
@@ -420,7 +420,6 @@ ATGAACAAAGTAGCGAGGAAGAACAAAACATCAGGTGAACAAAAAAAAAACTCAATCCACATCAAAGTTACAATAACTGA
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'C', 'T', 'G', 'G', 'G', 'G', 'A', 'T', 'G', 'G', 'A', 'G', 'A',
            'G', 'G', 'G', 'A', 'A', 'C', 'A', 'G', 'A', 'G', 'T', '-', 'T'],
           ['G', 'C', 'T', 'G', 'G', 'G', 'G', 'A', 'T', 'G', 'G', 'A', 'G', 'A',
@@ -472,7 +471,6 @@ GCTGGGGATGGAGAGGGAACAGAGTAG
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['D', '-', 'V', 'L', 'L', 'G', 'A', 'N', 'G', 'G', 'V', 'L', 'V',
            'F', 'E', 'P', 'N', 'D', 'F', 'S', 'V', 'K', 'A', 'G', 'E', 'T',
            'I', 'T', 'F', 'K', 'N', 'N', 'A', 'G', 'Y', 'P', 'H', 'N', 'V',

--- a/Tests/test_Align_hhr.py
+++ b/Tests/test_Align_hhr.py
@@ -107,7 +107,6 @@ class Align_hhr_2uvo_hhblits(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  0, 171],
                           [  0, 171]])
                 # fmt: on
@@ -117,7 +116,6 @@ class Align_hhr_2uvo_hhblits(unittest.TestCase):
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'R', 'C', 'G', 'E', 'Q', 'G', 'S', 'N', 'M', 'E', 'C', 'P',
            'N', 'N', 'L', 'C', 'C', 'S', 'Q', 'Y', 'G', 'Y', 'C', 'G', 'M',
            'G', 'G', 'D', 'Y', 'C', 'G', 'K', 'G', 'C', 'Q', 'N', 'G', 'A',
@@ -219,7 +217,6 @@ np.array([['E', 'R', 'C', 'G', 'E', 'Q', 'G', 'S', 'N', 'M', 'E', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  48,  48,  90,  90, 131, 131, 163],
                           [  1,  48,  50,  92,  94, 135, 137, 169]])
                 # fmt: on
@@ -229,7 +226,6 @@ np.array([['E', 'R', 'C', 'G', 'E', 'Q', 'G', 'S', 'N', 'M', 'E', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'X', 'G', 'C', 'X', 'G', 'X', 'X', 'M', 'Y', 'C', 'S', 'T',
            'N', 'N', 'C', 'C', 'X', 'X', 'W', 'E', 'S', 'C', 'G', 'S', 'G',
            'G', 'Y', 'X', 'C', 'G', 'E', 'G', 'C', 'N', 'L', 'G', 'A', 'C',
@@ -330,7 +326,6 @@ np.array([['G', 'X', 'G', 'C', 'X', 'G', 'X', 'X', 'M', 'Y', 'C', 'S', 'T',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  39,  39,  40,  40,  80,  80,  81,  81, 121],
                           [  0,  38,  39,  40,  41,  81,  82,  83,  84, 124]])
                 # fmt: on
@@ -340,7 +335,6 @@ np.array([['G', 'X', 'G', 'C', 'X', 'G', 'X', 'X', 'M', 'Y', 'C', 'S', 'T',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['P', 'V', 'C', 'G', 'V', 'R', 'A', 'S', 'G', 'R', 'V', 'C', 'P',
            'D', 'G', 'Y', 'C', 'C', 'S', 'Q', 'W', 'G', 'Y', 'C', 'G', 'T',
            'T', 'E', 'E', 'Y', 'C', 'G', 'K', 'G', 'C', 'Q', 'S', 'Q', '-',
@@ -434,7 +428,6 @@ np.array([['P', 'V', 'C', 'G', 'V', 'R', 'A', 'S', 'G', 'R', 'V', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  39,  39,  40,  40,  80,  80,  81,  81, 121],
                           [ 43,  81,  82,  83,  84, 124, 125, 126, 127, 167]])
                 # fmt: on
@@ -444,7 +437,6 @@ np.array([['P', 'V', 'C', 'G', 'V', 'R', 'A', 'S', 'G', 'R', 'V', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['P', 'V', 'C', 'G', 'V', 'R', 'A', 'S', 'G', 'R', 'V', 'C', 'P',
            'D', 'G', 'Y', 'C', 'C', 'S', 'Q', 'W', 'G', 'Y', 'C', 'G', 'T',
            'T', 'E', 'E', 'Y', 'C', 'G', 'K', 'G', 'C', 'Q', 'S', 'Q', '-',
@@ -538,7 +530,6 @@ np.array([['P', 'V', 'C', 'G', 'V', 'R', 'A', 'S', 'G', 'R', 'V', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1, 126],
                           [ 44, 169]])
                 # fmt: on
@@ -548,7 +539,6 @@ np.array([['P', 'V', 'C', 'G', 'V', 'R', 'A', 'S', 'G', 'R', 'V', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'C', 'G', 'E', 'Q', 'G', 'S', 'N', 'M', 'E', 'C', 'P', 'N',
            'N', 'L', 'C', 'C', 'S', 'Q', 'Y', 'G', 'Y', 'C', 'G', 'M', 'G',
            'G', 'D', 'Y', 'C', 'G', 'K', 'G', 'C', 'Q', 'N', 'G', 'A', 'C',
@@ -638,7 +628,6 @@ np.array([['R', 'C', 'G', 'E', 'Q', 'G', 'S', 'N', 'M', 'E', 'C', 'P', 'N',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  2,  48,  48,  90,  90, 123],
                           [ 45,  91,  93, 135, 137, 170]])
                 # fmt: on
@@ -648,7 +637,6 @@ np.array([['R', 'C', 'G', 'E', 'Q', 'G', 'S', 'N', 'M', 'E', 'C', 'P', 'N',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['X', 'G', 'C', 'X', 'G', 'X', 'X', 'M', 'Y', 'C', 'S', 'T', 'N',
            'N', 'C', 'C', 'X', 'X', 'W', 'E', 'S', 'C', 'G', 'S', 'G', 'G',
            'Y', 'X', 'C', 'G', 'E', 'G', 'C', 'N', 'L', 'G', 'A', 'C', 'Q',
@@ -738,7 +726,6 @@ np.array([['X', 'G', 'C', 'X', 'G', 'X', 'X', 'M', 'Y', 'C', 'S', 'T', 'N',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  39,  39,  79],
                           [ 43,  81,  83, 123]])
                 # fmt: on
@@ -748,7 +735,6 @@ np.array([['X', 'G', 'C', 'X', 'G', 'X', 'X', 'M', 'Y', 'C', 'S', 'T', 'N',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['P', 'E', 'C', 'G', 'E', 'R', 'A', 'S', 'G', 'K', 'R', 'C', 'P',
            'N', 'G', 'K', 'C', 'C', 'S', 'Q', 'W', 'G', 'Y', 'C', 'G', 'T',
            'T', 'D', 'N', 'Y', 'C', 'G', 'Q', 'G', 'C', 'Q', 'S', 'Q', '-',
@@ -832,7 +818,6 @@ np.array([['P', 'E', 'C', 'G', 'E', 'R', 'A', 'S', 'G', 'K', 'R', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 0, 38, 38, 40, 44, 80, 81, 86],
                           [ 0, 38, 39, 41, 41, 77, 77, 82]])
                 # fmt: on
@@ -842,7 +827,6 @@ np.array([['P', 'E', 'C', 'G', 'E', 'R', 'A', 'S', 'G', 'K', 'R', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'R', 'C', 'G', 'S', 'Q', 'G', 'G', 'G', 'S', 'T', 'C', 'P',
            'G', 'L', 'R', 'C', 'C', 'S', 'I', 'W', 'G', 'W', 'C', 'G', 'D',
            'S', 'E', 'P', 'Y', 'C', 'G', 'R', 'T', 'C', 'E', 'N', 'K', '-',
@@ -926,7 +910,6 @@ np.array([['E', 'R', 'C', 'G', 'S', 'Q', 'G', 'G', 'G', 'S', 'T', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  38,  38,  40,  44,  80,  81,  85],
                           [ 44,  81,  82,  84,  84, 120, 120, 124]])
                 # fmt: on
@@ -936,7 +919,6 @@ np.array([['E', 'R', 'C', 'G', 'S', 'Q', 'G', 'G', 'G', 'S', 'T', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'C', 'G', 'S', 'Q', 'G', 'G', 'G', 'S', 'T', 'C', 'P', 'G',
            'L', 'R', 'C', 'C', 'S', 'I', 'W', 'G', 'W', 'C', 'G', 'D', 'S',
            'E', 'P', 'Y', 'C', 'G', 'R', 'T', 'C', 'E', 'N', 'K', '-', 'C',
@@ -1020,7 +1002,6 @@ np.array([['R', 'C', 'G', 'S', 'Q', 'G', 'G', 'G', 'S', 'T', 'C', 'P', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  2,  39,  39,  40,  40,  80],
                           [ 87, 124, 125, 126, 127, 167]])
                 # fmt: on
@@ -1030,7 +1011,6 @@ np.array([['R', 'C', 'G', 'S', 'Q', 'G', 'G', 'G', 'S', 'T', 'C', 'P', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'C', 'G', 'E', 'R', 'A', 'S', 'G', 'K', 'R', 'C', 'P', 'N',
            'G', 'K', 'C', 'C', 'S', 'Q', 'W', 'G', 'Y', 'C', 'G', 'T', 'T',
            'D', 'N', 'Y', 'C', 'G', 'Q', 'G', 'C', 'Q', 'S', 'Q', '-', 'C',
@@ -1102,7 +1082,6 @@ np.array([['E', 'C', 'G', 'E', 'R', 'A', 'S', 'G', 'K', 'R', 'C', 'P', 'N',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  33,  35,  40],
                           [ 87, 119, 119, 124]])
                 # fmt: on
@@ -1112,7 +1091,6 @@ np.array([['E', 'C', 'G', 'E', 'R', 'A', 'S', 'G', 'K', 'R', 'C', 'P', 'N',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'K', 'L', 'C', 'P', 'D',
            'N', 'L', 'C', 'C', 'S', 'Q', 'W', 'G', 'W', 'C', 'G', 'S', 'T',
            'D', 'E', 'Y', 'C', 'S', 'P', 'D', 'H', 'N', 'C', 'Q', 'S', 'N'],
@@ -1177,7 +1155,6 @@ np.array([['Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'K', 'L', 'C', 'P', 'D',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 0,  5,  5, 32, 33, 38],
                           [ 0,  5,  6, 33, 33, 38]])
                 # fmt: on
@@ -1187,7 +1164,6 @@ np.array([['Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'K', 'L', 'C', 'P', 'D',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'T', 'C', 'A', 'S', '-', 'R', 'C', 'P', 'R', 'P', 'C', 'N',
            'A', 'G', 'L', 'C', 'C', 'S', 'I', 'Y', 'G', 'Y', 'C', 'G', 'S',
            'G', 'A', 'A', 'Y', 'C', 'G', 'A', 'G', 'N', 'C', 'R', 'C', 'Q'],
@@ -1252,7 +1228,6 @@ np.array([['E', 'T', 'C', 'A', 'S', '-', 'R', 'C', 'P', 'R', 'P', 'C', 'N',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,   5,   5,  33,  34,  38],
                           [ 87,  91,  92, 120, 120, 124]])
                 # fmt: on
@@ -1262,7 +1237,6 @@ np.array([['E', 'T', 'C', 'A', 'S', '-', 'R', 'C', 'P', 'R', 'P', 'C', 'N',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'C', 'A', 'S', '-', 'R', 'C', 'P', 'R', 'P', 'C', 'N', 'A',
            'G', 'L', 'C', 'C', 'S', 'I', 'Y', 'G', 'Y', 'C', 'G', 'S', 'G',
            'A', 'A', 'Y', 'C', 'G', 'A', 'G', 'N', 'C', 'R', 'C', 'Q'],
@@ -1327,7 +1301,6 @@ np.array([['T', 'C', 'A', 'S', '-', 'R', 'C', 'P', 'R', 'P', 'C', 'N', 'A',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 0, 33, 35, 40],
                           [ 0, 33, 33, 38]])
                 # fmt: on
@@ -1337,7 +1310,6 @@ np.array([['T', 'C', 'A', 'S', '-', 'R', 'C', 'P', 'R', 'P', 'C', 'N', 'A',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'K', 'L', 'C', 'P',
            'D', 'N', 'L', 'C', 'C', 'S', 'Q', 'W', 'G', 'W', 'C', 'G', 'S',
            'T', 'D', 'E', 'Y', 'C', 'S', 'P', 'D', 'H', 'N', 'C', 'Q', 'S',
@@ -1403,7 +1375,6 @@ np.array([['E', 'Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'K', 'L', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 3, 40],
                           [ 1, 38]])
                 # fmt: on
@@ -1413,7 +1384,6 @@ np.array([['E', 'Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'K', 'L', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'A', 'L', 'C', 'P', 'G',
            'G', 'L', 'C', 'C', 'S', 'Q', 'Y', 'G', 'W', 'C', 'A', 'N', 'T',
            'P', 'E', 'Y', 'C', 'G', 'S', 'G', 'C', 'Q', 'S', 'Q'],
@@ -1478,7 +1448,6 @@ np.array([['Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'A', 'L', 'C', 'P', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  2,  35,  36,  40],
                           [ 87, 120, 120, 124]])
                 # fmt: on
@@ -1488,7 +1457,6 @@ np.array([['Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'A', 'L', 'C', 'P', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'C', 'G', 'D', 'Q', 'A', 'R', 'G', 'A', 'K', 'C', 'P', 'N',
            'C', 'L', 'C', 'C', 'G', 'K', 'Y', 'G', 'F', 'C', 'G', 'S', 'G',
            'D', 'A', 'Y', 'C', 'G', 'A', 'G', 'S', 'C', 'Q', 'S', 'Q'],
@@ -1553,7 +1521,6 @@ np.array([['R', 'C', 'G', 'D', 'Q', 'A', 'R', 'G', 'A', 'K', 'C', 'P', 'N',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  2,  40],
                           [ 86, 124]])
                 # fmt: on
@@ -1563,7 +1530,6 @@ np.array([['R', 'C', 'G', 'D', 'Q', 'A', 'R', 'G', 'A', 'K', 'C', 'P', 'N',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'A', 'L', 'C', 'P',
            'G', 'G', 'L', 'C', 'C', 'S', 'Q', 'Y', 'G', 'W', 'C', 'A', 'N',
            'T', 'P', 'E', 'Y', 'C', 'G', 'S', 'G', 'C', 'Q', 'S', 'Q'],
@@ -1628,7 +1594,6 @@ np.array([['E', 'Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'A', 'L', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 1, 35, 36, 40],
                           [ 0, 34, 34, 38]])
                 # fmt: on
@@ -1638,7 +1603,6 @@ np.array([['E', 'Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'A', 'L', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['Q', 'R', 'C', 'G', 'D', 'Q', 'A', 'R', 'G', 'A', 'K', 'C', 'P',
            'N', 'C', 'L', 'C', 'C', 'G', 'K', 'Y', 'G', 'F', 'C', 'G', 'S',
            'G', 'D', 'A', 'Y', 'C', 'G', 'A', 'G', 'S', 'C', 'Q', 'S', 'Q'],
@@ -1701,7 +1665,6 @@ np.array([['Q', 'R', 'C', 'G', 'D', 'Q', 'A', 'R', 'G', 'A', 'K', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 2, 12, 12, 34],
                           [41, 51, 53, 75]])
                 # fmt: on
@@ -1711,7 +1674,6 @@ np.array([['Q', 'R', 'C', 'G', 'D', 'Q', 'A', 'R', 'G', 'A', 'K', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['P', 'N', 'G', 'Q', 'C', 'G', 'P', 'G', 'W', 'G', '-', '-', 'G',
            'C', 'R', 'G', 'G', 'L', 'C', 'C', 'S', 'Q', 'Y', 'G', 'Y', 'C',
            'G', 'S', 'G', 'P', 'K', 'Y', 'C', 'A'],
@@ -1773,7 +1735,6 @@ np.array([['P', 'N', 'G', 'Q', 'C', 'G', 'P', 'G', 'W', 'G', '-', '-', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  2,  12,  12,  34],
                           [ 84,  94,  96, 118]])
                 # fmt: on
@@ -1783,7 +1744,6 @@ np.array([['P', 'N', 'G', 'Q', 'C', 'G', 'P', 'G', 'W', 'G', '-', '-', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['P', 'N', 'G', 'Q', 'C', 'G', 'P', 'G', 'W', 'G', '-', '-', 'G',
            'C', 'R', 'G', 'G', 'L', 'C', 'C', 'S', 'Q', 'Y', 'G', 'Y', 'C',
            'G', 'S', 'G', 'P', 'K', 'Y', 'C', 'A'],
@@ -1843,7 +1803,6 @@ np.array([['P', 'N', 'G', 'Q', 'C', 'G', 'P', 'G', 'W', 'G', '-', '-', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  5,  30],
                           [ 94, 119]])
                 # fmt: on
@@ -1853,7 +1812,6 @@ np.array([['P', 'N', 'G', 'Q', 'C', 'G', 'P', 'G', 'W', 'G', '-', '-', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'G', 'R', 'C', 'P', 'S', 'G', 'M', 'C', 'C', 'S', 'Q', 'F',
            'G', 'Y', 'C', 'G', 'K', 'G', 'P', 'K', 'Y', 'C', 'G', 'R'],
           ['G', 'K', 'L', 'C', 'P', 'N', 'N', 'L', 'C', 'C', 'S', 'Q', 'W',
@@ -1912,7 +1870,6 @@ np.array([['R', 'G', 'R', 'C', 'P', 'S', 'G', 'M', 'C', 'C', 'S', 'Q', 'F',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 3, 30],
                           [ 6, 33]])
                 # fmt: on
@@ -1922,7 +1879,6 @@ np.array([['R', 'G', 'R', 'C', 'P', 'S', 'G', 'M', 'C', 'C', 'S', 'Q', 'F',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'V', 'R', 'G', 'R', 'C', 'P', 'S', 'G', 'M', 'C', 'C', 'S',
            'Q', 'F', 'G', 'Y', 'C', 'G', 'K', 'G', 'P', 'K', 'Y', 'C', 'G',
            'R'],
@@ -1982,7 +1938,6 @@ np.array([['C', 'V', 'R', 'G', 'R', 'C', 'P', 'S', 'G', 'M', 'C', 'C', 'S',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  7,  30],
                           [ 95, 118]])
                 # fmt: on
@@ -1992,7 +1947,6 @@ np.array([['C', 'V', 'R', 'G', 'R', 'C', 'P', 'S', 'G', 'M', 'C', 'C', 'S',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'R', 'C', 'S', 'G', 'G', 'L', 'C', 'C', 'S', 'K', 'Y', 'G',
            'Y', 'C', 'G', 'S', 'G', 'P', 'A', 'Y', 'C', 'G'],
           ['K', 'L', 'C', 'P', 'N', 'N', 'L', 'C', 'C', 'S', 'Q', 'W', 'G',
@@ -2050,7 +2004,6 @@ np.array([['G', 'R', 'C', 'S', 'G', 'G', 'L', 'C', 'C', 'S', 'K', 'Y', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 3,  6,  6, 30],
                           [ 1,  4,  8, 32]])
                 # fmt: on
@@ -2060,7 +2013,6 @@ np.array([['G', 'R', 'C', 'S', 'G', 'G', 'L', 'C', 'C', 'S', 'K', 'Y', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['Q', 'C', 'Y', '-', '-', '-', '-', 'R', 'G', 'R', 'C', 'S', 'G',
            'G', 'L', 'C', 'C', 'S', 'K', 'Y', 'G', 'Y', 'C', 'G', 'S', 'G',
            'P', 'A', 'Y', 'C', 'G'],
@@ -2124,7 +2076,6 @@ np.array([['Q', 'C', 'Y', '-', '-', '-', '-', 'R', 'G', 'R', 'C', 'S', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  39],
                           [ 86, 124]])
                 # fmt: on
@@ -2134,7 +2085,6 @@ np.array([['Q', 'C', 'Y', '-', '-', '-', '-', 'R', 'G', 'R', 'C', 'S', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'Q', 'C', 'G', 'A', 'Q', 'A', 'G', 'G', 'A', 'R', 'C', 'P',
            'N', 'C', 'L', 'C', 'C', 'S', 'R', 'W', 'G', 'W', 'C', 'G', 'T',
            'T', 'S', 'D', 'F', 'C', 'G', 'D', 'G', 'C', 'Q', 'S', 'Q'],
@@ -2199,7 +2149,6 @@ np.array([['E', 'Q', 'C', 'G', 'A', 'Q', 'A', 'G', 'G', 'A', 'R', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 1, 39],
                           [43, 81]])
                 # fmt: on
@@ -2209,7 +2158,6 @@ np.array([['E', 'Q', 'C', 'G', 'A', 'Q', 'A', 'G', 'G', 'A', 'R', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'Q', 'C', 'G', 'A', 'Q', 'A', 'G', 'G', 'A', 'R', 'C', 'P',
            'N', 'C', 'L', 'C', 'C', 'S', 'R', 'W', 'G', 'W', 'C', 'G', 'T',
            'T', 'S', 'D', 'F', 'C', 'G', 'D', 'G', 'C', 'Q', 'S', 'Q'],
@@ -2270,7 +2218,6 @@ np.array([['E', 'Q', 'C', 'G', 'A', 'Q', 'A', 'G', 'G', 'A', 'R', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 47,  65,  66,  70],
                           [143, 161, 161, 165]])
                 # fmt: on
@@ -2280,7 +2227,6 @@ np.array([['E', 'Q', 'C', 'G', 'A', 'Q', 'A', 'G', 'G', 'A', 'R', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['D', 'H', 'C', 'C', 'S', 'E', 'W', 'G', 'W', 'C', 'G', 'R', 'E',
            'T', 'S', 'H', 'C', 'T', 'C', 'S', 'S', 'C', 'V'],
           ['N', 'Y', 'C', 'C', 'S', 'K', 'W', 'G', 'S', 'C', 'G', 'I', 'G',
@@ -2354,7 +2300,6 @@ np.array([['D', 'H', 'C', 'C', 'S', 'E', 'W', 'G', 'W', 'C', 'G', 'R', 'E',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 10,  49,  49,  90,  90, 131, 131, 160],
                           [ 10,  49,  51,  92,  94, 135, 137, 166]])
                 # fmt: on
@@ -2364,7 +2309,6 @@ np.array([['D', 'H', 'C', 'C', 'S', 'E', 'W', 'G', 'W', 'C', 'G', 'R', 'E',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['X', 'C', 'X', 'X', 'X', 'X', 'C', 'C', 'X', 'X', 'X', 'X', 'X',
            'C', 'X', 'X', 'X', 'X', 'X', 'X', 'C', 'X', 'X', 'X', 'C', 'X',
            'X', 'X', 'X', 'C', 'X', 'X', 'X', 'X', 'X', 'C', 'X', 'X', 'X',
@@ -2447,7 +2391,6 @@ np.array([['X', 'C', 'X', 'X', 'X', 'X', 'C', 'C', 'X', 'X', 'X', 'X', 'X',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[26, 32, 37, 44, 47, 66, 67, 70],
                           [ 1,  7,  7, 14, 14, 33, 33, 36]])
                 # fmt: on
@@ -2457,7 +2400,6 @@ np.array([['X', 'C', 'X', 'X', 'X', 'X', 'C', 'C', 'X', 'X', 'X', 'X', 'X',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P', 'D', 'A', 'N', 'P',
            'G', 'E', 'C', 'N', 'P', 'H', 'A', 'V', 'D', 'H', 'C', 'C', 'S',
            'E', 'W', 'G', 'W', 'C', 'G', 'R', 'E', 'T', 'S', 'H', 'C', 'T',
@@ -2519,7 +2461,6 @@ np.array([['R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P', 'D', 'A', 'N', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 29,  49,  50,  54],
                           [ 99, 119, 119, 123]])
                 # fmt: on
@@ -2529,7 +2470,6 @@ np.array([['R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P', 'D', 'A', 'N', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['V', 'D', 'H', 'C', 'C', 'S', 'E', 'W', 'G', 'W', 'C', 'G', 'R',
            'E', 'T', 'S', 'H', 'C', 'T', 'C', 'S', 'S', 'C', 'V', 'D'],
           ['N', 'N', 'L', 'C', 'C', 'S', 'Q', 'W', 'G', 'F', 'C', 'G', 'L',
@@ -2592,7 +2532,6 @@ np.array([['V', 'D', 'H', 'C', 'C', 'S', 'E', 'W', 'G', 'W', 'C', 'G', 'R',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 8, 15, 20, 27, 30, 49, 50, 54],
                           [ 0,  7,  7, 14, 14, 33, 33, 37]])
                 # fmt: on
@@ -2602,7 +2541,6 @@ np.array([['V', 'D', 'H', 'C', 'C', 'S', 'E', 'W', 'G', 'W', 'C', 'G', 'R',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P', 'D', 'A', 'N',
            'P', 'G', 'E', 'C', 'N', 'P', 'H', 'A', 'V', 'D', 'H', 'C', 'C',
            'S', 'E', 'W', 'G', 'W', 'C', 'G', 'R', 'E', 'T', 'S', 'H', 'C',
@@ -2676,7 +2614,6 @@ np.array([['G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P', 'D', 'A', 'N',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 10,  49,  49,  90,  90, 116],
                           [ 53,  92,  94, 135, 137, 163]])
                 # fmt: on
@@ -2686,7 +2623,6 @@ np.array([['G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P', 'D', 'A', 'N',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['X', 'C', 'X', 'X', 'X', 'X', 'C', 'C', 'X', 'X', 'X', 'X', 'X',
            'C', 'X', 'X', 'X', 'X', 'X', 'X', 'C', 'X', 'X', 'X', 'C', 'X',
            'X', 'X', 'X', 'C', 'X', 'X', 'X', 'X', 'X', 'C', 'X', 'X', 'X',
@@ -2802,7 +2738,6 @@ class Align_hhr_2uvo_hhsearch(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  0, 171],
                           [  0, 171]])
                 # fmt: on
@@ -2812,7 +2747,6 @@ class Align_hhr_2uvo_hhsearch(unittest.TestCase):
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'R', 'C', 'G', 'E', 'Q', 'G', 'S', 'N', 'M', 'E', 'C', 'P',
            'N', 'N', 'L', 'C', 'C', 'S', 'Q', 'Y', 'G', 'Y', 'C', 'G', 'M',
            'G', 'G', 'D', 'Y', 'C', 'G', 'K', 'G', 'C', 'Q', 'N', 'G', 'A',
@@ -2914,7 +2848,6 @@ np.array([['E', 'R', 'C', 'G', 'E', 'Q', 'G', 'S', 'N', 'M', 'E', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  48,  48,  90,  90, 130, 130, 163],
                           [  1,  48,  50,  92,  94, 134, 136, 169]])
                 # fmt: on
@@ -2924,7 +2857,6 @@ np.array([['E', 'R', 'C', 'G', 'E', 'Q', 'G', 'S', 'N', 'M', 'E', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'X', 'G', 'C', 'X', 'G', 'X', 'X', 'M', 'Y', 'C', 'S', 'T',
            'N', 'N', 'C', 'C', 'X', 'X', 'W', 'E', 'S', 'C', 'G', 'S', 'G',
            'G', 'Y', 'X', 'C', 'G', 'E', 'G', 'C', 'N', 'L', 'G', 'A', 'C',
@@ -3025,7 +2957,6 @@ np.array([['G', 'X', 'G', 'C', 'X', 'G', 'X', 'X', 'M', 'Y', 'C', 'S', 'T',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  0, 126],
                           [ 43, 169]])
                 # fmt: on
@@ -3035,7 +2966,6 @@ np.array([['G', 'X', 'G', 'C', 'X', 'G', 'X', 'X', 'M', 'Y', 'C', 'S', 'T',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'R', 'C', 'G', 'E', 'Q', 'G', 'S', 'N', 'M', 'E', 'C', 'P',
            'N', 'N', 'L', 'C', 'C', 'S', 'Q', 'Y', 'G', 'Y', 'C', 'G', 'M',
            'G', 'G', 'D', 'Y', 'C', 'G', 'K', 'G', 'C', 'Q', 'N', 'G', 'A',
@@ -3129,7 +3059,6 @@ np.array([['E', 'R', 'C', 'G', 'E', 'Q', 'G', 'S', 'N', 'M', 'E', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  39,  39,  41,  41,  80,  80,  81,  81, 121],
                           [ 43,  81,  82,  84,  85, 124, 125, 126, 127, 167]])
                 # fmt: on
@@ -3139,7 +3068,6 @@ np.array([['E', 'R', 'C', 'G', 'E', 'Q', 'G', 'S', 'N', 'M', 'E', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['P', 'V', 'C', 'G', 'V', 'R', 'A', 'S', 'G', 'R', 'V', 'C', 'P',
            'D', 'G', 'Y', 'C', 'C', 'S', 'Q', 'W', 'G', 'Y', 'C', 'G', 'T',
            'T', 'E', 'E', 'Y', 'C', 'G', 'K', 'G', 'C', 'Q', 'S', 'Q', '-',
@@ -3233,7 +3161,6 @@ np.array([['P', 'V', 'C', 'G', 'V', 'R', 'A', 'S', 'G', 'R', 'V', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  39,  39,  41,  41,  80,  80,  82,  82, 120],
                           [  0,  38,  39,  41,  42,  81,  82,  84,  85, 123]])
                 # fmt: on
@@ -3243,7 +3170,6 @@ np.array([['P', 'V', 'C', 'G', 'V', 'R', 'A', 'S', 'G', 'R', 'V', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['P', 'V', 'C', 'G', 'V', 'R', 'A', 'S', 'G', 'R', 'V', 'C', 'P',
            'D', 'G', 'Y', 'C', 'C', 'S', 'Q', 'W', 'G', 'Y', 'C', 'G', 'T',
            'T', 'E', 'E', 'Y', 'C', 'G', 'K', 'G', 'C', 'Q', 'S', 'Q', '-',
@@ -3337,7 +3263,6 @@ np.array([['P', 'V', 'C', 'G', 'V', 'R', 'A', 'S', 'G', 'R', 'V', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  48,  48,  90,  90, 122],
                           [ 44,  91,  93, 135, 137, 169]])
                 # fmt: on
@@ -3347,7 +3272,6 @@ np.array([['P', 'V', 'C', 'G', 'V', 'R', 'A', 'S', 'G', 'R', 'V', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'X', 'G', 'C', 'X', 'G', 'X', 'X', 'M', 'Y', 'C', 'S', 'T',
            'N', 'N', 'C', 'C', 'X', 'X', 'W', 'E', 'S', 'C', 'G', 'S', 'G',
            'G', 'Y', 'X', 'C', 'G', 'E', 'G', 'C', 'N', 'L', 'G', 'A', 'C',
@@ -3437,7 +3361,6 @@ np.array([['G', 'X', 'G', 'C', 'X', 'G', 'X', 'X', 'M', 'Y', 'C', 'S', 'T',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  39,  39,  40,  40,  80],
                           [ 43,  81,  82,  83,  84, 124]])
                 # fmt: on
@@ -3447,7 +3370,6 @@ np.array([['G', 'X', 'G', 'C', 'X', 'G', 'X', 'X', 'M', 'Y', 'C', 'S', 'T',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['P', 'E', 'C', 'G', 'E', 'R', 'A', 'S', 'G', 'K', 'R', 'C', 'P',
            'N', 'G', 'K', 'C', 'C', 'S', 'Q', 'W', 'G', 'Y', 'C', 'G', 'T',
            'T', 'D', 'N', 'Y', 'C', 'G', 'Q', 'G', 'C', 'Q', 'S', 'Q', '-',
@@ -3531,7 +3453,6 @@ np.array([['P', 'E', 'C', 'G', 'E', 'R', 'A', 'S', 'G', 'K', 'R', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  38,  38,  41,  45,  80,  81,  85],
                           [ 44,  81,  82,  85,  85, 120, 120, 124]])
                 # fmt: on
@@ -3541,7 +3462,6 @@ np.array([['P', 'E', 'C', 'G', 'E', 'R', 'A', 'S', 'G', 'K', 'R', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'C', 'G', 'S', 'Q', 'G', 'G', 'G', 'S', 'T', 'C', 'P', 'G',
            'L', 'R', 'C', 'C', 'S', 'I', 'W', 'G', 'W', 'C', 'G', 'D', 'S',
            'E', 'P', 'Y', 'C', 'G', 'R', 'T', 'C', 'E', 'N', 'K', '-', 'C',
@@ -3625,7 +3545,6 @@ np.array([['R', 'C', 'G', 'S', 'Q', 'G', 'G', 'G', 'S', 'T', 'C', 'P', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 0, 38, 38, 41, 45, 80, 81, 85],
                           [ 0, 38, 39, 42, 42, 77, 77, 81]])
                 # fmt: on
@@ -3635,7 +3554,6 @@ np.array([['R', 'C', 'G', 'S', 'Q', 'G', 'G', 'G', 'S', 'T', 'C', 'P', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'R', 'C', 'G', 'S', 'Q', 'G', 'G', 'G', 'S', 'T', 'C', 'P',
            'G', 'L', 'R', 'C', 'C', 'S', 'I', 'W', 'G', 'W', 'C', 'G', 'D',
            'S', 'E', 'P', 'Y', 'C', 'G', 'R', 'T', 'C', 'E', 'N', 'K', '-',
@@ -3719,7 +3637,6 @@ np.array([['E', 'R', 'C', 'G', 'S', 'Q', 'G', 'G', 'G', 'S', 'T', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  2,  39,  39,  80],
                           [ 87, 124, 126, 167]])
                 # fmt: on
@@ -3729,7 +3646,6 @@ np.array([['E', 'R', 'C', 'G', 'S', 'Q', 'G', 'G', 'G', 'S', 'T', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'C', 'G', 'E', 'R', 'A', 'S', 'G', 'K', 'R', 'C', 'P', 'N',
            'G', 'K', 'C', 'C', 'S', 'Q', 'W', 'G', 'Y', 'C', 'G', 'T', 'T',
            'D', 'N', 'Y', 'C', 'G', 'Q', 'G', 'C', 'Q', 'S', 'Q', '-', '-',
@@ -3801,7 +3717,6 @@ np.array([['E', 'C', 'G', 'E', 'R', 'A', 'S', 'G', 'K', 'R', 'C', 'P', 'N',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  40,  40,  42],
                           [ 85, 124, 125, 127]])
                 # fmt: on
@@ -3811,7 +3726,6 @@ np.array([['E', 'C', 'G', 'E', 'R', 'A', 'S', 'G', 'K', 'R', 'C', 'P', 'N',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['M', 'E', 'Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'A', 'L', 'C',
            'P', 'G', 'G', 'L', 'C', 'C', 'S', 'Q', 'Y', 'G', 'W', 'C', 'A',
            'N', 'T', 'P', 'E', 'Y', 'C', 'G', 'S', 'G', 'C', 'Q', 'S', 'Q',
@@ -3877,7 +3791,6 @@ np.array([['M', 'E', 'Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'A', 'L', 'C',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  33,  35,  40],
                           [ 87, 119, 119, 124]])
                 # fmt: on
@@ -3887,7 +3800,6 @@ np.array([['M', 'E', 'Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'A', 'L', 'C',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'K', 'L', 'C', 'P', 'D',
            'N', 'L', 'C', 'C', 'S', 'Q', 'W', 'G', 'W', 'C', 'G', 'S', 'T',
            'D', 'E', 'Y', 'C', 'S', 'P', 'D', 'H', 'N', 'C', 'Q', 'S', 'N'],
@@ -3952,7 +3864,6 @@ np.array([['Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'K', 'L', 'C', 'P', 'D',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 3, 40, 40, 44],
                           [ 1, 38, 39, 43]])
                 # fmt: on
@@ -3962,7 +3873,6 @@ np.array([['Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'K', 'L', 'C', 'P', 'D',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'A', 'L', 'C', 'P', 'G',
            'G', 'L', 'C', 'C', 'S', 'Q', 'Y', 'G', 'W', 'C', 'A', 'N', 'T',
            'P', 'E', 'Y', 'C', 'G', 'S', 'G', 'C', 'Q', 'S', 'Q', '-', 'C',
@@ -4028,7 +3938,6 @@ np.array([['Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'A', 'L', 'C', 'P', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  2,  35,  36,  40],
                           [ 87, 120, 120, 124]])
                 # fmt: on
@@ -4038,7 +3947,6 @@ np.array([['Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'A', 'L', 'C', 'P', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'C', 'G', 'D', 'Q', 'A', 'R', 'G', 'A', 'K', 'C', 'P', 'N',
            'C', 'L', 'C', 'C', 'G', 'K', 'Y', 'G', 'F', 'C', 'G', 'S', 'G',
            'D', 'A', 'Y', 'C', 'G', 'A', 'G', 'S', 'C', 'Q', 'S', 'Q'],
@@ -4103,7 +4011,6 @@ np.array([['R', 'C', 'G', 'D', 'Q', 'A', 'R', 'G', 'A', 'K', 'C', 'P', 'N',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 0,  4,  4, 33, 34, 38],
                           [ 0,  4,  5, 34, 34, 38]])
                 # fmt: on
@@ -4113,7 +4020,6 @@ np.array([['R', 'C', 'G', 'D', 'Q', 'A', 'R', 'G', 'A', 'K', 'C', 'P', 'N',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'T', 'C', 'A', '-', 'S', 'R', 'C', 'P', 'R', 'P', 'C', 'N',
            'A', 'G', 'L', 'C', 'C', 'S', 'I', 'Y', 'G', 'Y', 'C', 'G', 'S',
            'G', 'A', 'A', 'Y', 'C', 'G', 'A', 'G', 'N', 'C', 'R', 'C', 'Q'],
@@ -4174,7 +4080,6 @@ np.array([['E', 'T', 'C', 'A', '-', 'S', 'R', 'C', 'P', 'R', 'P', 'C', 'N',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  2,  29],
                           [ 91, 118]])
                 # fmt: on
@@ -4184,7 +4089,6 @@ np.array([['E', 'T', 'C', 'A', '-', 'S', 'R', 'C', 'P', 'R', 'P', 'C', 'N',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'C', 'V', 'R', 'G', 'R', 'C', 'P', 'S', 'G', 'M', 'C', 'C',
            'S', 'Q', 'F', 'G', 'Y', 'C', 'G', 'K', 'G', 'P', 'K', 'Y', 'C',
            'G'],
@@ -4248,7 +4152,6 @@ np.array([['E', 'C', 'V', 'R', 'G', 'R', 'C', 'P', 'S', 'G', 'M', 'C', 'C',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,   4,   4,  33,  34,  38],
                           [ 87,  90,  91, 120, 120, 124]])
                 # fmt: on
@@ -4258,7 +4161,6 @@ np.array([['E', 'C', 'V', 'R', 'G', 'R', 'C', 'P', 'S', 'G', 'M', 'C', 'C',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'C', 'A', '-', 'S', 'R', 'C', 'P', 'R', 'P', 'C', 'N', 'A',
            'G', 'L', 'C', 'C', 'S', 'I', 'Y', 'G', 'Y', 'C', 'G', 'S', 'G',
            'A', 'A', 'Y', 'C', 'G', 'A', 'G', 'N', 'C', 'R', 'C', 'Q'],
@@ -4323,7 +4225,6 @@ np.array([['T', 'C', 'A', '-', 'S', 'R', 'C', 'P', 'R', 'P', 'C', 'N', 'A',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 0, 33, 35, 40],
                           [ 0, 33, 33, 38]])
                 # fmt: on
@@ -4333,7 +4234,6 @@ np.array([['T', 'C', 'A', '-', 'S', 'R', 'C', 'P', 'R', 'P', 'C', 'N', 'A',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'K', 'L', 'C', 'P',
            'D', 'N', 'L', 'C', 'C', 'S', 'Q', 'W', 'G', 'W', 'C', 'G', 'S',
            'T', 'D', 'E', 'Y', 'C', 'S', 'P', 'D', 'H', 'N', 'C', 'Q', 'S',
@@ -4399,7 +4299,6 @@ np.array([['E', 'Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'K', 'L', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 1, 35, 36, 40],
                           [ 0, 34, 34, 38]])
                 # fmt: on
@@ -4409,7 +4308,6 @@ np.array([['E', 'Q', 'C', 'G', 'R', 'Q', 'A', 'G', 'G', 'K', 'L', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['Q', 'R', 'C', 'G', 'D', 'Q', 'A', 'R', 'G', 'A', 'K', 'C', 'P',
            'N', 'C', 'L', 'C', 'C', 'G', 'K', 'Y', 'G', 'F', 'C', 'G', 'S',
            'G', 'D', 'A', 'Y', 'C', 'G', 'A', 'G', 'S', 'C', 'Q', 'S', 'Q'],
@@ -4470,7 +4368,6 @@ np.array([['Q', 'R', 'C', 'G', 'D', 'Q', 'A', 'R', 'G', 'A', 'K', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  4,  30],
                           [ 92, 118]])
                 # fmt: on
@@ -4480,7 +4377,6 @@ np.array([['Q', 'R', 'C', 'G', 'D', 'Q', 'A', 'R', 'G', 'A', 'K', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'Y', 'R', 'G', 'R', 'C', 'S', 'G', 'G', 'L', 'C', 'C', 'S',
            'K', 'Y', 'G', 'Y', 'C', 'G', 'S', 'G', 'P', 'A', 'Y', 'C', 'G'],
           ['A', 'G', 'G', 'K', 'L', 'C', 'P', 'N', 'N', 'L', 'C', 'C', 'S',
@@ -4543,7 +4439,6 @@ np.array([['C', 'Y', 'R', 'G', 'R', 'C', 'S', 'G', 'G', 'L', 'C', 'C', 'S',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  12,  12,  34],
                           [ 83,  94,  96, 118]])
                 # fmt: on
@@ -4553,7 +4448,6 @@ np.array([['C', 'Y', 'R', 'G', 'R', 'C', 'S', 'G', 'G', 'L', 'C', 'C', 'S',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'P', 'N', 'G', 'Q', 'C', 'G', 'P', 'G', 'W', 'G', '-', '-',
            'G', 'C', 'R', 'G', 'G', 'L', 'C', 'C', 'S', 'Q', 'Y', 'G', 'Y',
            'C', 'G', 'S', 'G', 'P', 'K', 'Y', 'C', 'A'],
@@ -4617,7 +4511,6 @@ np.array([['G', 'P', 'N', 'G', 'Q', 'C', 'G', 'P', 'G', 'W', 'G', '-', '-',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  2,  39],
                           [ 87, 124]])
                 # fmt: on
@@ -4627,7 +4520,6 @@ np.array([['G', 'P', 'N', 'G', 'Q', 'C', 'G', 'P', 'G', 'W', 'G', '-', '-',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['Q', 'C', 'G', 'A', 'Q', 'A', 'G', 'G', 'A', 'R', 'C', 'P', 'N',
            'C', 'L', 'C', 'C', 'S', 'R', 'W', 'G', 'W', 'C', 'G', 'T', 'T',
            'S', 'D', 'F', 'C', 'G', 'D', 'G', 'C', 'Q', 'S', 'Q'],
@@ -4688,7 +4580,6 @@ np.array([['Q', 'C', 'G', 'A', 'Q', 'A', 'G', 'G', 'A', 'R', 'C', 'P', 'N',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 2, 30],
                           [ 5, 33]])
                 # fmt: on
@@ -4698,7 +4589,6 @@ np.array([['Q', 'C', 'G', 'A', 'Q', 'A', 'G', 'G', 'A', 'R', 'C', 'P', 'N',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'C', 'V', 'R', 'G', 'R', 'C', 'P', 'S', 'G', 'M', 'C', 'C',
            'S', 'Q', 'F', 'G', 'Y', 'C', 'G', 'K', 'G', 'P', 'K', 'Y', 'C',
            'G', 'R'],
@@ -4758,7 +4648,6 @@ np.array([['E', 'C', 'V', 'R', 'G', 'R', 'C', 'P', 'S', 'G', 'M', 'C', 'C',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 3,  6,  6, 30],
                           [ 1,  4,  8, 32]])
                 # fmt: on
@@ -4768,7 +4657,6 @@ np.array([['E', 'C', 'V', 'R', 'G', 'R', 'C', 'P', 'S', 'G', 'M', 'C', 'C',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['Q', 'C', 'Y', '-', '-', '-', '-', 'R', 'G', 'R', 'C', 'S', 'G',
            'G', 'L', 'C', 'C', 'S', 'K', 'Y', 'G', 'Y', 'C', 'G', 'S', 'G',
            'P', 'A', 'Y', 'C', 'G'],
@@ -4832,7 +4720,6 @@ np.array([['Q', 'C', 'Y', '-', '-', '-', '-', 'R', 'G', 'R', 'C', 'S', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 1, 39],
                           [43, 81]])
                 # fmt: on
@@ -4842,7 +4729,6 @@ np.array([['Q', 'C', 'Y', '-', '-', '-', '-', 'R', 'G', 'R', 'C', 'S', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'Q', 'C', 'G', 'A', 'Q', 'A', 'G', 'G', 'A', 'R', 'C', 'P',
            'N', 'C', 'L', 'C', 'C', 'S', 'R', 'W', 'G', 'W', 'C', 'G', 'T',
            'T', 'S', 'D', 'F', 'C', 'G', 'D', 'G', 'C', 'Q', 'S', 'Q'],
@@ -4905,7 +4791,6 @@ np.array([['E', 'Q', 'C', 'G', 'A', 'Q', 'A', 'G', 'G', 'A', 'R', 'C', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 3, 12, 12, 35],
                           [42, 51, 53, 76]])
                 # fmt: on
@@ -4915,7 +4800,6 @@ np.array([['E', 'Q', 'C', 'G', 'A', 'Q', 'A', 'G', 'G', 'A', 'R', 'C', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['N', 'G', 'Q', 'C', 'G', 'P', 'G', 'W', 'G', '-', '-', 'G', 'C',
            'R', 'G', 'G', 'L', 'C', 'C', 'S', 'Q', 'Y', 'G', 'Y', 'C', 'G',
            'S', 'G', 'P', 'K', 'Y', 'C', 'A', 'H'],
@@ -4991,7 +4875,6 @@ np.array([['N', 'G', 'Q', 'C', 'G', 'P', 'G', 'W', 'G', '-', '-', 'G', 'C',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  8,  49,  49,  90,  90, 131, 131, 163],
                           [  8,  49,  51,  92,  94, 135, 137, 169]])
                 # fmt: on
@@ -5001,7 +4884,6 @@ np.array([['N', 'G', 'Q', 'C', 'G', 'P', 'G', 'W', 'G', '-', '-', 'G', 'C',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['X', 'X', 'X', 'C', 'X', 'X', 'X', 'X', 'C', 'C', 'X', 'X', 'X',
            'X', 'X', 'C', 'X', 'X', 'X', 'X', 'X', 'X', 'C', 'X', 'X', 'X',
            'C', 'X', 'X', 'X', 'X', 'C', 'X', 'X', 'X', 'X', 'X', 'C', 'X',
@@ -5085,7 +4967,6 @@ np.array([['X', 'X', 'X', 'C', 'X', 'X', 'X', 'X', 'C', 'C', 'X', 'X', 'X',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  5,  15,  20,  27,  30,  48],
                           [ 83,  93,  93, 100, 100, 118]])
                 # fmt: on
@@ -5095,7 +4976,6 @@ np.array([['X', 'X', 'X', 'C', 'X', 'X', 'X', 'X', 'C', 'C', 'X', 'X', 'X',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'S', 'D', 'G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P',
            'D', 'A', 'N', 'P', 'G', 'E', 'C', 'N', 'P', 'H', 'A', 'V', 'D',
            'H', 'C', 'C', 'S', 'E', 'W', 'G', 'W', 'C', 'G', 'R', 'E', 'T',
@@ -5161,7 +5041,6 @@ np.array([['R', 'S', 'D', 'G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 7, 15, 20, 27, 30, 48],
                           [42, 50, 50, 57, 57, 75]])
                 # fmt: on
@@ -5171,7 +5050,6 @@ np.array([['R', 'S', 'D', 'G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['D', 'G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P', 'D', 'A',
            'N', 'P', 'G', 'E', 'C', 'N', 'P', 'H', 'A', 'V', 'D', 'H', 'C',
            'C', 'S', 'E', 'W', 'G', 'W', 'C', 'G', 'R', 'E', 'T', 'S', 'H',
@@ -5237,7 +5115,6 @@ np.array([['D', 'G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P', 'D', 'A',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 22,  32,  37,  44,  47,  65],
                           [ 83,  93,  93, 100, 100, 118]])
                 # fmt: on
@@ -5247,7 +5124,6 @@ np.array([['D', 'G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P', 'D', 'A',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'S', 'D', 'G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P',
            'D', 'A', 'N', 'P', 'G', 'E', 'C', 'N', 'P', 'H', 'A', 'V', 'D',
            'H', 'C', 'C', 'S', 'E', 'W', 'G', 'W', 'C', 'G', 'R', 'E', 'T',
@@ -5313,7 +5189,6 @@ np.array([['R', 'S', 'D', 'G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[25, 32, 37, 44, 47, 65, 66, 70],
                           [43, 50, 50, 57, 57, 75, 75, 79]])
                 # fmt: on
@@ -5323,7 +5198,6 @@ np.array([['R', 'S', 'D', 'G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P', 'D', 'A', 'N',
            'P', 'G', 'E', 'C', 'N', 'P', 'H', 'A', 'V', 'D', 'H', 'C', 'C',
            'S', 'E', 'W', 'G', 'W', 'C', 'G', 'R', 'E', 'T', 'S', 'H', 'C',
@@ -5401,7 +5275,6 @@ np.array([['G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P', 'D', 'A', 'N',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 49,  90,  90, 131, 131, 163],
                           [  8,  49,  51,  92,  94, 126]])
                 # fmt: on
@@ -5411,7 +5284,6 @@ np.array([['G', 'R', 'C', 'G', 'P', 'N', 'Y', 'P', 'A', 'P', 'D', 'A', 'N',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['X', 'X', 'X', 'C', 'X', 'X', 'X', 'X', 'C', 'C', 'X', 'X', 'X',
            'X', 'X', 'C', 'X', 'X', 'X', 'X', 'X', 'X', 'C', 'X', 'X', 'X',
            'C', 'X', 'X', 'X', 'X', 'C', 'X', 'X', 'X', 'X', 'X', 'C', 'X',
@@ -5505,7 +5377,6 @@ Only X am        38 X 39
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23, 24],
                           [38, 39]])
                 # fmt: on
@@ -5562,7 +5433,6 @@ Only X am         3 X  4
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 9, 10],
                           [ 3,  4]])
                 # fmt: on
@@ -5619,7 +5489,6 @@ Only X am         3 X 4
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[0, 1],
                           [3, 4]])
                 # fmt: on
@@ -5676,7 +5545,6 @@ Only X am         3 X  4
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10, 11],
                           [ 3,  4]])
                 # fmt: on
@@ -5733,7 +5601,6 @@ Only X am         3 X 4
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[5, 6],
                           [3, 4]])
                 # fmt: on
@@ -5790,7 +5657,6 @@ Only X am        37 X 38
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[28, 29],
                           [37, 38]])
                 # fmt: on
@@ -5847,7 +5713,6 @@ Only X am         1 X 2
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[0, 1],
                           [1, 2]])
                 # fmt: on
@@ -5902,7 +5767,6 @@ Only X am        35 X 36
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[16, 17],
                           [35, 36]])
                 # fmt: on
@@ -5959,7 +5823,6 @@ Only X am        35 X 36
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[28, 29],
                           [35, 36]])
                 # fmt: on
@@ -6016,7 +5879,6 @@ Only X am         3 X 4
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[0, 1],
                           [3, 4]])
                 # fmt: on
@@ -6126,7 +5988,6 @@ class Align_hhr_4p79_hhsearch_server_NOssm(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  0, 198],
                           [  0, 198]])
                 # fmt: on
@@ -6136,7 +5997,6 @@ class Align_hhr_4p79_hhsearch_server_NOssm(unittest.TestCase):
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'S', 'E', 'F', 'M', 'S', 'V', 'A', 'V', 'E', 'T', 'F', 'G',
            'F', 'F', 'M', 'S', 'A', 'L', 'G', 'L', 'L', 'M', 'L', 'G', 'L',
            'T', 'L', 'S', 'N', 'S', 'Y', 'W', 'R', 'V', 'S', 'T', 'V', 'H',
@@ -6247,7 +6107,6 @@ np.array([['G', 'S', 'E', 'F', 'M', 'S', 'V', 'A', 'V', 'E', 'T', 'F', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  0,  38,  39, 153, 154, 185],
                           [  3,  41,  41, 155, 155, 186]])
                 # fmt: on
@@ -6257,7 +6116,6 @@ np.array([['G', 'S', 'E', 'F', 'M', 'S', 'V', 'A', 'V', 'E', 'T', 'F', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['M', 'A', 'N', 'S', 'G', 'L', 'Q', 'L', 'L', 'G', 'Y', 'F', 'L',
            'A', 'L', 'G', 'G', 'W', 'V', 'G', 'I', 'I', 'A', 'S', 'T', 'A',
            'L', 'P', 'Q', 'W', 'K', 'Q', 'S', 'S', 'Y', 'A', 'G', 'D', 'A',
@@ -6366,7 +6224,6 @@ np.array([['M', 'A', 'N', 'S', 'G', 'L', 'Q', 'L', 'L', 'G', 'Y', 'F', 'L',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[167, 207, 208, 279, 279, 321, 322, 364],
                           [  1,  41,  41, 112, 113, 155, 155, 197]])
                 # fmt: on
@@ -6376,7 +6233,6 @@ np.array([['M', 'A', 'N', 'S', 'G', 'L', 'Q', 'L', 'L', 'G', 'Y', 'F', 'L',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'G', 'M', 'A', 'S', 'M', 'G', 'L', 'Q', 'V', 'M', 'G', 'I',
            'A', 'L', 'A', 'V', 'L', 'G', 'W', 'L', 'A', 'V', 'M', 'L', 'C',
            'C', 'A', 'L', 'P', 'M', 'W', 'R', 'V', 'T', 'A', 'F', 'I', 'G',
@@ -6487,7 +6343,6 @@ np.array([['K', 'G', 'M', 'A', 'S', 'M', 'G', 'L', 'Q', 'V', 'M', 'G', 'I',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  0,  41,  52,  86,  97, 128, 128, 212],
                           [  0,  41,  41,  75,  75, 106, 114, 198]])
                 # fmt: on
@@ -6497,7 +6352,6 @@ np.array([['K', 'G', 'M', 'A', 'S', 'M', 'G', 'L', 'Q', 'V', 'M', 'G', 'I',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['M', 'G', 'L', 'F', 'D', 'R', 'G', 'V', 'Q', 'M', 'L', 'L', 'T',
            'T', 'V', 'G', 'A', 'F', 'A', 'A', 'F', 'S', 'L', 'M', 'T', 'I',
            'A', 'V', 'G', 'T', 'D', 'Y', 'W', 'L', 'Y', 'S', 'R', 'G', 'V',
@@ -6611,7 +6465,6 @@ np.array([['M', 'G', 'L', 'F', 'D', 'R', 'G', 'V', 'Q', 'M', 'L', 'L', 'T',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  0,  41,  43,  63,  76,  87,  98, 131, 131, 214],
                           [  1,  42,  42,  62,  62,  73,  73, 106, 115, 198]])
                 # fmt: on
@@ -6621,7 +6474,6 @@ np.array([['M', 'G', 'L', 'F', 'D', 'R', 'G', 'V', 'Q', 'M', 'L', 'L', 'T',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['M', 'S', 'P', 'T', 'E', 'A', 'P', 'K', 'V', 'R', 'V', 'T', 'L',
            'F', 'C', 'I', 'L', 'V', 'G', 'I', 'V', 'L', 'A', 'M', 'T', 'A',
            'V', 'V', 'S', 'D', 'H', 'W', 'A', 'V', 'L', 'S', 'P', 'H', 'M',
@@ -6736,7 +6588,6 @@ np.array([['M', 'S', 'P', 'T', 'E', 'A', 'P', 'K', 'V', 'R', 'V', 'T', 'L',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 27,  64,  64,  80,  81,  95,  97, 128, 128, 165, 172, 218],
                           [  4,  41,  45,  61,  61,  75,  75, 106, 115, 152, 152, 198]])
                 # fmt: on
@@ -6746,7 +6597,6 @@ np.array([['M', 'S', 'P', 'T', 'E', 'A', 'P', 'K', 'V', 'R', 'V', 'T', 'L',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['N', 'S', 'R', 'A', 'V', 'G', 'V', 'M', 'W', 'G', 'T', 'L', 'T',
            'I', 'C', 'F', 'S', 'V', 'L', 'V', 'M', 'A', 'L', 'F', 'I', 'Q',
            'P', 'Y', 'W', 'I', 'G', 'D', 'S', 'V', 'S', 'T', 'P', '-', '-',
@@ -6857,7 +6707,6 @@ np.array([['N', 'S', 'R', 'A', 'V', 'G', 'V', 'M', 'W', 'G', 'T', 'L', 'T',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 819,  851,  862,  902,  913,  946,  946, 1030],
                           [   1,   33,   33,   73,   73,  106,  114,  198]])
                 # fmt: on
@@ -6867,7 +6716,6 @@ np.array([['N', 'S', 'R', 'A', 'V', 'G', 'V', 'M', 'W', 'G', 'T', 'L', 'T',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'L', 'F', 'D', 'R', 'G', 'V', 'Q', 'M', 'L', 'L', 'T', 'T',
            'V', 'G', 'A', 'F', 'A', 'A', 'F', 'S', 'L', 'M', 'T', 'I', 'A',
            'V', 'G', 'T', 'D', 'Y', 'W', 'L', 'Y', 'S', 'R', 'G', 'V', 'C',
@@ -6959,7 +6807,6 @@ np.array([['G', 'L', 'F', 'D', 'R', 'G', 'V', 'Q', 'M', 'L', 'L', 'T', 'T',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 8, 34, 36, 42],
                           [ 5, 31, 31, 37]])
                 # fmt: on
@@ -6969,7 +6816,6 @@ np.array([['G', 'L', 'F', 'D', 'R', 'G', 'V', 'Q', 'M', 'L', 'L', 'T', 'T',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'T', 'S', 'V', 'V', 'V', 'S', 'T', 'L', 'L', 'G', 'L', 'V',
            'M', 'A', 'L', 'L', 'I', 'H', 'F', 'V', 'V', 'L', 'S', 'S', 'G',
            'A', 'F', 'N', 'W', 'L', 'R', 'A', 'P'],
@@ -7078,7 +6924,6 @@ class Align_hhr_4y9h_hhsearch_server_NOssm(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1, 227],
                           [  0, 226]])
                 # fmt: on
@@ -7088,7 +6933,6 @@ class Align_hhr_4y9h_hhsearch_server_NOssm(unittest.TestCase):
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'R', 'P', 'E', 'W', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'A',
            'L', 'M', 'G', 'L', 'G', 'T', 'L', 'Y', 'F', 'L', 'V', 'K', 'G',
            'M', 'G', 'V', 'S', 'D', 'P', 'D', 'A', 'K', 'K', 'F', 'Y', 'A',
@@ -7203,7 +7047,6 @@ np.array([['G', 'R', 'P', 'E', 'W', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'A',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 18, 244],
                           [  0, 226]])
                 # fmt: on
@@ -7213,7 +7056,6 @@ np.array([['G', 'R', 'P', 'E', 'W', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'A',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'R', 'P', 'E', 'W', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'A',
            'L', 'M', 'G', 'L', 'G', 'T', 'L', 'Y', 'F', 'L', 'V', 'K', 'G',
            'M', 'G', 'V', 'S', 'D', 'P', 'D', 'A', 'K', 'K', 'F', 'Y', 'A',
@@ -7328,7 +7170,6 @@ np.array([['G', 'R', 'P', 'E', 'W', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'A',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  5, 194, 195, 231],
                           [  1, 190, 190, 226]])
                 # fmt: on
@@ -7338,7 +7179,6 @@ np.array([['G', 'R', 'P', 'E', 'W', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'A',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'P', 'E', 'S', 'I', 'W', 'L', 'W', 'I', 'G', 'T', 'I', 'G',
            'M', 'T', 'L', 'G', 'T', 'L', 'Y', 'F', 'V', 'G', 'R', 'G', 'R',
            'G', 'V', 'R', 'D', 'R', 'K', 'M', 'Q', 'E', 'F', 'Y', 'I', 'I',
@@ -7453,7 +7293,6 @@ np.array([['G', 'P', 'E', 'S', 'I', 'W', 'L', 'W', 'I', 'G', 'T', 'I', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 15,  80,  81, 242],
                           [  0,  65,  65, 226]])
                 # fmt: on
@@ -7463,7 +7302,6 @@ np.array([['G', 'P', 'E', 'S', 'I', 'W', 'L', 'W', 'I', 'G', 'T', 'I', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'R', 'P', 'E', 'T', 'L', 'W', 'L', 'G', 'I', 'G', 'T', 'L',
            'L', 'M', 'L', 'I', 'G', 'T', 'F', 'Y', 'F', 'I', 'A', 'R', 'G',
            'W', 'G', 'V', 'T', 'D', 'K', 'E', 'A', 'R', 'E', 'Y', 'Y', 'A',
@@ -7578,7 +7416,6 @@ np.array([['G', 'R', 'P', 'E', 'T', 'L', 'W', 'L', 'G', 'I', 'G', 'T', 'L',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  4, 128, 134, 234],
                           [  1, 125, 125, 225]])
                 # fmt: on
@@ -7588,7 +7425,6 @@ np.array([['G', 'R', 'P', 'E', 'T', 'L', 'W', 'L', 'G', 'I', 'G', 'T', 'L',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'G', 'E', 'A', 'I', 'W', 'L', 'W', 'L', 'G', 'T', 'A', 'G',
            'M', 'F', 'L', 'G', 'M', 'L', 'Y', 'F', 'I', 'A', 'R', 'G', 'W',
            'G', 'E', 'T', 'D', 'S', 'R', 'R', 'Q', 'K', 'F', 'Y', 'I', 'A',
@@ -7703,7 +7539,6 @@ np.array([['E', 'G', 'E', 'A', 'I', 'W', 'L', 'W', 'L', 'G', 'T', 'A', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 13,  78,  79, 239],
                           [  1,  66,  66, 226]])
                 # fmt: on
@@ -7713,7 +7548,6 @@ np.array([['E', 'G', 'E', 'A', 'I', 'W', 'L', 'W', 'L', 'G', 'T', 'A', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'G', 'E', 'G', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'I', 'G',
            'M', 'L', 'L', 'G', 'M', 'L', 'Y', 'F', 'I', 'A', 'D', 'G', 'L',
            'D', 'V', 'Q', 'D', 'P', 'R', 'Q', 'K', 'E', 'F', 'Y', 'V', 'I',
@@ -7828,7 +7662,6 @@ np.array([['E', 'G', 'E', 'G', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'I', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  30,  30,  63,  63, 120, 120, 218],
                           [  1,  30,  31,  64,  68, 125, 126, 224]])
                 # fmt: on
@@ -7838,7 +7671,6 @@ np.array([['E', 'G', 'E', 'G', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'I', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['V', 'G', 'L', 'T', 'T', 'L', 'F', 'W', 'L', 'G', 'A', 'I', 'G',
            'M', 'L', 'V', 'G', 'T', 'L', 'A', 'F', 'A', 'W', 'A', 'G', 'R',
            'D', 'A', 'G', '-', 'S', 'G', 'E', 'R', 'R', 'Y', 'Y', 'V', 'T',
@@ -7953,7 +7785,6 @@ np.array([['V', 'G', 'L', 'T', 'T', 'L', 'F', 'W', 'L', 'G', 'A', 'I', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  5,  35,  35,  69,  69, 188, 188, 225],
                           [  0,  30,  31,  65,  68, 187, 188, 225]])
                 # fmt: on
@@ -7963,7 +7794,6 @@ np.array([['V', 'G', 'L', 'T', 'T', 'L', 'F', 'W', 'L', 'G', 'A', 'I', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'E', 'T', 'G', 'M', 'I', 'A', 'Q', 'W', 'I', 'V', 'F', 'A',
            'I', 'M', 'A', 'A', 'A', 'A', 'I', 'A', 'F', 'G', 'V', 'A', 'V',
            'H', 'F', 'R', 'P', '-', 'S', 'E', 'L', 'K', 'S', 'A', 'Y', 'Y',
@@ -8074,7 +7904,6 @@ np.array([['T', 'E', 'T', 'G', 'M', 'I', 'A', 'Q', 'W', 'I', 'V', 'F', 'A',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  2,  29,  29,  62,  62, 119, 119, 217],
                           [  3,  30,  31,  64,  68, 125, 126, 224]])
                 # fmt: on
@@ -8084,7 +7913,6 @@ np.array([['T', 'E', 'T', 'G', 'M', 'I', 'A', 'Q', 'W', 'I', 'V', 'F', 'A',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'T', 'T', 'L', 'F', 'W', 'L', 'G', 'A', 'I', 'G', 'M', 'L',
            'V', 'G', 'T', 'L', 'A', 'F', 'A', 'W', 'A', 'G', 'R', 'D', 'A',
            'G', '-', 'S', 'G', 'E', 'R', 'R', 'Y', 'Y', 'V', 'T', 'L', 'V',
@@ -8198,7 +8026,6 @@ np.array([['L', 'T', 'T', 'L', 'F', 'W', 'L', 'G', 'A', 'I', 'G', 'M', 'L',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 21,  45,  45,  77,  79, 141, 141, 201, 201, 239],
                           [  6,  30,  31,  63,  63, 125, 126, 186, 187, 225]])
                 # fmt: on
@@ -8208,7 +8035,6 @@ np.array([['L', 'T', 'T', 'L', 'F', 'W', 'L', 'G', 'A', 'I', 'G', 'M', 'L',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'Q', 'W', 'V', 'V', 'F', 'A', 'V', 'M', 'A', 'L', 'A', 'A',
            'I', 'V', 'F', 'S', 'I', 'A', 'V', 'Q', 'F', 'R', 'P', '-', 'L',
            'P', 'L', 'R', 'L', 'T', 'Y', 'Y', 'V', 'N', 'I', 'A', 'I', 'C',
@@ -8322,7 +8148,6 @@ np.array([['A', 'Q', 'W', 'V', 'V', 'F', 'A', 'V', 'M', 'A', 'L', 'A', 'A',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  28,  28,  63,  63,  93,  97, 225],
                           [  1,  28,  29,  64,  68,  98,  98, 226]])
                 # fmt: on
@@ -8332,7 +8157,6 @@ np.array([['A', 'Q', 'W', 'V', 'V', 'F', 'A', 'V', 'M', 'A', 'L', 'A', 'A',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['N', 'L', 'E', 'S', 'L', 'L', 'H', 'W', 'I', 'Y', 'V', 'A', 'G',
            'M', 'T', 'I', 'G', 'A', 'L', 'H', 'F', 'W', 'S', 'L', 'S', 'R',
            'N', '-', 'P', 'R', 'G', 'V', 'P', 'Q', 'Y', 'E', 'Y', 'L', 'V',
@@ -8447,7 +8271,6 @@ np.array([['N', 'L', 'E', 'S', 'L', 'L', 'H', 'W', 'I', 'Y', 'V', 'A', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 36,  95, 111, 172, 173, 206, 206, 269],
                           [  6,  65,  65, 126, 126, 159, 161, 224]])
                 # fmt: on
@@ -8457,7 +8280,6 @@ np.array([['N', 'L', 'E', 'S', 'L', 'L', 'H', 'W', 'I', 'Y', 'V', 'A', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['S', 'L', 'Y', 'I', 'N', 'I', 'A', 'L', 'A', 'G', 'L', 'S', 'I',
            'L', 'L', 'F', 'V', 'F', 'M', 'T', 'R', 'G', 'L', 'D', 'D', 'P',
            'R', 'A', 'K', 'L', 'I', 'A', 'V', 'S', 'T', 'I', 'L', 'V', 'P',
@@ -8574,7 +8396,6 @@ np.array([['S', 'L', 'Y', 'I', 'N', 'I', 'A', 'L', 'A', 'G', 'L', 'S', 'I',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 31,  91,  97, 156, 156, 157, 159, 188, 188, 224, 225, 257],
                           [  6,  66,  66, 125, 126, 127, 127, 156, 158, 194, 194, 226]])
                 # fmt: on
@@ -8584,7 +8405,6 @@ np.array([['S', 'L', 'Y', 'I', 'N', 'I', 'A', 'L', 'A', 'G', 'L', 'S', 'I',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['S', 'L', 'W', 'V', 'N', 'V', 'A', 'L', 'A', 'G', 'I', 'A', 'I',
            'L', 'V', 'F', 'V', 'Y', 'M', 'G', 'R', 'T', 'I', 'R', 'P', 'G',
            'R', 'P', 'R', 'L', 'I', 'W', 'G', 'A', 'T', 'L', 'M', 'I', 'P',
@@ -8699,7 +8519,6 @@ np.array([['S', 'L', 'W', 'V', 'N', 'V', 'A', 'L', 'A', 'G', 'I', 'A', 'I',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1, 149, 149, 196],
                           [  0, 148, 170, 217]])
                 # fmt: on
@@ -8709,7 +8528,6 @@ np.array([['S', 'L', 'W', 'V', 'N', 'V', 'A', 'L', 'A', 'G', 'I', 'A', 'I',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'R', 'P', 'E', 'W', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'A',
            'L', 'M', 'G', 'L', 'G', 'T', 'L', 'Y', 'F', 'L', 'V', 'K', 'G',
            'M', 'G', 'V', 'S', 'D', 'P', 'D', 'A', 'K', 'K', 'F', 'Y', 'A',
@@ -8826,7 +8644,6 @@ np.array([['G', 'R', 'P', 'E', 'W', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'A',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 24,  54,  54,  90,  97, 103, 105, 136, 140, 161,
                            163, 227, 231, 236, 238, 268],
                           [  0,  30,  31,  67,  67,  73,  73, 104, 104, 125,
@@ -8838,7 +8655,6 @@ np.array([['G', 'R', 'P', 'E', 'W', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'A',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['Y', 'Q', 'F', 'T', 'S', 'H', 'I', 'L', 'T', 'L', 'G', 'Y', 'A',
            'V', 'M', 'L', 'A', 'G', 'L', 'L', 'Y', 'F', 'I', 'L', 'T', 'I',
            'K', 'N', 'V', 'D', '-', 'K', 'K', 'F', 'Q', 'M', 'S', 'N', 'I',
@@ -8956,7 +8772,6 @@ np.array([['Y', 'Q', 'F', 'T', 'S', 'H', 'I', 'L', 'T', 'L', 'G', 'Y', 'A',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 87, 117, 117, 127, 130, 150, 150, 182, 185, 210,
                            210, 242, 243, 311],
                           [  0,  30,  31,  41,  41,  61,  68, 100, 100, 125,
@@ -8968,7 +8783,6 @@ np.array([['Y', 'Q', 'F', 'T', 'S', 'H', 'I', 'L', 'T', 'L', 'G', 'Y', 'A',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'I', 'G', 'A', 'Q', 'V', 'C', 'Q', 'W', 'I', 'A', 'F', 'S',
            'I', 'A', 'I', 'A', 'L', 'L', 'T', 'F', 'Y', 'G', 'F', 'S', 'A',
            'W', 'K', 'A', 'T', '-', 'C', 'G', 'W', 'E', 'E', 'V', 'Y', 'V',
@@ -9084,7 +8898,6 @@ np.array([['K', 'I', 'G', 'A', 'Q', 'V', 'C', 'Q', 'W', 'I', 'A', 'F', 'S',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 12,  37,  37,  67,  67,  97, 101, 129, 129, 158,
                            160, 189, 189, 226],
                           [  5,  30,  31,  61,  68,  98,  98, 126, 128, 157,
@@ -9096,7 +8909,6 @@ np.array([['K', 'I', 'G', 'A', 'Q', 'V', 'C', 'Q', 'W', 'I', 'A', 'F', 'S',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'S', 'F', 'W', 'L', 'A', 'A', 'A', 'I', 'M', 'L', 'A', 'S',
            'T', 'V', 'F', 'F', 'F', 'V', 'E', 'R', 'S', 'D', 'V', 'P', '-',
            'V', 'K', 'W', 'K', 'T', 'S', 'L', 'T', 'V', 'A', 'G', 'L', 'V',
@@ -9211,7 +9023,6 @@ np.array([['I', 'S', 'F', 'W', 'L', 'A', 'A', 'A', 'I', 'M', 'L', 'A', 'S',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 23,  47,  47,  82,  88,  95,  95, 122, 126, 151,
                            153, 251],
                           [  6,  30,  31,  66,  66,  73,  74, 101, 101, 126,
@@ -9223,7 +9034,6 @@ np.array([['I', 'S', 'F', 'W', 'L', 'A', 'A', 'A', 'I', 'M', 'L', 'A', 'S',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'L', 'T', 'M', 'G', 'V', 'G', 'V', 'H', 'F', 'A', 'A', 'L',
            'I', 'F', 'F', 'L', 'V', 'V', 'S', 'Q', 'F', 'V', 'A', '-', 'P',
            'K', 'Y', 'R', 'I', 'A', 'T', 'A', 'L', 'S', 'C', 'I', 'V', 'M',
@@ -9338,7 +9148,6 @@ np.array([['L', 'L', 'T', 'M', 'G', 'V', 'G', 'V', 'H', 'F', 'A', 'A', 'L',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  7,  37,  37,  79,  79, 103, 107, 134, 139, 238],
                           [  0,  30,  31,  73,  74,  98,  98, 125, 125, 224]])
                 # fmt: on
@@ -9348,7 +9157,6 @@ np.array([['L', 'L', 'T', 'M', 'G', 'V', 'G', 'V', 'H', 'F', 'A', 'A', 'L',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['V', 'L', 'A', 'T', 'Q', 'Y', 'M', 'F', 'W', 'V', 'G', 'F', 'V',
            'G', 'M', 'A', 'A', 'G', 'T', 'L', 'Y', 'F', 'L', 'V', 'E', 'R',
            'N', 'S', 'L', 'A', '-', 'P', 'E', 'Y', 'R', 'S', 'T', 'A', 'T',
@@ -9464,7 +9272,6 @@ np.array([['V', 'L', 'A', 'T', 'Q', 'Y', 'M', 'F', 'W', 'V', 'G', 'F', 'V',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 26,  56,  56,  86,  86, 117, 121, 147, 147, 170,
                            171, 208, 209, 246],
                           [  0,  30,  31,  61,  68,  99,  99, 125, 127, 150,
@@ -9476,7 +9283,6 @@ np.array([['V', 'L', 'A', 'T', 'Q', 'Y', 'M', 'F', 'W', 'V', 'G', 'F', 'V',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['S', 'D', 'T', 'V', 'G', 'V', 'S', 'F', 'W', 'L', 'V', 'T', 'A',
            'G', 'M', 'L', 'A', 'A', 'T', 'V', 'F', 'F', 'F', 'V', 'E', 'R',
            'D', 'Q', 'V', 'S', '-', 'A', 'K', 'W', 'K', 'T', 'S', 'L', 'T',
@@ -9591,7 +9397,6 @@ np.array([['S', 'D', 'T', 'V', 'G', 'V', 'S', 'F', 'W', 'L', 'V', 'T', 'A',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 18,  41,  41,  66,  67,  78,  82, 114, 118, 176,
                            178, 211, 212, 246],
                           [  7,  30,  31,  56,  56,  67,  67,  99,  99, 157,
@@ -9603,7 +9408,6 @@ np.array([['S', 'D', 'T', 'V', 'G', 'V', 'S', 'F', 'W', 'L', 'V', 'T', 'A',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'S', 'L', 'T', 'I', 'A', 'G', 'M', 'L', 'A', 'A', 'F', 'V',
            'F', 'F', 'L', 'L', 'A', 'R', 'S', 'Y', 'V', 'A', '-', 'P', 'R',
            'Y', 'H', 'I', 'A', 'L', 'Y', 'L', 'S', 'A', 'L', 'I', 'V', 'F',
@@ -9718,7 +9522,6 @@ np.array([['L', 'S', 'L', 'T', 'I', 'A', 'G', 'M', 'L', 'A', 'A', 'F', 'V',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 18,  42,  42,  79,  82,  89,  91, 118, 122, 146,
                            149, 212, 215, 222, 225, 253],
                           [  6,  30,  31,  68,  68,  75,  75, 102, 102, 126,
@@ -9730,7 +9533,6 @@ np.array([['L', 'S', 'L', 'T', 'I', 'A', 'G', 'M', 'L', 'A', 'A', 'F', 'V',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['M', 'F', 'S', 'F', 'T', 'V', 'A', 'T', 'M', 'T', 'A', 'S', 'F',
            'V', 'F', 'F', 'V', 'L', 'A', 'R', 'N', 'N', 'V', 'A', '-', 'P',
            'K', 'Y', 'R', 'I', 'S', 'M', 'M', 'V', 'S', 'A', 'L', 'V', 'V',
@@ -9847,7 +9649,6 @@ np.array([['M', 'F', 'S', 'F', 'T', 'V', 'A', 'T', 'M', 'T', 'A', 'S', 'F',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 68,  94,  94, 106, 107, 111, 111, 127, 127, 160,
                            163, 187, 187, 220, 221, 286],
                           [  4,  30,  31,  43,  43,  47,  49,  65,  68, 101,
@@ -9859,7 +9660,6 @@ np.array([['M', 'F', 'S', 'F', 'T', 'V', 'A', 'T', 'M', 'T', 'A', 'S', 'F',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['N', 'I', 'L', 'Q', 'W', 'I', 'T', 'F', 'A', 'L', 'S', 'A', 'L',
            'C', 'L', 'M', 'F', 'Y', 'G', 'Y', 'Q', 'T', 'W', 'K', 'S', 'T',
            '-', 'C', 'G', 'W', 'E', 'E', 'I', 'Y', 'V', 'A', 'T', 'I', 'E',
@@ -9974,7 +9774,6 @@ np.array([['N', 'I', 'L', 'Q', 'W', 'I', 'T', 'F', 'A', 'L', 'S', 'A', 'L',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  6,  31,  31,  60,  60,  93,  96, 120, 121, 145,
                            145, 182, 182, 185, 185, 213],
                           [  5,  30,  31,  60,  68, 101, 101, 125, 125, 149,
@@ -9986,7 +9785,6 @@ np.array([['N', 'I', 'L', 'Q', 'W', 'I', 'T', 'F', 'A', 'L', 'S', 'A', 'L',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'L', 'F', 'M', 'V', 'A', 'T', 'V', 'G', 'M', 'L', 'A', 'G',
            'T', 'V', 'F', 'L', 'L', 'A', 'S', 'S', 'R', 'E', 'V', 'K', '-',
            'P', 'E', 'H', 'R', 'R', 'G', 'V', 'Y', 'I', 'S', 'A', 'L', 'V',
@@ -10101,7 +9899,6 @@ np.array([['R', 'L', 'F', 'M', 'V', 'A', 'T', 'V', 'G', 'M', 'L', 'A', 'G',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 26,  34,  34,  53,  53,  82,  82, 114, 117, 167,
                            174, 248],
                           [  0,   8,  11,  30,  36,  65,  68, 100, 100, 150,
@@ -10113,7 +9910,6 @@ np.array([['R', 'L', 'F', 'M', 'V', 'A', 'T', 'V', 'G', 'M', 'L', 'A', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['D', 'G', 'I', 'K', 'Y', 'V', 'Q', 'L', '-', '-', '-', 'V', 'M',
            'A', 'V', 'V', 'S', 'A', 'C', 'Q', 'V', 'F', 'F', 'M', 'V', 'T',
            'R', 'A', 'P', 'K', '-', '-', '-', '-', '-', '-', 'V', 'P', 'W',
@@ -10229,7 +10025,6 @@ np.array([['D', 'G', 'I', 'K', 'Y', 'V', 'Q', 'L', '-', '-', '-', 'V', 'M',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  8,  22,  23,  38,  38,  65,  65,  98, 103, 126,
                            126, 184, 189, 226],
                           [  0,  14,  14,  29,  31,  58,  69, 102, 102, 125,
@@ -10241,7 +10036,6 @@ np.array([['D', 'G', 'I', 'K', 'Y', 'V', 'Q', 'L', '-', '-', '-', 'V', 'M',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'G', 'F', 'G', 'S', 'Q', 'P', 'F', 'I', 'L', 'A', 'Y', 'I',
            'I', 'T', 'A', 'M', 'I', 'S', 'G', 'L', 'L', 'F', 'L', 'Y', 'L',
            'P', 'R', 'K', 'L', '-', '-', 'D', 'V', 'P', 'Q', 'K', 'F', 'G',
@@ -10350,7 +10144,6 @@ np.array([['G', 'G', 'F', 'G', 'S', 'Q', 'P', 'F', 'I', 'L', 'A', 'Y', 'I',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  1,  69],
                           [158, 226]])
                 # fmt: on
@@ -10360,7 +10153,6 @@ np.array([['G', 'G', 'F', 'G', 'S', 'Q', 'P', 'F', 'I', 'L', 'A', 'Y', 'I',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'P', 'E', 'V', 'A', 'S', 'T', 'F', 'K', 'V', 'L', 'R', 'N',
            'V', 'T', 'V', 'V', 'L', 'W', 'S', 'A', 'Y', 'P', 'V', 'V', 'W',
            'L', 'I', 'G', 'S', 'E', 'G', 'A', 'G', 'I', 'V', 'P', 'L', 'N',
@@ -10443,7 +10235,6 @@ np.array([['R', 'P', 'E', 'V', 'A', 'S', 'T', 'F', 'K', 'V', 'L', 'R', 'N',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 5, 33, 34, 36, 36, 71],
                           [ 0, 28, 28, 30, 31, 66]])
                 # fmt: on
@@ -10453,7 +10244,6 @@ np.array([['R', 'P', 'E', 'V', 'A', 'S', 'T', 'F', 'K', 'V', 'L', 'R', 'N',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'R', 'P', 'E', 'W', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'A',
            'L', 'M', 'G', 'L', 'G', 'T', 'L', 'Y', 'F', 'L', 'V', 'K', 'G',
            'M', 'G', 'V', 'S', 'D', '-', 'P', 'D', 'A', 'K', 'K', 'F', 'Y',
@@ -10530,7 +10320,6 @@ np.array([['G', 'R', 'P', 'E', 'W', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'A',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[14, 37, 37, 65],
                           [ 7, 30, 31, 59]])
                 # fmt: on
@@ -10540,7 +10329,6 @@ np.array([['G', 'R', 'P', 'E', 'W', 'I', 'W', 'L', 'A', 'L', 'G', 'T', 'A',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['F', 'W', 'L', 'V', 'T', 'A', 'A', 'L', 'L', 'A', 'S', 'T', 'V',
            'F', 'F', 'F', 'V', 'E', 'R', 'D', 'R', 'V', 'S', '-', 'A', 'K',
            'W', 'K', 'T', 'S', 'L', 'T', 'V', 'S', 'G', 'L', 'V', 'T', 'G',
@@ -10663,7 +10451,6 @@ sp|Q9BSU1       363 KPVVLHRSSSPNNTNPFGSTFCFGLQRMIFEVMQNNHIASVTLY 407
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  0, 121, 121, 140, 142, 156, 165, 169, 170, 208,
                            208, 260, 260, 317, 317, 322, 328, 346, 346, 394],
                           [ 21, 142, 147, 166, 166, 180, 180, 184, 184, 222,
@@ -10675,7 +10462,6 @@ sp|Q9BSU1       363 KPVVLHRSSSPNNTNPFGSTFCFGLQRMIFEVMQNNHIASVTLY 407
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'M', 'H', 'F', 'S', 'Q', 'S', 'V', 'A', 'I', 'I', 'Q', 'S',
            'Q', 'V', 'G', 'T', 'I', 'R', 'G', 'V', 'Q', 'V', 'L', 'Y', 'S',
            'D', 'Q', 'N', 'P', 'L', 'S', 'V', 'D', 'L', 'V', 'I', 'N', 'M',
@@ -10817,7 +10603,6 @@ sp|Q9BSU1       397 NNHIASVTLYGP 409
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 11,  14,  23,  46,  46,  67,  67,  77,  82,  93,
                             93, 108, 108, 119, 119, 132, 138, 145, 146, 159],
                           [238, 241, 241, 264, 277, 298, 299, 309, 309, 320,
@@ -10829,7 +10614,6 @@ sp|Q9BSU1       397 NNHIASVTLYGP 409
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'K', 'V', 'T', 'T', 'D', 'Q', 'N', 'H', 'F', 'S', 'G', 'G',
            'T', 'S', 'I', 'E', 'Q', 'L', 'K', 'Q', 'W', 'F', 'G', 'D', 'P',
            'N', 'K', 'S', 'E', 'Q', 'R', 'N', 'A', 'G', '-', '-', '-', '-',
@@ -10913,7 +10697,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 11,  31],
                           [238, 258]])
                 # fmt: on
@@ -10923,7 +10706,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'Q', 'I', 'G', 'M', 'S', 'E', 'S', 'Q', 'V', 'T', 'Y', 'L',
            'L', 'G', 'N', 'P', 'M', 'L', 'R'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -10985,7 +10767,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 26,  46],
                           [238, 258]])
                 # fmt: on
@@ -10995,7 +10776,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'R', 'V', 'G', 'M', 'T', 'Q', 'Q', 'Q', 'V', 'A', 'Y', 'A',
            'L', 'G', 'T', 'P', 'L', 'M', 'S'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -11053,7 +10833,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 33,  53],
                           [238, 258]])
                 # fmt: on
@@ -11063,7 +10842,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'S', 'L', 'G', 'M', 'T', 'R', 'D', 'Q', 'V', 'M', 'T', 'L',
            'M', 'G', 'T', 'A', 'D', 'F', 'N'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -11125,7 +10903,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 29,  49],
                           [238, 258]])
                 # fmt: on
@@ -11135,7 +10912,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'R', 'P', 'G', 'M', 'T', 'K', 'D', 'Q', 'V', 'L', 'L', 'L',
            'L', 'G', 'S', 'P', 'I', 'L', 'R'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -11217,7 +10993,6 @@ sp|Q9BSU1       125 LFHLNFR--------GLSFSFQ 139
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 11,  34,  36,  59,  59,  70,  71, 100, 100, 106,
                            116, 126, 134, 141],
                           [ 18,  41,  41,  64,  74,  85,  85, 114, 116, 122,
@@ -11229,7 +11004,6 @@ sp|Q9BSU1       125 LFHLNFR--------GLSFSFQ 139
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'Q', 'F', 'G', 'M', 'D', 'R', 'T', 'L', 'V', 'W', 'Q', 'L',
            'A', 'G', 'A', 'D', 'Q', 'S', 'C', 'S', 'D', 'Q', 'V', 'E', 'R',
            'I', 'I', 'C', 'Y', 'N', 'N', 'P', 'D', 'H', 'Y', 'G', 'P', 'Q',
@@ -11322,7 +11096,6 @@ sp|Q9BSU1       298 ANTHKVKKFVLHTN 312
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 61,  98,  98, 131],
                           [238, 275, 279, 312]])
                 # fmt: on
@@ -11332,7 +11105,6 @@ sp|Q9BSU1       298 ANTHKVKKFVLHTN 312
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['F', 'H', 'I', 'G', 'Q', 'P', 'V', 'S', 'E', 'I', 'Y', 'S', 'S',
            'V', 'F', 'I', 'D', 'T', 'N', 'I', 'N', 'F', 'Q', 'Y', 'K', 'G',
            'S', 'S', 'Y', 'R', 'F', 'E', 'L', 'S', 'E', 'D', 'D', '-', '-',
@@ -11402,7 +11174,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 12,  32],
                           [238, 258]])
                 # fmt: on
@@ -11412,7 +11183,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'R', 'V', 'G', 'M', 'T', 'Q', 'Q', 'Q', 'V', 'A', 'Y', 'A',
            'L', 'G', 'T', 'P', 'L', 'M', 'S'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -11486,7 +11256,6 @@ sp|Q9BSU1       299 NTHKVKKFVLHTN 312
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  0,  24,  24,  32,  33,  55],
                           [240, 264, 282, 290, 290, 312]])
                 # fmt: on
@@ -11496,7 +11265,6 @@ sp|Q9BSU1       299 NTHKVKKFVLHTN 312
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'G', 'K', 'N', 'A', 'S', 'D', 'L', 'Q', 'V', 'L', 'L', 'G',
            'D', 'P', 'E', 'R', 'K', 'D', 'P', 'S', 'E', 'Y', 'G', '-', '-',
            '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',
@@ -11566,7 +11334,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 23,  43],
                           [238, 258]])
                 # fmt: on
@@ -11576,7 +11343,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['V', 'E', 'K', 'G', 'M', 'S', 'Q', 'Q', 'E', 'V', 'L', 'R', 'I',
            'G', 'G', 'T', 'P', 'S', 'G', 'T'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -11650,7 +11416,6 @@ sp|Q9BSU1        67 MFDAFNQRLKVIEVCD  83
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 60,  61,  61,  81,  86, 107, 107, 130],
                           [ 12,  13,  18,  38,  38,  59,  60,  83]])
                 # fmt: on
@@ -11660,7 +11425,6 @@ sp|Q9BSU1        67 MFDAFNQRLKVIEVCD  83
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['P', '-', '-', '-', '-', '-', 'F', 'H', 'I', 'G', 'Q', 'P', 'V',
            'S', 'E', 'I', 'Y', 'S', 'S', 'V', 'F', 'I', 'D', 'T', 'N', 'I',
            'N', 'F', 'Q', 'Y', 'K', 'G', 'S', 'S', 'Y', 'R', 'F', 'E', 'L',
@@ -11747,7 +11511,6 @@ sp|Q9BSU1       127 HLNF-RG----LSFSFQLDSWTEAPKYEPNFAHGLASLQIPHGATVKRMYIY 174
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 10,  16,  16,  23,  24,  34,  34,  44,  44,  64,
                             64,  78,  78,  89,  89, 105, 106, 108, 112, 123,
                            123, 135],
@@ -11761,7 +11524,6 @@ sp|Q9BSU1       127 HLNF-RG----LSFSFQLDSWTEAPKYEPNFAHGLASLQIPHGATVKRMYIY 174
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'K', 'V', 'F', 'N', 'S', '-', '-', '-', 'D', 'F', 'P', 'A',
            'K', 'D', 'T', 'N', 'I', 'D', 'S', 'V', 'E', 'S', 'K', 'W', 'G',
            'K', '-', '-', '-', '-', '-', '-', 'A', 'D', 'N', 'S', 'E', 'W',
@@ -11843,7 +11605,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  7,  27],
                           [238, 258]])
                 # fmt: on
@@ -11853,7 +11614,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'Q', 'F', 'G', 'M', 'D', 'R', 'T', 'L', 'V', 'W', 'Q', 'L',
            'A', 'G', 'A', 'D', 'Q', 'S', 'C'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -11911,7 +11671,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKVFYKSEDK 265
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 10,  37],
                           [238, 265]])
                 # fmt: on
@@ -11921,7 +11680,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKVFYKSEDK 265
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'Q', 'T', 'G', 'D', 'T', 'K', 'A', 'E', 'V', 'I', 'A', 'K',
            'C', 'G', 'D', 'P', 'V', 'F', 'T', 'D', 'H', 'Y', 'C', 'A', 'P',
            'M'],
@@ -12001,7 +11759,6 @@ sp|Q9BSU1       116 PGVYNSAE----QLFHLNFR----------GLSFSF 138
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 10,  20,  20,  44,  51,  57,  57,  67,  67,  82,
                             83, 109, 109, 118, 122, 130, 140, 146],
                           [  4,  14,  18,  42,  42,  48,  60,  70,  72,  87,
@@ -12013,7 +11770,6 @@ sp|Q9BSU1       116 PGVYNSAE----QLFHLNFR----------GLSFSF 138
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'I', 'K', 'V', 'T', 'T', 'D', 'Q', 'N', 'H', '-', '-', '-',
            '-', 'F', 'S', 'G', 'G', 'T', 'S', 'I', 'E', 'Q', 'L', 'K', 'Q',
            'W', 'F', 'G', 'D', 'P', 'N', 'K', 'S', 'E', 'Q', 'R', 'N', 'A',
@@ -12108,7 +11864,6 @@ sp|Q9BSU1        77 VIEVC 82
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 4, 42, 46, 63, 64, 69],
                           [22, 60, 60, 77, 77, 82]])
                 # fmt: on
@@ -12118,7 +11873,6 @@ sp|Q9BSU1        77 VIEVC 82
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'T', 'P', 'D', 'K', 'A', 'V', 'E', 'Y', 'L', 'K', 'D', 'N',
            'V', 'K', 'I', 'H', 'D', 'N', 'L', 'E', 'I', 'S', 'Y', 'N', 'R',
            'I', 'F', 'G', 'S', 'G', 'E', 'V', 'L', 'N', 'M', 'D', 'F', 'S',
@@ -12187,7 +11941,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 25,  45],
                           [238, 258]])
                 # fmt: on
@@ -12197,7 +11950,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'Q', 'V', 'G', 'Q', 'S', 'K', 'Q', 'Q', 'V', 'S', 'A', 'L',
            'L', 'G', 'T', 'P', 'S', 'I', 'P'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -12259,7 +12011,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 11,  31],
                           [238, 258]])
                 # fmt: on
@@ -12269,7 +12020,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'Q', 'F', 'G', 'M', 'D', 'R', 'T', 'L', 'V', 'W', 'Q', 'L',
            'A', 'G', 'A', 'D', 'Q', 'S', 'C'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -12331,7 +12081,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 45,  65],
                           [238, 258]])
                 # fmt: on
@@ -12341,7 +12090,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'R', 'V', 'G', 'M', 'T', 'Q', 'Q', 'Q', 'V', 'A', 'Y', 'A',
            'L', 'G', 'T', 'P', 'L', 'M', 'S'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -12419,7 +12167,6 @@ sp|Q9BSU1       289 TLGVDILFDANTHKVKKFVLH 310
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 30,  33,  42,  65,  65,  86,  86,  97],
                           [238, 241, 241, 264, 277, 298, 299, 310]])
                 # fmt: on
@@ -12429,7 +12176,6 @@ sp|Q9BSU1       289 TLGVDILFDANTHKVKKFVLH 310
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'K', 'V', 'T', 'T', 'D', 'Q', 'N', 'H', 'F', 'S', 'G', 'G',
            'T', 'S', 'I', 'E', 'Q', 'L', 'K', 'Q', 'W', 'F', 'G', 'D', 'P',
            'N', 'K', 'S', 'E', 'Q', 'R', 'N', 'A', 'G', '-', '-', '-', '-',
@@ -12521,7 +12267,6 @@ sp|Q9BSU1       121 SAEQ----LFHLNF----------RGLSFSFQ 139
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 30,  33,  42,  60,  67,  76,  76,  86,  86, 100,
                            101, 129, 129, 138, 142, 148, 158, 166],
                           [ 18,  21,  21,  39,  39,  48,  60,  70,  72,  86,
@@ -12533,7 +12278,6 @@ sp|Q9BSU1       121 SAEQ----LFHLNF----------RGLSFSFQ 139
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'K', 'V', 'T', 'T', 'D', 'Q', 'N', 'H', 'F', 'S', 'G', 'G',
            'T', 'S', 'I', 'E', 'Q', 'L', 'K', 'Q', 'W', 'F', 'G', 'D', 'P',
            'N', 'K', 'S', 'E', 'Q', 'R', 'N', 'A', 'G', 'N', 'I', 'T', 'L',
@@ -12611,7 +12355,6 @@ sp|Q9BSU1        87 KLKYCGVHFNSQAIAPTIEQIDQSFGATHP 117
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  4,  34],
                           [ 87, 117]])
                 # fmt: on
@@ -12621,7 +12364,6 @@ sp|Q9BSU1        87 KLKYCGVHFNSQAIAPTIEQIDQSFGATHP 117
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['V', 'F', 'K', 'F', 'D', 'G', 'K', 'V', 'L', 'D', 'D', 'P', 'N',
            'P', 'K', 'S', 'T', 'P', 'E', 'Q', 'V', 'K', 'T', 'F', 'Y', 'A',
            'P', 'T', 'Y', 'P'],
@@ -12685,7 +12427,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 11,  31],
                           [238, 258]])
                 # fmt: on
@@ -12695,7 +12436,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'Q', 'F', 'G', 'M', 'T', 'R', 'Q', 'Q', 'V', 'L', 'D', 'I',
            'A', 'G', 'A', 'E', 'N', 'C', 'E'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -12757,7 +12497,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 84, 104],
                           [238, 258]])
                 # fmt: on
@@ -12767,7 +12506,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'Q', 'T', 'G', 'M', 'T', 'E', 'A', 'Q', 'F', 'W', 'A', 'A',
            'V', 'P', 'S', 'D', 'T', 'C', 'S'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -12841,7 +12579,6 @@ sp|Q9BSU1       297 DANTHKVKKF 307
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 17,  23,  24,  45,  45,  62,  62,  69],
                           [238, 244, 244, 265, 282, 299, 300, 307]])
                 # fmt: on
@@ -12851,7 +12588,6 @@ sp|Q9BSU1       297 DANTHKVKKF 307
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['F', 'P', 'A', 'K', 'D', 'T', 'N', 'I', 'D', 'S', 'V', 'E', 'S',
            'K', 'W', 'G', 'K', 'A', 'D', 'N', 'S', 'E', 'W', 'V', 'A', 'S',
            'A', 'K', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',
@@ -12917,7 +12653,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 94, 114],
                           [238, 258]])
                 # fmt: on
@@ -12927,7 +12662,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'K', 'I', 'G', 'E', 'S', 'Y', 'K', 'K', 'V', 'V', 'E', 'K',
            'L', 'G', 'E', 'P', 'D', 'V', 'L'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -12989,7 +12723,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKVF 259
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 42,  63],
                           [238, 259]])
                 # fmt: on
@@ -12999,7 +12732,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKVF 259
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'W', 'V', 'G', 'K', 'D', 'I', 'K', 'V', 'L', 'T', 'S', 'K',
            'F', 'G', 'Q', 'A', 'D', 'R', 'V', 'Y'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -13072,7 +12804,6 @@ sp|Q9BSU1        66 LMFDAFN  73
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[101, 128, 130, 140, 144, 151, 151, 167],
                           [ 12,  39,  39,  49,  49,  56,  57,  73]])
                 # fmt: on
@@ -13082,7 +12813,6 @@ sp|Q9BSU1        66 LMFDAFN  73
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'W', 'E', 'H', 'V', 'E', 'L', 'V', 'L', 'P', 'V', 'A', 'P',
            'E', 'I', 'L', 'S', 'T', 'A', 'A', 'K', 'A', 'L', 'L', 'P', 'Q',
            'P', 'L', 'P', 'A', 'G', 'F', 'S', 'V', 'K', 'E', 'S', 'Q', 'P',
@@ -13176,7 +12906,6 @@ sp|Q9BSU1       170 MYIYS 175
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  8,  15,  15,  21,  21,  53,  53,  65,  65,  82,
                             82,  95, 111, 147, 147, 157],
                           [  6,  13,  18,  24,  29,  61,  62,  74,  76,  93,
@@ -13188,7 +12917,6 @@ sp|Q9BSU1       170 MYIYS 175
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'P', 'G', 'E', 'G', 'T', 'G', '-', '-', '-', '-', '-', 'I',
            'Q', 'L', 'S', 'A', 'G', '-', '-', '-', '-', '-', 'Q', 'I', 'L',
            'K', 'F', 'Y', 'N', 'V', 'P', 'I', 'A', 'E', 'I', 'I', 'V', 'E',
@@ -13276,7 +13004,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[113, 133],
                           [238, 258]])
                 # fmt: on
@@ -13286,7 +13013,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'K', 'I', 'G', 'E', 'S', 'Y', 'K', 'K', 'I', 'V', 'E', 'K',
            'L', 'G', 'E', 'P', 'D', 'V', 'L'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -13348,7 +13074,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 90, 110],
                           [238, 258]])
                 # fmt: on
@@ -13358,7 +13083,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['V', 'T', 'V', 'G', 'M', 'T', 'R', 'A', 'Q', 'V', 'L', 'A', 'T',
            'V', 'G', 'Q', 'G', 'S', 'C', 'T'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -13416,7 +13140,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKVF 259
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 80, 101],
                           [238, 259]])
                 # fmt: on
@@ -13426,7 +13149,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKVF 259
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'Q', 'T', 'G', 'M', 'T', 'E', 'A', 'Q', 'F', 'W', 'A', 'A',
            'V', 'P', 'S', 'D', 'T', 'C', 'S', 'A'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -13500,7 +13222,6 @@ sp|Q9BSU1        78 IEVCDLTKVKLKYCGVH-FNSQAIAPTIEQIDQSFGA 114
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  7,  42,  42,  53,  53,  76,  77,  96],
                           [ 18,  53,  60,  71,  72,  95,  95, 114]])
                 # fmt: on
@@ -13510,7 +13231,6 @@ sp|Q9BSU1        78 IEVCDLTKVKLKYCGVH-FNSQAIAPTIEQIDQSFGA 114
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'Q', 'F', 'G', 'M', 'D', 'R', 'T', 'L', 'V', 'W', 'Q', 'L',
            'A', 'G', 'A', 'D', 'Q', 'S', 'C', 'S', 'D', 'Q', 'V', 'E', 'R',
            'I', 'I', 'C', 'Y', 'N', 'N', 'P', 'D', 'H', '-', '-', '-', '-',
@@ -13640,7 +13360,6 @@ sp|Q9BSU1       368 HRSSSPNNTNPFGSTFCFGLQRMIFEVMQNNHIASVTLY 407
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  0,   4,   4, 329, 331, 395],
                           [ 10,  14,  18, 343, 343, 407]])
                 # fmt: on
@@ -13650,7 +13369,6 @@ sp|Q9BSU1       368 HRSSSPNNTNPFGSTFCFGLQRMIFEVMQNNHIASVTLY 407
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['E', 'Q', 'W', 'E', '-', '-', '-', '-', 'F', 'A', 'L', 'G', 'M',
            'P', 'L', 'A', 'Q', 'A', 'I', 'S', 'I', 'L', 'Q', 'K', 'H', 'C',
            'R', 'I', 'I', 'K', 'N', 'V', 'Q', 'V', 'L', 'Y', 'S', 'E', 'Q',
@@ -13766,7 +13484,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 11,  31],
                           [238, 258]])
                 # fmt: on
@@ -13776,7 +13493,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'Q', 'I', 'G', 'M', 'S', 'E', 'S', 'Q', 'V', 'T', 'Y', 'L',
            'L', 'G', 'N', 'P', 'M', 'L', 'R'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -13834,7 +13550,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 33,  53],
                           [238, 258]])
                 # fmt: on
@@ -13844,7 +13559,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'S', 'L', 'G', 'M', 'T', 'R', 'D', 'Q', 'V', 'M', 'T', 'L',
            'M', 'G', 'T', 'A', 'D', 'F', 'N'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -13918,7 +13632,6 @@ sp|Q9BSU1       297 DANTHKVKKFVLHTNYPG 315
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 17,  23,  24,  45,  45,  78],
                           [238, 244, 244, 265, 282, 315]])
                 # fmt: on
@@ -13928,7 +13641,6 @@ sp|Q9BSU1       297 DANTHKVKKFVLHTNYPG 315
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['F', 'P', 'A', 'K', 'D', 'T', 'N', 'I', 'D', 'S', 'V', 'E', 'S',
            'K', 'W', 'G', 'K', 'A', 'D', 'N', 'S', 'E', 'W', 'V', 'A', 'S',
            'A', 'K', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',
@@ -13995,7 +13707,6 @@ sp|Q9BSU1       228 DAKMRVFERSVYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  0,  30],
                           [228, 258]])
                 # fmt: on
@@ -14005,7 +13716,6 @@ sp|Q9BSU1       228 DAKMRVFERSVYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'S', 'A', 'L', 'R', 'C', 'D', 'N', 'K', 'I', 'V', 'S', 'E',
            'G', 'A', 'S', 'Q', 'V', 'D', 'A', 'L', 'A', 'K', 'C', 'G', 'Q',
            'P', 'V', 'T', 'K'],
@@ -14065,7 +13775,6 @@ sp|Q9BSU1       240 FGDSCQDVLSMLGSPHKVF 259
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  0,  19],
                           [240, 259]])
                 # fmt: on
@@ -14075,7 +13784,6 @@ sp|Q9BSU1       240 FGDSCQDVLSMLGSPHKVF 259
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'G', 'K', 'N', 'A', 'S', 'D', 'L', 'Q', 'V', 'L', 'L', 'G',
            'D', 'P', 'E', 'R', 'K', 'D'],
           ['F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M', 'L', 'G',
@@ -14149,7 +13857,6 @@ sp|Q9BSU1       289 TLGVDILFDANTHKVKKFVL 309
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 61,  81,  90,  96,  96, 128],
                           [238, 258, 258, 264, 277, 309]])
                 # fmt: on
@@ -14159,7 +13866,6 @@ sp|Q9BSU1       289 TLGVDILFDANTHKVKKFVL 309
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['F', 'H', 'I', 'G', 'Q', 'P', 'V', 'S', 'E', 'I', 'Y', 'S', 'S',
            'V', 'F', 'I', 'D', 'T', 'N', 'I', 'N', 'F', 'Q', 'Y', 'K', 'G',
            'S', 'S', 'Y', 'R', 'F', 'E', 'L', 'S', 'E', '-', '-', '-', '-',
@@ -14227,7 +13933,6 @@ sp|Q9BSU1        87 KLKYCGVHFNSQAIAPTIEQIDQSFGATHP 117
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[  4,  34],
                           [ 87, 117]])
                 # fmt: on
@@ -14237,7 +13942,6 @@ sp|Q9BSU1        87 KLKYCGVHFNSQAIAPTIEQIDQSFGATHP 117
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['V', 'F', 'K', 'F', 'D', 'G', 'K', 'V', 'L', 'D', 'D', 'P', 'N',
            'P', 'K', 'S', 'T', 'P', 'E', 'Q', 'V', 'K', 'T', 'F', 'Y', 'A',
            'P', 'T', 'Y', 'P'],
@@ -14321,7 +14025,6 @@ sp|Q9BSU1       174
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 10,  16,  16,  23,  24,  32,  32,  39,  46,  65,
                             65,  72,  72,  90,  90, 106, 107, 108, 112, 123,
                            123, 135],
@@ -14335,7 +14038,6 @@ sp|Q9BSU1       174
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'K', 'V', 'F', 'N', 'S', '-', '-', '-', 'D', 'F', 'P', 'A',
            'K', 'D', 'T', 'N', 'I', 'D', 'S', 'V', 'E', 'S', 'K', 'W', '-',
            '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',
@@ -14432,7 +14134,6 @@ sp|Q9BSU1        65 KLMFDAFN  73
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[101, 129, 131, 139, 144, 156, 156, 167],
                           [ 12,  40,  40,  48,  48,  60,  62,  73]])
                 # fmt: on
@@ -14442,7 +14143,6 @@ sp|Q9BSU1        65 KLMFDAFN  73
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'W', 'E', 'H', 'V', 'E', 'L', 'V', 'L', 'P', 'V', 'A', 'P',
            'E', 'I', 'L', 'S', 'T', 'A', 'A', 'K', 'A', 'L', 'L', 'P', 'Q',
            'P', 'L', 'P', 'A', 'G', 'F', 'S', 'V', 'K', 'E', 'S', 'Q', 'P',
@@ -14508,7 +14208,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 94, 114],
                           [238, 258]])
                 # fmt: on
@@ -14518,7 +14217,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'K', 'I', 'G', 'E', 'S', 'Y', 'K', 'K', 'V', 'V', 'E', 'K',
            'L', 'G', 'E', 'P', 'D', 'V', 'L'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -14592,7 +14290,6 @@ sp|Q9BSU1        67 MFDAFNQRLKVIEVCD  83
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 60,  61,  61,  81,  86, 107, 107, 130],
                           [ 12,  13,  18,  38,  38,  59,  60,  83]])
                 # fmt: on
@@ -14602,7 +14299,6 @@ sp|Q9BSU1        67 MFDAFNQRLKVIEVCD  83
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['P', '-', '-', '-', '-', '-', 'F', 'H', 'I', 'G', 'Q', 'P', 'V',
            'S', 'E', 'I', 'Y', 'S', 'S', 'V', 'F', 'I', 'D', 'T', 'N', 'I',
            'N', 'F', 'Q', 'Y', 'K', 'G', 'S', 'S', 'Y', 'R', 'F', 'E', 'L',
@@ -14685,7 +14381,6 @@ sp|Q9BSU1        77 VIEVC 82
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 4, 42, 46, 63, 64, 69],
                           [22, 60, 60, 77, 77, 82]])
                 # fmt: on
@@ -14695,7 +14390,6 @@ sp|Q9BSU1        77 VIEVC 82
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'T', 'P', 'D', 'K', 'A', 'V', 'E', 'Y', 'L', 'K', 'D', 'N',
            'V', 'K', 'I', 'H', 'D', 'N', 'L', 'E', 'I', 'S', 'Y', 'N', 'R',
            'I', 'F', 'G', 'S', 'G', 'E', 'V', 'L', 'N', 'M', 'D', 'F', 'S',
@@ -14760,7 +14454,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 39,  59],
                           [238, 258]])
                 # fmt: on
@@ -14770,7 +14463,6 @@ sp|Q9BSU1       238 VYFGDSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'Q', 'F', 'G', 'M', 'T', 'F', 'D', 'E', 'V', 'W', 'E', 'I',
            'G', 'G', 'G', 'E', 'A', 'A', 'C'],
           ['V', 'Y', 'F', 'G', 'D', 'S', 'C', 'Q', 'D', 'V', 'L', 'S', 'M',
@@ -14828,7 +14520,6 @@ sp|Q9BSU1       238 VYFG---------DSCQDVLSMLGSPHKV 258
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 11,  15,  24,  40],
                           [238, 242, 242, 258]])
                 # fmt: on
@@ -14838,7 +14529,6 @@ sp|Q9BSU1       238 VYFG---------DSCQDVLSMLGSPHKV 258
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'K', 'V', 'T', 'T', 'D', 'Q', 'N', 'H', 'F', 'S', 'G', 'G',
            'T', 'S', 'I', 'E', 'Q', 'L', 'K', 'Q', 'W', 'F', 'G', 'D', 'P',
            'N', 'K', 'S'],
@@ -14898,7 +14588,6 @@ sp|Q9BSU1        61 QDGIKLMFDAFNQRLKVIEVCDLT 85
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[25, 35, 35, 48],
                           [61, 71, 72, 85]])
                 # fmt: on
@@ -14908,7 +14597,6 @@ sp|Q9BSU1        61 QDGIKLMFDAFNQRLKVIEVCDLT 85
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'P', 'N', 'V', 'I', 'F', 'D', 'Y', 'D', 'A', '-', 'E', 'G',
            'R', 'I', 'V', 'G', 'I', 'E', 'L', 'L', 'D', 'A', 'R'],
           ['Q', 'D', 'G', 'I', 'K', 'L', 'M', 'F', 'D', 'A', 'F', 'N', 'Q',

--- a/Tests/test_Align_maf.py
+++ b/Tests/test_Align_maf.py
@@ -32,7 +32,6 @@ class TestAlign_reading(unittest.TestCase):
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'C', 'A', 'T', 'A', 'G', 'G', 'T', 'A', 'T', 'T', 'T', 'A',
            'T', 'T', 'T', 'T', 'T', 'A', 'A', 'A', 'T', 'A', 'T', 'G', 'G',
            'T', 'T', 'T', 'G', 'C', 'T', 'T', 'T', 'A', 'T', 'G', 'G', 'C',
@@ -97,7 +96,6 @@ np.array([['T', 'C', 'A', 'T', 'A', 'G', 'G', 'T', 'A', 'T', 'T', 'T', 'A',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[3009319, 3009392, 3009392, 3009481],
                           [  11087,   11160,   11162,   11251],
                          ])
@@ -211,7 +209,6 @@ i oryCun1.scaffold_133159 N 0 N 0
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'C', 'A', 'T', 'A', 'G', 'G', 'T', 'A', 'T', 'T', 'T', 'A',
            'T', 'T', 'T', 'T', 'T', 'A', 'A', 'A', 'T', 'A', 'T', 'G', 'G',
            'T', 'T', 'T', 'G', 'C', 'T', 'T', 'T', 'A', 'T', 'G', 'G', 'C',
@@ -540,7 +537,6 @@ i otoGar1.scaffold_334.1-359464 N 0 C 0
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'G', 'G', 'G', 'T', 'C', 'C', 'C', 'C', 'T', 'T', 'G', 'G',
            'C', 'A', 'C', 'A', 'T', 'C', 'C', 'A', 'G', 'A', 'T', 'C', 'T',
            'C', 'C', 'C', 'C', 'A', 'G', 'T', 'T', 'A', 'A', 'C', 'C', 'T',
@@ -1333,7 +1329,6 @@ e ponAbe2.chr6                     16161337    2 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['a', 'g', 'c', 'c', 'a', 'g', 'g', 'c', 'g', 't', 'g', 'g', 't',
            'g', 'g', 'c', 'a', 'c', 'a', 'c', 'a', 'c', 'c', 't', 't', 't',
            'a', 'c', 't', 'c', 'c', 'c', 'a', 'g', 'c', 'a', 't', 't', 't',
@@ -1488,7 +1483,6 @@ e otoGar1.scaffold_334.1-359464      181217 2931 -    359464 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'C', 'C', 'A', 'A', 'A', 'A', 'T', 'G', 'G', 'T', 'T', 'A',
            'G', 'C', 'T', 'A', 'T', 'G', 'C', 'C', 'C', 'A', 'A', 'C', 'T',
            'C', 'C', 'T', 'T', 'T', 'C', 'A', 'C', 'T', 'C', 'C', 'A', 'A',
@@ -1804,7 +1798,6 @@ e ponAbe2.chr6                     16161448 8044 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'T', 'G', 'T', 'A', 'C', 'C', '-', '-', '-', 'C', 'T',
            'T', 'T', 'G', 'G', 'T', 'G', 'A', 'G', 'A', 'A', 'T', 'T', 'T',
            'T', 'T', 'G', 'T', 'T', 'T', 'C', 'A', 'G', 'T', 'G', 'T', 'T',
@@ -1998,7 +1991,6 @@ e ponAbe2.chr6                     16161448 8044 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'G', 'G', 'A', 'G', 'C', 'A', 'T', 'A', 'A', 'A', 'A', 'C',
            'T', 'C', 'T', 'A', 'A', 'A', 'T', 'C', 'T', 'G', 'C', 'T', 'A',
            'A', 'A', 'T', 'G', 'T', 'C', 'T', 'T', 'G', 'T', 'C', 'C', 'C',
@@ -2159,7 +2151,6 @@ e ponAbe2.chr6                     16161448 8044 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'A', 'G', 'T', 'T', 'C', 'C', 'C', 'T', 'C', 'C', 'A', 'T',
            'A', 'A', 'T', 'T', 'C', 'C', 'T', 'T', 'C', 'C', 'T', 'C', 'C',
            'C', 'A', 'C', 'C', 'C', 'C', 'C', 'A', 'C', 'A'],
@@ -2262,7 +2253,6 @@ e ponAbe2.chr6                     16161448 8044 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'C', 'C', 'C', 'A', 'T', 'G', 'T', 'C', 'C', 'A', 'C', 'C',
            'C', 'T', 'G', 'A']], dtype='U')
                 # fmt: on
@@ -2511,7 +2501,6 @@ e echTel1.scaffold_288249             87661 7564 +    100002 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'T', 'T', 'T', 'C', 'A', 'G', 'G', 'G', 'G', 'C', 'A', 'G',
            'C', 'T', 'C', 'G', 'C', 'T', 'G', '-', '-', '-', '-', '-', '-',
            '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'T', 'T', 'A',
@@ -3115,7 +3104,6 @@ e panTro2.chr6                     157518570    0 + 173908612 C
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['c', 'c', 'a', 't', 't', 't', 't', '-', '-', '-', '-', '-', '-',
            '-', '-', '-', '-', 't', 't', 'a', 't', 't', 'a', 'g', 'g', 't',
            'a', 't', 't', 't', 'a', 'g', 'c', 't', 'c', 'a', 't', 't', 't',
@@ -3476,7 +3464,6 @@ e ponAbe2.chr6                     16169743   75 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'T', 'T', 'T', 'T', 'A', 'T', 'T', 'T', 'G', 'C', 'A', 'G',
            'G', 'T', 'T', 'T', 'C', 'T', 'T', 'T', 'A', 'C', '-', '-', '-',
            '-', 'A', 'G', 'T', 'T', 'C', 'T', 'C', 'T', 'T', 'T', 'C', 'A',
@@ -3614,7 +3601,6 @@ e ponAbe2.chr6                     16169743   75 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'C', 'C', 'A', 'C', 'A', 'G', 'A', 'C', 'C', 'T', 'T', 'C',
            'T', 'G', 'T', 'T', 'T', 'A', 'G', 'T', 'C', 'C', 'A', 'A', 'A',
            'G', 'G', 'A', 'C', 'G', 'C', 'A', 'A', 'A', 'T', 'T', 'A', 'T',
@@ -3800,7 +3786,6 @@ e otoGar1.scaffold_334.1-359464      184575  137 -    359464 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'T', 'C', 'C', 'A', 'C', 'A', 'A', 'A', 'A', 'G', 'A', 'G',
            'A', 'C', '-', '-', '-', '-', '-', 'A', 'A', 'A', 'G', 'A', 'A',
            'G', 'A', 'A', 'A', 'A', 'C', 'C', 'A', 'A', 'A', 'A', 'G', 'A',
@@ -3972,7 +3957,6 @@ e ponAbe2.chr6                     16169879   97 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'G', 'G', 'A', '-', 'C', 'A', 'A', 'A', 'A', 'T', 'A', 'A',
            'T', 'A', 'C', 'A', 'G', 'A', 't', 't', 't', 't', 't', 't', 't',
            't', 't', 't', 't', 't', 't', 't', 't', 't', 't', 't', 't', 't',
@@ -4191,7 +4175,6 @@ e cavPor2.scaffold_216473              8048 1372 -     10026 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'T', '-', 'C', 'A', 'A', 'A', 'C', 'A', 'T', 'G', 'C', 'A',
            'T', 'A', 'C', 'A', 'T', 'G', 'C', 'A', 'T', 'T', 'C', 'A', 'T',
            'G', 'T', 'C', 'T', 'C', 'A', 'T', 'A', 'A', '-', 'T', 'A', 'A',
@@ -4352,7 +4335,6 @@ e ponAbe2.chr6                     16170105 2523 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['t', 'c', 't', 't', 'c', 'a', 't', 'c', 't', 'c', 'c', 't', 'c',
            't', 't', 't', 't', 'c', 'c', 't', 'c', 'c', 't', 't', 't', 't',
            't', 't', 't', 't', 't', 't', 'c', 't', 'c', 'a', 't', 't', 't',
@@ -4515,7 +4497,6 @@ e ponAbe2.chr6                     16170105 2523 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'G', 'G', 'G', 'T', 'A', 'G', 'G', 'C', 'C', 'A', 'A', 'G',
            'T', 'G', 'C', 'C', 'T', 'T', 'G', 'G', 'G', 'A', 'A', 'G', 'T',
            'A', 'G', 'T', 'T', 'G', 'T', 'T', 'G', 'G', 'T', 'A', 'G', 'A',
@@ -4693,7 +4674,6 @@ e ponAbe2.chr6                     16170105 2523 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'T', 'G', 'C', 'C', 'T', 'T', 'C', 'C', 'A', 'T', 'T', 'A',
            'C', 'G', 'A', 'T', 'T', 'T', 'A', 'C', 'T', 'G', 'A', 'T', 'C',
            'A', 'C', 'T', 'T', 'A', 'C', 'A', 'A', 'C', 'C', 'C', 'T', 'C',
@@ -4832,7 +4812,6 @@ e ponAbe2.chr6                     16170105 2523 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['g', 't', 'c', 't', 'g', 'a', 'g', 't', 't', 'a', 'g', 'g', 'g',
            't', 't', 't', 't', 'a', 'c', 't', 'g', 'c', 't', 'g', 't', 'g',
            'a', 'a', 'c', 'a', 'g', 'a', 'c', 'a', 'c', 'c', 'a', 't', 'g',
@@ -5003,7 +4982,6 @@ e ponAbe2.chr6                     16170105 2523 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'A', 'G', 'A', 'C', 'C', 'A', 'A', 'A', 'T', 'G', '-', '-',
            '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'T', 'G', 'G',
            'C', 'G', 'C', 'T', 'C', 'A', 'C', 'G', '-', 'T', 'G', 'A', 'G',
@@ -5186,7 +5164,6 @@ e ponAbe2.chr6                     16170105 2523 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'C', 'C', 'A', 'G', 'C', 'A', 'T', 'T', 'C', 'T', 'G',
            'G', 'C', 'A', 'G', 'A', 'C', 'A', 'C', 'A', 'G', 'T', 'G', '-',
            'A', 'A', 'A', 'A', 'G', 'A', 'G', 'A', 'C', 'A', 'G', 'A', 'T',
@@ -5396,7 +5373,6 @@ e ponAbe2.chr6                     16170105 2523 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'A', 'G', 'A', 'T', 'A', 'G', 'A', 'T', 'A', 'T', 'T', 'T',
            'A', 'G', 'A', 'A', 'G', 'T', 'A', 'G', 'C', 'T', 'T', 'T', 'T',
            'T', 'A', 'T', 'G', 'T', 'T', 'T', 'T', 'T', 'C', 'T', 'G', 'A',
@@ -5620,7 +5596,6 @@ e ponAbe2.chr6                     16170105 2523 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'G', 'C', 'A', 'T', 'C', 'A', 'T', 'T', 'A', 'A', 'G', 'A',
            'C', 'T', 'A', 'G', 'A', 'G', 'T', 'T', 'C', 'C', 'T', '-', '-',
            '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',
@@ -5788,7 +5763,6 @@ e ponAbe2.chr6                      16170105 2523 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['t', 't', 't', 'g', 'g', 't', 't', 't', 'g', 'g', 't', 't', 't',
            'g', 'g', 't', 't', 't', 't', 't', 't', 'c', 'a', 'a', 'g', 'a',
            'c', 'a', 'g', 'g', 'g', 't', 't', 't', 'c', 't', 't', 't', 'g',
@@ -5939,7 +5913,6 @@ e ponAbe2.chr6                      16170105 2523 - 174210431 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['t', 'c', 't', 'g', 'c', 'c', 't', 'g', 'c', 'c', 't', 'c', 't',
            'g', 'c', 'c', 't', 'c', 'c', 'c', 'a', 'a', 'g', '-', '-', '-',
            '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',
@@ -6172,7 +6145,6 @@ e panTro2.chr6                     157515610    0 + 173908612 C
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',
            '-', '-', '-', '-', 'c', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c',
            't', 'g', 'c', 'c', 'c', 't', 'g', 'c', 'C', 'T', '-', '-', '-',
@@ -6699,7 +6671,6 @@ e oryCun1.scaffold_156751                426   37 -      4726 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['a', 'c', 't', 'a', 'g', 'g', 'g', 'a', 't', 'g', 'g', 'g', 'a',
            'g', 'a', 'g', 'g', 'c', 't', 'c', 'c', 'c', 'a', 'g', 'a', 'a',
            'c', 'c', 'c', 'a', 'g', 't', 'a', 'a', 't', 'g', 'a', 't', 'g',
@@ -6924,7 +6895,6 @@ e oryCun1.scaffold_156751               426   37 -      4726 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'G', 'T', 'C', 'A', 'A', 'A', 'C', 'A', 'T', 'G', 'C', 'A',
            'T', 'A', 'A', 'A', 'G', 'A', 'T', 'A', 'T', 'A', 'C', 'T', '-',
            'G', 'A', 'G', 'G', 'A', 'G', 'C', 'C', 'C', 'A', 'T', 'G', 'A',
@@ -7067,7 +7037,6 @@ e oryCun1.scaffold_156751               426   37 -      4726 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'A', 'T', 'A', 'T', 'A', 'T', 'G', 'C', 'T', 'A', 'T', 'C',
            'C', 'G', 'T', 'G', 'T', 'G', 'C', 'T', 'G', 'T', 'G', 'A', 'T',
            'T', 'T', 'T', 'T', 'G', 'T', 'T', 'T', 'T', 'A', 'A', 'A', 'T',
@@ -7352,7 +7321,6 @@ e otoGar1.scaffold_334.1-359464      187778  358 -    359464 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'A', 'G', 'G', 'T', 'T', 'T', 'G', 'T', 'G', 'A', 'C', 'T',
            'T', 'T', 'T', 'A', 'A', 'T', 'A', '-', '-', '-', '-', '-', '-',
            '-', '-', '-', '-', 'C', 'T', 'G', 'A', 'T', 'T', 'G', 'T', 'T',
@@ -7667,7 +7635,6 @@ e cavPor2.scaffold_216473              9502   28 -     10026 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'C', 'C', 'T', 'T', 'G', 'G', 'T', 'G', 'A', 'C', 'G', 'C',
            'C', 'A', 'C', 'T', 'G', 'G', 'A', 'T', 'T', 'T', 'T', 'G', 'T',
            'A', 'T', 'G', 'A', 'C', 'T', 'G', 'A', 'A', 'T', 'A', 'C', 'T',
@@ -8013,7 +7980,6 @@ e echTel1.scaffold_288249             87661 7564 +    100002 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'T', 'C', 'A', 'T', 'T', 'T', 'G', 'G', 'G', 'A', 'A', 'C',
            'T', 'T', 'A', 'C', 'A', 'G', 'G', 'T', 'C', 'A', 'G', 'C', 'A',
            'A', 'A', 'G', 'G', 'C', 'T', 'T', 'C', 'C', 'A', 'G', '-', '-',
@@ -8347,7 +8313,6 @@ e tupBel1.scaffold_114895.1-498454   174338  623 -    498454 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'T', 'G', 'T', 'T', 'A', 'G', 'T', 'G', 'C', 'T', 'G', 'T',
            'T', 'T', 'T', '-', '-', '-', 'A', 'A', 'T', 'G', 'T', 'A', 'C',
            'C', 'T', 'C', 'G', 'C', 'A', 'G', 'T', 'A'],
@@ -8758,7 +8723,6 @@ e tupBel1.scaffold_114895.1-498454   174338  623 -    498454 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'G', 'G', 'C', 'A', 'A', 'A', 'T', 'G', 'A', 'G', 'G', 'T',
            'G', 'A', 'T', 'A', 'A', 'G', 'A', '-', '-', '-', '-', '-', '-',
            '-', 'T', 'T', 'G', 'T', 'G', 'T', 'T', '-', '-', '-', '-', '-',
@@ -9178,7 +9142,6 @@ e ornAna1.chr2                     14751195 5690 -  54797317 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-', '-',
            '-', '-', '-', '-', '-', '-', 'T', 'C', 'C', 'C', '-', '-', '-',
            '-', '-', '-', '-', 'A', 'G', 'A', 'G', 'A', 'G', 'T', 'C', 'T',
@@ -10651,7 +10614,6 @@ e oryCun1.scaffold_156751              1033  2345 -      4726 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'C', 'T', '-', '-', 'A', 'C', 'A', 'C', 'T', 'G', 'T',
            'C', '-', '-', '-', '-', 'A', 'A', 'G', 'T', 'G', 'G', 'G', 'A',
            'G', 'G', 'A', 'G', 'A', 'C', 'A', 'G', 'T', '-', '-', '-', '-',
@@ -10863,7 +10825,6 @@ e oryCun1.scaffold_156751              1033  2345 -      4726 I
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'G', 'T', 'T', 'T', 'A', 'G', 'T', 'A', 'C', 'C', '-', '-',
            '-', '-', 'A', 'T', 'G', 'C', 'T', 'T', 'A', 'G', 'G', 'A', 'A',
            'T', 'G', 'A', 'T', 'A', 'A', 'A', 'C', 'T', 'C', 'A', 'C', 'T',
@@ -11118,7 +11079,6 @@ s rn3.chr4     81344243 40 + 187371129 -AA-GGGGATGCTAAGCCAATGAGTTGTTGTCTCTCAATGT
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'A', 'A', '-', 'G', 'G', 'G', 'A', 'A', 'T', 'G', 'T', 'T',
            'A', 'A', 'C', 'C', 'A', 'A', 'A', 'T', 'G', 'A', '-', '-', '-',
            'A', 'T', 'T', 'G', 'T', 'C', 'T', 'C', 'T', 'T', 'A', 'C', 'G',
@@ -11207,7 +11167,6 @@ s rn3.chr4     81444246 6 + 187371129 taagga
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['T', 'A', 'A', 'A', 'G', 'A'],
           ['T', 'A', 'A', 'A', 'G', 'A'],
           ['T', 'A', 'A', 'A', 'G', 'A'],
@@ -11282,7 +11241,6 @@ s mm4.chr6     53310102 13 + 151104725 ACAGCTGAAAATA
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['g', 'c', 'a', 'g', 'c', 't', 'g', 'a', 'a', 'a', 'a', 'c', 'a'],
           ['g', 'c', 'a', 'g', 'c', 't', 'g', 'a', 'a', 'a', 'a', 'c', 'a'],
           ['g', 'c', 'a', 'g', 'c', 't', 'g', 'a', 'a', 'a', 'a', 'c', 'a'],

--- a/Tests/test_Align_mauve.py
+++ b/Tests/test_Align_mauve.py
@@ -137,7 +137,6 @@ AAGCCCTGC--GCGCTCAGCCGGAGTGTCCCGGGCCCTGCTTTCCTTTT
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'A', 'G', 'C', 'C', 'C', 'T', 'C', 'C', 'T', 'A', 'G', 'C',
            'A', 'C', 'A', 'C', 'A', 'C', 'C', 'C', 'G', 'G', 'A', 'G', 'T',
            'G', 'G', '-', 'C', 'C', 'G', 'G', 'G', 'C', 'C', 'G', 'T', 'A',
@@ -243,7 +242,6 @@ GAAGAGGAAAAGTAGATCCCTGGCGTCCGGAGCTGGGACGT
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'A', 'A', 'G', 'A', 'G', 'G', 'A', 'A', 'A', 'A', 'G', 'T',
            'A', 'G', 'A', 'T', 'C', 'C', 'C', 'T', 'G', 'G', 'C', 'G', 'T',
            'C', 'C', 'G', 'G', 'A', 'G', 'C', 'T', 'G', 'G', 'G', 'A', 'C',
@@ -483,7 +481,6 @@ mm9.fa           19 ---------------------------------GGATCTACTTTTCCTCTTC  0
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[50, 40, 38, 19, 19, 18, 10, 10,  0],
                               [ 0, 10, 10, 29, 30, 31, 39, 39, 49],
                               [19, 19, 19, 19, 19, 19, 11, 10,  0]]),
@@ -506,7 +503,6 @@ CAAGCCCTGC--GCGCTCAGCCGGAGTGTCCCGGGCCCTGC-TTTCCTTTTC
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['T', 'A', 'A', 'G', 'C', 'C', 'C', 'T', 'C', 'C', 'T', 'A', 'G',
            'C', 'A', 'C', 'A', 'C', 'A', 'C', 'C', 'C', 'G', 'G', 'A', 'G',
            'T', 'G', 'G', 'C', 'C', '-', 'G', 'G', 'G', 'C', 'C', 'G', 'T',
@@ -556,7 +552,6 @@ CTGGCGTCCGGAGCTGGGACGT
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['C', 'T', 'G', 'G', 'C', 'G', 'T', 'C', 'C', 'G', 'G',
            'A', 'G', 'C', 'T', 'G', 'G', 'G', 'A', 'C', 'G', 'T']], dtype='U')
                     # fmt: on

--- a/Tests/test_Align_nexus.py
+++ b/Tests/test_Align_nexus.py
@@ -124,7 +124,6 @@ t9                0 cccccccccccccccccccNc-ccccccccccccccccccccNc-c 44
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 0,  1,  1,  2,  2,  3,  3,  4,  5,  6,  8, 12,
                            13, 14, 16, 16, 17, 17, 18, 18, 18, 18, 19, 20,
                            21, 23, 27, 28, 29, 31, 31, 32, 32, 33],
@@ -195,7 +194,6 @@ end;
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', '-', 'C', '-', 'G', '-', 'T', 'c', 'g', 't', 'g', 't', 'g',
            't', 'g', 'c', 't', 'c', 't', '-', 't', '-', 't', '-', '-', '-',
            '-', '-', '-', 'a', 'c', 'g', 't', 'g', 't', 'g', 't', 'g', 'c',
@@ -281,7 +279,6 @@ end;
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'A', 'A', 'A', 'A', 'G', 'G', 'C', 'A', 'T', 'T', 'G', 'T',
            'G', 'G', 'T', 'G', 'G', 'G', 'A', 'A', 'T'],
           ['?', '?', '?', '?', '?', '?', '?', '?', '?', 'T', 'T', 'G', 'T',

--- a/Tests/test_Align_phylip.py
+++ b/Tests/test_Align_phylip.py
@@ -196,7 +196,6 @@ HISJ_E_CO       219 GLRKED--NELREALNKAFAEMRADGTYEKLAKKYFDFDVYGG--- 260
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array(
                     [[  0,   0,   0,  13,  13,  16,  17,  17,  17,  17,  17,
                        17,  17,  17,  17,  18,  41,  41,  41,  90,  91, 109,
@@ -364,7 +363,6 @@ Tax5      CCATCTCACGGTCGGTAAGATACACCTGCTTTTGGCGGGAAATGGTCAATATTAAAAGGT
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'A', 'G', 'C', 'T', 'N', 'G', 'G', 'G', 'C', 'A', 'T', 'T',
            'T', 'C', 'A', 'G', 'G', 'G', 'T', 'G', 'A', 'G', 'C', 'C', 'C',
            'G', 'G', 'G', 'C', 'A', 'A', 'T', 'A', 'C', 'A', 'G', 'G', 'G',
@@ -621,7 +619,6 @@ CATH_HUMA       311 YFLIERGKNMCGLAACASYPIPLV 335
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array(
        [[ 0,   0,   1,  18,  18,  18,  26,  26,  40,  40,  63,  67,  93,
          94, 103, 105, 113, 115, 128, 128, 180, 188, 222, 223, 242, 242,
@@ -747,7 +744,6 @@ IXI_237         113 PPAYAGDRSHE 124
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[0, 15, 22, 23, 24, 35, 39, 74, 84, 97, 99, 131],
                           [0, 15, 15, 15, 15, 26, 30, 65, 65, 78, 80, 112],
                           [0, 15, 22, 22, 22, 33, 37, 72, 82, 95, 95, 127],

--- a/Tests/test_Align_psl.py
+++ b/Tests/test_Align_psl.py
@@ -81,7 +81,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42530895, 42530958, 42532020, 42532095, 42532563, 42532606],
                           [     181,      118,      118,       43,       43,        0]])
                 # fmt: on
@@ -94,7 +93,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[36.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0., 40.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  0., 57.,  0.,  0.,  0.,  0.,  0.],
@@ -260,7 +258,6 @@ NR_046654        31 CCAGGTATGCATCTGCTGCCAAGCCAGGGAG        0
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42530895, 42530922, 42530922, 42530958, 42532020,
                            42532037, 42532039, 42532095, 42532563, 42532606],
                           [     185,      158,      155,      119,      119,
@@ -276,7 +273,6 @@ NR_046654        31 CCAGGTATGCATCTGCTGCCAAGCCAGGGAG        0
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[34.,  0.,  0.,  1.,  0.,  0.,  0.,  0.],
                       [ 0., 40.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  0., 57.,  0.,  0.,  0.,  0.,  0.],
@@ -443,7 +439,6 @@ NR_046654        37 TTCCCAGGTATGCATCTGCTGCCAAGCCAGGGAG        3
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array( [[48663767, 48663813, 48665640, 48665722, 48669098, 48669174],
                               [       0,        46,      46,      128,      128,      204]]),
                 # fmt: on
@@ -456,7 +451,6 @@ NR_046654        37 TTCCCAGGTATGCATCTGCTGCCAAGCCAGGGAG        3
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[53.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0., 35.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  0., 50.,  0.,  0.,  0.,  0.,  0.],
@@ -870,7 +864,6 @@ NR_111921       197 TAAAAAA      204
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48663767, 48663795, 48663796, 48663813, 48665640,
                            48665716, 48665716, 48665722, 48669098, 48669174],
                           [       3,       31,       31,       48,       48,
@@ -886,7 +879,6 @@ NR_111921       197 TAAAAAA      204
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
             np.array([[53.,  0.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0., 34.,  0.,  0.,  0.,  0.,  0.,  0.],
                       [ 0.,  2., 48.,  0.,  0.,  0.,  0.,  0.],
@@ -1381,7 +1373,6 @@ hg18_dna         11 aggtaaactgccttca       27
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'g', 'g', 't', 'a', 'a', 'a', 'c', 't', 'g', 'c', 'c', 't',
            't', 'c', 'a'],
           ['a', 'g', 'g', 't', 'a', 'a', 'a', 'c', 't', 'g', 'c', 'c', 't',
@@ -1393,7 +1384,6 @@ np.array([['a', 'g', 'g', 't', 'a', 'a', 'a', 'c', 't', 'g', 'c', 'c', 't',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [      11,       27]]),
                 # fmt: on
@@ -1445,7 +1435,6 @@ hg18_dna          0 atgagcttccaaggtaaactgccttcaagattc       33
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 't', 'g', 'a', 'g', 'c', 't', 't', 'c', 'c', 'a', 'a', 'g',
            'g', 't', 'a', 'a', 'a', 'c', 't', 'g', 'c', 'c', 't', 't', 'c',
            'a', 'a', 'g', 'a', 't', 't', 'c'],
@@ -1459,7 +1448,6 @@ np.array([['a', 't', 'g', 'a', 'g', 'c', 't', 't', 'c', 'c', 'a', 'a', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -1512,7 +1500,6 @@ hg18_dna         25 aaggcagtttaccttgg        8
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'a', 'g', 'g', 'c', 'a', 'g', 't', 't', 't', 'a', 'c', 'c',
            't', 't', 'g', 'g'],
           ['a', 'a', 'g', 'g', 'c', 'a', 'g', 't', 't', 't', 'a', 'c', 'c',
@@ -1524,7 +1511,6 @@ np.array([['a', 'a', 'g', 'g', 'c', 'a', 'g', 't', 't', 't', 'a', 'c', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      25,        8]]),
                 # fmt: on
@@ -1578,7 +1564,6 @@ hg19_dna          9 acaaaggggctgggcgtggtggctcacacctgtaatcccaa       50
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g',
            'g', 'c', 'g', 'c', 'a', 'g', 't', 'g', 'g', 'c', 't', 'c', 'a',
            'c', 'g', 'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c', 'c',
@@ -1594,7 +1579,6 @@ np.array([['a', 'c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       9,       50]]),
                 # fmt: on
@@ -1648,7 +1632,6 @@ hg19_dna          8 cacaaaggggctgggcgtggtggctcacacctgtaatccca       49
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['c', 'a', 'c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g',
            'g', 'g', 'c', 'g', 't', 'g', 'g', 't', 'g', 'g', 'c', 't', 'c',
            'a', 'c', 'a', 'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c',
@@ -1664,7 +1647,6 @@ np.array([['c', 'a', 'c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       8,       49]]),
                 # fmt: on
@@ -1718,7 +1700,6 @@ hg19_dna         11 aaaggggctgggcgtggtggctcacacctgtaatcc       47
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g', 'c',
            'g', 't', 'g', 'g', 't', 'a', 'g', 'c', 't', 'c', 'a', 't', 'g',
            'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c'],
@@ -1732,7 +1713,6 @@ np.array([['a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [      11,       47]]),
                 # fmt: on
@@ -1790,7 +1770,6 @@ hg19_dna          1 aaaaat????aaaggggctgggcgtggtggctcacacctgtaatccca        49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183925990, 183926028],
                           [        1,         7,        11,        49]]),
                 # fmt: on
@@ -1860,7 +1839,6 @@ hg19_dna         35 ---------------------------------------cacctgtaatc       46
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [      10,       35,       35,       46]]),
                 # fmt: on
@@ -1914,7 +1892,6 @@ hg19_dna         10 caaaggggctgggcgtggtggctcacacctgtaatccca       49
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g',
            'c', 'g', 't', 'g', 'g', 't', 'g', 'g', 'c', 't', 'c', 'a', 'c',
            'a', 'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c', 'c', 'a'],
@@ -1929,7 +1906,6 @@ np.array([['c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [      10,       49]]),
                 # fmt: on
@@ -1982,7 +1958,6 @@ hg19_dna         21 ggcgtggtggctcacacctgtaatccca       49
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['g', 'g', 'c', 'g', 't', 'g', 'g', 't', 'g', 'g', 'c', 't', 'c',
            'a', 'c', 'g', 'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c',
            'c', 'a'],
@@ -1996,7 +1971,6 @@ np.array([['g', 'g', 'c', 'g', 't', 'g', 'g', 't', 'g', 'g', 'c', 't', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [      21,       49]]),
                 # fmt: on
@@ -2062,7 +2036,6 @@ hg19_dna         49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759160, 52759198],
                           [       1,        8,        8,       11,       49]]),
                 # fmt: on
@@ -2114,7 +2087,6 @@ hg19_dna          0 caaaaattcacaaaggggctgggcgtggtggctcacacctgtaatcccaa      50
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['c', 'a', 'a', 'a', 'a', 'a', 't', 't', 'c', 'a', 'c', 'a', 'a',
            'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g', 'c', 'g', 't',
            'g', 'g', 't', 'g', 'g', 'c', 't', 'c', 'a', 'c', 'a', 'c', 'c',
@@ -2131,7 +2103,6 @@ np.array([['c', 'a', 'a', 'a', 'a', 'a', 't', 't', 'c', 'a', 'c', 'a', 'a',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -2185,7 +2156,6 @@ hg19_dna          1 aaaaattcacaaaggggctgggcgtggtggctca       35
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'a', 'a', 'a', 'a', 't', 'g', 'a', 'a', 'c', 'a', 'a', 'a',
            'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g', 'c', 'g', 'c', 'g',
            'g', 't', 'g', 'g', 'c', 't', 'c', 'a'],
@@ -2199,7 +2169,6 @@ np.array([['a', 'a', 'a', 'a', 'a', 't', 'g', 'a', 'a', 'c', 'a', 'a', 'a',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       1,       35]]),
                 # fmt: on
@@ -2256,7 +2225,6 @@ hg19_dna         49 tgggattaca------??????????accacgcccagccccttt       11
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558173, 37558191],
                           [      49,       39,       39,       29,       11]]),
                 # fmt: on
@@ -2310,7 +2278,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccctt       12
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
            'g', 'g', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't', 't'],
@@ -2325,7 +2292,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      49,       12]]),
                 # fmt: on
@@ -2379,7 +2345,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccct        13
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
            'g', 't', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't'],
@@ -2393,7 +2358,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       49,        13]]),
                 # fmt: on
@@ -2447,7 +2411,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccctttg       10
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 't',
            'g', 't', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't', 't', 't', 'g'],
@@ -2462,7 +2425,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 't',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      49,       10]]),
                 # fmt: on
@@ -2516,7 +2478,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccctttg     10
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 'g', 'a', 'c', 'a', 'g', 'g', 'g',
            'g', 't', 'g', 'a', 'g', 'g', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't', 't', 't', 'g'],
@@ -2531,7 +2492,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 'g', 'a', 'c', 'a', 'g', 'g', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    49,     10]]),
                 # fmt: on
@@ -2585,7 +2545,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccct       13
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 't', 'a', 'g', 'g', 'c',
            'a', 't', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't'],
@@ -2599,7 +2558,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 't', 'a', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      49,       13]]),
                 # fmt: on
@@ -2652,7 +2610,6 @@ hg19_dna         35 tgagccaccacgcccagcccctttg        10
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'a', 'g', 't', 'c', 'a', 'c', 'c', 'a', 'c', 'g', 'c',
            'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't', 't', 't', 'g'],
           ['t', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g', 'c',
@@ -2665,7 +2622,6 @@ np.array([['t', 'g', 'a', 'g', 't', 'c', 'a', 'c', 'c', 'a', 'c', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       35,        10]]),
                 # fmt: on
@@ -2719,7 +2675,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccct       13
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
            'g', 't', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't'],
@@ -2733,7 +2688,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[39368490, 39368526],
                           [      49,       13]]),
                 # fmt: on
@@ -2787,7 +2741,6 @@ hg19_dna         47 ggattacaggtgtgagccaccacgcccagcccct        13
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c', 'g', 't',
            'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g', 'c', 'c',
            'c', 'a', 'g', 'c', 'c', 'c', 'c', 't'],
@@ -2801,7 +2754,6 @@ np.array([['g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c', 'g', 't',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       47,        13]]),
                 # fmt: on
@@ -2907,7 +2859,6 @@ hg18_dna         11 aggtaaactgccttca       27
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'g', 'g', 't', 'a', 'a', 'a', 'c', 't', 'g', 'c', 'c', 't',
            't', 'c', 'a'],
           ['a', 'g', 'g', 't', 'a', 'a', 'a', 'c', 't', 'g', 'c', 'c', 't',
@@ -2919,7 +2870,6 @@ np.array([['a', 'g', 'g', 't', 'a', 'a', 'a', 'c', 't', 'g', 'c', 'c', 't',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [      11,       27]]),
                 # fmt: on
@@ -2971,7 +2921,6 @@ hg18_dna          0 atgagcttccaaggtaaactgccttcaagattc       33
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 't', 'g', 'a', 'g', 'c', 't', 't', 'c', 'c', 'a', 'a', 'g',
            'g', 't', 'a', 'a', 'a', 'c', 't', 'g', 'c', 'c', 't', 't', 'c',
            'a', 'a', 'g', 'a', 't', 't', 'c'],
@@ -2985,7 +2934,6 @@ np.array([['a', 't', 'g', 'a', 'g', 'c', 't', 't', 'c', 'c', 'a', 'a', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -3038,7 +2986,6 @@ hg18_dna         25 aaggcagtttaccttgg        8
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'a', 'g', 'g', 'c', 'a', 'g', 't', 't', 't', 'a', 'c', 'c',
            't', 't', 'g', 'g'],
           ['a', 'a', 'g', 'g', 'c', 'a', 'g', 't', 't', 't', 'a', 'c', 'c',
@@ -3050,7 +2997,6 @@ np.array([['a', 'a', 'g', 'g', 'c', 'a', 'g', 't', 't', 't', 'a', 'c', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      25,        8]]),
                 # fmt: on
@@ -3130,7 +3076,6 @@ hg19_dna          9 acaaaggggctgggcgtggtggctcacacctgtaatcccaa       50
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g',
            'g', 'c', 'g', 'c', 'a', 'g', 't', 'g', 'g', 'c', 't', 'c', 'a',
            'c', 'g', 'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c', 'c',
@@ -3146,7 +3091,6 @@ np.array([['a', 'c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       9,       50]]),
                 # fmt: on
@@ -3200,7 +3144,6 @@ hg19_dna          8 cacaaaggggctgggcgtggtggctcacacctgtaatccca       49
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['c', 'a', 'c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g',
            'g', 'g', 'c', 'g', 't', 'g', 'g', 't', 'g', 'g', 'c', 't', 'c',
            'a', 'c', 'a', 'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c',
@@ -3216,7 +3159,6 @@ np.array([['c', 'a', 'c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       8,       49]]),
                 # fmt: on
@@ -3270,7 +3212,6 @@ hg19_dna         11 aaaggggctgggcgtggtggctcacacctgtaatcc       47
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g', 'c',
            'g', 't', 'g', 'g', 't', 'a', 'g', 'c', 't', 'c', 'a', 't', 'g',
            'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c'],
@@ -3284,7 +3225,6 @@ np.array([['a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [      11,       47]]),
                 # fmt: on
@@ -3342,7 +3282,6 @@ hg19_dna          1 aaaaat????aaaggggctgggcgtggtggctcacacctgtaatccca        49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183925990, 183926028],
                           [        1,         7,        11,        49]]),
                 # fmt: on
@@ -3412,7 +3351,6 @@ hg19_dna         35 ---------------------------------------cacctgtaatc       46
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [      10,       35,       35,       46]]),
                 # fmt: on
@@ -3466,7 +3404,6 @@ hg19_dna         10 caaaggggctgggcgtggtggctcacacctgtaatccca       49
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g',
            'c', 'g', 't', 'g', 'g', 't', 'g', 'g', 'c', 't', 'c', 'a', 'c',
            'a', 'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c', 'c', 'a'],
@@ -3481,7 +3418,6 @@ np.array([['c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [      10,       49]]),
                 # fmt: on
@@ -3534,7 +3470,6 @@ hg19_dna         21 ggcgtggtggctcacacctgtaatccca       49
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['g', 'g', 'c', 'g', 't', 'g', 'g', 't', 'g', 'g', 'c', 't', 'c',
            'a', 'c', 'g', 'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c',
            'c', 'a'],
@@ -3548,7 +3483,6 @@ np.array([['g', 'g', 'c', 'g', 't', 'g', 'g', 't', 'g', 'g', 'c', 't', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [      21,       49]]),
                 # fmt: on
@@ -3614,7 +3548,6 @@ hg19_dna         49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759160, 52759198],
                           [       1,        8,        8,       11,       49]]),
                 # fmt: on
@@ -3666,7 +3599,6 @@ hg19_dna          0 caaaaattcacaaaggggctgggcgtggtggctcacacctgtaatcccaa      50
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['c', 'a', 'a', 'a', 'a', 'a', 't', 't', 'c', 'a', 'c', 'a', 'a',
            'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g', 'c', 'g', 't',
            'g', 'g', 't', 'g', 'g', 'c', 't', 'c', 'a', 'c', 'a', 'c', 'c',
@@ -3683,7 +3615,6 @@ np.array([['c', 'a', 'a', 'a', 'a', 'a', 't', 't', 'c', 'a', 'c', 'a', 'a',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -3737,7 +3668,6 @@ hg19_dna          1 aaaaattcacaaaggggctgggcgtggtggctca       35
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'a', 'a', 'a', 'a', 't', 'g', 'a', 'a', 'c', 'a', 'a', 'a',
            'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g', 'c', 'g', 'c', 'g',
            'g', 't', 'g', 'g', 'c', 't', 'c', 'a'],
@@ -3751,7 +3681,6 @@ np.array([['a', 'a', 'a', 'a', 'a', 't', 'g', 'a', 'a', 'c', 'a', 'a', 'a',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       1,       35]]),
                 # fmt: on
@@ -3808,7 +3737,6 @@ hg19_dna         49 tgggattaca------??????????accacgcccagccccttt       11
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558173, 37558191],
                           [      49,       39,       39,       29,       11]]),
                 # fmt: on
@@ -3862,7 +3790,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccctt       12
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
            'g', 'g', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't', 't'],
@@ -3877,7 +3804,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      49,       12]]),
                 # fmt: on
@@ -3931,7 +3857,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccct        13
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
            'g', 't', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't'],
@@ -3945,7 +3870,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       49,        13]]),
                 # fmt: on
@@ -3999,7 +3923,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccctttg       10
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 't',
            'g', 't', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't', 't', 't', 'g'],
@@ -4014,7 +3937,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 't',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      49,       10]]),
                 # fmt: on
@@ -4068,7 +3990,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccctttg     10
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 'g', 'a', 'c', 'a', 'g', 'g', 'g',
            'g', 't', 'g', 'a', 'g', 'g', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't', 't', 't', 'g'],
@@ -4083,7 +4004,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 'g', 'a', 'c', 'a', 'g', 'g', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    49,     10]]),
                 # fmt: on
@@ -4137,7 +4057,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccct       13
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 't', 'a', 'g', 'g', 'c',
            'a', 't', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't'],
@@ -4151,7 +4070,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 't', 'a', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      49,       13]]),
                 # fmt: on
@@ -4204,7 +4122,6 @@ hg19_dna         35 tgagccaccacgcccagcccctttg        10
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'a', 'g', 't', 'c', 'a', 'c', 'c', 'a', 'c', 'g', 'c',
            'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't', 't', 't', 'g'],
           ['t', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g', 'c',
@@ -4217,7 +4134,6 @@ np.array([['t', 'g', 'a', 'g', 't', 'c', 'a', 'c', 'c', 'a', 'c', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       35,        10]]),
                 # fmt: on
@@ -4271,7 +4187,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccct       13
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
            'g', 't', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't'],
@@ -4285,7 +4200,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[39368490, 39368526],
                           [      49,       13]]),
                 # fmt: on
@@ -4339,7 +4253,6 @@ hg19_dna         47 ggattacaggtgtgagccaccacgcccagcccct        13
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c', 'g', 't',
            'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g', 'c', 'c',
            'c', 'a', 'g', 'c', 'c', 'c', 'c', 't'],
@@ -4353,7 +4266,6 @@ np.array([['g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c', 'g', 't',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       47,        13]]),
                 # fmt: on
@@ -4431,7 +4343,6 @@ hg18_dna         11 aggtaaactgccttca       27
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'g', 'g', 't', 'a', 'a', 'a', 'c', 't', 'g', 'c', 'c', 't',
            't', 'c', 'a'],
           ['a', 'g', 'g', 't', 'a', 'a', 'a', 'c', 't', 'g', 'c', 'c', 't',
@@ -4443,7 +4354,6 @@ np.array([['a', 'g', 'g', 't', 'a', 'a', 'a', 'c', 't', 'g', 'c', 'c', 't',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [      11,       27]]),
                 # fmt: on
@@ -4495,7 +4405,6 @@ hg18_dna          0 atgagcttccaaggtaaactgccttcaagattc       33
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 't', 'g', 'a', 'g', 'c', 't', 't', 'c', 'c', 'a', 'a', 'g',
            'g', 't', 'a', 'a', 'a', 'c', 't', 'g', 'c', 'c', 't', 't', 'c',
            'a', 'a', 'g', 'a', 't', 't', 'c'],
@@ -4509,7 +4418,6 @@ np.array([['a', 't', 'g', 'a', 'g', 'c', 't', 't', 'c', 'c', 'a', 'a', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -4562,7 +4470,6 @@ hg18_dna         25 aaggcagtttaccttgg        8
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'a', 'g', 'g', 'c', 'a', 'g', 't', 't', 't', 'a', 'c', 'c',
            't', 't', 'g', 'g'],
           ['a', 'a', 'g', 'g', 'c', 'a', 'g', 't', 't', 't', 'a', 'c', 'c',
@@ -4574,7 +4481,6 @@ np.array([['a', 'a', 'g', 'g', 'c', 'a', 'g', 't', 't', 't', 'a', 'c', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      25,        8]]),
                 # fmt: on
@@ -4628,7 +4534,6 @@ hg19_dna          9 acaaaggggctgggcgtggtggctcacacctgtaatcccaa       50
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g',
            'g', 'c', 'g', 'c', 'a', 'g', 't', 'g', 'g', 'c', 't', 'c', 'a',
            'c', 'g', 'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c', 'c',
@@ -4644,7 +4549,6 @@ np.array([['a', 'c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       9,       50]]),
                 # fmt: on
@@ -4698,7 +4602,6 @@ hg19_dna          8 cacaaaggggctgggcgtggtggctcacacctgtaatccca       49
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['c', 'a', 'c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g',
            'g', 'g', 'c', 'g', 't', 'g', 'g', 't', 'g', 'g', 'c', 't', 'c',
            'a', 'c', 'a', 'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c',
@@ -4714,7 +4617,6 @@ np.array([['c', 'a', 'c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       8,       49]]),
                 # fmt: on
@@ -4768,7 +4670,6 @@ hg19_dna         11 aaaggggctgggcgtggtggctcacacctgtaatcc       47
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g', 'c',
            'g', 't', 'g', 'g', 't', 'a', 'g', 'c', 't', 'c', 'a', 't', 'g',
            'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c'],
@@ -4782,7 +4683,6 @@ np.array([['a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [      11,       47]]),
                 # fmt: on
@@ -4840,7 +4740,6 @@ hg19_dna          1 aaaaat????aaaggggctgggcgtggtggctcacacctgtaatccca        49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183925990, 183926028],
                           [        1,         7,        11,        49]]),
                 # fmt: on
@@ -4910,7 +4809,6 @@ hg19_dna         35 ---------------------------------------cacctgtaatc       46
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [      10,       35,       35,       46]]),
                 # fmt: on
@@ -4964,7 +4862,6 @@ hg19_dna         10 caaaggggctgggcgtggtggctcacacctgtaatccca       49
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g',
            'c', 'g', 't', 'g', 'g', 't', 'g', 'g', 'c', 't', 'c', 'a', 'c',
            'a', 'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c', 'c', 'a'],
@@ -4979,7 +4876,6 @@ np.array([['c', 'a', 'a', 'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [      10,       49]]),
                 # fmt: on
@@ -5032,7 +4928,6 @@ hg19_dna         21 ggcgtggtggctcacacctgtaatccca       49
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['g', 'g', 'c', 'g', 't', 'g', 'g', 't', 'g', 'g', 'c', 't', 'c',
            'a', 'c', 'g', 'c', 'c', 't', 'g', 't', 'a', 'a', 't', 'c', 'c',
            'c', 'a'],
@@ -5046,7 +4941,6 @@ np.array([['g', 'g', 'c', 'g', 't', 'g', 'g', 't', 'g', 'g', 'c', 't', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [      21,       49]]),
                 # fmt: on
@@ -5112,7 +5006,6 @@ hg19_dna         49
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759154, 52759160, 52759160, 52759198],
                           [       1,        8,        8,       11,       49]]),
                 # fmt: on
@@ -5164,7 +5057,6 @@ hg19_dna          0 caaaaattcacaaaggggctgggcgtggtggctcacacctgtaatcccaa      50
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['c', 'a', 'a', 'a', 'a', 'a', 't', 't', 'c', 'a', 'c', 'a', 'a',
            'a', 'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g', 'c', 'g', 't',
            'g', 'g', 't', 'g', 'g', 'c', 't', 'c', 'a', 'c', 'a', 'c', 'c',
@@ -5181,7 +5073,6 @@ np.array([['c', 'a', 'a', 'a', 'a', 'a', 't', 't', 'c', 'a', 'c', 'a', 'a',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -5235,7 +5126,6 @@ hg19_dna          1 aaaaattcacaaaggggctgggcgtggtggctca       35
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['a', 'a', 'a', 'a', 'a', 't', 'g', 'a', 'a', 'c', 'a', 'a', 'a',
            'g', 'g', 'g', 'g', 'c', 't', 'g', 'g', 'g', 'c', 'g', 'c', 'g',
            'g', 't', 'g', 'g', 'c', 't', 'c', 'a'],
@@ -5249,7 +5139,6 @@ np.array([['a', 'a', 'a', 'a', 'a', 't', 'g', 'a', 'a', 'c', 'a', 'a', 'a',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       1,       35]]),
                 # fmt: on
@@ -5306,7 +5195,6 @@ hg19_dna         49 tgggattaca------??????????accacgcccagccccttt       11
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558167, 37558173, 37558173, 37558191],
                           [      49,       39,       39,       29,       11]]),
                 # fmt: on
@@ -5360,7 +5248,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccctt       12
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
            'g', 'g', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't', 't'],
@@ -5375,7 +5262,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      49,       12]]),
                 # fmt: on
@@ -5429,7 +5315,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccct        13
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
            'g', 't', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't'],
@@ -5443,7 +5328,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       49,        13]]),
                 # fmt: on
@@ -5497,7 +5381,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccctttg       10
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 't',
            'g', 't', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't', 't', 't', 'g'],
@@ -5512,7 +5395,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 't',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      49,       10]]),
                 # fmt: on
@@ -5566,7 +5448,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccctttg     10
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 'g', 'a', 'c', 'a', 'g', 'g', 'g',
            'g', 't', 'g', 'a', 'g', 'g', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't', 't', 't', 'g'],
@@ -5581,7 +5462,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 'g', 'a', 'c', 'a', 'g', 'g', 'g',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    49,     10]]),
                 # fmt: on
@@ -5635,7 +5515,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccct       13
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 't', 'a', 'g', 'g', 'c',
            'a', 't', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't'],
@@ -5649,7 +5528,6 @@ np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 't', 'a', 'g', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      49,       13]]),
                 # fmt: on
@@ -5702,7 +5580,6 @@ hg19_dna         35 tgagccaccacgcccagcccctttg        10
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'a', 'g', 't', 'c', 'a', 'c', 'c', 'a', 'c', 'g', 'c',
            'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't', 't', 't', 'g'],
           ['t', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g', 'c',
@@ -5715,7 +5592,6 @@ np.array([['t', 'g', 'a', 'g', 't', 'c', 'a', 'c', 'c', 'a', 'c', 'g', 'c',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       35,        10]]),
                 # fmt: on
@@ -5769,7 +5645,6 @@ hg19_dna         49 tgggattacaggtgtgagccaccacgcccagcccct       13
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['t', 'g', 'g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c',
            'g', 't', 'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g',
            'c', 'c', 'c', 'a', 'g', 'c', 'c', 'c', 'c', 't'],
@@ -5836,7 +5711,6 @@ hg19_dna         47 ggattacaggtgtgagccaccacgcccagcccct        13
                 np.array_equal(
                     np.array(alignment, "U"),
                     # fmt: off
-# flake8: noqa
 np.array([['g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c', 'g', 't',
            'g', 'a', 'g', 'c', 'c', 'a', 'c', 'c', 'a', 'c', 'g', 'c', 'c',
            'c', 'a', 'g', 'c', 'c', 'c', 'c', 't'],
@@ -5850,7 +5724,6 @@ np.array([['g', 'g', 'a', 't', 't', 'a', 'c', 'a', 'g', 'g', 'c', 'g', 't',
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       47,        13]]),
                 # fmt: on
@@ -5948,7 +5821,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75566694, 75566850],
                           [      61,      113]]),
                 # fmt: on
@@ -5997,7 +5869,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75560749, 75560881],
                           [      17,       61]]),
                 # fmt: on
@@ -6054,7 +5925,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75549820, 75549865, 75567225, 75567225, 75567312],
                           [       0,       15,       15,      113,      142]]),
                 # fmt: on
@@ -6111,7 +5981,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75604767, 75604827, 75605728, 75605809],
                           [     183,      203,      203,      230]]),
                 # fmt: on
@@ -6156,7 +6025,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75594914, 75594989],
                           [     158,      183]]),
                 # fmt: on
@@ -6199,7 +6067,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[75569459, 75569507],
                           [     142,      158]]),
                 # fmt: on
@@ -6247,7 +6114,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[41260685, 41260787],
                           [      76,      110]]),
                 # fmt: on
@@ -6304,7 +6170,6 @@ class TestAlign_dnax_prot(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[41257605, 41257731, 41263227, 41263227, 41263290],
                           [      17,       59,       59,      162,      183]]),
                 # fmt: on
@@ -6559,7 +6424,6 @@ CAG33136.        60 YEL 63
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[9712654, 9712786, 9715941, 9716097, 9716445, 9716532, 9718374,
                            9718422, 9739264, 9739339, 9743706, 9743766, 9744511, 9744592],
                           [     17,      61,      61,     113,     113,     142,     142,
@@ -6623,7 +6487,6 @@ CAG33136.        60 YEL 63
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[2103463, 2103523, 2103522, 2103522, 2104149],
                           [      0,      20,      20,      21,     230]]),
                 # fmt: on
@@ -6685,7 +6548,6 @@ CAG33136.        60 YEL 63
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[20873021, 20872472, 20872471, 20872471, 20872390],
                           [       0,      183,      183,      203,      230]]),
                 # fmt: on

--- a/Tests/test_Align_sam.py
+++ b/Tests/test_Align_sam.py
@@ -327,7 +327,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42530895, 42530958, 42532020, 42532095, 42532563, 42532606],
                           [     181,      118,      118,       43,       43,        0]])
                 # fmt: on
@@ -337,7 +336,6 @@ class TestAlign_dna_rna(unittest.TestCase):
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
                 np.array([[38.,  0.,  0.,  0.],
                           [ 0., 41.,  0.,  0.],
                           [ 0.,  0., 60.,  0.],
@@ -503,7 +501,6 @@ NR_046654.1	16	chr3	42530896	0	63M1062N75M468N43M	*	0	0	CGGAAGTACTTCTGGGGGTACATA
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42530895, 42530922, 42530922, 42530958, 42532020,
                            42532037, 42532039, 42532095, 42532563, 42532606],
                           [     185,      158,      155,      119,      119,
@@ -516,7 +513,6 @@ NR_046654.1	16	chr3	42530896	0	63M1062N75M468N43M	*	0	0	CGGAAGTACTTCTGGGGGTACATA
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
                 np.array([[36.,  0.,  0.,  1.],
                           [ 0., 41.,  0.,  0.],
                           [ 0.,  0., 60.,  0.],
@@ -679,7 +675,6 @@ NR_046654.1_modified	16	chr3	42530896	0	5S27M3I36M1062N17M2D56M468N43M3S	*	0	0	A
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array( [[48663767, 48663813, 48665640, 48665722, 48669098, 48669174],
                               [       0,        46,      46,      128,      128,      204]]),
                 # fmt: on
@@ -689,7 +684,6 @@ NR_046654.1_modified	16	chr3	42530896	0	5S27M3I36M1062N17M2D56M468N43M3S	*	0	0	A
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
                 np.array([[62.,  0.,  0.,  0.],
                           [ 0., 42.,  0.,  0.],
                           [ 0.,  0., 66.,  0.],
@@ -1100,7 +1094,6 @@ NR_111921.1	0	chr3	48663768	0	46M1827N82M3376N76M12H	*	0	0	CACGAGAGGAGCGGAGGCGAG
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48663767, 48663795, 48663796, 48663813, 48665640,
                            48665716, 48665716, 48665722, 48669098, 48669174],
                           [       3,       31,       31,       48,       48,
@@ -1113,7 +1106,6 @@ NR_111921.1	0	chr3	48663768	0	46M1827N82M3376N76M12H	*	0	0	CACGAGAGGAGCGGAGGCGAG
             np.array_equal(
                 alignment.substitutions,
                 # fmt: off
-# flake8: noqa
                 np.array([[62.,  0.,  0.,  0.],
                           [ 0., 41.,  0.,  0.],
                           [ 0.,  2., 64.,  0.],
@@ -1641,7 +1633,6 @@ class TestAlign_dna(unittest.TestCase):
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [       0,       16]]),
                 # fmt: on
@@ -1676,7 +1667,6 @@ hg18_dna	0	chr4	61646096	0	11H16M6H	*	0	0	*	*	AS:i:16
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -1711,7 +1701,6 @@ hg18_dna	0	chr1	10271784	0	33M	*	0	0	*	*	AS:i:33
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      17,        0]]),
                 # fmt: on
@@ -1746,7 +1735,6 @@ hg18_dna	16	chr2	53575981	0	8H17M8H	*	0	0	*	*	AS:i:17
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       0,       41]]),
                 # fmt: on
@@ -1781,7 +1769,6 @@ hg19_dna	0	chr9	85737866	0	9H41M	*	0	0	*	*	AS:i:29
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       0,       41]]),
                 # fmt: on
@@ -1816,7 +1803,6 @@ hg19_dna	0	chr8	95160480	0	8H41M1H	*	0	0	*	*	AS:i:41
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [       0,       36]]),
                 # fmt: on
@@ -1850,7 +1836,6 @@ hg19_dna	0	chr22	42144401	0	11H36M3H	*	0	0	*	*	AS:i:24
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183925990, 183926028],
                           [        0,         6,        10,        48]]),
                 # fmt: on
@@ -1885,7 +1870,6 @@ hg19_dna	0	chr2	183925985	0	1H6M4I38M1H	*	0	0	*	*	AS:i:27
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [       0,       25,       25,       36]]),
                 # fmt: on
@@ -1928,7 +1912,6 @@ hg19_dna	0	chr19	35483341	0	10H25M134D11M4H	*	0	0	*	*	AS:i:0
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [       0,       39]]),
                 # fmt: on
@@ -1963,7 +1946,6 @@ hg19_dna	0	chr18	23891311	0	10H39M1H	*	0	0	*	*	AS:i:39
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [       0,       28]]),
                 # fmt: on
@@ -1998,7 +1980,6 @@ hg19_dna	0	chr18	43252218	0	21H28M1H	*	0	0	*	*	AS:i:24
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759157, 52759160, 52759198],
                           [       0,       10,       10,       48]]),
                 # fmt: on
@@ -2033,7 +2014,6 @@ hg19_dna	0	chr13	52759148	0	1H10M3D38M1H	*	0	0	*	*	AS:i:30
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -2068,7 +2048,6 @@ hg19_dna	0	chr1	1207057	0	50M	*	0	0	*	*	AS:i:50
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       0,       34]]),
                 # fmt: on
@@ -2103,7 +2082,6 @@ hg19_dna	0	chr1	61700838	0	1H34M15H	*	0	0	*	*	AS:i:22
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558173, 37558173, 37558191],
                           [      38,       22,       18,        0]]),
                 # fmt: on
@@ -2137,7 +2115,6 @@ hg19_dna	16	chr4	37558158	0	1H16M4I18M11H	*	0	0	*	*	AS:i:15
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      37,        0]]),
                 # fmt: on
@@ -2172,7 +2149,6 @@ hg19_dna	16	chr22	48997406	0	1H37M12H	*	0	0	*	*	AS:i:29
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       36,         0]]),
                 # fmt: on
@@ -2207,7 +2183,6 @@ hg19_dna	16	chr2	120641741	0	1H36M13H	*	0	0	*	*	AS:i:32
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      39,        0]]),
                 # fmt: on
@@ -2242,7 +2217,6 @@ hg19_dna	16	chr19	54017131	0	1H39M10H	*	0	0	*	*	AS:i:39
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    39,      0]]),
                 # fmt: on
@@ -2277,7 +2251,6 @@ hg19_dna	16	chr19	553743	0	1H39M10H	*	0	0	*	*	AS:i:27
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      36,        0]]),
                 # fmt: on
@@ -2312,7 +2285,6 @@ hg19_dna	16	chr10	99388556	0	1H36M13H	*	0	0	*	*	AS:i:24
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       25,         0]]),
                 # fmt: on
@@ -2347,7 +2319,6 @@ hg19_dna	16	chr10	112178172	0	15H25M10H	*	0	0	*	*	AS:i:21
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[39368490, 39368526],
                           [      36,        0]]),
                 # fmt: on
@@ -2382,7 +2353,6 @@ hg19_dna	16	chr1	39368491	0	1H36M13H	*	0	0	*	*	AS:i:32
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       34,         0]]),
                 # fmt: on
@@ -2502,7 +2472,6 @@ hg19_dna	16	chr1	220325688	0	3H34M13H	*	0	0	*	*	AS:i:30
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [       0,       16]]),
                 # fmt: on
@@ -2537,7 +2506,6 @@ hg18_dna	0	chr4	61646096	0	11H16M6H	*	0	0	*	*	AS:i:16
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -2572,7 +2540,6 @@ hg18_dna	0	chr1	10271784	0	33M	*	0	0	*	*	AS:i:33
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      17,        0]]),
                 # fmt: on
@@ -2692,7 +2659,6 @@ hg18_dna	16	chr2	53575981	0	8H17M8H	*	0	0	*	*	AS:i:17
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       0,       41]]),
                 # fmt: on
@@ -2727,7 +2693,6 @@ hg19_dna	0	chr9	85737866	0	9H41M	*	0	0	*	*	AS:i:29
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       0,       41]]),
                 # fmt: on
@@ -2762,7 +2727,6 @@ hg19_dna	0	chr8	95160480	0	8H41M1H	*	0	0	*	*	AS:i:41
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [       0,       36]]),
                 # fmt: on
@@ -2797,7 +2761,6 @@ hg19_dna	0	chr22	42144401	0	11H36M3H	*	0	0	*	*	AS:i:24
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183925990, 183926028],
                           [        0,         6,        10,        48]]),
                 # fmt: on
@@ -2832,7 +2795,6 @@ hg19_dna	0	chr2	183925985	0	1H6M4I38M1H	*	0	0	*	*	AS:i:27
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [       0,       25,       25,       36]]),
                 # fmt: on
@@ -2875,7 +2837,6 @@ hg19_dna	0	chr19	35483341	0	10H25M134D11M4H	*	0	0	*	*	AS:i:0
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [       0,       39]]),
                 # fmt: on
@@ -2910,7 +2871,6 @@ hg19_dna	0	chr18	23891311	0	10H39M1H	*	0	0	*	*	AS:i:39
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [       0,       28]]),
                 # fmt: on
@@ -2945,7 +2905,6 @@ hg19_dna	0	chr18	43252218	0	21H28M1H	*	0	0	*	*	AS:i:24
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759157, 52759160, 52759198],
                           [       0,       10,       10,       48]]),
                 # fmt: on
@@ -2980,7 +2939,6 @@ hg19_dna	0	chr13	52759148	0	1H10M3D38M1H	*	0	0	*	*	AS:i:30
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -3015,7 +2973,6 @@ hg19_dna	0	chr1	1207057	0	50M	*	0	0	*	*	AS:i:50
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       0,       34]]),
                 # fmt: on
@@ -3050,7 +3007,6 @@ hg19_dna	0	chr1	61700838	0	1H34M15H	*	0	0	*	*	AS:i:22
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558173, 37558173, 37558191],
                           [      38,       22,       18,        0]]),
                 # fmt: on
@@ -3085,7 +3041,6 @@ hg19_dna	16	chr4	37558158	0	1H16M4I18M11H	*	0	0	*	*	AS:i:15
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      37,        0]]),
                 # fmt: on
@@ -3120,7 +3075,6 @@ hg19_dna	16	chr22	48997406	0	1H37M12H	*	0	0	*	*	AS:i:29
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       36,         0]]),
                 # fmt: on
@@ -3155,7 +3109,6 @@ hg19_dna	16	chr2	120641741	0	1H36M13H	*	0	0	*	*	AS:i:32
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      39,        0]]),
                 # fmt: on
@@ -3190,7 +3143,6 @@ hg19_dna	16	chr19	54017131	0	1H39M10H	*	0	0	*	*	AS:i:39
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    39,      0]]),
                 # fmt: on
@@ -3225,7 +3177,6 @@ hg19_dna	16	chr19	553743	0	1H39M10H	*	0	0	*	*	AS:i:27
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      36,        0]]),
                 # fmt: on
@@ -3260,7 +3211,6 @@ hg19_dna	16	chr10	99388556	0	1H36M13H	*	0	0	*	*	AS:i:24
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       25,         0]]),
                 # fmt: on
@@ -3295,7 +3245,6 @@ hg19_dna	16	chr10	112178172	0	15H25M10H	*	0	0	*	*	AS:i:21
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[39368490, 39368526],
                           [      36,        0]]),
                 # fmt: on
@@ -3330,7 +3279,6 @@ hg19_dna	16	chr1	39368491	0	1H36M13H	*	0	0	*	*	AS:i:32
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       34,         0]]),
                 # fmt: on
@@ -3450,7 +3398,6 @@ hg19_dna	16	chr1	220325688	0	3H34M13H	*	0	0	*	*	AS:i:30
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61646095, 61646111],
                           [      11,       27]]),
                 # fmt: on
@@ -3485,7 +3432,6 @@ hg18_dna	0	chr4	61646096	0	11S16M6S	*	0	0	*	*	AS:i:16
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[10271783, 10271816],
                           [       0,       33]]),
                 # fmt: on
@@ -3520,7 +3466,6 @@ hg18_dna	0	chr1	10271784	0	33M	*	0	0	*	*	AS:i:33
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[53575980, 53575997],
                           [      25,        8]]),
                 # fmt: on
@@ -3555,7 +3500,6 @@ hg18_dna	16	chr2	53575981	0	8S17M8S	*	0	0	*	*	AS:i:17
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[85737865, 85737906],
                           [       9,       50]]),
                 # fmt: on
@@ -3590,7 +3534,6 @@ hg19_dna	0	chr9	85737866	0	9S41M	*	0	0	*	*	AS:i:29
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[95160479, 95160520],
                           [       8,       49]]),
                 # fmt: on
@@ -3625,7 +3568,6 @@ hg19_dna	0	chr8	95160480	0	8S41M1S	*	0	0	*	*	AS:i:41
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[42144400, 42144436],
                           [      11,       47]]),
                 # fmt: on
@@ -3660,7 +3602,6 @@ hg19_dna	0	chr22	42144401	0	11S36M3S	*	0	0	*	*	AS:i:24
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[183925984, 183925990, 183925990, 183926028],
                           [        1,         7,        11,        49]]),
                 # fmt: on
@@ -3695,7 +3636,6 @@ hg19_dna	0	chr2	183925985	0	1S6M4I38M1S	*	0	0	*	*	AS:i:27
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[35483340, 35483365, 35483499, 35483510],
                           [      10,       35,       35,       46]]),
                 # fmt: on
@@ -3738,7 +3678,6 @@ hg19_dna	0	chr19	35483341	0	10S25M134D11M4S	*	0	0	*	*	AS:i:0
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[23891310, 23891349],
                           [      10,       49]]),
                 # fmt: on
@@ -3773,7 +3712,6 @@ hg19_dna	0	chr18	23891311	0	10S39M1S	*	0	0	*	*	AS:i:39
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[43252217, 43252245],
                           [      21,       49]]),
                 # fmt: on
@@ -3808,7 +3746,6 @@ hg19_dna	0	chr18	43252218	0	21S28M1S	*	0	0	*	*	AS:i:24
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[52759147, 52759157, 52759160, 52759198],
                           [       1,       11,       11,       49]]),
                 # fmt: on
@@ -3843,7 +3780,6 @@ hg19_dna	0	chr13	52759148	0	1S10M3D38M1S	*	0	0	*	*	AS:i:30
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[1207056, 1207106],
                           [      0,      50]]),
                 # fmt: on
@@ -3878,7 +3814,6 @@ hg19_dna	0	chr1	1207057	0	50M	*	0	0	*	*	AS:i:50
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[61700837, 61700871],
                           [       1,       35]]),
                 # fmt: on
@@ -3913,7 +3848,6 @@ hg19_dna	0	chr1	61700838	0	1S34M15S	*	0	0	*	*	AS:i:22
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[37558157, 37558173, 37558173, 37558191],
                           [      49,       33,       29,       11]]),
                 # fmt: on
@@ -3948,7 +3882,6 @@ hg19_dna	16	chr4	37558158	0	1S16M4I18M11S	*	0	0	*	*	AS:i:15
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[48997405, 48997442],
                           [      49,       12]]),
                 # fmt: on
@@ -3983,7 +3916,6 @@ hg19_dna	16	chr22	48997406	0	1S37M12S	*	0	0	*	*	AS:i:29
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[120641740, 120641776],
                           [       49,        13]]),
                 # fmt: on
@@ -4018,7 +3950,6 @@ hg19_dna	16	chr2	120641741	0	1S36M13S	*	0	0	*	*	AS:i:32
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[54017130, 54017169],
                           [      49,       10]]),
                 # fmt: on
@@ -4053,7 +3984,6 @@ hg19_dna	16	chr19	54017131	0	1S39M10S	*	0	0	*	*	AS:i:39
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[553742, 553781],
                           [    49,     10]]),
                 # fmt: on
@@ -4088,7 +4018,6 @@ hg19_dna	16	chr19	553743	0	1S39M10S	*	0	0	*	*	AS:i:27
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[99388555, 99388591],
                           [      49,       13]]),
                 # fmt: on
@@ -4123,7 +4052,6 @@ hg19_dna	16	chr10	99388556	0	1S36M13S	*	0	0	*	*	AS:i:24
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[112178171, 112178196],
                           [       35,        10]]),
                 # fmt: on
@@ -4192,7 +4120,6 @@ hg19_dna	16	chr1	39368491	0	1S36M13S	*	0	0	*	*	AS:i:32
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[220325687, 220325721],
                           [       47,        13]]),
                 # fmt: on
@@ -4558,7 +4485,6 @@ query             0 CCCCCC  6
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'C', 'C', 'C', 'C'],
           ['C', 'C', 'C', 'C', 'C', 'C']], dtype='U')
                 # fmt: on
@@ -4598,7 +4524,6 @@ query             0 --------CCCCCC  6
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'C', 'C', 'C', 'C', 'C',
            'C'],
           ['-', '-', '-', '-', '-', '-', '-', '-', 'C', 'C', 'C', 'C', 'C',
@@ -4640,7 +4565,6 @@ query             0 --------CCCCCC  6
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'C', 'C', 'C', 'C', 'C',
            'C'],
           ['-', '-', '-', '-', '-', '-', '-', '-', 'C', 'C', 'C', 'C', 'C',
@@ -4684,7 +4608,6 @@ query             0 AAAAAAAACCCCCC 14
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['-', '-', '-', '-', '-', '-', '-', '-', 'C', 'C', 'C', 'C', 'C',
            'C'],
           ['A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'C', 'C', 'C', 'C', 'C',
@@ -4728,7 +4651,6 @@ query             0 AAAAAAAACCCCCC 14
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['-', '-', '-', '-', '-', '-', '-', '-', 'C', 'C', 'C', 'C', 'C',
            'C'],
           ['A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'C', 'C', 'C', 'C', 'C',
@@ -4772,7 +4694,6 @@ query             8 CCCCCC 14
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'C', 'C', 'C', 'C'],
           ['C', 'C', 'C', 'C', 'C', 'C']], dtype='U')
                 # fmt: on
@@ -4814,7 +4735,6 @@ query             4 --------CCCCCC 10
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'C', 'C', 'C', 'C', 'C',
            'C'],
           ['-', '-', '-', '-', '-', '-', '-', '-', 'C', 'C', 'C', 'C', 'C',
@@ -4858,7 +4778,6 @@ query             0 GGGG--------CCCCCC 10
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['-', '-', '-', '-', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'C',
            'C', 'C', 'C', 'C', 'C'],
           ['G', 'G', 'G', 'G', '-', '-', '-', '-', '-', '-', '-', '-', 'C',
@@ -4902,7 +4821,6 @@ query             4 CCCCCC 10
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'C', 'C', 'C', 'C'],
           ['C', 'C', 'C', 'C', 'C', 'C']], dtype='U')
                 # fmt: on
@@ -4944,7 +4862,6 @@ query             0 ----AAAAAAAACCCCCC 14
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'G', 'G', 'G', '-', '-', '-', '-', '-', '-', '-', '-', 'C',
            'C', 'C', 'C', 'C', 'C'],
           ['-', '-', '-', '-', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'C',
@@ -4988,7 +4905,6 @@ query             4 AAAAAAAACCCCCC 18
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['-', '-', '-', '-', '-', '-', '-', '-', 'C', 'C', 'C', 'C', 'C',
            'C'],
           ['A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'C', 'C', 'C', 'C', 'C',

--- a/Tests/test_Align_stockholm.py
+++ b/Tests/test_Align_stockholm.py
@@ -112,7 +112,6 @@ class TestStockholm_reading(unittest.TestCase):
                 alignment.coordinates,
                 np.array(
                     # fmt: off
-# flake8: noqa
 [[0, 0, 0, 1, 5, 17, 19, 46, 47, 50, 51, 55, 78, 78, 79, 80, 146, 147, 148, 153],
  [0, 1, 1, 1, 5, 17, 19, 46, 47, 50, 51, 55, 78, 78, 79, 80, 146, 147, 148, 153],
  [0, 1, 1, 1, 5, 17, 19, 46, 47, 50, 51, 55, 78, 78, 79, 80, 146, 147, 148, 153],
@@ -5935,7 +5934,6 @@ G4FEQ2/2-92                     VERYSLSPMKDLWTEEAKYRRWLEVELAVTRAYEELGMIPKGVTERIR
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'A', 'E', 'Q', 'I', 'A', 'K', 'E', '-', '-', '-', '-', '-',
            'E', 'D', 'D', 'R', 'K', 'F', 'R', 'A', 'F', 'L', 'S', 'N', 'Q',
            'D', 'N', 'Y', 'A', 'L', 'I', 'N', 'K', 'A', 'F', 'E', 'D', 'T',
@@ -5988,7 +5986,6 @@ np.array([['L', 'A', 'E', 'Q', 'I', 'A', 'K', 'E', '-', '-', '-', '-', '-',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['L', 'A', 'E', 'Q', 'I', 'A', 'K', 'E', '-', '-', '-', '-', '-',
            'E', 'D', 'D', 'R', 'K', 'F', 'R', 'A', 'F', 'L', 'S', 'N', 'Q',
            'D', 'N', 'Y', 'A', 'L', 'I', 'N', 'K', 'A', 'F', 'E', 'D', 'T',
@@ -6043,7 +6040,6 @@ np.array([['L', 'A', 'E', 'Q', 'I', 'A', 'K', 'E', '-', '-', '-', '-', '-',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'I', 'K', 'F', 'K', 'Y', 'K', 'G', 'Q', 'D', 'L', 'E', 'V',
            'D', 'I', 'S', 'K', 'V', 'K', 'K', 'V', 'W', 'K', 'V', 'G', 'K',
            'M', 'V', 'S', 'F', 'T', 'Y', 'D', 'D', '-', 'N', 'G', 'K', 'T',
@@ -6073,7 +6069,6 @@ np.array([['K', 'I', 'K', 'F', 'K', 'Y', 'K', 'G', 'Q', 'D', 'L', 'E', 'V',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'I', 'K', 'F', 'K', 'Y', 'K', 'G', 'Q', 'D', 'L', 'E', 'V',
            'D', 'I', 'S', 'K', 'V', 'K', 'K', 'V', 'W', 'K', 'V', 'G', 'K',
            'M', 'V', 'S', 'F', 'T', 'Y', 'D', 'D', '-', 'N', 'G', 'K', 'T',
@@ -6203,7 +6198,6 @@ np.array([['K', 'I', 'K', 'F', 'K', 'Y', 'K', 'G', 'Q', 'D', 'L', 'E', 'V',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'S', 'W', 'S', 'P', 'V', 'V', 'G', 'Q', 'L', 'V', 'Q', 'E',
            'R', 'V', 'A', 'R', 'P', 'A', 'S', 'L', 'R', 'P', 'R', 'W', 'H',
            'K', 'P', 'S', 'T', 'V', 'L', 'E', 'V', 'L', 'N', 'P', 'R', 'T',
@@ -6224,7 +6218,6 @@ np.array([['R', 'S', 'W', 'S', 'P', 'V', 'V', 'G', 'Q', 'L', 'V', 'Q', 'E',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['R', 'S', 'W', 'S', 'P', 'V', 'V', 'G', 'Q', 'L', 'V', 'Q', 'E',
            'R', 'V', 'A', 'R', 'P', 'A', 'S', 'L', 'R', 'P', 'R', 'W', 'H',
            'K', 'P', 'S', 'T', 'V', 'L', 'E', 'V', 'L', 'N', 'P', 'R', 'T',
@@ -6249,7 +6242,6 @@ np.array([['R', 'S', 'W', 'S', 'P', 'V', 'V', 'G', 'Q', 'L', 'V', 'Q', 'E',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'U', 'A', 'A', 'G', 'U', 'A', 'A', 'A', 'A', 'G', 'U', 'G',
            'U', 'A', 'A', 'C', 'A', 'G', 'G', 'A', 'A', 'G', 'A', 'A', 'A',
            'G', 'U', 'U', 'G', 'C', 'A', 'G', 'C', 'A', 'U', 'A', 'U', 'A',
@@ -6312,7 +6304,6 @@ np.array([['G', 'U', 'A', 'A', 'G', 'U', 'A', 'A', 'A', 'A', 'G', 'U', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'U', 'A', 'A', 'G', 'U', 'A', 'A', 'A', 'A', 'G', 'U', 'G',
            'U', 'A', 'A', 'C', 'A', 'G', 'G', 'A', 'A', 'G', 'A', 'A', 'A',
            'G', 'U', 'U', 'G', 'C', 'A', 'G', 'C', 'A', 'U', 'A', 'U', 'A',
@@ -6394,7 +6385,6 @@ np.array([['G', 'U', 'A', 'A', 'G', 'U', 'A', 'A', 'A', 'A', 'G', 'U', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'C', 'C', 'G', 'G', 'C', 'G', 'C', 'A', 'G', 'A', 'G', 'G',
            'A', 'G', 'A', 'C', 'A', 'A', 'U', 'G', 'C', 'C', 'G', 'G', 'A',
            'C', 'U', 'U', 'A', 'A', 'G', 'A', 'C', 'G', 'C', 'G', 'G', 'A',
@@ -6441,7 +6431,6 @@ np.array([['A', 'C', 'C', 'G', 'G', 'C', 'G', 'C', 'A', 'G', 'A', 'G', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'C', 'C', 'G', 'G', 'C', 'G', 'C', 'A', 'G', 'A', 'G', 'G',
            'A', 'G', 'A', 'C', 'A', 'A', 'U', 'G', 'C', 'C', 'G', 'G', 'A',
            'C', 'U', 'U', 'A', 'A', 'G', 'A', 'C', 'G', 'C', 'G', 'G', 'A',
@@ -6506,7 +6495,6 @@ np.array([['A', 'C', 'C', 'G', 'G', 'C', 'G', 'C', 'A', 'G', 'A', 'G', 'G',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'C', 'U', 'U', 'U', 'G', 'G', 'C', 'U', 'A', 'A', 'G', 'U',
            'U', 'U', 'A', 'A', 'A', 'A', 'G', 'C', 'U', 'U'],
           ['A', 'C', 'U', 'U', 'U', 'G', 'G', 'C', 'U', 'A', 'A', 'G', 'G',
@@ -6525,7 +6513,6 @@ np.array([['A', 'C', 'U', 'U', 'U', 'G', 'G', 'C', 'U', 'A', 'A', 'G', 'U',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'C', 'U', 'U', 'U', 'G', 'G', 'C', 'U', 'A', 'A', 'G', 'U',
            'U', 'U', 'A', 'A', 'A', 'A', 'G', 'C', 'U', 'U'],
           ['A', 'C', 'U', 'U', 'U', 'G', 'G', 'C', 'U', 'A', 'A', 'G', 'G',
@@ -6546,7 +6533,6 @@ np.array([['A', 'C', 'U', 'U', 'U', 'G', 'G', 'C', 'U', 'A', 'A', 'G', 'U',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'E', 'K', 'P', 'Y', 'E', 'C', 'L', 'E', 'C', 'G', 'K', 'R',
            'F', 'T', 'A', 'R']], dtype='U')
                 # fmt: on
@@ -6563,7 +6549,6 @@ np.array([['G', 'E', 'K', 'P', 'Y', 'E', 'C', 'L', 'E', 'C', 'G', 'K', 'R',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'E', 'K', 'P', 'Y', 'E', 'C', 'L', 'E', 'C', 'G', 'K', 'R',
            'F', 'T', 'A', 'R']], dtype='U')
                 # fmt: on
@@ -6582,7 +6567,6 @@ np.array([['G', 'E', 'K', 'P', 'Y', 'E', 'C', 'L', 'E', 'C', 'G', 'K', 'R',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'N', 'F', 'N', 'V', 'P', 'K', 'L', 'G', 'V', 'F', 'P', 'V',
            'A', 'A', 'V', 'F', 'D', 'I', 'D', 'N', 'V', 'P', 'E', 'D', 'S',
            'S', 'A', 'T', 'G', 'S', 'R', 'W', 'L', 'P', 'S', 'I', 'Y', 'Q',
@@ -6603,7 +6587,6 @@ np.array([['A', 'N', 'F', 'N', 'V', 'P', 'K', 'L', 'G', 'V', 'F', 'P', 'V',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'N', 'F', 'N', 'V', 'P', 'K', 'L', 'G', 'V', 'F', 'P', 'V',
            'A', 'A', 'V', 'F', 'D', 'I', 'D', 'N', 'V', 'P', 'E', 'D', 'S',
            'S', 'A', 'T', 'G', 'S', 'R', 'W', 'L', 'P', 'S', 'I', 'Y', 'Q',
@@ -6626,7 +6609,6 @@ np.array([['A', 'N', 'F', 'N', 'V', 'P', 'K', 'L', 'G', 'V', 'F', 'P', 'V',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['V', 'E', 'R', 'Y', 'S', 'L', 'S', 'P', 'M', 'K', 'D', 'L', 'W',
            'T', 'E', 'E', 'A', 'K', 'Y', 'R', 'R', 'W', 'L', 'E', 'V', 'E',
            'L', 'A', 'V', 'T', 'R', 'A', 'Y', 'E', 'E', 'L', 'G', 'M', 'I',
@@ -6670,7 +6652,6 @@ np.array([['V', 'E', 'R', 'Y', 'S', 'L', 'S', 'P', 'M', 'K', 'D', 'L', 'W',
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['V', 'E', 'R', 'Y', 'S', 'L', 'S', 'P', 'M', 'K', 'D', 'L', 'W',
            'T', 'E', 'E', 'A', 'K', 'Y', 'R', 'R', 'W', 'L', 'E', 'V', 'E',
            'L', 'A', 'V', 'T', 'R', 'A', 'Y', 'E', 'E', 'L', 'G', 'M', 'I',

--- a/Tests/test_Align_tabular.py
+++ b/Tests/test_Align_tabular.py
@@ -116,7 +116,6 @@ sp|P10649       180 ?????????????????????????????????????? 218
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['M', 'P', 'M', 'I', 'L', 'G', 'Y', 'W', 'D', 'I', 'R', 'G', 'L',
            'A', 'H', 'A', 'I', 'R', 'L', 'L', 'L', 'E', 'Y', 'T', 'D', 'S',
            'S', 'Y', 'E', 'E', 'K', 'K', 'Y', 'T', 'M', 'G', 'D', 'A', 'P',
@@ -191,7 +190,6 @@ sp|P10649       175 ??????????????????????????????????????????? 218
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 5,  33,  33,  46,  48,  58,  59,  62,
                            62, 101, 102, 125, 127, 142, 144, 218],
                           [ 3,  31,  40,  53,  53,  63,  63,  66,
@@ -218,7 +216,6 @@ sp|P10649       175 ??????????????????????????????????????????? 218
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['V', 'L', 'H', 'Y', 'F', 'N', 'A', 'R', 'G', 'R', 'M', 'E', 'C',
            'I', 'R', 'W', 'L', 'L', 'A', 'A', 'A', 'G', 'V', 'E', 'F', 'D',
            'E', 'K', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'F', 'I',
@@ -283,7 +280,6 @@ sp|P10649       176 ????????????????????????-?????????????? 214
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 35,  48,  48,  58,  59,  73],
                           [176, 189, 190, 200, 200, 214]]),
                 # fmt: on
@@ -302,7 +298,6 @@ sp|P10649       176 ????????????????????????-?????????????? 214
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['S', 'F', 'P', 'T', 'T', 'K', 'T', 'Y', 'F', 'P', 'H', 'F', 'D',
            '-', 'L', 'S', 'H', 'G', 'S', 'A', 'Q', 'V', 'K', 'G', 'H', 'G',
            'K', 'K', 'V', 'A', 'D', 'A', 'L', 'T', 'N', 'A', 'V', 'A', 'H'],
@@ -342,7 +337,6 @@ sp|P10649       194 ???????????? 206
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[228, 274, 276, 300],
                           [136, 182, 182, 206]])
                 # fmt: on
@@ -367,7 +361,6 @@ sp|P10649       194 ???????????? 206
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'Y', 'E', 'M', 'A', 'A', 'G', 'Y', 'P', 'P', 'F', 'F', 'A',
            'D', 'Q', 'P', 'I', 'Q', 'I', 'Y', 'E', 'K', 'I', 'V', 'S', 'G',
            'K', 'V', 'R', 'F', 'P', 'S', 'H', 'F', 'S', 'S', 'D', 'L', 'K',
@@ -420,7 +413,6 @@ sp|P10649         6 ??????? 13
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['Y', 'W', 'D', 'L', 'W', 'G', 'L'],
           ['Y', 'W', 'N', 'V', 'R', 'G', 'L']], dtype='U')
                 # fmt: on
@@ -451,7 +443,6 @@ sp|P10649       149 ??????????????---????????---????--??????????-????? 190
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 15,  29,  32,  40,  43,  47,
                             49,  51,  51,  58,  59,  64],
                           [149, 163, 163, 171, 171, 175,
@@ -476,7 +467,6 @@ sp|P10649       149 ??????????????---????????---????--??????????-????? 190
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'D', 'R', 'V', 'T', 'I', 'T', 'C', 'Q', 'A', 'S', 'Q', 'D',
            'I', 'N', 'H', 'Y', 'L', 'N', 'W', 'Y', 'Q', 'Q', 'G', 'P', 'K',
            'K', 'A', 'P', 'K', 'I', 'L', 'I', 'Y', 'D', 'A', '-', 'S', 'N',
@@ -518,7 +508,6 @@ sp|P10649       185 ???????? 193
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 27,  47,  50,  58,  58,  68,
                             68,  73,  73,  82,  82,  88],
                           [128, 148, 148, 156, 157, 167,
@@ -545,7 +534,6 @@ sp|P10649       185 ???????? 193
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'T', 'G', 'P', 'N', 'L', 'H', 'G', 'L', 'F', 'G', 'R', 'K',
            'T', 'G', 'Q', 'A', 'P', 'G', 'Y', 'S', 'Y', 'T', 'A', 'A', 'N',
            'K', 'N', 'K', 'G', 'I', '-', 'I', 'W', 'G', 'E', 'D', 'T', 'L',
@@ -586,7 +574,6 @@ sp|P10649        43 ????????????????????????????--???????????---?????????? 92
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array(
                     [[12, 26, 26, 36, 38, 49, 52, 62],
                      [43, 57, 61, 71, 71, 82, 82, 92]])
@@ -610,7 +597,6 @@ sp|P10649        43 ????????????????????????????--???????????---?????????? 92
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['S', 'E', 'E', 'M', 'I', 'A', 'E', 'F', 'K', 'A', 'A', 'F', 'D',
            'M', '-', '-', '-', '-', 'F', 'D', 'A', 'D', 'G', 'G', 'G', 'D',
            'I', 'S', 'V', 'K', 'E', 'L', 'G', 'T', 'V', 'M', 'R', 'M', 'L',
@@ -649,7 +635,6 @@ sp|P10649       114 ??????????? 125
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 85,  86,  86,  89,  89,  94],
                           [114, 115, 116, 119, 120, 125]])
                 # fmt: on
@@ -668,7 +653,6 @@ sp|P10649       114 ??????????? 125
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', '-', 'N', 'P', 'H', '-', 'P', 'K', 'Q', 'R', 'P'],
           ['C', 'Y', 'N', 'P', 'D', 'F', 'E', 'K', 'Q', 'K', 'P']],
          dtype='U')
@@ -715,7 +699,6 @@ sp|P10649       170 ???? 174
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'P', 'E', 'C'],
           ['E', 'P', 'K', 'C']], dtype='U')
                 # fmt: on
@@ -761,7 +744,6 @@ sp|P10649        73 ??????????-???????????????????????????? 111
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['N', 'R', 'V', 'I', 'E', 'K', 'T', 'N', 'E', 'K', 'F', 'H', 'Q',
            'I', 'E', 'K', 'E', 'F', 'S', 'E', 'V', 'E', 'G', 'R', 'I', 'Q',
            'D', 'L', 'E', 'K', 'Y', 'V', 'E', 'D', 'T', 'K', 'I', 'D', 'L'],
@@ -801,7 +783,6 @@ sp|P10649       113 ??????????? 124
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[11, 25, 27,  67,  69,  82],
                           [57, 71, 71, 111, 111, 124]])
                 # fmt: on
@@ -825,7 +806,6 @@ sp|P10649       113 ??????????? 124
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['P', 'S', 'D', 'E', 'Q', 'L', 'K', 'S', 'G', 'T', 'A', 'S', 'V',
            'V', 'C', 'L', 'L', 'N', 'N', 'F', 'Y', 'P', 'R', 'E', 'A', 'K',
            'V', 'Q', 'W', 'K', 'V', 'D', 'N', 'A', 'L', 'Q', 'S', 'G', 'N',
@@ -916,7 +896,6 @@ sp|P10649       180 ?????????????????????????????????????? 218
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['M', 'P', 'M', 'I', 'L', 'G', 'Y', 'W', 'D', 'I', 'R', 'G', 'L',
            'A', 'H', 'A', 'I', 'R', 'L', 'L', 'L', 'E', 'Y', 'T', 'D', 'S',
            'S', 'Y', 'E', 'E', 'K', 'K', 'Y', 'T', 'M', 'G', 'D', 'A', 'P',
@@ -991,7 +970,6 @@ sp|P10649       175 ??????????????????????????????????????????? 218
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 5,  33,  33,  46,  48,  58,  59,  62,
                            62, 101, 102, 125, 127, 142, 144, 218],
                           [ 3,  31,  40,  53,  53,  63,  63,  66,
@@ -1018,7 +996,6 @@ sp|P10649       175 ??????????????????????????????????????????? 218
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['V', 'L', 'H', 'Y', 'F', 'N', 'A', 'R', 'G', 'R', 'M', 'E', 'C',
            'I', 'R', 'W', 'L', 'L', 'A', 'A', 'A', 'G', 'V', 'E', 'F', 'D',
            'E', 'K', '-', '-', '-', '-', '-', '-', '-', '-', '-', 'F', 'I',
@@ -1083,7 +1060,6 @@ sp|P10649       176 ????????????????????????-?????????????? 214
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 35,  48,  48,  58,  59,  73],
                           [176, 189, 190, 200, 200, 214]])
                 # fmt: on
@@ -1102,7 +1078,6 @@ sp|P10649       176 ????????????????????????-?????????????? 214
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['S', 'F', 'P', 'T', 'T', 'K', 'T', 'Y', 'F', 'P', 'H', 'F', 'D',
            '-', 'L', 'S', 'H', 'G', 'S', 'A', 'Q', 'V', 'K', 'G', 'H', 'G',
            'K', 'K', 'V', 'A', 'D', 'A', 'L', 'T', 'N', 'A', 'V', 'A', 'H'],
@@ -1142,7 +1117,6 @@ sp|P10649       194 ???????????? 206
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[228, 274, 276, 300],
                           [136, 182, 182, 206]]),
                 # fmt: on
@@ -1167,7 +1141,6 @@ sp|P10649       194 ???????????? 206
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['I', 'Y', 'E', 'M', 'A', 'A', 'G', 'Y', 'P', 'P', 'F', 'F', 'A',
            'D', 'Q', 'P', 'I', 'Q', 'I', 'Y', 'E', 'K', 'I', 'V', 'S', 'G',
            'K', 'V', 'R', 'F', 'P', 'S', 'H', 'F', 'S', 'S', 'D', 'L', 'K',
@@ -1220,7 +1193,6 @@ sp|P10649         6 ??????? 13
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['Y', 'W', 'D', 'L', 'W', 'G', 'L'],
           ['Y', 'W', 'N', 'V', 'R', 'G', 'L']], dtype='U')
                 # fmt: on
@@ -1251,7 +1223,6 @@ sp|P10649       149 ??????????????---????????---????--??????????-????? 190
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[15,  29,  32,  40,  43,  47,
                            49,  51,  51,  58,  59,  64],
                          [149, 163, 163, 171, 171, 175,
@@ -1276,7 +1247,6 @@ sp|P10649       149 ??????????????---????????---????--??????????-????? 190
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'D', 'R', 'V', 'T', 'I', 'T', 'C', 'Q', 'A', 'S', 'Q', 'D',
            'I', 'N', 'H', 'Y', 'L', 'N', 'W', 'Y', 'Q', 'Q', 'G', 'P', 'K',
            'K', 'A', 'P', 'K', 'I', 'L', 'I', 'Y', 'D', 'A', '-', 'S', 'N',
@@ -1318,7 +1288,6 @@ sp|P10649       185 ???????? 193
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 27,  47,  50,  58,  58,  68,
                             68,  73,  73,  82,  82,  88],
                           [128, 148, 148, 156, 157, 167,
@@ -1345,7 +1314,6 @@ sp|P10649       185 ???????? 193
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'T', 'G', 'P', 'N', 'L', 'H', 'G', 'L', 'F', 'G', 'R', 'K',
            'T', 'G', 'Q', 'A', 'P', 'G', 'Y', 'S', 'Y', 'T', 'A', 'A', 'N',
            'K', 'N', 'K', 'G', 'I', '-', 'I', 'W', 'G', 'E', 'D', 'T', 'L',
@@ -1386,7 +1354,6 @@ sp|P10649        43 ????????????????????????????--???????????---?????????? 92
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[12, 26, 26, 36, 38, 49, 52, 62],
                           [43, 57, 61, 71, 71, 82, 82, 92]])
                 # fmt: on
@@ -1409,7 +1376,6 @@ sp|P10649        43 ????????????????????????????--???????????---?????????? 92
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['S', 'E', 'E', 'M', 'I', 'A', 'E', 'F', 'K', 'A', 'A', 'F', 'D',
            'M', '-', '-', '-', '-', 'F', 'D', 'A', 'D', 'G', 'G', 'G', 'D',
            'I', 'S', 'V', 'K', 'E', 'L', 'G', 'T', 'V', 'M', 'R', 'M', 'L',
@@ -1448,7 +1414,6 @@ sp|P10649       114 ??????????? 125
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[ 85,  86,  86,  89,  89,  94],
                           [114, 115, 116, 119, 120, 125]]),
                 # fmt: on
@@ -1467,7 +1432,6 @@ sp|P10649       114 ??????????? 125
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', '-', 'N', 'P', 'H', '-', 'P', 'K', 'Q', 'R', 'P'],
           ['C', 'Y', 'N', 'P', 'D', 'F', 'E', 'K', 'Q', 'K', 'P']],
          dtype='U')
@@ -1499,7 +1463,6 @@ sp|P10649        73 ??????????-???????????????????????????? 111
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[398, 408, 409, 437],
                           [ 73,  83,  83, 111]])
                 # fmt: on
@@ -1518,7 +1481,6 @@ sp|P10649        73 ??????????-???????????????????????????? 111
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['N', 'R', 'V', 'I', 'E', 'K', 'T', 'N', 'E', 'K', 'F', 'H', 'Q',
            'I', 'E', 'K', 'E', 'F', 'S', 'E', 'V', 'E', 'G', 'R', 'I', 'Q',
            'D', 'L', 'E', 'K', 'Y', 'V', 'E', 'D', 'T', 'K', 'I', 'D', 'L'],
@@ -1569,7 +1531,6 @@ sp|P10649       170 ???? 174
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['K', 'P', 'E', 'C'],
           ['E', 'P', 'K', 'C']], dtype='U')
                 # fmt: on
@@ -1604,7 +1565,6 @@ sp|P10649       113 ??????????? 124
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[11, 25, 27,  67,  69,  82],
                           [57, 71, 71, 111, 111, 124]])
                 # fmt: on
@@ -1628,7 +1588,6 @@ sp|P10649       113 ??????????? 124
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['P', 'S', 'D', 'E', 'Q', 'L', 'K', 'S', 'G', 'T', 'A', 'S', 'V',
            'V', 'C', 'L', 'L', 'N', 'N', 'F', 'Y', 'P', 'R', 'E', 'A', 'K',
            'V', 'Q', 'W', 'K', 'V', 'D', 'N', 'A', 'L', 'Q', 'S', 'G', 'N',
@@ -1888,7 +1847,6 @@ pGT875          580 ?????????????? 594
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[227, 376, 376, 383, 384, 401, 401, 461, 466, 472,
                            473, 486, 488, 501, 505, 535, 537, 543, 543, 655],
                           [175, 324, 325, 332, 332, 349, 352, 412, 412, 418,
@@ -1915,7 +1873,6 @@ pGT875          580 ?????????????? 594
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'G', 'C', 'T', 'C', 'C', 'C', 'C', 'A', 'A', 'G', 'T', 'T',
            'C', 'C', 'A', 'G', 'G', 'A', 'C', 'G', 'G', 'A', 'G', 'A', 'C',
            'C', 'T', 'C', 'A', 'C', 'G', 'C', 'T', 'G', 'T', 'A', 'C', 'C',
@@ -2020,7 +1977,6 @@ pGT875          274 ??????????????? 289
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[156, 171, 173, 190, 190, 201, 202,
                            260, 261, 272, 272, 279, 279, 287],
                           [158, 173, 173, 190, 192, 203, 203,
@@ -2047,7 +2003,6 @@ pGT875          274 ??????????????? 289
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'G', 'G', 'T', 'A', 'T', 'T', 'G', 'A', 'T', 'G', 'T', 'T',
            'C', 'C', 'A', 'G', 'C', 'A', 'A', 'G', 'T', 'G', 'C', 'C', 'C',
            'A', 'T', 'G', 'G', 'T', 'T', 'G', 'A', '-', '-', 'G', 'A', 'T',
@@ -2098,7 +2053,6 @@ pGT875          265 ????????????????????????  289
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[2302, 2319, 2319, 2325],
                           [ 265,  282,  283,  289]])
                 # fmt: on
@@ -2117,7 +2071,6 @@ pGT875          265 ????????????????????????  289
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'G', 'A', 'C', 'A', 'G', 'A', 'G', 'G', 'A', 'G', 'G', 'A',
            'G', 'A', 'A', 'G', '-', 'T', 'C', 'T', 'G', 'T', 'G'],
           ['A', 'G', 'A', 'C', 'A', 'G', 'A', 'G', 'G', 'A', 'G', 'G', 'A',
@@ -2151,7 +2104,6 @@ pGT875          240 ????????????????????????????????-?????????????  285
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[4973, 4987, 4987, 4990, 4990, 5002, 5003, 5016],
                           [ 240,  254,  256,  259,  260,  272,  272,  285]])
                 # fmt: on
@@ -2170,7 +2122,6 @@ pGT875          240 ????????????????????????????????-?????????????  285
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'C', 'T', 'G', 'G', 'A', 'G', 'A', 'G', 'A', 'G', 'C', 'C',
            'A', '-', '-', 'T', 'G', 'G', '-', 'T', 'G', 'G', 'A', 'G', 'G',
            'C', 'T', 'G', 'C', 'G', 'A', 'T', 'G', 'G', 'A', 'G', 'G', 'A',
@@ -2222,7 +2173,6 @@ pGT875          316 ????????????  304
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'A', 'T', 'G', 'A', 'C', 'C', 'T', 'G', 'G', 'T'],
           ['C', 'C', 'A', 'T', 'G', 'A', 'C', 'C', 'T', 'G', 'G', 'T']],
          dtype='U')
@@ -2269,7 +2219,6 @@ pGT875          316 ????????????  304
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'A', 'T', 'G', 'A', 'C', 'C', 'T', 'G', 'G', 'T'],
           ['C', 'C', 'A', 'T', 'G', 'A', 'C', 'C', 'T', 'G', 'G', 'T']],
          dtype='U')
@@ -2316,7 +2265,6 @@ pGT875          160 ???????????????? 144
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'T', 'G', 'G', 'T', 'T', 'G', 'A', 'A', 'C', 'T', 'T',
            'C', 'T', 'C'],
           ['C', 'C', 'A', 'G', 'C', 'T', 'T', 'G', 'A', 'A', 'C', 'T', 'T',
@@ -2374,7 +2322,6 @@ pGT875          182 ????????????????????????  158
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'C', 'A', 'T', 'G', 'G', 'C', 'T', 'G', 'G', 'G', 'T', 'G',
            'G', 'G', 'G', 'C', 'A', 'G', 'G', 'A', 'T', 'T', 'A', 'G', 'T',
            'G', 'T', 'G', 'G', 'G', 'G', 'G', 'G', 'A', 'G', 'T', 'T', 'G',
@@ -2432,7 +2379,6 @@ pGT875          310 ?????????? 300
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'T', 'G', 'G', 'T', 'T', 'C', 'T', 'C'],
           ['C', 'C', 'T', 'G', 'G', 'T', 'T', 'C', 'T', 'C']], dtype='U')
                 # fmt: on
@@ -2467,7 +2413,6 @@ pGT875          318 ?????????????? 304
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[280, 304, 304, 312, 312, 351],
                           [378, 354, 353, 345, 343, 304]])
                 # fmt: on
@@ -2491,7 +2436,6 @@ pGT875          318 ?????????????? 304
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'T', 'G', 'C', 'G', 'G', 'C', 'A', 'C', 'C', 'T', 'G', 'G',
            'G', 'C', 'C', 'G', 'C', 'A', 'C', 'C', 'C', 'T', 'C', '-', 'G',
            'G', 'G', 'C', 'T', 'G', 'T', 'A', '-', '-', 'T', 'G', 'G', 'G',
@@ -2741,7 +2685,6 @@ pGT875          580 ?????????????? 594
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[227, 376, 376, 383, 384, 401, 401, 461, 466, 472,
                            473, 486, 488, 501, 505, 535, 537, 543, 543, 655],
                           [175, 324, 325, 332, 332, 349, 352, 412, 412, 418,
@@ -2768,7 +2711,6 @@ pGT875          580 ?????????????? 594
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'G', 'C', 'T', 'C', 'C', 'C', 'C', 'A', 'A', 'G', 'T', 'T',
            'C', 'C', 'A', 'G', 'G', 'A', 'C', 'G', 'G', 'A', 'G', 'A', 'C',
            'C', 'T', 'C', 'A', 'C', 'G', 'C', 'T', 'G', 'T', 'A', 'C', 'C',
@@ -2873,7 +2815,6 @@ pGT875          274 ??????????????? 289
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[156, 171, 173, 190, 190, 201, 202,
                            260, 261, 272, 272, 279, 279, 287],
                           [158, 173, 173, 190, 192, 203, 203,
@@ -2900,7 +2841,6 @@ pGT875          274 ??????????????? 289
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'G', 'G', 'T', 'A', 'T', 'T', 'G', 'A', 'T', 'G', 'T', 'T',
            'C', 'C', 'A', 'G', 'C', 'A', 'A', 'G', 'T', 'G', 'C', 'C', 'C',
            'A', 'T', 'G', 'G', 'T', 'T', 'G', 'A', '-', '-', 'G', 'A', 'T',
@@ -2951,7 +2891,6 @@ pGT875          265 ????????????????????????  289
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[2302, 2319, 2319, 2325],
                            [265,  282,  283,  289]]),
                 # fmt: on
@@ -2970,7 +2909,6 @@ pGT875          265 ????????????????????????  289
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['A', 'G', 'A', 'C', 'A', 'G', 'A', 'G', 'G', 'A', 'G', 'G', 'A',
            'G', 'A', 'A', 'G', '-', 'T', 'C', 'T', 'G', 'T', 'G'],
           ['A', 'G', 'A', 'C', 'A', 'G', 'A', 'G', 'G', 'A', 'G', 'G', 'A',
@@ -3004,7 +2942,6 @@ pGT875          240 ????????????????????????????????-?????????????  285
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[4973, 4987, 4987, 4990, 4990, 5002, 5003, 5016],
                           [ 240,  254,  256,  259,  260,  272,  272,  285]])
                 # fmt: on
@@ -3023,7 +2960,6 @@ pGT875          240 ????????????????????????????????-?????????????  285
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'C', 'T', 'G', 'G', 'A', 'G', 'A', 'G', 'A', 'G', 'C', 'C',
            'A', '-', '-', 'T', 'G', 'G', '-', 'T', 'G', 'G', 'A', 'G', 'G',
            'C', 'T', 'G', 'C', 'G', 'A', 'T', 'G', 'G', 'A', 'G', 'G', 'A',
@@ -3075,7 +3011,6 @@ pGT875          316 ????????????  304
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'A', 'T', 'G', 'A', 'C', 'C', 'T', 'G', 'G', 'T'],
           ['C', 'C', 'A', 'T', 'G', 'A', 'C', 'C', 'T', 'G', 'G', 'T']],
          dtype='U')
@@ -3122,7 +3057,6 @@ pGT875          316 ????????????  304
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'A', 'T', 'G', 'A', 'C', 'C', 'T', 'G', 'G', 'T'],
           ['C', 'C', 'A', 'T', 'G', 'A', 'C', 'C', 'T', 'G', 'G', 'T']],
          dtype='U')
@@ -3169,7 +3103,6 @@ pGT875          160 ???????????????? 144
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'T', 'G', 'G', 'T', 'T', 'G', 'A', 'A', 'C', 'T', 'T',
            'C', 'T', 'C'],
           ['C', 'C', 'A', 'G', 'C', 'T', 'T', 'G', 'A', 'A', 'C', 'T', 'T',
@@ -3227,7 +3160,6 @@ pGT875          182 ????????????????????????  158
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['G', 'C', 'A', 'T', 'G', 'G', 'C', 'T', 'G', 'G', 'G', 'T', 'G',
            'G', 'G', 'G', 'C', 'A', 'G', 'G', 'A', 'T', 'T', 'A', 'G', 'T',
            'G', 'T', 'G', 'G', 'G', 'G', 'G', 'G', 'A', 'G', 'T', 'T', 'G',
@@ -3285,7 +3217,6 @@ pGT875          310 ?????????? 300
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'C', 'T', 'G', 'G', 'T', 'T', 'C', 'T', 'C'],
           ['C', 'C', 'T', 'G', 'G', 'T', 'T', 'C', 'T', 'C']], dtype='U')
                 # fmt: on
@@ -3320,7 +3251,6 @@ pGT875          318 ?????????????? 304
             np.array_equal(
                 alignment.coordinates,
                 # fmt: off
-# flake8: noqa
                 np.array([[280, 304, 304, 312, 312, 351],
                           [378, 354, 353, 345, 343, 304]])
                 # fmt: on
@@ -3344,7 +3274,6 @@ pGT875          318 ?????????????? 304
             np.array_equal(
                 np.array(alignment, "U"),
                 # fmt: off
-# flake8: noqa
 np.array([['C', 'T', 'G', 'C', 'G', 'G', 'C', 'A', 'C', 'C', 'T', 'G', 'G',
            'G', 'C', 'C', 'G', 'C', 'A', 'C', 'C', 'C', 'T', 'C', '-', 'G',
            'G', 'G', 'C', 'T', 'G', 'T', 'A', '-', '-', 'T', 'G', 'G', 'G',
@@ -3963,7 +3892,6 @@ gi|160806        94
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[ 0, 35, 43, 59],
                               [43, 78, 78, 94]])
                     # fmt: on
@@ -4037,7 +3965,6 @@ gi|160806        94
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[ 0, 35, 43, 59],
                               [43, 78, 78, 94]])
                     # fmt: on
@@ -4168,7 +4095,6 @@ gi|114649        85 RDAWVRDIKKA 96
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[ 0, 25, 26, 39, 42, 71],
                               [29, 54, 54, 67, 67, 96]])
                     # fmt: on
@@ -4302,7 +4228,6 @@ gi|114649        56 QDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA  96
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[0, 27, 29, 54, 58, 100],
                               [2, 29, 29, 54, 54,  96]])
                     # fmt: on
@@ -4436,7 +4361,6 @@ gi|114649        60 KRMF----VLKITTTKQQDHFFQAAFLEERDAWVRDIKKA  96
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[0, 27, 29, 64, 68, 100],
                               [2, 29, 29, 64, 64,  96]])
                     # fmt: on
@@ -4570,7 +4494,6 @@ gi|114649        56 QDFGKRMFVLKITTTKQQDHFFQAAFLEERDAWVRDIKKA  96
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[0, 27, 29, 54, 58, 100],
                               [2, 29, 29, 54, 54,  96]])
                     # fmt: on
@@ -4635,7 +4558,6 @@ gi|114649        11 GSVFNTWKPMWVVLL---------EDGIEFYKKKSDNSPKGMIPLKGSTLTS 54
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[ 0, 15, 24, 52],
                               [11, 26, 26, 54]])
                     # fmt: on
@@ -4953,7 +4875,6 @@ gi|296147        60 SLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K 116
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0, 116],
                               [  0, 116]])
                     # fmt: on
@@ -5041,7 +4962,6 @@ gi|296147        60 DVFLAPQNYVLFSISQWIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSWP 116
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[0, 116],
                               [0, 116]])
                     # fmt: on
@@ -5129,7 +5049,6 @@ gi|296147        60 MSF*LLKTMYSFQYLNGFITSMANG*ISSFRFGR*RTQFCFKLPLHGVKPSSVHGH 116
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0, 116],
                               [  0, 116]])
                     # fmt: on
@@ -5217,7 +5136,6 @@ gi|296147        60 PFRVGLPIKEC*NDDPGNAMPTGTVNRSIYSSKPAV*NFGCLH*GYSSRDGDSIKS 116
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0, 116],
                               [  0, 116]])
                     # fmt: on
@@ -5305,7 +5223,6 @@ gi|296147        60 GCLSSSSKLCTLFNISMDLSLAWRMVEFLLFDSEDKERNSASSCLCMESNPPVFMA 116
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0, 116],
                               [  0, 116]])
                     # fmt: on
@@ -5393,7 +5310,6 @@ gi|296147        60 PRSRLSEILDAFIEATHLAMEIQLK 85
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  85],
                               [  0,  85]])
                     # fmt: on
@@ -5477,7 +5393,6 @@ gi|296147         0 MAMNTGGFDSMQRQ 14
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[ 0, 14],
                               [ 0, 14]])
                     # fmt: on
@@ -5559,7 +5474,6 @@ gi|296147        60 PRSRLSEILDAFIEATHLAMEIQLK 85
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  85],
                               [  0,  85]])
                     # fmt: on
@@ -5640,7 +5554,6 @@ gi|296147         0 FRIEKKKFNHSPC* 14
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[ 0, 14],
                               [ 0, 14]])
                     # fmt: on
@@ -5715,7 +5628,6 @@ gi|296147         0 TFN*ISIAR*VASMKASKISDSRLRGIDGTVDSPCRHCIARVVILAFLDWQANTK 55
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  55],
                               [  0,  55]])
                     # fmt: on
@@ -5796,7 +5708,6 @@ gi|296147         0 LFNISMDLSLAWRMVEFLLFDSEDKERNSASSCLCMESN 39
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  39],
                               [  0,  39]])
                     # fmt: on
@@ -5879,7 +5790,6 @@ gi|296147        60 *RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K 103
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0, 103],
                               [  0, 103]])
                     # fmt: on
@@ -5964,7 +5874,6 @@ gi|296147        60 FRFGR 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -6049,7 +5958,6 @@ gi|296147        60 PRSRLSEILDAFIEATHLAMEIQLK 85
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  85],
                               [  0,  85]])
                     # fmt: on
@@ -6130,7 +6038,6 @@ gi|296147         0 TFN*ISIAR*VASMKASKISDSRLRGIDGTVDSPCRHCIARVVILAFLDWQANT 54
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  54],
                               [  0,  54]])
                     # fmt: on
@@ -6211,7 +6118,6 @@ gi|296147         0 LFNISMDLSLAWRMVEFLLFDSEDKERNSASSC 33
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  33],
                               [  0,  33]])
                     # fmt: on
@@ -6290,7 +6196,6 @@ gi|296147        60 SF*LLKTMYSFQYLNGFITSMANG*ISSFRFGR*RTQFCFKLPLHGVKPSSVHGH 115
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0, 115],
                               [  0, 115]])
                     # fmt: on
@@ -6375,7 +6280,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEIQLK 84
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  84],
                               [  0,  84]])
                     # fmt: on
@@ -6456,7 +6360,6 @@ gi|296147         0 TFN*ISIAR*VASMKASKISDSRLRGIDGTVDSPCRHCIARVVILAFLDWQANTK 55
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  55],
                               [  0,  55]])
                     # fmt: on
@@ -6541,7 +6444,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEIQLK 84
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  84],
                               [  0,  84]])
                     # fmt: on
@@ -6622,7 +6524,6 @@ gi|296147         0 TFN*ISIAR*VASMKASKISDSRLRGIDGTVDSPCRHCIARVVILAFLD 49
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  49],
                               [  0,  49]])
                     # fmt: on
@@ -6702,7 +6603,6 @@ gi|296147         0 TLFNISMDLSLAWRMVEFLLFDSEDKERNSASSCLCMESNPP 42
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  42],
                               [  0,  42]])
                     # fmt: on
@@ -6785,7 +6685,6 @@ gi|296147        60 GNAMPTGTVNRSIYSSKPAV*NFGCLH*GYSSRDGDSIK 99
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  99],
                               [  0,  99]])
                     # fmt: on
@@ -6870,7 +6769,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEIQLK 84
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  84],
                               [  0,  84]])
                     # fmt: on
@@ -6955,7 +6853,6 @@ gi|296147        60 SLSCWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWMPSLRLLISRWRFN*K 116
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0, 116],
                               [  0, 116]])
                     # fmt: on
@@ -7040,7 +6937,6 @@ gi|296147        60 MSF*LLKTMYSFQYLNGFITSMANG*ISSFRFGR*RTQFCFKLPLHGVKPSSVHGH 116
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0, 116],
                               [  0, 116]])
                     # fmt: on
@@ -7121,7 +7017,6 @@ gi|296147         0 TFN*ISIAR*VASMKASKISDSRLRGIDGTVDSPCRHCIARVVILAF 47
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  47],
                               [  0,  47]])
                     # fmt: on
@@ -7204,7 +7099,6 @@ gi|296147        60
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  60],
                               [  0,  60]])
                     # fmt: on
@@ -7289,7 +7183,6 @@ gi|296147        60 *NDDPGNAMPTGTVNRSIYSSKPAV*NFGCLH*GYSSRDGDSIKS 105
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0, 105],
                               [  0, 105]])
                     # fmt: on
@@ -7370,7 +7263,6 @@ gi|296147         0 TLFNISMDLSLAWRMVEFLLFDSEDKERNSASSC 34
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  34],
                               [  0,  34]])
                     # fmt: on
@@ -7449,7 +7341,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEIQLK 84
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  84],
                               [  0,  84]])
                     # fmt: on
@@ -7534,7 +7425,6 @@ gi|296147        60 GCLSSSSKLCTLFNISMDLSLAWRMVEFLLFDSEDKERNSASSCL 105
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0, 105],
                               [  0, 105]])
                     # fmt: on
@@ -7619,7 +7509,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEIQLK 84
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  84],
                               [  0,  84]])
                     # fmt: on
@@ -7704,7 +7593,6 @@ gi|296147        60 GCLSSSSKLCTLFNISMDLSLAWRMVEFLLFDSEDKERNSASSCLCMESN 110
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0, 110],
                               [  0, 110]])
                     # fmt: on
@@ -7789,7 +7677,6 @@ gi|296147        60 MSF*LLKTMYSFQYLNGFITSMANG*ISSFRFGR*RTQFCFKLP 104
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0, 104],
                               [  0, 104]])
                     # fmt: on
@@ -7874,7 +7761,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEIQLK 84
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  84],
                               [  0,  84]])
                     # fmt: on
@@ -7955,7 +7841,6 @@ gi|296147         0 TFN*ISIAR*VASMKASKISDSRLRGIDGTVDSPCRHCIARVVILAFL 48
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  48],
                               [  0,  48]])
                     # fmt: on
@@ -8034,7 +7919,6 @@ gi|296147         0 LFNISMDLSLAWRMVEFLLFDSEDKERNSASSCL 34
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  34],
                               [  0,  34]])
                     # fmt: on
@@ -8113,7 +7997,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEIQLK 84
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  84],
                               [  0,  84]])
                     # fmt: on
@@ -8194,7 +8077,6 @@ gi|296147         0 TFN*ISIAR*VASMKASKISDSRLRGIDGTVDSPCRHCIARVVILAFLDWQANTK 55
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  55],
                               [  0,  55]])
                     # fmt: on
@@ -8275,7 +8157,6 @@ gi|296147         0 LFNISMDLSLAWRMVEFLLFDSEDK 25
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  25],
                               [  0,  25]])
                     # fmt: on
@@ -8354,7 +8235,6 @@ gi|296147        60
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  60],
                               [  0,  60]])
                     # fmt: on
@@ -8439,7 +8319,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEIQLK 84
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  84],
                               [  0,  84]])
                     # fmt: on
@@ -8520,7 +8399,6 @@ gi|296147         0 TFN*ISIAR*VASMKASKISDSRLRGIDGTVDSPCRHCIARVVILAFLDWQANTK 55
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  55],
                               [  0,  55]])
                     # fmt: on
@@ -8601,7 +8479,6 @@ gi|296147         0 TLFNISMDLSLAWRMVEFLLFDSED 25
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  25],
                               [  0,  25]])
                     # fmt: on
@@ -8680,7 +8557,6 @@ gi|296147        60 FGR*RTQFCFKL 72
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  72],
                               [  0,  72]])
                     # fmt: on
@@ -8761,7 +8637,6 @@ gi|296147         0 *HSLIGKPTRKGVRNPDVFLAPQNYVLFSISQWIYH*HGEWLNFFFSIRK 50
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  50],
                               [  0,  50]])
                     # fmt: on
@@ -8846,7 +8721,6 @@ gi|296147        60 TGTVNRSIY 69
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  69],
                               [  0,  69]])
                     # fmt: on
@@ -8931,7 +8805,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEIQLK 84
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  84],
                               [  0,  84]])
                     # fmt: on
@@ -9012,7 +8885,6 @@ gi|296147         0 NPDVFLAPQNYVLFSISQWIYH*HGEWLNFFFSIRKIKNAILLQVAFAWSQTLQ 54
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  54],
                               [  0,  54]])
                     # fmt: on
@@ -9093,7 +8965,6 @@ gi|296147         0 TFN*ISIAR*VASMKASKISDSRLRGIDGTVDSPCRHCIARVVILA 46
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  46],
                               [  0,  46]])
                     # fmt: on
@@ -9176,7 +9047,6 @@ gi|296147        60 TMYSFQYLNGFITSMANG*ISSFRFGR*RTQ 91
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  91],
                               [  0,  91]])
                     # fmt: on
@@ -9257,7 +9127,6 @@ gi|296147         0 QNCVLYLPNRKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRI 42
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[ 0, 42],
                               [ 0, 42]])
                     # fmt: on
@@ -9340,7 +9209,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEIQLK 84
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  84],
                               [  0,  84]])
                     # fmt: on
@@ -9421,7 +9289,6 @@ gi|296147         0 TFN*ISIAR*VASMKASKISDSRLRGIDGTVDSPCRHCIARVVILAFLDWQ 51
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  51],
                               [  0,  51]])
                     # fmt: on
@@ -9502,7 +9369,6 @@ gi|296147         0 TLFNISMDLSLAWRMVEFLLFDSEDKERNSASSCL 35
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  35],
                               [  0,  35]])
                     # fmt: on
@@ -9583,7 +9449,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEIQLK 84
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  84],
                               [  0,  84]])
                     # fmt: on
@@ -9668,7 +9533,6 @@ gi|296147        60 ILDAFIEATHLAMEIQLK 78
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  78],
                               [  0,  78]])
                     # fmt: on
@@ -9753,7 +9617,6 @@ gi|296147        60 ILDAFIEATHLAMEIQLK 78
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  78],
                               [  0,  78]])
                     # fmt: on
@@ -9838,7 +9701,6 @@ gi|296147        60 MEIQLK 66
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  66],
                               [  0,  66]])
                     # fmt: on
@@ -9923,7 +9785,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -10008,7 +9869,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -10093,7 +9953,6 @@ gi|296147        60 ILDAFIEATHLAMEIQLK 78
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  78],
                               [  0,  78]])
                     # fmt: on
@@ -10178,7 +10037,6 @@ gi|296147        60 ILDAFIEATHLAMEIQLK 78
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  78],
                               [  0,  78]])
                     # fmt: on
@@ -10263,7 +10121,6 @@ gi|296147        60 ILDAFIEATHLAMEIQLK 78
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  78],
                               [  0,  78]])
                     # fmt: on
@@ -10348,7 +10205,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -10433,7 +10289,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -10518,7 +10373,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -10603,7 +10457,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -10688,7 +10541,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -10773,7 +10625,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -10858,7 +10709,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -10943,7 +10793,6 @@ gi|296147        60 ILDAFIEATHLAMEIQLK 78
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  78],
                               [  0,  78]])
                     # fmt: on
@@ -11028,7 +10877,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -11113,7 +10961,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -11198,7 +11045,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -11283,7 +11129,6 @@ gi|296147        60 ILDAFIEATHLAMEIQLK 78
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  78],
                               [  0,  78]])
                     # fmt: on
@@ -11368,7 +11213,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -11453,7 +11297,6 @@ gi|296147        60 MEIQLK 66
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  66],
                               [  0,  66]])
                     # fmt: on
@@ -11538,7 +11381,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -11623,7 +11465,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -11708,7 +11549,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -11793,7 +11633,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -11878,7 +11717,6 @@ gi|296147        60 EIQLK 65
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  65],
                               [  0,  65]])
                     # fmt: on
@@ -11963,7 +11801,6 @@ gi|296147        60 ILDAFIEATHLAMEIQLK 78
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  78],
                               [  0,  78]])
                     # fmt: on
@@ -12048,7 +11885,6 @@ gi|296147        60 EATHLAMEIQLK 72
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  72],
                               [  0,  72]])
                     # fmt: on
@@ -12133,7 +11969,6 @@ gi|296147        59
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  59],
                               [  0,  59]])
                     # fmt: on
@@ -12214,7 +12049,6 @@ gi|296147         0 PFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 55
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  55],
                               [  0,  55]])
                     # fmt: on
@@ -12295,7 +12129,6 @@ gi|296147         0 KRVHSFEELERHPDFALPFVLACQSRNAKMTTLAM 35
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  35],
                               [  0,  35]])
                     # fmt: on
@@ -12372,7 +12205,6 @@ gi|296147         0 IPRSRLSEILDAFIEATHLAMEIQLK 26
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  26],
                               [  0,  26]])
                     # fmt: on
@@ -12451,7 +12283,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAME 80
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  80],
                               [  0,  80]])
                     # fmt: on
@@ -12536,7 +12367,6 @@ gi|296147        60 ILDAFIEATHLAMEIQLK 78
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  78],
                               [  0,  78]])
                     # fmt: on
@@ -12621,7 +12451,6 @@ gi|296147        60 ILDAFIEATHLAMEIQLK 78
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  78],
                               [  0,  78]])
                     # fmt: on
@@ -12702,7 +12531,6 @@ gi|296147         0 ACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 51
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  51],
                               [  0,  51]])
                     # fmt: on
@@ -12787,7 +12615,6 @@ gi|296147        60 ILDAFIEATHLAMEIQLK 78
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  78],
                               [  0,  78]])
                     # fmt: on
@@ -12868,7 +12695,6 @@ gi|296147         0 PFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 55
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  55],
                               [  0,  55]])
                     # fmt: on
@@ -12949,7 +12775,6 @@ gi|296147         0 CVLYLPNRKEEIQPFAM 17
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[ 0, 17],
                               [ 0, 17]])
                     # fmt: on
@@ -13028,7 +12853,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAME 80
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  80],
                               [  0,  80]])
                     # fmt: on
@@ -13113,7 +12937,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEI 81
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  81],
                               [  0,  81]])
                     # fmt: on
@@ -13198,7 +13021,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEI 81
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  81],
                               [  0,  81]])
                     # fmt: on
@@ -13279,7 +13101,6 @@ gi|296147         0 ALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 57
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  57],
                               [  0,  57]])
                     # fmt: on
@@ -13364,7 +13185,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAME 80
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  80],
                               [  0,  80]])
                     # fmt: on
@@ -13449,7 +13269,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAME 80
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  80],
                               [  0,  80]])
                     # fmt: on
@@ -13534,7 +13353,6 @@ gi|296147        60 PRSRLSEIL 69
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  69],
                               [  0,  69]])
                     # fmt: on
@@ -13619,7 +13437,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAME 80
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  80],
                               [  0,  80]])
                     # fmt: on
@@ -13704,7 +13521,6 @@ gi|296147        60 RSRLSEILDAFIEATHLA 78
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  78],
                               [  0,  78]])
                     # fmt: on
@@ -13789,7 +13605,6 @@ gi|296147        60 RSRLSEILDAFIEA 74
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  74],
                               [  0,  74]])
                     # fmt: on
@@ -13870,7 +13685,6 @@ gi|296147         0 ELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEIL 49
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  49],
                               [  0,  49]])
                     # fmt: on
@@ -13954,7 +13768,6 @@ gi|296147        60 PRSRLSEILDAFIEATHLAMEI 82
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  82],
                               [  0,  82]])
                     # fmt: on
@@ -14035,7 +13848,6 @@ gi|296147         0 PFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 55
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  55],
                               [  0,  55]])
                     # fmt: on
@@ -14120,7 +13932,6 @@ gi|296147        59
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  59],
                               [  0,  59]])
                     # fmt: on
@@ -14205,7 +14016,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAME 80
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  80],
                               [  0,  80]])
                     # fmt: on
@@ -14290,7 +14100,6 @@ gi|296147        60 RSRLSEIL 68
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  68],
                               [  0,  68]])
                     # fmt: on
@@ -14375,7 +14184,6 @@ gi|296147        60 RSRLSEILDAFIEATHLAMEI 81
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  81],
                               [  0,  81]])
                     # fmt: on
@@ -14460,7 +14268,6 @@ gi|296147        60 RSRLSEIL 68
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  68],
                               [  0,  68]])
                     # fmt: on
@@ -14545,7 +14352,6 @@ gi|296147        60 RSRLSEIL 68
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  68],
                               [  0,  68]])
                     # fmt: on
@@ -14626,7 +14432,6 @@ gi|296147         0 TLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 41
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  41],
                               [  0,  41]])
                     # fmt: on
@@ -14705,7 +14510,6 @@ gi|296147         0 TLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 41
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  41],
                               [  0,  41]])
                     # fmt: on
@@ -14788,7 +14592,6 @@ gi|296147        60 LSEILDAFI 69
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  69],
                               [  0,  69]])
                     # fmt: on
@@ -14869,7 +14672,6 @@ gi|296147         0 VLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEI 50
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  50],
                               [  0,  50]])
                     # fmt: on
@@ -14950,7 +14752,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -15025,7 +14826,6 @@ gi|296147         0 LACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 52
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  52],
                               [  0,  52]])
                     # fmt: on
@@ -15106,7 +14906,6 @@ gi|296147         0 TLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 41
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  41],
                               [  0,  41]])
                     # fmt: on
@@ -15185,7 +14984,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -15260,7 +15058,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -15335,7 +15132,6 @@ gi|296147         0 LQGLSTVPSIPRSRLSEILDAFIEATHLAMEI 32
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  32],
                               [  0,  32]])
                     # fmt: on
@@ -15410,7 +15206,6 @@ gi|296147         0 SIEILKRVHSFEELERH 17
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  17],
                               [  0,  17]])
                     # fmt: on
@@ -15485,7 +15280,6 @@ gi|296147         0 TLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 41
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  41],
                               [  0,  41]])
                     # fmt: on
@@ -15564,7 +15358,6 @@ gi|296147         0 TLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 41
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  41],
                               [  0,  41]])
                     # fmt: on
@@ -15643,7 +15436,6 @@ gi|296147         0 LPFVLACQSRNAKMTTLAMQCLQGL 25
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  25],
                               [  0,  25]])
                     # fmt: on
@@ -15718,7 +15510,6 @@ gi|296147         0 LPFVLACQSRNAKMTTLAMQCLQGL 25
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  25],
                               [  0,  25]])
                     # fmt: on
@@ -15793,7 +15584,6 @@ gi|296147         0 TLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 41
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  41],
                               [  0,  41]])
                     # fmt: on
@@ -15872,7 +15662,6 @@ gi|296147         0 TLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 41
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  41],
                               [  0,  41]])
                     # fmt: on
@@ -15951,7 +15740,6 @@ gi|296147         0 TLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 41
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  41],
                               [  0,  41]])
                     # fmt: on
@@ -16030,7 +15818,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -16109,7 +15896,6 @@ gi|296147        60 RSRLSEIL 68
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  68],
                               [  0,  68]])
                     # fmt: on
@@ -16190,7 +15976,6 @@ gi|296147         0 TLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 41
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  41],
                               [  0,  41]])
                     # fmt: on
@@ -16269,7 +16054,6 @@ gi|296147         0 TLAMQCLQGLSTVPSIPRSRLSEILDAFIEATHLAMEIQLK 41
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  41],
                               [  0,  41]])
                     # fmt: on
@@ -16348,7 +16132,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -16423,7 +16206,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -16498,7 +16280,6 @@ gi|296147         0 LQGLSTVPSIPRSRLSEILDAFIEATHLAMEI 32
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  32],
                               [  0,  32]])
                     # fmt: on
@@ -16573,7 +16354,6 @@ gi|296147         0 KSIEILKRVHSFEELERH 18
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  18],
                               [  0,  18]])
                     # fmt: on
@@ -16648,7 +16428,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -16723,7 +16502,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -16798,7 +16576,6 @@ gi|296147         0 PFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEI 38
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  38],
                               [  0,  38]])
                     # fmt: on
@@ -16877,7 +16654,6 @@ gi|296147         0 AGCLKFWMPSLRLLISRWRF 20
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  20],
                               [  0,  20]])
                     # fmt: on
@@ -16952,7 +16728,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -17027,7 +16802,6 @@ gi|296147         0 EGIQNFRQPASRNRWNG*QSL*ALHCQGRHFSIP*LAS 38
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  38],
                               [  0,  38]])
                     # fmt: on
@@ -17106,7 +16880,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -17181,7 +16954,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -17256,7 +17028,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -17331,7 +17102,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -17406,7 +17176,6 @@ gi|296147         0 AGCLKFWMPSLRLLISRWRF 20
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  20],
                               [  0,  20]])
                     # fmt: on
@@ -17481,7 +17250,6 @@ gi|296147         0 AGCLKFWMPSLRLLISRWRF 20
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  20],
                               [  0,  20]])
                     # fmt: on
@@ -17556,7 +17324,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -17631,7 +17398,6 @@ gi|296147         0 AGCLKFWMPSLRLLISRWRF 20
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  20],
                               [  0,  20]])
                     # fmt: on
@@ -17706,7 +17472,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -17781,7 +17546,6 @@ gi|296147         0 AGCLKFWMPSLRLLISRWRF 20
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  20],
                               [  0,  20]])
                     # fmt: on
@@ -17856,7 +17620,6 @@ gi|296147         0 AGCLKFWMPSLRLLISRWRF 20
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  20],
                               [  0,  20]])
                     # fmt: on
@@ -17931,7 +17694,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -18006,7 +17768,6 @@ gi|296147         0 PWQCNAYRDCQPFHLFLEAGCLKFWMPSL 29
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  29],
                               [  0,  29]])
                     # fmt: on
@@ -18081,7 +17842,6 @@ gi|296147         0 SFEELERHPDFALPFVLACQSRNAKM 26
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  26],
                               [  0,  26]])
                     # fmt: on
@@ -18156,7 +17916,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -18231,7 +17990,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -18306,7 +18064,6 @@ gi|296147         0 DFALPFVLACQSRNAKMTTLAMQCLQGL 28
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  28],
                               [  0,  28]])
                     # fmt: on
@@ -18381,7 +18138,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -18456,7 +18212,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -18531,7 +18286,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -18606,7 +18360,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -18681,7 +18434,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -18756,7 +18508,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -18831,7 +18582,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -18906,7 +18656,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -18981,7 +18730,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -19056,7 +18804,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -19131,7 +18878,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -19206,7 +18952,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -19281,7 +19026,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -19356,7 +19100,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -19431,7 +19174,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -19506,7 +19248,6 @@ gi|296147         0 YVLFSISQWIYH*HGEWLNFFFS 23
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  23],
                               [  0,  23]])
                     # fmt: on
@@ -19581,7 +19322,6 @@ gi|296147         0 GEWLNFFFSIRKIKNAILLQVAFAWSQTLQCSW 33
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  33],
                               [  0,  33]])
                     # fmt: on
@@ -19656,7 +19396,6 @@ gi|296147         0 CQPFHLFLEAGCLKFWMPSLRLL 23
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  23],
                               [  0,  23]])
                     # fmt: on
@@ -19731,7 +19470,6 @@ gi|296147         0 RNAKMTTLAMQCLQGLSTVPSI 22
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  22],
                               [  0,  22]])
                     # fmt: on
@@ -19806,7 +19544,6 @@ gi|296147         0 CQPFHLFLEAGCLKFWMPSLRLL 23
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  23],
                               [  0,  23]])
                     # fmt: on
@@ -19881,7 +19618,6 @@ gi|296147         0 RNAKMTTLAMQCLQGLSTVPSI 22
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  22],
                               [  0,  22]])
                     # fmt: on
@@ -19956,7 +19692,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -20031,7 +19766,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -20106,7 +19840,6 @@ gi|296147         0 FVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSE 36
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  36],
                               [  0,  36]])
                     # fmt: on
@@ -20185,7 +19918,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -20260,7 +19992,6 @@ gi|296147         0 RKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSL 37
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  37],
                               [  0,  37]])
                     # fmt: on
@@ -20339,7 +20070,6 @@ gi|296147         0 RKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSL 37
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  37],
                               [  0,  37]])
                     # fmt: on
@@ -20418,7 +20148,6 @@ gi|296147         0 RKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSL 37
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  37],
                               [  0,  37]])
                     # fmt: on
@@ -20497,7 +20226,6 @@ gi|296147         0 RKEEIQPFAMLVINPLRY*KEYIVLRS*KDIRISHSL 37
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  37],
                               [  0,  37]])
                     # fmt: on
@@ -20576,7 +20304,6 @@ gi|296147         0 CWLANQGMLK*RPWQCNAYRDCQPFHLFLEAGCLKFWM 38
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  38],
                               [  0,  38]])
                     # fmt: on
@@ -20655,7 +20382,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -20730,7 +20456,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -20805,7 +20530,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -20880,7 +20604,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -20955,7 +20678,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -21030,7 +20752,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -21105,7 +20826,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -21180,7 +20900,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -21255,7 +20974,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -21330,7 +21048,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -21405,7 +21122,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -21480,7 +21196,6 @@ gi|296147         0 AGCLKFWMPSLRLLISRWRF 20
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  20],
                               [  0,  20]])
                     # fmt: on
@@ -21555,7 +21270,6 @@ gi|296147         0 AGCLKFWMPSLRLLISRWRF 20
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  20],
                               [  0,  20]])
                     # fmt: on
@@ -21630,7 +21344,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -21705,7 +21418,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -21780,7 +21492,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -21855,7 +21566,6 @@ gi|296147         0 AGCLKFWMPSLRLLISRWRF 20
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  20],
                               [  0,  20]])
                     # fmt: on
@@ -21930,7 +21640,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22005,7 +21714,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22080,7 +21788,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22155,7 +21862,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22230,7 +21936,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22305,7 +22010,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22380,7 +22084,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22455,7 +22158,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22530,7 +22232,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22605,7 +22306,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22680,7 +22380,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22755,7 +22454,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22830,7 +22528,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22905,7 +22602,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -22980,7 +22676,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -23055,7 +22750,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -23133,7 +22827,6 @@ gi|296147         0 RVHSFEELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEIL 55
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  55],
                               [  0,  55]])
                     # fmt: on
@@ -23214,7 +22907,6 @@ gi|296147         0 RVHSFEELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEIL 55
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  55],
                               [  0,  55]])
                     # fmt: on
@@ -23295,7 +22987,6 @@ gi|296147         0 RVHSFEELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEIL 55
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  55],
                               [  0,  55]])
                     # fmt: on
@@ -23376,7 +23067,6 @@ gi|296147         0 RVHSFEELERHPDFALPFVLACQSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEIL 55
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  55],
                               [  0,  55]])
                     # fmt: on
@@ -23457,7 +23147,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -23532,7 +23221,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -23607,7 +23295,6 @@ gi|296147         0 NISMDLSLAWRMVEFLLFDSEDKERNSASSCLCMESNPPVFMA 43
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  43],
                               [  0,  43]])
                     # fmt: on
@@ -23686,7 +23373,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -23761,7 +23447,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -23836,7 +23521,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -23911,7 +23595,6 @@ gi|296147         0 FALPFVLACQSRNAKMTTLAMQCLQGL 27
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  27],
                               [  0,  27]])
                     # fmt: on
@@ -23986,7 +23669,6 @@ gi|296147         0 QSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFI 37
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  37],
                               [  0,  37]])
                     # fmt: on
@@ -24065,7 +23747,6 @@ gi|296147         0 QSRNAKMTTLAMQCLQGLSTVPSIPRSRLSEILDAFI 37
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  37],
                               [  0,  37]])
                     # fmt: on
@@ -24144,7 +23825,6 @@ gi|296147         0 HSLIGKPTRKGVRNPDVFLAPQNYVLFSIS 30
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  30],
                               [  0,  30]])
                     # fmt: on
@@ -24219,7 +23899,6 @@ gi|296147         0 LFNISMDLSLAWRMVEFLLFDSEDKERNSASSCLCMES 38
                 np.array_equal(
                     alignment.coordinates,
                     # fmt: off
-# flake8: noqa
                     np.array([[  0,  38],
                               [  0,  38]])
                     # fmt: on

--- a/Tests/test_pairwise_alignment_map.py
+++ b/Tests/test_pairwise_alignment_map.py
@@ -919,7 +919,6 @@ $"""
         self.assertRegex(str(alignment).replace("|", ":").replace(".", "X"), text)
         lifted_alignment = chain.map(alignment)
         # fmt: off
-# flake8: noqa
         self.assertTrue(
             np.array_equal(lifted_alignment.coordinates,
                            np.array([[111982717, 111982775, 111987921,


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This means we can bend/ignore the flake8 whitespace rules where we are already opting out of black formatting - typically np.array layouts with aligned columns.