### PR TITLE
Allow Entrez.parse("myfilename")

### DIFF
--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -394,7 +394,7 @@ class DataHandler(metaclass=DataHandlerMeta):
         except TypeError:  # not a path, assume we received a stream
             if source.read(0) != b"":
                 raise StreamModeError(
-                    f"the XML file must be opened in binary mode."
+                    "the XML file must be opened in binary mode."
                 ) from None
             stream = source
         if stream.read(0) != b"":
@@ -454,7 +454,7 @@ class DataHandler(metaclass=DataHandlerMeta):
         except TypeError:  # not a path, assume we received a stream
             if source.read(0) != b"":
                 raise StreamModeError(
-                    f"the XML file must be opened in binary mode."
+                    "the XML file must be opened in binary mode."
                 ) from None
             stream = source
         if stream.read(0) != b"":

--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -48,6 +48,8 @@ from xml.sax.saxutils import escape
 from urllib.request import urlopen
 from urllib.parse import urlparse
 
+from Bio import StreamModeError
+
 
 # The following four classes are used to add a member .attributes to integers,
 # strings, lists, and dictionaries, respectively.
@@ -383,14 +385,22 @@ class DataHandler(metaclass=DataHandlerMeta):
         else:
             self.characterDataHandler = self.characterDataHandlerRaw
 
-    def read(self, handle):
-        """Set up the parser and let it parse the XML results."""
+    def read(self, source):
+        """Set up the parser and let it read the XML results."""
         # Expat's parser.ParseFile function only accepts binary data;
         # see also the comment below for Entrez.parse.
-        if handle.read(0) != b"":
+        try:
+            stream = open(source, "rb")
+        except TypeError:  # not a path, assume we received a stream
+            if source.read(0) != b"":
+                raise StreamModeError(
+                    f"the XML file must be opened in binary mode."
+                ) from None
+            stream = source
+        if stream.read(0) != b"":
             raise TypeError("file should be opened in binary mode")
         try:
-            self.parser.ParseFile(handle)
+            self.parser.ParseFile(stream)
         except expat.ExpatError as e:
             if self.parser.StartElementHandler:
                 # We saw the initial <!xml declaration, so we can be sure that
@@ -401,6 +411,9 @@ class DataHandler(metaclass=DataHandlerMeta):
                 # We have not seen the initial <!xml declaration, so probably
                 # the input data is not in XML format.
                 raise NotXMLError(e) from None
+        finally:
+            if stream is not source:
+                stream.close()
         try:
             record = self.record
         except AttributeError:
@@ -421,71 +434,83 @@ class DataHandler(metaclass=DataHandlerMeta):
             del record.key
             return record
 
-    def parse(self, handle):
-        """Parse the XML in the given file handle."""
-        # The handle should have been opened in binary mode; data read from
-        # the handle are then bytes. Expat will pick up the encoding from the
-        # XML declaration (or assume UTF-8 if it is missing), and use this
-        # encoding to convert the binary data to a string before giving it to
-        # characterDataHandler.
+    def parse(self, source):
+        """Set up the parser and let it read the XML results."""
+        # The source must be a filename, or a file-like object opened in binary
+        # mode. Data read from the file or file-like object as bytes. Expat will
+        # pick up the encoding from the XML declaration (or assume UTF-8 if it
+        # is missing), and use this encoding to convert the binary data to a
+        # string before giving it to characterDataHandler.
         # While parser.ParseFile only accepts binary data, parser.Parse accepts
         # both binary data and strings. However, a file in text mode may have
         # been opened with an encoding different from the encoding specified in
         # the XML declaration at the top of the file. If so, the data in the
         # file will have been decoded with an incorrect encoding. To avoid
         # this, and to be consistent with parser.ParseFile (which is used in
-        # the Entrez.read function above), we require the handle to be in
+        # the Entrez.read function above), we require the source data to be in
         # binary mode here as well.
-        if handle.read(0) != b"":
+        try:
+            stream = open(source, "rb")
+        except TypeError:  # not a path, assume we received a stream
+            if source.read(0) != b"":
+                raise StreamModeError(
+                    f"the XML file must be opened in binary mode."
+                ) from None
+            stream = source
+        if stream.read(0) != b"":
             raise TypeError("file should be opened in binary mode")
         BLOCK = 1024
-        while True:
-            # Read in another block of data from the file.
-            data = handle.read(BLOCK)
-            try:
+        try:
+            while True:
+                # Read in another block of data from the file.
+                data = stream.read(BLOCK)
                 self.parser.Parse(data, False)
-            except expat.ExpatError as e:
-                if self.parser.StartElementHandler:
-                    # We saw the initial <!xml declaration, so we can be sure
-                    # that we are parsing XML data. Most likely, the XML file
-                    # is corrupted.
-                    raise CorruptedXMLError(e) from None
-                else:
-                    # We have not seen the initial <!xml declaration, so
-                    # probably the input data is not in XML format.
-                    raise NotXMLError(e) from None
-            try:
-                records = self.record
-            except AttributeError:
-                if self.parser.StartElementHandler:
-                    # We saw the initial <!xml declaration, and expat
-                    # didn't notice any errors, so self.record should be
-                    # defined. If not, this is a bug.
+                try:
+                    records = self.record
+                except AttributeError:
+                    if self.parser.StartElementHandler:
+                        # We saw the initial <!xml declaration, and expat
+                        # didn't notice any errors, so self.record should be
+                        # defined. If not, this is a bug.
 
-                    raise RuntimeError(
-                        "Failed to parse the XML file correctly, possibly due to a "
-                        "bug in Bio.Entrez. Please contact the Biopython "
-                        "developers via the mailing list or GitHub for assistance."
-                    ) from None
-                else:
-                    # We did not see the initial <!xml declaration, so
-                    # probably the input data is not in XML format.
-                    raise NotXMLError("XML declaration not found") from None
+                        raise RuntimeError(
+                            "Failed to parse the XML file correctly, possibly due to a "
+                            "bug in Bio.Entrez. Please contact the Biopython "
+                            "developers via the mailing list or GitHub for assistance."
+                        ) from None
+                    else:
+                        # We did not see the initial <!xml declaration, so
+                        # probably the input data is not in XML format.
+                        raise NotXMLError("XML declaration not found") from None
 
-            if not isinstance(records, list):
-                raise ValueError(
-                    "The XML file does not represent a list. Please use Entrez.read "
-                    "instead of Entrez.parse"
-                )
+                if not isinstance(records, list):
+                    raise ValueError(
+                        "The XML file does not represent a list. Please use "
+                        "Entrez.read instead of Entrez.parse."
+                    )
 
-            if not data:
-                break
+                if not data:
+                    break
 
-            while len(records) >= 2:
-                # Then the first record is finished, while the second record
-                # is still a work in progress.
-                record = records.pop(0)
-                yield record
+                while len(records) >= 2:
+                    # Then the first record is finished, while the second record
+                    # is still a work in progress.
+                    record = records.pop(0)
+                    yield record
+
+        except expat.ExpatError as e:
+            if self.parser.StartElementHandler:
+                # We saw the initial <!xml declaration, so we can be sure
+                # that we are parsing XML data. Most likely, the XML file
+                # is corrupted.
+                raise CorruptedXMLError(e) from None
+            else:
+                # We have not seen the initial <!xml declaration, so
+                # probably the input data is not in XML format.
+                raise NotXMLError(e) from None
+        finally:
+            if stream is not source:
+                stream.close()
 
         # We have reached the end of the XML file
         self.parser = None

--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -460,7 +460,7 @@ def ecitmatch(**keywds):
     return _open(request)
 
 
-def read(handle, validate=True, escape=False, ignore_errors=False):
+def read(source, validate=True, escape=False, ignore_errors=False):
     """Parse an XML file from the NCBI Entrez Utilities into python objects.
 
     This function parses an XML file created by NCBI's Entrez Utilities,
@@ -469,18 +469,28 @@ def read(handle, validate=True, escape=False, ignore_errors=False):
     this function, provided its DTD is available. Biopython includes the
     DTDs for most commonly used Entrez Utilities.
 
-    The handle must be in binary mode. This allows the parser to detect the
-    encoding from the XML file, and to use it to convert all text in the XML
-    to the correct Unicode string. The functions in Bio.Entrez to access NCBI
-    Entrez will automatically return XML data in binary mode. For files,
-    please use mode "rb" when opening the file, as in
+    The argument ``source`` must be a file or file-like object opened in binary
+    mode, or a filename. The parser detects the encoding from the XML file, and
+    uses it to convert all text in the XML to the correct Unicode string. The
+    functions in Bio.Entrez to access NCBI Entrez will automatically return XML
+    data in binary mode. For files, use mode "rb" when opening the file, as in
 
         >>> from Bio import Entrez
-        >>> handle = open("Entrez/esearch1.xml", "rb")  # opened in binary mode
-        >>> record = Entrez.read(handle)
+        >>> path = "Entrez/esearch1.xml"
+        >>> stream = open(path, "rb")  # opened in binary mode
+        >>> record = Entrez.read(stream)
         >>> print(record['QueryTranslation'])
         biopython[All Fields]
-        >>> handle.close()
+        >>> stream.close()
+
+    Alternatively, you can use the filename directly, as in
+
+        >>> record = Entrez.read(path)
+        >>> print(record['QueryTranslation'])
+        biopython[All Fields]
+
+    which is safer, as the file stream will automatically be closed after the
+    record has been read, or if an error occurs.
 
     If validate is True (default), the parser will validate the XML file
     against the DTD, and raise an error if the XML file contains tags that
@@ -505,11 +515,11 @@ def read(handle, validate=True, escape=False, ignore_errors=False):
     from .Parser import DataHandler
 
     handler = DataHandler(validate, escape, ignore_errors)
-    record = handler.read(handle)
+    record = handler.read(source)
     return record
 
 
-def parse(handle, validate=True, escape=False, ignore_errors=False):
+def parse(source, validate=True, escape=False, ignore_errors=False):
     """Parse an XML file from the NCBI Entrez Utilities into python objects.
 
     This function parses an XML file created by NCBI's Entrez Utilities,
@@ -524,21 +534,34 @@ def parse(handle, validate=True, escape=False, ignore_errors=False):
     this function, provided its DTD is available. Biopython includes the
     DTDs for most commonly used Entrez Utilities.
 
-    The handle must be in binary mode. This allows the parser to detect the
-    encoding from the XML file, and to use it to convert all text in the XML
-    to the correct Unicode string. The functions in Bio.Entrez to access NCBI
-    Entrez will automatically return XML data in binary mode. For files,
-    please use mode "rb" when opening the file, as in
+    The argument ``source`` must be a file or file-like object opened in binary
+    mode, or a filename. The parser detects the encoding from the XML file, and
+    uses it to convert all text in the XML to the correct Unicode string. The
+    functions in Bio.Entrez to access NCBI Entrez will automatically return XML
+    data in binary mode. For files, use mode "rb" when opening the file, as in
 
         >>> from Bio import Entrez
-        >>> handle = open("Entrez/pubmed1.xml", "rb")  # opened in binary mode
-        >>> records = Entrez.parse(handle)
+        >>> path = "Entrez/pubmed1.xml"
+        >>> stream = open(path, "rb")  # opened in binary mode
+        >>> records = Entrez.parse(stream)
         >>> for record in records:
         ...     print(record['MedlineCitation']['Article']['Journal']['Title'])
         ...
         Social justice (San Francisco, Calif.)
         Biochimica et biophysica acta
-        >>> handle.close()
+        >>> stream.close()
+
+    Alternatively, you can use the filename directly, as in
+
+        >>> records = Entrez.parse(path)
+        >>> for record in records:
+        ...     print(record['MedlineCitation']['Article']['Journal']['Title'])
+        ...
+        Social justice (San Francisco, Calif.)
+        Biochimica et biophysica acta
+
+    which is safer, as the file stream will automatically be closed after all
+    the records have been read, or if an error occurs.
 
     If validate is True (default), the parser will validate the XML file
     against the DTD, and raise an error if the XML file contains tags that
@@ -563,7 +586,7 @@ def parse(handle, validate=True, escape=False, ignore_errors=False):
     from .Parser import DataHandler
 
     handler = DataHandler(validate, escape, ignore_errors)
-    records = handler.parse(handle)
+    records = handler.parse(source)
     return records
 
 

--- a/Doc/Tutorial/chapter_entrez.tex
+++ b/Doc/Tutorial/chapter_entrez.tex
@@ -12,7 +12,7 @@ The output returned by the Entrez Programming Utilities is typically in XML form
   \item Use one of the XML parsers available in Python's standard library;
   \item Read the XML output as raw text, and parse it by string searching and manipulation.
 \end{enumerate}
-See the Python documentation for a description of the XML parsers in Python's standard library. Here, we discuss the parser in Biopython's \verb+Bio.Entrez+ module. This parser can be used to parse data as provided through \verb+Bio.Entrez+'s programmatic access functions to Entrez, but can also be used to parse XML data from NCBI Entrez that are stored in a file. In the latter case, the XML file should be opened in binary mode (e.g. \verb+open("myfile.xml", "rb")+) for the XML parser in \verb+Bio.Entrez+ to work correctly.
+See the Python documentation for a description of the XML parsers in Python's standard library. Here, we discuss the parser in Biopython's \verb+Bio.Entrez+ module. This parser can be used to parse data as provided through \verb+Bio.Entrez+'s programmatic access functions to Entrez, but can also be used to parse XML data from NCBI Entrez that are stored in a file. In the latter case, the XML file should be opened in binary mode (e.g. \verb+open("myfile.xml", "rb")+) for the XML parser in \verb+Bio.Entrez+ to work correctly. Alternatively, you can pass the file name or path to the XML file, and let \verb+Bio.Entrez+ take care of opening and closing the file.
 
 NCBI uses DTD (Document Type Definition) files to describe the structure of the information contained in XML files. Most of the DTD files used by NCBI are included in the Biopython distribution. The \verb+Bio.Entrez+ parser makes use of the DTD files when parsing an XML file returned by NCBI Entrez.
 
@@ -71,9 +71,9 @@ EInfo provides field index term counts, last update, and available links for eac
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.einfo()
->>> result = handle.read()
->>> handle.close()
+>>> stream = Entrez.einfo()
+>>> result = stream.read()
+>>> stream.close()
 \end{minted}
 The variable \verb+result+ now contains a list of databases in XML format:
 \begin{minted}{pycon}
@@ -129,8 +129,8 @@ Since this is a fairly simple XML file, we could extract the information it cont
 %doctest . internet
 \begin{minted}{pycon}
 >>> from Bio import Entrez
->>> handle = Entrez.einfo()
->>> record = Entrez.read(handle)
+>>> stream = Entrez.einfo()
+>>> record = Entrez.read(stream)
 \end{minted}
 Now \verb+record+ is a dictionary with exactly one key:
 %cont-doctest
@@ -156,8 +156,8 @@ For each of these databases, we can use EInfo again to obtain more information:
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.einfo(db="pubmed")
->>> record = Entrez.read(handle)
+>>> stream = Entrez.einfo(db="pubmed")
+>>> record = Entrez.read(stream)
 >>> record["DbInfo"]["Description"]
 'PubMed bibliographic record'
 \end{minted}
@@ -203,8 +203,8 @@ To search any of these databases, we use \verb+Bio.Entrez.esearch()+. For exampl
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.esearch(db="pubmed", term="biopython[title]", retmax="40")
->>> record = Entrez.read(handle)
+>>> stream = Entrez.esearch(db="pubmed", term="biopython[title]", retmax="40")
+>>> record = Entrez.read(stream)
 >>> "19304878" in record["IdList"]
 True
 \end{minted}
@@ -222,10 +222,10 @@ find out which fields you can search in each Entrez database):
 
 % Search results too changeable for use in doctest
 \begin{minted}{pycon}
->>> handle = Entrez.esearch(
+>>> stream = Entrez.esearch(
 ...     db="nucleotide", term="Cypripedioideae[Orgn] AND matK[Gene]", idtype="acc"
 ... )
->>> record = Entrez.read(handle)
+>>> record = Entrez.read(stream)
 >>> record["Count"]
 '348'
 >>> record["IdList"]
@@ -239,8 +239,8 @@ Note that instead of a species name like \texttt{Cypripedioideae[Orgn]}, you can
 
 As a final example, let's get a list of computational journal titles:
 \begin{minted}{pycon}
->>> handle = Entrez.esearch(db="nlmcatalog", term="computational[Journal]", retmax="20")
->>> record = Entrez.read(handle)
+>>> stream = Entrez.esearch(db="nlmcatalog", term="computational[Journal]", retmax="20")
+>>> record = Entrez.read(stream)
 >>> print("{} computational journals found".format(record["Count"]))
 117 computational Journals found
 >>> print("The first 20 are\n{}".format(record["IdList"]))
@@ -305,8 +305,8 @@ ESummary retrieves document summaries from a list of primary IDs (see the  \href
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.esummary(db="nlmcatalog", id="101660833")
->>> record = Entrez.read(handle)
+>>> stream = Entrez.esummary(db="nlmcatalog", id="101660833")
+>>> record = Entrez.read(stream)
 >>> info = record[0]["TitleMainList"][0]
 >>> print("Journal info\nid: {}\nTitle: {}".format(record[0]["Id"], info["Title"]))
 Journal info
@@ -328,8 +328,8 @@ One common usage is downloading sequences in the FASTA or GenBank/GenPept plain 
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.efetch(db="nucleotide", id="EU490707", rettype="gb", retmode="text")
->>> print(handle.read())
+>>> stream = Entrez.efetch(db="nucleotide", id="EU490707", rettype="gb", retmode="text")
+>>> print(stream.read())
 LOCUS       EU490707                1302 bp    DNA     linear   PLN 26-JUL-2016
 DEFINITION  Selenipedium aequinoctiale maturase K (matK) gene, partial cds;
             chloroplast.
@@ -423,9 +423,9 @@ If you fetch the record in one of the formats accepted by \verb+Bio.SeqIO+ (see 
 >>> from Bio import SeqIO
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.efetch(db="nucleotide", id="EU490707", rettype="gb", retmode="text")
->>> record = SeqIO.read(handle, "genbank")
->>> handle.close()
+>>> stream = Entrez.efetch(db="nucleotide", id="EU490707", rettype="gb", retmode="text")
+>>> record = SeqIO.read(stream, "genbank")
+>>> stream.close()
 >>> print(record.id)
 EU490707.1
 >>> print(record.name)
@@ -449,13 +449,11 @@ Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
 filename = "EU490707.gbk"
 if not os.path.isfile(filename):
     # Downloading...
-    net_handle = Entrez.efetch(
-        db="nucleotide", id="EU490707", rettype="gb", retmode="text"
-    )
-    out_handle = open(filename, "w")
-    out_handle.write(net_handle.read())
-    out_handle.close()
-    net_handle.close()
+    stream = Entrez.efetch(db="nucleotide", id="EU490707", rettype="gb", retmode="text")
+    output = open(filename, "w")
+    output.write(streame.read())
+    output.close()
+    stream.close()
     print("Saved")
 
 print("Parsing...")
@@ -469,9 +467,9 @@ To get the output in XML format, which you can parse using the \verb+Bio.Entrez.
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.efetch(db="nucleotide", id="EU490707", retmode="xml")
->>> record = Entrez.read(handle)
->>> handle.close()
+>>> stream = Entrez.efetch(db="nucleotide", id="EU490707", retmode="xml")
+>>> record = Entrez.read(stream)
+>>> stream.close()
 >>> record[0]["GBSeq_definition"]
 'Selenipedium aequinoctiale maturase K (matK) gene, partial cds; chloroplast'
 >>> record[0]["GBSeq_source"]
@@ -575,8 +573,8 @@ In this example, we use \verb+Bio.Entrez.egquery()+ to obtain the counts for ``B
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.egquery(term="biopython")
->>> record = Entrez.read(handle)
+>>> stream = Entrez.egquery(term="biopython")
+>>> record = Entrez.read(stream)
 >>> for row in record["eGQueryResult"]:
 ...     print(row["DbName"], row["Count"])
 ...
@@ -594,8 +592,8 @@ ESpell retrieves spelling suggestions. In this example, we use \verb+Bio.Entrez.
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.espell(term="biopythooon")
->>> record = Entrez.read(handle)
+>>> stream = Entrez.espell(term="biopythooon")
+>>> record = Entrez.read(stream)
 >>> record["Query"]
 'biopythooon'
 >>> record["CorrectedQuery"]
@@ -621,8 +619,15 @@ The XML file \verb+Homo_sapiens.xml+ consists of a list of Entrez gene records, 
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = open("Homo_sapiens.xml", "b")
->>> records = Entrez.parse(handle)
+>>> stream = open("Homo_sapiens.xml", "rb")
+>>> records = Entrez.parse(stream)
+\end{minted}{pycon}
+Alternatively, you can use
+\begin{minted}{pycon}
+>>> records = Entrez.parse("Homo_sapiens.xml")
+\end{minted}{pycon}
+and let \verb+Bio.Entrez+ take care of opening and closing the file. This is safer, as the file will then automatically be closed after parsing it, or if an error occurs.
+\begin{minted}{pycon}
 >>> for record in records:
 ...     status = record["Entrezgene_track-info"]["Gene-track"]["Gene-track_status"]
 ...     if status.attributes["value"] == "discontinued":
@@ -659,7 +664,7 @@ in the XML returned by Entrez, is converted to the Python string
 \end{minted}
 by the \verb+Bio.Entrez+ parser. While this is more human-readable, it is not valid HTML due to the less-than sign, and makes further processing of the text e.g. by an HTML parser impractical. To ensure that all strings returned by the parser are valid HTML, call \verb+Entrez.read+ or \verb+Entrez.parse+ with the \verb+escape+ argument set to \verb+True+:
 \begin{minted}{pycon}
->>> record = Entrez.read(handle, escape=True)
+>>> record = Entrez.read(stream, escape=True)
 \end{minted}
 The parser will then replace all characters disallowed in HTML by their HTML-escaped equivalent; in the example above, the parser will generate
 \begin{minted}{text}
@@ -676,8 +681,8 @@ For example, this error occurs if you try to parse a Fasta file as if it were an
 %doctest ../Tests/GenBank
 \begin{minted}{pycon}
 >>> from Bio import Entrez
->>> handle = open("NC_005816.fna", "rb")  # a Fasta file
->>> record = Entrez.read(handle)
+>>> stream = open("NC_005816.fna", "rb")  # a Fasta file
+>>> record = Entrez.read(stream)
 Traceback (most recent call last):
   ...
 Bio.Entrez.Parser.NotXMLError: Failed to parse the XML data (syntax error: line 1, column 0). Please make sure that the input data are in XML format.
@@ -708,7 +713,7 @@ Here is an example of an XML file that ends prematurely:
 \end{minted}
 which will generate the following traceback:
 \begin{minted}{pycon}
->>> Entrez.read(handle)
+>>> Entrez.read(stream)
 Traceback (most recent call last):
   ...
 Bio.Entrez.Parser.CorruptedXMLError: Failed to parse the XML data (no element found: line 16, column 0). Please make sure that the input data are not corrupted.
@@ -752,8 +757,8 @@ In this file, for some reason the tag \verb|<DocsumList>| (and several others) a
 %doctest ../Tests/Entrez/
 \begin{minted}{pycon}
 >>> from Bio import Entrez
->>> handle = open("einfo3.xml", "rb")
->>> record = Entrez.read(handle)
+>>> stream = open("einfo3.xml", "rb")
+>>> record = Entrez.read(stream)
 Traceback (most recent call last):
   ...
 Bio.Entrez.Parser.ValidationError: Failed to find tag 'DocsumList' in the DTD. To skip all tags that are not represented in the DTD, please call Bio.Entrez.read or Bio.Entrez.parse with validate=False.
@@ -763,9 +768,9 @@ Optionally, you can instruct the parser to skip such tags instead of raising a V
 %doctest ../Tests/Entrez/
 \begin{minted}{pycon}
 >>> from Bio import Entrez
->>> handle = open("einfo3.xml", "rb")
->>> record = Entrez.read(handle, validate=False)
->>> handle.close()
+>>> stream = open("einfo3.xml", "rb")
+>>> record = Entrez.read(stream, validate=False)
+>>> stream.close()
 \end{minted}
 Of course, the information contained in the XML tags that are not in the DTD are not present in the record returned by \verb|Entrez.read|.
 
@@ -844,8 +849,8 @@ We first open the file and then parse it:
 %doctest ../Tests/Medline
 \begin{minted}{pycon}
 >>> from Bio import Medline
->>> with open("pubmed_result1.txt") as handle:
-...     record = Medline.read(handle)
+>>> with open("pubmed_result1.txt") as stream:
+...     record = Medline.read(stream)
 ...
 \end{minted}
 The \verb+record+ now contains the Medline record as a Python dictionary:
@@ -877,8 +882,8 @@ To parse a file containing multiple Medline records, you can use the \verb+parse
 %doctest ../Tests/Medline
 \begin{minted}{pycon}
 >>> from Bio import Medline
->>> with open("pubmed_result2.txt") as handle:
-...     for record in Medline.parse(handle):
+>>> with open("pubmed_result2.txt") as stream:
+...     for record in Medline.parse(stream):
 ...         print(record["TI"])
 ...
 A high level interface to SCOP and ASTRAL implemented in python.
@@ -891,20 +896,20 @@ Instead of parsing Medline records stored in files, you can also parse Medline r
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.esearch(db="pubmed", term="biopython")
->>> record = Entrez.read(handle)
+>>> stream = Entrez.esearch(db="pubmed", term="biopython")
+>>> record = Entrez.read(stream)
 >>> record["IdList"]
 ['19304878', '18606172', '16403221', '16377612', '14871861', '14630660', '12230038']
 \end{minted}
 We now use \verb+Bio.Entrez.efetch+ to download these Medline records:
 \begin{minted}{pycon}
 >>> idlist = record["IdList"]
->>> handle = Entrez.efetch(db="pubmed", id=idlist, rettype="medline", retmode="text")
+>>> stream = Entrez.efetch(db="pubmed", id=idlist, rettype="medline", retmode="text")
 \end{minted}
 Here, we specify \verb+rettype="medline", retmode="text"+ to obtain the Medline records in plain-text Medline format. Now we use \verb+Bio.Medline+ to parse these records:
 \begin{minted}{pycon}
 >>> from Bio import Medline
->>> records = Medline.parse(handle)
+>>> records = Medline.parse(stream)
 >>> for record in records:
 ...     print(record["AU"])
 ...
@@ -919,8 +924,8 @@ Here, we specify \verb+rettype="medline", retmode="text"+ to obtain the Medline 
 
 For comparison, here we show an example using the XML format:
 \begin{minted}{pycon}
->>> handle = Entrez.efetch(db="pubmed", id=idlist, rettype="medline", retmode="xml")
->>> records = Entrez.read(handle)
+>>> stream = Entrez.efetch(db="pubmed", id=idlist, rettype="medline", retmode="xml")
+>>> records = Entrez.read(stream)
 >>> for record in records["PubmedArticle"]:
 ...     print(record["MedlineCitation"]["Article"]["ArticleTitle"])
 ...
@@ -952,8 +957,8 @@ The following code fragment shows how to parse the example GEO file
 
 \begin{minted}{pycon}
 >>> from Bio import Geo
->>> handle = open("GSE16.txt")
->>> records = Geo.parse(handle)
+>>> stream = open("GSE16.txt")
+>>> records = Geo.parse(stream)
 >>> for record in records:
 ...     print(record)
 ...
@@ -965,9 +970,9 @@ You can search the ``gds'' database (GEO datasets) with ESearch:
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.esearch(db="gds", term="GSE16")
->>> record = Entrez.read(handle)
->>> handle.close()
+>>> stream = Entrez.esearch(db="gds", term="GSE16")
+>>> record = Entrez.read(stream)
+>>> stream.close()
 >>> record["Count"]
 '27'
 \end{minted}
@@ -1112,8 +1117,8 @@ In this example, we will query PubMed for all articles having to do with orchids
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.egquery(term="orchid")
->>> record = Entrez.read(handle)
+>>> stream = Entrez.egquery(term="orchid")
+>>> record = Entrez.read(stream)
 >>> for row in record["eGQueryResult"]:
 ...     if row["DbName"] == "pubmed":
 ...         print(row["Count"])
@@ -1127,9 +1132,9 @@ Now we use the \verb+Bio.Entrez.efetch+ function to download the PubMed IDs of t
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.esearch(db="pubmed", term="orchid", retmax=463)
->>> record = Entrez.read(handle)
->>> handle.close()
+>>> stream = Entrez.esearch(db="pubmed", term="orchid", retmax=463)
+>>> record = Entrez.read(stream)
+>>> stream.close()
 >>> idlist = record["IdList"]
 \end{minted}
 
@@ -1146,8 +1151,8 @@ Now that we've got them, we obviously want to get the corresponding Medline reco
 %cont-doctest
 \begin{minted}{pycon}
 >>> from Bio import Medline
->>> handle = Entrez.efetch(db="pubmed", id=idlist, rettype="medline", retmode="text")
->>> records = Medline.parse(handle)
+>>> stream = Entrez.efetch(db="pubmed", id=idlist, rettype="medline", retmode="text")
+>>> records = Medline.parse(stream)
 \end{minted}
 
 NOTE - We've just done a separate search and fetch here, the NCBI much prefer you to take advantage of their history support in this situation.  See Section~\ref{sec:entrez-webenv}.
@@ -1202,8 +1207,8 @@ First, we use EGQuery to find out the number of results we will get before actua
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.egquery(term="Cypripedioideae")
->>> record = Entrez.read(handle)
+>>> stream = Entrez.egquery(term="Cypripedioideae")
+>>> record = Entrez.read(stream)
 >>> for row in record["eGQueryResult"]:
 ...     if row["DbName"] == "nuccore":
 ...         print(row["Count"])
@@ -1218,11 +1223,11 @@ Let's use the \verb+retmax+ argument to restrict the maximum number of records r
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.esearch(
+>>> stream = Entrez.esearch(
 ...     db="nucleotide", term="Cypripedioideae", retmax=814, idtype="acc"
 ... )
->>> record = Entrez.read(handle)
->>> handle.close()
+>>> record = Entrez.read(stream)
+>>> stream.close()
 \end{minted}
 
 Here, \verb+record+ is a Python dictionary containing the search results and some auxiliary information. Just for information, let's look at what is stored in this dictionary:
@@ -1257,8 +1262,8 @@ However, in this situation you should ideally be using the history feature descr
 >>> idlist = ",".join(record["IdList"][:5])
 >>> print(idlist)
 KX265015.1, KX265014.1, KX265013.1, KX265012.1, KX265011.1]
->>> handle = Entrez.efetch(db="nucleotide", id=idlist, retmode="xml")
->>> records = Entrez.read(handle)
+>>> stream = Entrez.efetch(db="nucleotide", id=idlist, retmode="xml")
+>>> records = Entrez.read(stream)
 >>> len(records)
 5
 \end{minted}
@@ -1301,8 +1306,8 @@ First, we want to make a query and find out the ids of the records to retrieve. 
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.egquery(term="Opuntia AND rpl16")
->>> record = Entrez.read(handle)
+>>> stream = Entrez.egquery(term="Opuntia AND rpl16")
+>>> record = Entrez.read(stream)
 >>> for row in record["eGQueryResult"]:
 ...     if row["DbName"] == "nuccore":
 ...         print(row["Count"])
@@ -1311,8 +1316,8 @@ First, we want to make a query and find out the ids of the records to retrieve. 
 \end{minted}
 Now we download the list of GenBank identifiers:
 \begin{minted}{pycon}
->>> handle = Entrez.esearch(db="nuccore", term="Opuntia AND rpl16")
->>> record = Entrez.read(handle)
+>>> stream = Entrez.esearch(db="nuccore", term="Opuntia AND rpl16")
+>>> record = Entrez.read(stream)
 >>> gi_list = record["IdList"]
 >>> gi_list
 ['57240072', '57240071', '6273287', '6273291', '6273290', '6273289', '6273286',
@@ -1323,13 +1328,13 @@ Now we use these GIs to download the GenBank records - note that with older vers
 
 \begin{minted}{pycon}
 >>> gi_str = ",".join(gi_list)
->>> handle = Entrez.efetch(db="nuccore", id=gi_str, rettype="gb", retmode="text")
+>>> stream = Entrez.efetch(db="nuccore", id=gi_str, rettype="gb", retmode="text")
 \end{minted}
 
-If you want to look at the raw GenBank files, you can read from this handle and print out the result:
+If you want to look at the raw GenBank files, you can read from this stream and print out the result:
 
 \begin{minted}{pycon}
->>> text = handle.read()
+>>> text = stream.read()
 >>> print(text)
 LOCUS       AY851612                 892 bp    DNA     linear   PLN 10-APR-2007
 DEFINITION  Opuntia subulata rpl16 gene, intron; chloroplast.
@@ -1350,8 +1355,8 @@ In this case, we are just getting the raw records. To get the records in a more 
 
 \begin{minted}{pycon}
 >>> from Bio import SeqIO
->>> handle = Entrez.efetch(db="nuccore", id=gi_str, rettype="gb", retmode="text")
->>> records = SeqIO.parse(handle, "gb")
+>>> stream = Entrez.efetch(db="nuccore", id=gi_str, rettype="gb", retmode="text")
+>>> records = SeqIO.parse(stream, "gb")
 \end{minted}
 
 \noindent We can now step through the records and look at the information we are interested in:
@@ -1383,8 +1388,8 @@ Staying with a plant example, let's now find the lineage of the Cypripedioideae 
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "A.N.Other@example.com"  # Always tell NCBI who you are
->>> handle = Entrez.esearch(db="Taxonomy", term="Cypripedioideae")
->>> record = Entrez.read(handle)
+>>> stream = Entrez.esearch(db="Taxonomy", term="Cypripedioideae")
+>>> record = Entrez.read(stream)
 >>> record["IdList"]
 ['158330']
 >>> record["IdList"][0]
@@ -1394,8 +1399,8 @@ Now, we use \verb+efetch+ to download this entry in the Taxonomy database, and t
 
 %cont-doctest
 \begin{minted}{pycon}
->>> handle = Entrez.efetch(db="Taxonomy", id="158330", retmode="xml")
->>> records = Entrez.read(handle)
+>>> stream = Entrez.efetch(db="Taxonomy", id="158330", retmode="xml")
+>>> records = Entrez.read(stream)
 \end{minted}
 Again, this record stores lots of information:
 \begin{minted}{pycon}
@@ -1446,11 +1451,11 @@ additional argument of \verb|usehistory="y"|,
 \begin{minted}{pycon}
 >>> from Bio import Entrez
 >>> Entrez.email = "history.user@example.com"  # Always tell NCBI who you are
->>> search_handle = Entrez.esearch(
+>>> stream = Entrez.esearch(
 ...     db="nucleotide", term="Opuntia[orgn] and rpl16", usehistory="y", idtype="acc"
 ... )
->>> search_results = Entrez.read(search_handle)
->>> search_handle.close()
+>>> search_results = Entrez.read(stream)
+>>> stream.close()
 \end{minted}
 
 \noindent As before (see Section~\ref{sec:entrez_example_genbank}), the XML output includes the first \verb+retmax+ search results, with \verb+retmax+ defaulting to 20:
@@ -1485,11 +1490,11 @@ For example,
 # and set the variables count, webenv, query_key
 
 batch_size = 3
-out_handle = open("orchid_rpl16.fasta", "w")
+output = open("orchid_rpl16.fasta", "w")
 for start in range(0, count, batch_size):
     end = min(count, start + batch_size)
     print("Going to download record %i to %i" % (start + 1, end))
-    fetch_handle = Entrez.efetch(
+    stream = Entrez.efetch(
         db="nucleotide",
         rettype="fasta",
         retmode="text",
@@ -1499,10 +1504,10 @@ for start in range(0, count, batch_size):
         query_key=query_key,
         idtype="acc",
     )
-    data = fetch_handle.read()
-    fetch_handle.close()
-    out_handle.write(data)
-out_handle.close()
+    data = stream.read()
+    stream.close()
+    output.write(data)
+output.close()
 \end{minted}
 
 \noindent For illustrative purposes, this example downloaded the FASTA records in batches of three.  Unless you are downloading genomes or chromosomes, you would normally pick a larger batch size.
@@ -1523,11 +1528,11 @@ count = int(search_results["Count"])
 print("Found %i results" % count)
 
 batch_size = 10
-out_handle = open("recent_orchid_papers.txt", "w")
+output = open("recent_orchid_papers.txt", "w")
 for start in range(0, count, batch_size):
     end = min(count, start + batch_size)
     print("Going to download record %i to %i" % (start + 1, end))
-    fetch_handle = Entrez.efetch(
+    stream = Entrez.efetch(
         db="pubmed",
         rettype="medline",
         retmode="text",
@@ -1536,10 +1541,10 @@ for start in range(0, count, batch_size):
         webenv=search_results["WebEnv"],
         query_key=search_results["QueryKey"],
     )
-    data = fetch_handle.read()
-    fetch_handle.close()
-    out_handle.write(data)
-out_handle.close()
+    data = stream.read()
+    stream.close()
+    output.write(data)
+output.close()
 \end{minted}
 
 \noindent At the time of writing, this gave 28 matches - but because this is a date dependent search, this will of course vary.  As described in Section~\ref{sec:entrez-and-medline} above, you can then use \verb|Bio.Medline| to parse the saved records.

--- a/Tests/test_Entrez_parser.py
+++ b/Tests/test_Entrez_parser.py
@@ -11,58 +11,59 @@ import pickle
 
 from io import BytesIO
 
+from Bio import StreamModeError
 from Bio import Entrez
 
 
 class GeneralTests(unittest.TestCase):
     """General tests for Bio.Entrez."""
 
-    def test_closed_handle(self):
-        """Test parsing closed handle fails gracefully."""
-        handle = open("Entrez/einfo1.xml", "rb")
-        handle.close()
-        self.assertRaises(ValueError, Entrez.read, handle)
+    def test_closed_file(self):
+        """Test parsing closed file fails gracefully."""
+        stream = open("Entrez/einfo1.xml", "rb")
+        stream.close()
+        self.assertRaises(ValueError, Entrez.read, stream)
 
-    def test_read_bytes_handle(self):
-        """Test reading a handle opened in binary mode."""
-        with open("Entrez/pubmed1.xml", "rb") as handle:
-            record = Entrez.read(handle)
+    def test_read_bytes_stream(self):
+        """Test reading a file opened in binary mode."""
+        with open("Entrez/pubmed1.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(len(record), 2)
         self.assertIn("MedlineCitation", record[0])
 
-    def test_parse_bytes_handle(self):
-        """Test parsing a handle opened in binary mode."""
-        with open("Entrez/pubmed1.xml", "rb") as handle:
-            records = Entrez.parse(handle)
+    def test_parse_bytes_stream(self):
+        """Test parsing a file opened in binary mode."""
+        with open("Entrez/pubmed1.xml", "rb") as stream:
+            records = Entrez.parse(stream)
             n = 0
             for record in records:
                 self.assertIn("MedlineCitation", record)
                 n += 1
         self.assertEqual(n, 2)
 
-    def test_read_text_handle(self):
-        """Test reading a handle opened in text mode."""
-        message = "^file should be opened in binary mode$"
-        with open("Entrez/pubmed1.xml") as handle:
-            with self.assertRaisesRegex(TypeError, message):
-                Entrez.read(handle)
+    def test_read_text_file(self):
+        """Test reading a file opened in text mode."""
+        message = "^the XML file must be opened in binary mode.$"
+        with open("Entrez/pubmed1.xml") as stream:
+            with self.assertRaisesRegex(StreamModeError, message):
+                Entrez.read(stream)
 
-    def test_parse_text_handle(self):
-        """Test parsing a handle opened in text mode."""
-        message = "^file should be opened in binary mode$"
-        with open("Entrez/einfo1.xml") as handle:
-            records = Entrez.parse(handle)
-            with self.assertRaisesRegex(TypeError, message):
+    def test_parse_text_file(self):
+        """Test parsing a file opened in text mode."""
+        message = "^the XML file must be opened in binary mode.$"
+        with open("Entrez/einfo1.xml") as stream:
+            records = Entrez.parse(stream)
+            with self.assertRaisesRegex(StreamModeError, message):
                 next(records)
 
     def test_BytesIO(self):
-        """Test parsing a BytesIO handle (bytes not string)."""
-        with open("Entrez/einfo1.xml", "rb") as in_handle:
-            data = in_handle.read()
-        handle = BytesIO(data)
-        record = Entrez.read(handle)
+        """Test parsing a BytesIO stream (bytes not string)."""
+        with open("Entrez/einfo1.xml", "rb") as stream:
+            data = stream.read()
+        stream = BytesIO(data)
+        record = Entrez.read(stream)
         self.assertIn("DbList", record)
-        handle.close()
+        stream.close()
 
     def test_pickle(self):
         """Test if records created by the parser can be pickled."""
@@ -100,8 +101,8 @@ class EInfoTest(unittest.TestCase):
         """Test parsing database list returned by EInfo."""
         # To create the XML file, use
         # >>> Bio.Entrez.einfo()
-        with open("Entrez/einfo1.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/einfo1.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(
             record["DbList"],
             [
@@ -149,8 +150,8 @@ class EInfoTest(unittest.TestCase):
         """Test parsing database info returned by EInfo."""
         # To create the XML file, use
         # >>> Bio.Entrez.einfo(db="pubmed")
-        with open("Entrez/einfo2.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/einfo2.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["DbInfo"]["DbName"], "pubmed")
         self.assertEqual(record["DbInfo"]["MenuName"], "PubMed")
         self.assertEqual(record["DbInfo"]["Description"], "PubMed bibliographic record")
@@ -190,8 +191,8 @@ class EInfoTest(unittest.TestCase):
         # included some tags that are not part of the corresponding DTD.
         from Bio.Entrez import Parser
 
-        with open("Entrez/einfo3.xml", "rb") as handle:
-            self.assertRaises(Parser.ValidationError, Entrez.read, handle)
+        with open("Entrez/einfo3.xml", "rb") as stream:
+            self.assertRaises(Parser.ValidationError, Entrez.read, stream)
 
     def test_pubmed3(self):
         """Test non-validating parser on XML with an inconsistent DTD."""
@@ -199,8 +200,8 @@ class EInfoTest(unittest.TestCase):
         # >>> Bio.Entrez.einfo(db="pubmed")
         # Starting some time in 2010, the results returned by Bio.Entrez
         # included some tags that are not part of the corresponding DTD.
-        with open("Entrez/einfo3.xml", "rb") as handle:
-            record = Entrez.read(handle, validate=False)
+        with open("Entrez/einfo3.xml", "rb") as stream:
+            record = Entrez.read(stream, validate=False)
         self.assertEqual(record["DbInfo"]["DbName"], "pubmed")
         self.assertEqual(record["DbInfo"]["MenuName"], "PubMed")
         self.assertEqual(record["DbInfo"]["Description"], "PubMed bibliographic record")
@@ -1249,8 +1250,8 @@ class EInfoTest(unittest.TestCase):
         # and manually delete the last couple of lines
         from Bio.Entrez import Parser
 
-        with open("Entrez/einfo4.xml", "rb") as handle:
-            self.assertRaises(Parser.CorruptedXMLError, Entrez.read, handle)
+        with open("Entrez/einfo4.xml", "rb") as stream:
+            self.assertRaises(Parser.CorruptedXMLError, Entrez.read, stream)
 
 
 class ESearchTest(unittest.TestCase):
@@ -1260,8 +1261,8 @@ class ESearchTest(unittest.TestCase):
         """Test parsing XML returned by ESearch from PubMed (first test)."""
         # To create the XML file, use
         # >>> Bio.Entrez.esearch(db="pubmed", term="biopython")
-        with open("Entrez/esearch1.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esearch1.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["Count"], "5")
         self.assertEqual(record["RetMax"], "5")
         self.assertEqual(record["RetStart"], "0")
@@ -1290,8 +1291,8 @@ class ESearchTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.esearch(db="pubmed", term="cancer", reldate=60,
         #                        datetype="edat", retmax=100, usehistory="y")
-        with open("Entrez/esearch2.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esearch2.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["Count"], "10238")
         self.assertEqual(record["RetMax"], "100")
         self.assertEqual(record["RetStart"], "0")
@@ -1466,8 +1467,8 @@ class ESearchTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.esearch(db="pubmed", term="PNAS[ta] AND 97[vi]",
         #                        retstart=6, retmax=6)
-        with open("Entrez/esearch3.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esearch3.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["Count"], "2652")
         self.assertEqual(record["RetMax"], "6")
         self.assertEqual(record["RetStart"], "6")
@@ -1508,8 +1509,8 @@ class ESearchTest(unittest.TestCase):
         # Search in Journals for the term obstetrics.
         # To create the XML file, use
         # >>> Bio.Entrez.esearch(db="journals", term="obstetrics")
-        with open("Entrez/esearch4.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esearch4.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["Count"], "177")
         self.assertEqual(record["RetMax"], "20")
         self.assertEqual(record["RetStart"], "0")
@@ -1553,8 +1554,8 @@ class ESearchTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.esearch(db="pmc",
         #                        term="stem cells AND free fulltext[filter]")
-        with open("Entrez/esearch5.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esearch5.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["Count"], "23492")
         self.assertEqual(record["RetMax"], "20")
         self.assertEqual(record["RetStart"], "0")
@@ -1664,8 +1665,8 @@ class ESearchTest(unittest.TestCase):
         # Search in Nucleotide for a property of the sequence,
         # To create the XML file, use
         # >>> Bio.Entrez.esearch(db="nucleotide", term="biomol trna[prop]")
-        with open("Entrez/esearch6.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esearch6.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["Count"], "699")
         self.assertEqual(record["RetMax"], "20")
         self.assertEqual(record["RetStart"], "0")
@@ -1698,8 +1699,8 @@ class ESearchTest(unittest.TestCase):
         # Search in Protein for a molecular weight
         # To create the XML file, use
         # >>> Bio.Entrez.esearch(db="protein", term="200020[molecular weight]")
-        with open("Entrez/esearch7.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esearch7.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["Count"], "3")
         self.assertEqual(record["RetMax"], "3")
         self.assertEqual(record["RetStart"], "0")
@@ -1724,8 +1725,8 @@ class ESearchTest(unittest.TestCase):
         """Test parsing XML returned by ESearch when no items were found."""
         # To create the XML file, use
         # >>> Bio.Entrez.esearch(db="protein", term="abcXYZ")
-        with open("Entrez/esearch8.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esearch8.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["Count"], "0")
         self.assertEqual(record["RetMax"], "0")
         self.assertEqual(record["RetStart"], "0")
@@ -1757,8 +1758,8 @@ class EPostTest(unittest.TestCase):
         """Test parsing XML returned by EPost."""
         # To create the XML file, use
         # >>> Bio.Entrez.epost(db="pubmed", id="11237011")
-        with open("Entrez/epost1.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/epost1.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["QueryKey"], "1")
         self.assertEqual(
             record["WebEnv"],
@@ -1769,10 +1770,10 @@ class EPostTest(unittest.TestCase):
         """Test parsing XML returned by EPost with incorrect arguments."""
         # To create the XML file, use
         # >>> Bio.Entrez.epost(db="nothing")
-        with open("Entrez/epost2.xml", "rb") as handle:
-            self.assertRaises(RuntimeError, Entrez.read, handle)
-        with open("Entrez/epost2.xml", "rb") as handle:
-            record = Entrez.read(handle, ignore_errors=True)
+        with open("Entrez/epost2.xml", "rb") as stream:
+            self.assertRaises(RuntimeError, Entrez.read, stream)
+        with open("Entrez/epost2.xml", "rb") as stream:
+            record = Entrez.read(stream, ignore_errors=True)
         self.assertEqual(len(record), 1)
         self.assertEqual(len(record.attributes), 0)
         self.assertEqual(record["ERROR"], "Wrong DB name")
@@ -1782,8 +1783,8 @@ class EPostTest(unittest.TestCase):
         """Test parsing XML returned by EPost with invalid id (overflow tag)."""
         # To create the XML file, use
         # >>> Bio.Entrez.epost(db="pubmed", id=99999999999999999999999999999999)
-        with open("Entrez/epost3.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/epost3.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["InvalidIdList"], ["-1"])
         self.assertEqual(record["QueryKey"], "1")
         self.assertEqual(
@@ -1806,8 +1807,8 @@ class ESummaryTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.esummary(db="pubmed", id=["11850928","11482001"],
         #                         retmode="xml")
-        with open("Entrez/esummary1.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esummary1.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record[0]["Id"], "11850928")
         self.assertEqual(record[0]["PubDate"], "1965 Aug")
         self.assertEqual(record[0]["EPubDate"], "")
@@ -1891,8 +1892,8 @@ class ESummaryTest(unittest.TestCase):
         # In Journals display records for journal IDs 27731,439,735,905
         # To create the XML file, use
         # >>> Bio.Entrez.esummary(db="journals", id="27731,439,735,905")
-        with open("Entrez/esummary2.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esummary2.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record[0]["Id"], "27731")
         self.assertEqual(
             record[0]["Title"],
@@ -1982,8 +1983,8 @@ class ESummaryTest(unittest.TestCase):
         # In Protein display records for GIs 28800982 and 28628843 in xml retrieval mode
         # To create the XML file, use
         # >>> Bio.Entrez.esummary(db="protein", id="28800982,28628843", retmode="xml")
-        with open("Entrez/esummary3.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esummary3.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record[0]["Id"], "28800982")
         self.assertEqual(record[0]["Caption"], "AAO47091")
         self.assertEqual(record[0]["Title"], "hemochromatosis [Homo sapiens]")
@@ -2023,8 +2024,8 @@ class ESummaryTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.esummary(db="nucleotide", id="28864546,28800981",
         #                         retmode="xml")
-        with open("Entrez/esummary4.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esummary4.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record[0]["Id"], "28864546")
         self.assertEqual(record[0]["Caption"], "AY207443")
         self.assertEqual(
@@ -2065,8 +2066,8 @@ class ESummaryTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.esummary(db="structure", id=["19923","12120"],
         #                         retmode="xml")
-        with open("Entrez/esummary5.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esummary5.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record[0]["Id"], "19923")
         self.assertEqual(record[0]["PdbAcc"], "1L5J")
         self.assertEqual(
@@ -2118,8 +2119,8 @@ class ESummaryTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.esummary(db="taxonomy", id=["9913","30521"],
         #                         retmode="xml")
-        with open("Entrez/esummary6.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esummary6.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record[0]["Id"], "9913")
         self.assertEqual(record[0]["Rank"], "species")
         self.assertEqual(record[0]["Division"], "even-toed ungulates")
@@ -2157,8 +2158,8 @@ class ESummaryTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.esummary(db="unists", id=["254085","254086"],
         #                         retmode="xml")
-        with open("Entrez/esummary7.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/esummary7.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record[0]["Id"], "254085")
         self.assertEqual(record[0]["Marker_Name"], "SE234324")
         self.assertEqual(len(record[0]["Map_Gene_Summary_List"]), 1)
@@ -2185,10 +2186,10 @@ class ESummaryTest(unittest.TestCase):
         """Test parsing XML returned by ESummary with incorrect arguments."""
         # To create the XML file, use
         # >>> Bio.Entrez.esummary()
-        with open("Entrez/esummary8.xml", "rb") as handle:
-            self.assertRaises(RuntimeError, Entrez.read, handle)
-        with open("Entrez/esummary8.xml", "rb") as handle:
-            record = Entrez.read(handle, ignore_errors=True)
+        with open("Entrez/esummary8.xml", "rb") as stream:
+            self.assertRaises(RuntimeError, Entrez.read, stream)
+        with open("Entrez/esummary8.xml", "rb") as stream:
+            record = Entrez.read(stream, ignore_errors=True)
         self.assertEqual(len(record), 1)
         self.assertEqual(len(record.attributes), 0)
         self.assertEqual(record[0], "Neither query_key nor id specified")
@@ -2198,8 +2199,8 @@ class ESummaryTest(unittest.TestCase):
         """Test parsing ESummary XML where an Integer is not defined."""
         # To create the XML file, use
         # >>> Entrez.esummary(db='pccompound', id='7488')
-        with open("Entrez/esummary9.xml", "rb") as handle:
-            records = Entrez.read(handle)
+        with open("Entrez/esummary9.xml", "rb") as stream:
+            records = Entrez.read(stream)
         self.assertEqual(len(records), 1)
         record = records[0]
         self.assertEqual(record["Id"], "7488")
@@ -2356,8 +2357,8 @@ class ELinkTest(unittest.TestCase):
         # Retrieve IDs from PubMed for PMID 9298984 to the PubMed database
         # To create the XML file, use
         # >>> Bio.Entrez.elink(dbfrom="pubmed", id="9298984", cmd="neighbor")
-        with open("Entrez/elink1.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/elink1.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(len(record), 1)
         self.assertEqual(len(record[0]), 5)
         self.assertEqual(record[0]["DbFrom"], "pubmed")
@@ -2565,8 +2566,8 @@ class ELinkTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.elink(dbfrom="nucleotide", db="protein",
         #                      id="48819,7140345")
-        with open("Entrez/elink2.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/elink2.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(len(record), 1)
         self.assertEqual(len(record[0]), 5)
         self.assertEqual(record[0]["DbFrom"], "nuccore")
@@ -2604,8 +2605,8 @@ class ELinkTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.elink(dbfrom="pubmed", id="11812492,11774222",
         #                      db="pubmed", mindate="1995", datetype="pdat")
-        with open("Entrez/elink3.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/elink3.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(len(record), 1)
         self.assertEqual(record[0]["DbFrom"], "pubmed")
         self.assertEqual(len(record[0]["IdList"]), 2)
@@ -2982,8 +2983,8 @@ class ELinkTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.elink(dbfrom="pubmed", id="12242737", db="pubmed",
         #                      term="medline[sb]")
-        with open("Entrez/elink4.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/elink4.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(len(record), 1)
         self.assertEqual(record[0]["DbFrom"], "pubmed")
         self.assertEqual(record[0]["IdList"], ["12242737"])
@@ -3214,8 +3215,8 @@ class ELinkTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.elink(dbfrom="pubmed", id="10611131", cmd="prlinks")
 
-        with open("Entrez/elink5.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/elink5.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(len(record), 1)
         self.assertEqual(len(record[0]), 5)
         self.assertEqual(record[0]["DbFrom"], "pubmed")
@@ -3277,8 +3278,8 @@ class ELinkTest(unittest.TestCase):
         # PMIDs 12085856 and 12085853
         # To create the XML file, use
         # >>> Bio.Entrez.elink(dbfrom="pubmed", id="12085856,12085853", cmd="llinks")
-        with open("Entrez/elink6.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/elink6.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record[0]["DbFrom"], "pubmed")
         self.assertEqual(len(record[0]["IdUrlList"]), 2)
         self.assertEqual(record[0]["IdUrlList"]["IdUrlSet"][0]["Id"], "12085856")
@@ -3479,8 +3480,8 @@ class ELinkTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.elink(dbfrom="pubmed", id="12169658,11748140",
         #                      cmd="acheck")
-        with open("Entrez/elink7.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/elink7.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(len(record), 1)
         self.assertEqual(record[0]["DbFrom"], "pubmed")
         self.assertEqual(len(record[0]["IdCheckList"]), 2)
@@ -4212,8 +4213,8 @@ class ELinkTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.elink(dbfrom="pubmed", id="12068369", cmd="ncheck")
 
-        with open("Entrez/elink8.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/elink8.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(len(record), 1)
         self.assertEqual(record[0]["DbFrom"], "pubmed")
         self.assertEqual(len(record[0]["IdCheckList"]), 2)
@@ -4234,8 +4235,8 @@ class EGQueryTest(unittest.TestCase):
         # Display counts in XML for stem cells in each Entrez database
         # To create the XML file, use
         # >>> Bio.Entrez.egquery(term="stem cells")
-        with open("Entrez/egquery1.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/egquery1.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["Term"], "stem cells")
         self.assertEqual(record["eGQueryResult"][0]["DbName"], "pubmed")
         self.assertEqual(record["eGQueryResult"][0]["MenuName"], "PubMed")
@@ -4445,8 +4446,8 @@ class EGQueryTest(unittest.TestCase):
         # Display counts in XML for brca1 or brca2 for each Entrez database
         # To create the XML file, use
         # >>> Bio.Entrez.egquery(term="brca1 OR brca2")
-        with open("Entrez/egquery2.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/egquery2.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["Term"], "brca1 OR brca2")
         self.assertEqual(record["eGQueryResult"][0]["DbName"], "pubmed")
         self.assertEqual(record["eGQueryResult"][0]["MenuName"], "PubMed")
@@ -4618,8 +4619,8 @@ class ESpellTest(unittest.TestCase):
         # Request suggestions for the PubMed search biopythooon
         # To create the XML file, use
         # >>> Bio.Entrez.espell(db="pubmed", term="biopythooon")
-        with open("Entrez/espell.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/espell.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record["Database"], "pubmed")
         self.assertEqual(record["Query"], "biopythooon")
         self.assertEqual(record["CorrectedQuery"], "biopython")
@@ -4638,8 +4639,8 @@ class EFetchTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.efetch(db='pubmed', id='12091962,9997',
         #                       retmode='xml', rettype='abstract')
-        with open("Entrez/pubmed1.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/pubmed1.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record[0]["MedlineCitation"].attributes["Owner"], "KIE")
         self.assertEqual(record[0]["MedlineCitation"].attributes["Status"], "MEDLINE")
         self.assertEqual(record[0]["MedlineCitation"]["PMID"], "12091962")
@@ -5317,8 +5318,8 @@ class EFetchTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.efetch(db='pubmed', id="11748933,11700088",
         #                       retmode="xml")
-        with open("Entrez/pubmed2.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/pubmed2.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record[0]["MedlineCitation"].attributes["Owner"], "NLM")
         self.assertEqual(record[0]["MedlineCitation"].attributes["Status"], "MEDLINE")
         self.assertEqual(record[0]["MedlineCitation"]["PMID"], "11748933")
@@ -6023,8 +6024,8 @@ class EFetchTest(unittest.TestCase):
         # In PubMed display PMIDs in xml retrieval mode.
         # To create the XML file, use
         # >>> Bio.Entrez.efetch(db='pubmed', retmode='xml', id='29106400')
-        with open("Entrez/pubmed4.xml", "rb") as handle:
-            records = Entrez.read(handle)
+        with open("Entrez/pubmed4.xml", "rb") as stream:
+            records = Entrez.read(stream)
         self.assertEqual(len(records), 2)
         self.assertEqual(len(records["PubmedBookArticle"]), 0)
         self.assertEqual(len(records["PubmedArticle"]), 1)
@@ -6358,8 +6359,8 @@ class EFetchTest(unittest.TestCase):
         # In PubMed display PMIDs in xml retrieval mode.
         # To create the XML file, use
         # >>> Bio.Entrez.efetch(db='pubmed', retmode='xml', id='28775130')
-        with open("Entrez/pubmed5.xml", "rb") as handle:
-            record = Entrez.read(handle, escape=True)
+        with open("Entrez/pubmed5.xml", "rb") as stream:
+            record = Entrez.read(stream, escape=True)
         self.assertEqual(len(record), 2)
         self.assertEqual(len(record["PubmedArticle"]), 1)
         self.assertEqual(len(record["PubmedBookArticle"]), 0)
@@ -7925,8 +7926,8 @@ class EFetchTest(unittest.TestCase):
         # To create the XML file, use
         # >>> Bio.Entrez.efetch(db="pubmed", id='30108519', rettype="null",
         #                       retmode="xml", parsed=True)
-        with open("Entrez/pubmed6.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/pubmed6.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(len(record), 2)
         self.assertEqual(record["PubmedBookArticle"], [])
         self.assertEqual(len(record["PubmedArticle"]), 1)
@@ -9054,8 +9055,8 @@ Maximal Lactate Steady State (MLSS) and Lactate Threshold (LT) are physiological
         # extensive MathML tags in the abstract text.
         # To create the XML file, use
         # >>> Bio.Entrez.efetch(db="pubmed", id="29963580", retmode="xml")
-        with open("Entrez/pubmed7.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/pubmed7.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(len(record), 2)
         self.assertEqual(record["PubmedBookArticle"], [])
         self.assertEqual(len(record["PubmedArticle"]), 1)
@@ -10427,8 +10428,8 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         # To create the XML file, use
         # >>> Bio.Entrez.efetch(db="omim", id="601100", retmode='xml',
         #                       rettype='full')
-        with open("Entrez/ncbi_mim.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/ncbi_mim.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(len(record), 1)
         self.assertEqual(record[0]["Mim-entry_mimNumber"], "601100")
         self.assertEqual(record[0]["Mim-entry_mimType"], "1")
@@ -11166,8 +11167,8 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         # Access the Taxonomy database using efetch.
         # To create the XML file, use
         # >>> Bio.Entrez.efetch(db="taxonomy", id="9685", retmode="xml")
-        with open("Entrez/taxonomy.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/taxonomy.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(len(record), 1)
         self.assertEqual(record[0]["TaxId"], "9685")
         self.assertEqual(record[0]["ScientificName"], "Felis catus")
@@ -11284,8 +11285,8 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         # Access the nucleotide database using efetch.
         # To create the XML file, use
         # >>> Bio.Entrez.efetch(db='nucleotide', id=5, retmode='xml')
-        with open("Entrez/nucleotide1.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/nucleotide1.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record[0]["GBSeq_locus"], "X60065")
         self.assertEqual(record[0]["GBSeq_length"], "1136")
         self.assertEqual(record[0]["GBSeq_strandedness"], "single")
@@ -11780,8 +11781,8 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         # To create the XML file, use
         # >>> Bio.Entrez.efetch(db='nucleotide', id=5,
         #                       rettype='fasta', complexity=0, retmode='xml')
-        with open("Entrez/nucleotide2.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/nucleotide2.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record[0]["TSeq_seqtype"], "")
         self.assertEqual(record[0]["TSeq_seqtype"].attributes["value"], "nucleotide")
         self.assertEqual(record[0]["TSeq_gi"], "5")
@@ -11817,8 +11818,8 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         # Access the protein database using efetch.
         # To create the XML file, use
         # >>> Bio.Entrez.efetch(db='protein', id=8, rettype='gp', retmode='xml')
-        with open("Entrez/protein.xml", "rb") as handle:
-            record = Entrez.read(handle)
+        with open("Entrez/protein.xml", "rb") as stream:
+            record = Entrez.read(stream)
         self.assertEqual(record[0]["GBSeq_locus"], "CAA35997")
         self.assertEqual(record[0]["GBSeq_length"], "100")
         self.assertEqual(record[0]["GBSeq_moltype"], "AA")
@@ -12168,8 +12169,8 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         """Test parsing XML using Schemas."""
         # To create the XML file,use
         # >>> Bio.Entrez.efetch("protein", id="783730874", rettype="ipg", retmode="xml")
-        with open("Entrez/efetch_schemas.xml", "rb") as handle:
-            records = Entrez.read(handle)
+        with open("Entrez/efetch_schemas.xml", "rb") as stream:
+            records = Entrez.read(stream)
         self.assertEqual(len(records), 1)
         record = records["IPGReport"]
         self.assertEqual(len(record.attributes), 2)
@@ -12277,20 +12278,20 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         # >>> Bio.Entrez.efetch(db='nucleotide', id='NT_019265', rettype='gb')
         from Bio.Entrez import Parser
 
-        with open("GenBank/NT_019265.gb", "rb") as handle:
-            self.assertRaises(Parser.NotXMLError, Entrez.read, handle)
-        with open("GenBank/NT_019265.gb", "rb") as handle:
-            iterator = Entrez.parse(handle)
+        with open("GenBank/NT_019265.gb", "rb") as stream:
+            self.assertRaises(Parser.NotXMLError, Entrez.read, stream)
+        with open("GenBank/NT_019265.gb", "rb") as stream:
+            iterator = Entrez.parse(stream)
             self.assertRaises(Parser.NotXMLError, next, iterator)
 
     def test_fasta(self):
         """Test error handling when presented with Fasta non-XML data."""
         from Bio.Entrez import Parser
 
-        with open("Fasta/wisteria.nu", "rb") as handle:
-            self.assertRaises(Parser.NotXMLError, Entrez.read, handle)
-        with open("Fasta/wisteria.nu", "rb") as handle:
-            iterator = Entrez.parse(handle)
+        with open("Fasta/wisteria.nu", "rb") as stream:
+            self.assertRaises(Parser.NotXMLError, Entrez.read, stream)
+        with open("Fasta/wisteria.nu", "rb") as stream:
+            iterator = Entrez.parse(stream)
             self.assertRaises(Parser.NotXMLError, next, iterator)
 
     def test_pubmed_html(self):
@@ -12299,11 +12300,11 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         # >>> Bio.Entrez.efetch(db="pubmed", id="19304878")
         from Bio.Entrez import Parser
 
-        with open("Entrez/pubmed3.html", "rb") as handle:
-            self.assertRaises(Parser.NotXMLError, Entrez.read, handle)
+        with open("Entrez/pubmed3.html", "rb") as stream:
+            self.assertRaises(Parser.NotXMLError, Entrez.read, stream)
         # Test if the error is also raised with Entrez.parse
-        with open("Entrez/pubmed3.html", "rb") as handle:
-            records = Entrez.parse(handle)
+        with open("Entrez/pubmed3.html", "rb") as stream:
+            records = Entrez.parse(stream)
             self.assertRaises(Parser.NotXMLError, next, records)
 
     def test_xml_without_declaration(self):
@@ -12312,22 +12313,22 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         # >>> Bio.Entrez.efetch(db="journals",id="2830,6011,7473",retmode='xml')
         from Bio.Entrez import Parser
 
-        with open("Entrez/journals.xml", "rb") as handle:
-            self.assertRaises(Parser.NotXMLError, Entrez.read, handle)
+        with open("Entrez/journals.xml", "rb") as stream:
+            self.assertRaises(Parser.NotXMLError, Entrez.read, stream)
         # Test if the error is also raised with Entrez.parse
-        with open("Entrez/journals.xml", "rb") as handle:
-            records = Entrez.parse(handle)
+        with open("Entrez/journals.xml", "rb") as stream:
+            records = Entrez.parse(stream)
             self.assertRaises(Parser.NotXMLError, next, records)
 
     def test_xml_without_definition(self):
         """Test error handling for a missing DTD or XML Schema."""
         # To create the XML file, use
         # >>> Bio.Entrez.efetch(db="biosample", id="3502652", rettype="xml")
-        with open("Entrez/biosample.xml", "rb") as handle:
-            self.assertRaises(ValueError, Entrez.read, handle)
+        with open("Entrez/biosample.xml", "rb") as stream:
+            self.assertRaises(ValueError, Entrez.read, stream)
         # Test if the error is also raised with Entrez.parse
-        with open("Entrez/biosample.xml", "rb") as handle:
-            records = Entrez.parse(handle)
+        with open("Entrez/biosample.xml", "rb") as stream:
+            records = Entrez.parse(stream)
             self.assertRaises(ValueError, next, records)
 
     def test_truncated_xml(self):
@@ -12339,10 +12340,10 @@ We designed and generated pulmonary imaging biomarker pipelines to facilitate hi
         <!DOCTYPE GBSet PUBLIC "-//NCBI//NCBI GBSeq/EN" "http://www.ncbi.nlm.nih.gov/dtd/NCBI_GBSeq.dtd">
         <GBSet><GBSeq><GBSeq_locus>
         """
-        handle = BytesIO()
-        handle.write(truncated_xml)
-        handle.seek(0)
-        records = Entrez.parse(handle)
+        stream = BytesIO()
+        stream.write(truncated_xml)
+        stream.seek(0)
+        records = Entrez.parse(stream)
         self.assertRaises(CorruptedXMLError, next, records)
 
 


### PR DESCRIPTION
This PR allows `Entrez.read` and `Entrez.parse` to accept file names and paths in addition to file handles.
This is for consistency with other Biopython modules and for convenience. Also, the file will be closed automatically after parsing the file, and if an error occurs.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
