### PR TITLE
Remove deprecated code from Bio.Seq for release 1.82

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1106,7 +1106,7 @@ class Alignment:
             if (row >= 0).all():
                 pass
             elif (row <= 0).all():
-                sequences[i] = reverse_complement(sequence, inplace=False)
+                sequences[i] = reverse_complement(sequence)
                 coordinates[i, :] = len(sequence) - coordinates[i, :]
                 steps[i, :] = -steps[i, :]
             else:
@@ -1309,7 +1309,7 @@ class Alignment:
             if (row >= 0).all():
                 pass
             elif (row <= 0).all():
-                sequences[i] = reverse_complement(sequence, inplace=False)
+                sequences[i] = reverse_complement(sequence)
                 coordinates[i, :] = len(sequence) - coordinates[i, :]
                 steps[i, :] = -steps[i, :]
             else:
@@ -1577,7 +1577,7 @@ class Alignment:
             if sum(aligned_steps > 0) < sum(aligned_steps < 0):
                 steps[i, :] = -steps[i, :]
                 if i == index:
-                    sequence = reverse_complement(sequence, inplace=False)
+                    sequence = reverse_complement(sequence)
                     coordinates = len(sequence) - coordinates
         gaps = steps.max(0)
         try:
@@ -2043,7 +2043,7 @@ class Alignment:
             elif (row <= 0).all():
                 steps[i, :] = -steps[i, :]
                 coordinates[i, :] = len(sequence) - coordinates[i, :]
-                sequences[i] = reverse_complement(sequence, inplace=False)
+                sequences[i] = reverse_complement(sequence)
                 try:
                     sequences[i].id = sequence.id
                 except AttributeError:
@@ -2229,7 +2229,7 @@ class Alignment:
                 row[:] = positions - start
             else:
                 steps[i, :] = -steps[i, :]
-                seq = reverse_complement(seq, inplace=False)
+                seq = reverse_complement(seq)
                 end = max(positions)
                 row[:] = end - positions
             if isinstance(seq, str):
@@ -2403,7 +2403,7 @@ class Alignment:
                 return self._format_generalized()
             if row[0] > row[-1]:  # mapped to reverse strand
                 row[:] = len(seq) - row[:]
-                seq = reverse_complement(seq, inplace=False)
+                seq = reverse_complement(seq)
             seqs.append(seq)
             try:
                 name = seq.id
@@ -3468,7 +3468,7 @@ class Alignment:
             if (row >= 0).all():
                 pass
             elif (row <= 0).all():
-                sequences[i] = reverse_complement(sequence, inplace=False)
+                sequences[i] = reverse_complement(sequence)
                 coordinates[i, :] = len(sequence) - coordinates[i, :]
             else:
                 raise ValueError(f"Inconsistent steps in row {i}")
@@ -3578,9 +3578,7 @@ class Alignment:
         >>> print(rc_alignment.column_annotations)
         {'score': [2, 2, 2, 3]}
         """
-        sequences = [
-            reverse_complement(sequence, inplace=False) for sequence in self.sequences
-        ]
+        sequences = [reverse_complement(sequence) for sequence in self.sequences]
         coordinates = np.array(
             [
                 len(sequence) - row[::-1]
@@ -3923,7 +3921,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         if strand == "+":
             sB = seqB
         else:  # strand == "-":
-            sB = reverse_complement(seqB, inplace=False)
+            sB = reverse_complement(seqB)
         if isinstance(seqB, (Seq, MutableSeq, SeqRecord)):
             sB = bytes(sB)
         score, paths = super().align(sA, sB, strand)
@@ -3935,7 +3933,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         if isinstance(seqA, (Seq, MutableSeq, SeqRecord)):
             seqA = bytes(seqA)
         if strand == "-":
-            seqB = reverse_complement(seqB, inplace=False)
+            seqB = reverse_complement(seqB)
         if isinstance(seqB, (Seq, MutableSeq, SeqRecord)):
             seqB = bytes(seqB)
         return super().score(seqA, seqB, strand)

--- a/Bio/Align/bigpsl.py
+++ b/Bio/Align/bigpsl.py
@@ -257,13 +257,13 @@ class AlignmentWriter(bigbed.AlignmentWriter):
             if coordinates[1, 0] > coordinates[1, -1]:
                 # DNA/RNA mapped to reverse strand of DNA/RNA
                 strand = "-"
-                query = reverse_complement(query, inplace=False)
+                query = reverse_complement(query)
                 coordinates = coordinates.copy()
                 coordinates[1, :] = qSize - coordinates[1, :]
             elif coordinates[0, 0] > coordinates[0, -1]:
                 # protein mapped to reverse strand of DNA
                 strand = "-"
-                target = reverse_complement(target, inplace=False)
+                target = reverse_complement(target)
                 coordinates = coordinates.copy()
                 coordinates[0, :] = tSize - coordinates[0, :]
                 dnax = True

--- a/Bio/Align/mauve.py
+++ b/Bio/Align/mauve.py
@@ -225,7 +225,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                     if strand == "+":
                         pass
                     elif strand == "-":
-                        seq = reverse_complement(seq, inplace=False)
+                        seq = reverse_complement(seq)
                         coordinates[index, :] = len(seq) - coordinates[index, :]
                     else:
                         raise ValueError("Unexpected strand '%s'" % strand)

--- a/Bio/Align/psl.py
+++ b/Bio/Align/psl.py
@@ -129,13 +129,13 @@ match	mis- 	rep. 	N's	Q gap	Q gap	T gap	T gap	strand	Q        	Q   	Q    	Q  	T 
         if coordinates[1, 0] > coordinates[1, -1]:
             # DNA/RNA mapped to reverse strand of DNA/RNA
             strand = "-"
-            query = reverse_complement(query, inplace=False)
+            query = reverse_complement(query)
             coordinates = coordinates.copy()
             coordinates[1, :] = qSize - coordinates[1, :]
         elif coordinates[0, 0] > coordinates[0, -1]:
             # protein mapped to reverse strand of DNA
             strand = "-"
-            target = reverse_complement(target, inplace=False)
+            target = reverse_complement(target)
             coordinates = coordinates.copy()
             coordinates[0, :] = tSize - coordinates[0, :]
             dnax = True

--- a/Bio/Align/sam.py
+++ b/Bio/Align/sam.py
@@ -149,7 +149,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             flag = 0
         else:  # mapped to reverse strand
             flag = 16
-            query = reverse_complement(query, inplace=False)
+            query = reverse_complement(query)
             coordinates = np.array(coordinates)
             coordinates[:, 1] = qSize - coordinates[:, 1]
             hard_clip_left, hard_clip_right = hard_clip_right, hard_clip_left

--- a/Bio/AlignIO/MafIO.py
+++ b/Bio/AlignIO/MafIO.py
@@ -845,11 +845,7 @@ class MafIndex:
         for seqid, seq in subseq.items():
             seq = Seq(seq)
 
-            seq = (
-                seq
-                if strand == ref_first_strand
-                else seq.reverse_complement()
-            )
+            seq = seq if strand == ref_first_strand else seq.reverse_complement()
 
             result_multiseq.append(SeqRecord(seq, id=seqid, name=seqid, description=""))
 

--- a/Bio/AlignIO/MafIO.py
+++ b/Bio/AlignIO/MafIO.py
@@ -848,8 +848,8 @@ class MafIndex:
             seq = (
                 seq
                 if strand == ref_first_strand
-                else seq.reverse_complement(inplace=False)
-            )  # TODO: remove inplace=False
+                else seq.reverse_complement()
+            )
 
             result_multiseq.append(SeqRecord(seq, id=seqid, name=seqid, description=""))
 

--- a/Bio/Restriction/PrintFormat.py
+++ b/Bio/Restriction/PrintFormat.py
@@ -363,9 +363,7 @@ class PrintFormat:
             mapping = remaining
         cutloc[x] = mapping
         sequence = str(self.sequence)
-        revsequence = str(
-            self.sequence.complement(inplace=False)
-        )  # TODO: remove inplace=False
+        revsequence = str(self.sequence.complement())
         a = "|"
         base, counter = 0, 0
         emptyline = " " * 60

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -28,7 +28,6 @@ from abc import ABC
 from abc import abstractmethod
 from typing import overload, Optional, Union, Dict
 
-from Bio import BiopythonDeprecationWarning
 from Bio import BiopythonWarning
 from Bio.Data import CodonTable
 from Bio.Data import IUPACData

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1177,7 +1177,7 @@ class _SeqAbstractBaseClass(ABC):
         in-place and returned.
 
         >>> seq = MutableSeq(" ACGT ")
-        >>> seq.strip(inplace=False)
+        >>> seq.strip()
         MutableSeq('ACGT')
         >>> seq
         MutableSeq(' ACGT ')
@@ -1287,7 +1287,7 @@ class _SeqAbstractBaseClass(ABC):
         in-place and returned.
 
         >>> seq = MutableSeq(" ACGT ")
-        >>> seq.rstrip(inplace=False)
+        >>> seq.rstrip()
         MutableSeq(' ACGT')
         >>> seq
         MutableSeq(' ACGT ')
@@ -1622,7 +1622,7 @@ class _SeqAbstractBaseClass(ABC):
             _translate_str(str(self), table, stop_symbol, to_stop, cds, gap=gap)
         )
 
-    def complement(self, inplace=None):
+    def complement(self, inplace=False):
         """Return the complement as a DNA sequence.
 
         >>> Seq("CGA").complement()
@@ -1630,7 +1630,7 @@ class _SeqAbstractBaseClass(ABC):
 
         Any U in the sequence is treated as a T:
 
-        >>> Seq("CGAUT").complement(inplace=False)
+        >>> Seq("CGAUT").complement()
         Seq('GCTAA')
 
         In contrast, ``complement_rna`` returns an RNA sequence:
@@ -1643,7 +1643,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> my_seq = MutableSeq("CGA")
         >>> my_seq
         MutableSeq('CGA')
-        >>> my_seq.complement(inplace=False)
+        >>> my_seq.complement()
         MutableSeq('GCT')
         >>> my_seq
         MutableSeq('CGA')
@@ -1658,54 +1658,6 @@ class _SeqAbstractBaseClass(ABC):
         """
         ttable = _dna_complement_table
         try:
-            if inplace is None:
-                # deprecated
-                if isinstance(self._data, bytearray):  # MutableSeq
-                    warnings.warn(
-                        "mutable_seq.complement() will change in the near "
-                        "future and will no longer change the sequence in-"
-                        "place by default. Please use\n"
-                        "\n"
-                        "mutable_seq.complement(inplace=True)\n"
-                        "\n"
-                        "if you want to continue to use this method to change "
-                        "a mutable sequence in-place.",
-                        BiopythonDeprecationWarning,
-                    )
-                    inplace = True
-                if isinstance(self._data, _PartiallyDefinedSequenceData):
-                    for seq in self._data._data.values():
-                        if b"U" in seq or b"u" in seq:
-                            warnings.warn(
-                                "seq.complement() will change in the near "
-                                "future to always return DNA nucleotides only. "
-                                "Please use\n"
-                                "\n"
-                                "seq.complement_rna()\n"
-                                "\n"
-                                "if you want to receive an RNA sequence instead.",
-                                BiopythonDeprecationWarning,
-                            )
-                            for seq in self._data._data.values():
-                                if b"t" in seq or b"T" in seq:
-                                    raise ValueError("Mixed RNA/DNA found")
-                            ttable = _rna_complement_table
-                            break
-
-                elif b"U" in self._data or b"u" in self._data:
-                    warnings.warn(
-                        "seq.complement() will change in the near future to "
-                        "always return DNA nucleotides only. "
-                        "Please use\n"
-                        "\n"
-                        "seq.complement_rna()\n"
-                        "\n"
-                        "if you want to receive an RNA sequence instead.",
-                        BiopythonDeprecationWarning,
-                    )
-                    if b"t" in self._data or b"T" in self._data:
-                        raise ValueError("Mixed RNA/DNA found")
-                    ttable = _rna_complement_table
             data = self._data.translate(ttable)
         except UndefinedSequenceError:
             # complement of an undefined sequence is an undefined sequence
@@ -1765,15 +1717,15 @@ class _SeqAbstractBaseClass(ABC):
             return self
         return self.__class__(data)
 
-    def reverse_complement(self, inplace=None):
+    def reverse_complement(self, inplace=False):
         """Return the reverse complement as a DNA sequence.
 
-        >>> Seq("CGA").reverse_complement(inplace=False)
+        >>> Seq("CGA").reverse_complement()
         Seq('TCG')
 
         Any U in the sequence is treated as a T:
 
-        >>> Seq("CGAUT").reverse_complement(inplace=False)
+        >>> Seq("CGAUT").reverse_complement()
         Seq('AATCG')
 
         In contrast, ``reverse_complement_rna`` returns an RNA sequence:
@@ -1786,7 +1738,7 @@ class _SeqAbstractBaseClass(ABC):
         >>> my_seq = MutableSeq("CGA")
         >>> my_seq
         MutableSeq('CGA')
-        >>> my_seq.reverse_complement(inplace=False)
+        >>> my_seq.reverse_complement()
         MutableSeq('TCG')
         >>> my_seq
         MutableSeq('CGA')
@@ -1801,54 +1753,6 @@ class _SeqAbstractBaseClass(ABC):
         ``inplace=True``.
         """
         try:
-            if inplace is None:
-                # deprecated
-                if isinstance(self._data, bytearray):  # MutableSeq
-                    warnings.warn(
-                        "mutable_seq.reverse_complement() will change in the "
-                        "near future and will no longer change the sequence in-"
-                        "place by default. Please use\n"
-                        "\n"
-                        "mutable_seq.reverse_complement(inplace=True)\n"
-                        "\n"
-                        "if you want to continue to use this method to change "
-                        "a mutable sequence in-place.",
-                        BiopythonDeprecationWarning,
-                    )
-                    inplace = True
-                else:
-                    inplace = False
-                if isinstance(self._data, _PartiallyDefinedSequenceData):
-                    for seq in self._data._data.values():
-                        if b"U" in seq or b"u" in seq:
-                            warnings.warn(
-                                "seq.reverse_complement() will change in the near "
-                                "future to always return DNA nucleotides only. "
-                                "Please use\n"
-                                "\n"
-                                "seq.reverse_complement_rna()\n"
-                                "\n"
-                                "if you want to receive an RNA sequence instead.",
-                                BiopythonDeprecationWarning,
-                            )
-                            for seq in self._data._data.values():
-                                if b"t" in seq or b"T" in seq:
-                                    raise ValueError("Mixed RNA/DNA found")
-                            return self.reverse_complement_rna(inplace=inplace)
-                elif b"U" in self._data or b"u" in self._data:
-                    warnings.warn(
-                        "seq.reverse_complement() will change in the near "
-                        "future to always return DNA nucleotides only. "
-                        "Please use\n"
-                        "\n"
-                        "seq.reverse_complement_rna()\n"
-                        "\n"
-                        "if you want to receive an RNA sequence instead.",
-                        BiopythonDeprecationWarning,
-                    )
-                    if b"t" in self._data or b"T" in self._data:
-                        raise ValueError("Mixed RNA/DNA found")
-                    return self.reverse_complement_rna(inplace=inplace)
             data = self._data.translate(_dna_complement_table)
         except UndefinedSequenceError:
             # reverse complement of an undefined sequence is an undefined sequence
@@ -1874,7 +1778,7 @@ class _SeqAbstractBaseClass(ABC):
 
         In contrast, ``reverse_complement`` returns a DNA sequence:
 
-        >>> Seq("CGA").reverse_complement(inplace=False)
+        >>> Seq("CGA").reverse_complement()
         Seq('TCG')
 
         The sequence is modified in-place and returned if inplace is True:
@@ -2269,33 +2173,6 @@ class Seq(_SeqAbstractBaseClass):
         would hash on object identity.
         """
         return hash(self._data)
-
-    def ungap(self, gap="-"):
-        """Return a copy of the sequence without the gap character(s) (DEPRECATED).
-
-        The gap character now defaults to the minus sign, and can only
-        be specified via the method argument. This is no longer possible
-        via the sequence's alphabet (as was possible up to Biopython 1.77):
-
-        >>> from Bio.Seq import Seq
-        >>> my_dna = Seq("-ATA--TGAAAT-TTGAAAA")
-        >>> my_dna
-        Seq('-ATA--TGAAAT-TTGAAAA')
-        >>> my_dna.ungap("-")
-        Seq('ATATGAAATTTGAAAA')
-
-        This method is DEPRECATED; please use my_dna.replace(gap, "") instead.
-        """
-        warnings.warn(
-            """\
-myseq.ungap(gap) is deprecated; please use myseq.replace(gap, "") instead.""",
-            BiopythonDeprecationWarning,
-        )
-        if not gap:
-            raise ValueError("Gap character required.")
-        elif len(gap) != 1 or not isinstance(gap, str):
-            raise ValueError(f"Unexpected gap character, {gap!r}")
-        return self.replace(gap, b"")
 
 
 class MutableSeq(_SeqAbstractBaseClass):
@@ -3143,7 +3020,7 @@ def translate(
         return _translate_str(sequence, table, stop_symbol, to_stop, cds, gap=gap)
 
 
-def reverse_complement(sequence, inplace=None):
+def reverse_complement(sequence, inplace=False):
     """Return the reverse complement as a DNA sequence.
 
     If given a string, returns a new string object.
@@ -3152,20 +3029,20 @@ def reverse_complement(sequence, inplace=None):
     Given a SeqRecord object, returns a new SeqRecord object.
 
     >>> my_seq = "CGA"
-    >>> reverse_complement(my_seq, inplace=False)
+    >>> reverse_complement(my_seq)
     'TCG'
     >>> my_seq = Seq("CGA")
-    >>> reverse_complement(my_seq, inplace=False)
+    >>> reverse_complement(my_seq)
     Seq('TCG')
     >>> my_seq = MutableSeq("CGA")
-    >>> reverse_complement(my_seq, inplace=False)
+    >>> reverse_complement(my_seq)
     MutableSeq('TCG')
     >>> my_seq
     MutableSeq('CGA')
 
     Any U in the sequence is treated as a T:
 
-    >>> reverse_complement(Seq("CGAUT"), inplace=False)
+    >>> reverse_complement(Seq("CGAUT"))
     Seq('AATCG')
 
     In contrast, ``reverse_complement_rna`` returns an RNA sequence:
@@ -3176,7 +3053,7 @@ def reverse_complement(sequence, inplace=None):
     Supports and lower- and upper-case characters, and unambiguous and
     ambiguous nucleotides. All other characters are not converted:
 
-    >>> reverse_complement("ACGTUacgtuXYZxyz", inplace=False)
+    >>> reverse_complement("ACGTUacgtuXYZxyz")
     'zrxZRXaacgtAACGT'
 
     The sequence is modified in-place and returned if inplace is True:
@@ -3193,50 +3070,6 @@ def reverse_complement(sequence, inplace=None):
     """
     from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
 
-    if inplace is None:
-        # deprecated
-        if isinstance(sequence, Seq):
-            if b"U" in sequence._data or b"u" in sequence._data:
-                warnings.warn(
-                    "reverse_complement(sequence) will change in the "
-                    "near future to always return DNA nucleotides only. "
-                    "Please use\n"
-                    "\n"
-                    "reverse_complement_rna(sequence)\n"
-                    "\n"
-                    "if you want to receive an RNA sequence instead.",
-                    BiopythonDeprecationWarning,
-                )
-                if b"T" in sequence._data or b"t" in sequence._data:
-                    raise ValueError("Mixed RNA/DNA found")
-                return sequence.reverse_complement_rna()
-        elif isinstance(sequence, MutableSeq):
-            # Return a Seq
-            # Don't use the MutableSeq reverse_complement method as it is
-            # 'in place'.
-            warnings.warn(
-                "reverse_complement(mutable_seq) will change in the near "
-                "future to return a MutableSeq object instead of a Seq object.",
-                BiopythonDeprecationWarning,
-            )
-            return Seq(sequence).reverse_complement()
-        else:  # str
-            if "U" in sequence or "u" in sequence:
-                warnings.warn(
-                    "reverse_complement(sequence) will change in the "
-                    "near future to always return DNA nucleotides only. "
-                    "Please use\n"
-                    "\n"
-                    "reverse_complement_rna(sequence)\n"
-                    "\n"
-                    "if you want to receive an RNA sequence instead.",
-                    BiopythonDeprecationWarning,
-                )
-                if "T" in sequence or "t" in sequence:
-                    raise ValueError("Mixed RNA/DNA found")
-                sequence = sequence.encode("ASCII")
-                sequence = sequence.translate(_rna_complement_table)
-                return sequence.decode("ASCII")[::-1]
     if isinstance(sequence, (Seq, MutableSeq)):
         return sequence.reverse_complement(inplace)
     if isinstance(sequence, SeqRecord):
@@ -3317,7 +3150,7 @@ def reverse_complement_rna(sequence, inplace=False):
     return sequence[::-1]
 
 
-def complement(sequence, inplace=None):
+def complement(sequence, inplace=False):
     """Return the complement as a DNA sequence.
 
     If given a string, returns a new string object.
@@ -3326,20 +3159,20 @@ def complement(sequence, inplace=None):
     Given a SeqRecord object, returns a new SeqRecord object.
 
     >>> my_seq = "CGA"
-    >>> complement(my_seq, inplace=False)
+    >>> complement(my_seq)
     'GCT'
     >>> my_seq = Seq("CGA")
-    >>> complement(my_seq, inplace=False)
+    >>> complement(my_seq)
     Seq('GCT')
     >>> my_seq = MutableSeq("CGA")
-    >>> complement(my_seq, inplace=False)
+    >>> complement(my_seq)
     MutableSeq('GCT')
     >>> my_seq
     MutableSeq('CGA')
 
     Any U in the sequence is treated as a T:
 
-    >>> complement(Seq("CGAUT"), inplace=False)
+    >>> complement(Seq("CGAUT"))
     Seq('GCTAA')
 
     In contrast, ``complement_rna`` returns an RNA sequence:
@@ -3350,7 +3183,7 @@ def complement(sequence, inplace=None):
     Supports and lower- and upper-case characters, and unambiguous and
     ambiguous nucleotides. All other characters are not converted:
 
-    >>> complement("ACGTUacgtuXYZxyz", inplace=False)
+    >>> complement("ACGTUacgtuXYZxyz")
     'TGCAAtgcaaXRZxrz'
 
     The sequence is modified in-place and returned if inplace is True:
@@ -3367,52 +3200,6 @@ def complement(sequence, inplace=None):
     """
     from Bio.SeqRecord import SeqRecord  # Lazy to avoid circular imports
 
-    if inplace is None:
-        # deprecated
-        if isinstance(sequence, Seq):
-            # Return a Seq
-            if b"U" in sequence._data or b"u" in sequence._data:
-                warnings.warn(
-                    "complement(sequence) will change in the near "
-                    "future to always return DNA nucleotides only. "
-                    "Please use\n"
-                    "\n"
-                    "complement_rna(sequence)\n"
-                    "\n"
-                    "if you want to receive an RNA sequence instead.",
-                    BiopythonDeprecationWarning,
-                )
-                if b"T" in sequence._data or b"t" in sequence._data:
-                    raise ValueError("Mixed RNA/DNA found")
-                return sequence.complement_rna()
-        elif isinstance(sequence, MutableSeq):
-            # Return a Seq
-            # Don't use the MutableSeq reverse_complement method as it is
-            # 'in place'.
-            warnings.warn(
-                "complement(mutable_seq) will change in the near future"
-                "to return a MutableSeq object instead of a Seq object.",
-                BiopythonDeprecationWarning,
-            )
-            return Seq(sequence).complement()
-        else:
-            if "U" in sequence or "u" in sequence:
-                warnings.warn(
-                    "complement(sequence) will change in the near "
-                    "future to always return DNA nucleotides only. "
-                    "Please use\n"
-                    "\n"
-                    "complement_rna(sequence)\n"
-                    "\n"
-                    "if you want to receive an RNA sequence instead.",
-                    BiopythonDeprecationWarning,
-                )
-                if "T" in sequence or "t" in sequence:
-                    raise ValueError("Mixed RNA/DNA found")
-                ttable = _rna_complement_table
-                sequence = sequence.encode("ASCII")
-                sequence = sequence.translate(ttable)
-                return sequence.decode("ASCII")
     if isinstance(sequence, (Seq, MutableSeq)):
         return sequence.complement(inplace)
     if isinstance(sequence, SeqRecord):
@@ -3420,7 +3207,7 @@ def complement(sequence, inplace=None):
             raise TypeError("SeqRecords are immutable")
         return sequence.complement()
     # Assume it's a string.
-    if inplace:
+    if inplace is True:
         raise TypeError("strings are immutable")
     sequence = sequence.encode("ASCII")
     sequence = sequence.translate(_dna_complement_table)
@@ -3454,7 +3241,7 @@ def complement_rna(sequence, inplace=False):
 
     In contrast, ``complement`` returns a DNA sequence:
 
-    >>> complement(Seq("CGAUT"),inplace=False)
+    >>> complement(Seq("CGAUT"))
     Seq('GCTAA')
 
     Supports and lower- and upper-case characters, and unambiguous and

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -1231,7 +1231,7 @@ class _SeqAbstractBaseClass(ABC):
         in-place and returned.
 
         >>> seq = MutableSeq(" ACGT ")
-        >>> seq.lstrip(inplace=False)
+        >>> seq.lstrip()
         MutableSeq('ACGT ')
         >>> seq
         MutableSeq(' ACGT ')

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1495,9 +1495,7 @@ class SimpleLocation(Location):
         if isinstance(f_seq, MutableSeq):
             f_seq = Seq(f_seq)
         if self.strand == -1:
-            f_seq = reverse_complement(
-                f_seq, inplace=False
-            )  # TODO: remove inplace=False
+            f_seq = reverse_complement(f_seq)
         return f_seq
 
 

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -1286,14 +1286,10 @@ class SeqRecord:
         if "protein" in cast(str, self.annotations.get("molecule_type", "")):
             raise ValueError("Proteins do not have complements!")
         if "RNA" in cast(str, self.annotations.get("molecule_type", "")):
-            seq = self.seq.reverse_complement_rna(
-                inplace=False
-            )  # TODO: remove inplace=False
+            seq = self.seq.reverse_complement_rna()
         else:
-            # Default to DNA)
-            seq = self.seq.reverse_complement(
-                inplace=False
-            )  # TODO: remove inplace=False
+            # Default to DNA
+            seq = self.seq.reverse_complement()
         if isinstance(self.seq, MutableSeq):
             seq = Seq(seq)
         answer = type(self)(seq)

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -479,7 +479,7 @@ def molecular_weight(
         if seq_type == "protein":
             raise ValueError("protein sequences cannot be double-stranded")
         elif seq_type == "DNA":
-            seq = complement(seq, inplace=False)  # TODO: remove inplace=False
+            seq = complement(seq)
         elif seq_type == "RNA":
             seq = complement_rna(seq)
         weight += sum(weight_table[x] for x in seq) - (len(seq) - 1) * water
@@ -519,7 +519,7 @@ def six_frame_translations(seq, genetic_code=1):
     if "u" in seq.lower():
         anti = reverse_complement_rna(seq)
     else:
-        anti = reverse_complement(seq, inplace=False)  # TODO: remove inplace=False
+        anti = reverse_complement(seq)
     comp = anti[::-1]
     length = len(seq)
     frames = {}

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -277,10 +277,7 @@ class Instances(list):
         instances = Instances(alphabet=self.alphabet)
         instances.length = self.length
         for instance in self:
-            # TODO: remove inplace=False
-            if isinstance(instance, (Seq, MutableSeq)):
-                instance = instance.reverse_complement(inplace=False)
-            elif isinstance(instance, SeqRecord):
+            if isinstance(instance, (Seq, MutableSeq, SeqRecord)):
                 instance = instance.reverse_complement()
             elif isinstance(instance, str):
                 instance = reverse_complement(instance)

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -226,6 +226,13 @@ is considered to be unknown, and any attempt to access the sequence contents
 (for example, by calling ``print`` on the object) will result in an
 ``UndefinedSequenceError``.
 
+Bio.Seq: Functions and methods ``complement`` and ``reverse_complement``
+------------------------------------------------------------------------
+Starting from release 1.82, the ``inplace`` argument of ``complement`` and
+``reverse_complement`` in ``Bio.Seq`` always default to ``False`` both for
+``Seq`` and ``MutableSeq`` objects.
+To modify a ``MutableSeq`` in-place, use ``inplace=True``.
+
 Iterator .next() methods
 ------------------------
 The .next() method defined for any Biopython iterator is deprecated as of

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -214,8 +214,8 @@ Bio.Seq.MutableSeq(myseq) or Bio.Seq.Seq(mymutableseq), respectively.
 
 Bio.Seq.Seq.ungap()
 -------------------
-Declared obsolete in release 1.79, and deprecated in release 1.80.
-Instead of myseq.ungap(), please use myseq.replace("-", "").
+Declared obsolete in release 1.79, deprecated in release 1.80, and removed in
+release 1.82.  Instead of myseq.ungap(), please use myseq.replace("-", "").
 
 Bio.Seq.UnknownSeq
 ------------------

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -16,6 +16,10 @@ The latest news is at the top of this file.
 This release of Biopython supports Python 3.8, 3.9, 3.10, 3.11 and 3.12. It
 has also been tested on PyPy3.8 v7.8.16.
 
+The ``inplace`` argument of ``complement`` and ``reverse_complement`` in
+``Bio.Seq`` now always default to ``False`` both for ``Seq`` and ``MutableSeq``
+objects. To modify a ``MutableSeq`` in-place, use ``inplace=True``.
+
 A new class ``CodonAligner`` was added to ``Bio.Align``. A ``CodonAligner``
 object can align a nucleotide sequence to the amino acid sequence it encodes,
 using a dynamic programming algorithm modeled on ``PairwiseAligner`` to take

--- a/Tests/test_Seq_objs.py
+++ b/Tests/test_Seq_objs.py
@@ -1794,18 +1794,14 @@ class PartialSequenceTests(unittest.TestCase):
         s = Seq({3: "AACC", 11: "CGT"}, length=20)
         u = Seq({3: "AACC", 11: "CGU"}, length=20)
         self.assertEqual(repr(s.complement()), "Seq({3: 'TTGG', 11: 'GCA'}, length=20)")
-        self.assertEqual(
-            repr(u.complement(inplace=False)), "Seq({3: 'TTGG', 11: 'GCA'}, length=20)"
-        )
-        # TODO: remove inplace=False
+        self.assertEqual(repr(u.complement()), "Seq({3: 'TTGG', 11: 'GCA'}, length=20)")
         self.assertEqual(
             repr(s.reverse_complement()), "Seq({6: 'ACG', 13: 'GGTT'}, length=20)"
         )
         self.assertEqual(
-            repr(u.reverse_complement(inplace=False)),
+            repr(u.reverse_complement()),
             "Seq({6: 'ACG', 13: 'GGTT'}, length=20)",
         )
-        # TODO: remove inplace=False
         self.assertEqual(
             repr(s.complement_rna()), "Seq({3: 'UUGG', 11: 'GCA'}, length=20)"
         )

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -744,14 +744,7 @@ class TestMutableSeq(unittest.TestCase):
         """Test reverse using -1 stride."""
         self.assertEqual(Seq.MutableSeq("GTACTACGTAGGAAAACT"), self.mutable_s[::-1])
 
-    def test_complement_old(self):
-        # old approach
-        with self.assertWarns(BiopythonDeprecationWarning):
-            self.mutable_s.complement()
-        self.assertEqual("AGTTTTCCTACGTAGTAC", self.mutable_s)
-
     def test_complement(self):
-        # new approach
         self.mutable_s.complement(inplace=True)
         self.assertEqual("AGTTTTCCTACGTAGTAC", self.mutable_s)
 
@@ -794,47 +787,22 @@ class TestMutableSeq(unittest.TestCase):
         self.assertEqual(d, "TCAAAAGGATGCATCATG")
 
     def test_complement_mixed_aphabets(self):
-        # new approach
         seq = Seq.MutableSeq("AUGaaaCTG")
         seq.complement_rna(inplace=True)
         self.assertEqual("UACuuuGAC", seq)
-        # old approach
-        seq = Seq.MutableSeq("AUGaaaCTG")
-        with self.assertWarns(BiopythonDeprecationWarning):
-            with self.assertRaises(ValueError):
-                seq.complement()
 
     def test_complement_rna_string(self):
-        # new approach
         seq = Seq.MutableSeq("AUGaaaCUG")
         seq.complement_rna(inplace=True)
-        self.assertEqual("UACuuuGAC", seq)
-        # old approach
-        seq = Seq.MutableSeq("AUGaaaCUG")
-        with self.assertWarns(BiopythonDeprecationWarning):
-            seq.complement()
         self.assertEqual("UACuuuGAC", seq)
 
     def test_complement_dna_string(self):
-        # new approach
         seq = Seq.MutableSeq("ATGaaaCTG")
         seq.complement(inplace=True)
         self.assertEqual("TACtttGAC", seq)
-        # old approach
-        seq = Seq.MutableSeq("ATGaaaCTG")
-        with self.assertWarns(BiopythonDeprecationWarning):
-            seq.complement()
-        self.assertEqual("TACtttGAC", seq)
 
     def test_reverse_complement(self):
-        # new approach
         self.mutable_s.reverse_complement(inplace=True)
-        self.assertEqual("CATGATGCATCCTTTTGA", self.mutable_s)
-
-    def test_reverse_complement_old(self):
-        # old approach
-        with self.assertWarns(BiopythonDeprecationWarning):
-            self.mutable_s.reverse_complement()
         self.assertEqual("CATGATGCATCCTTTTGA", self.mutable_s)
 
     def test_extend_method(self):
@@ -891,30 +859,21 @@ class TestComplement(unittest.TestCase):
 
     def test_complement_incompatible_letters(self):
         seq = Seq.Seq("CAGGTU")
-        # new approach
-        dna = seq.complement(inplace=False)  # TODO: remove inplace=False
+        dna = seq.complement()
         self.assertEqual("GTCCAA", dna)
         rna = seq.complement_rna()
         self.assertEqual("GUCCAA", rna)
-        # old approach
-        with self.assertWarns(BiopythonDeprecationWarning):
-            with self.assertRaises(ValueError):
-                seq.complement()
 
     def test_complement_of_mixed_dna_rna(self):
         seq = "AUGAAACTG"  # U and T
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=BiopythonDeprecationWarning)
-            self.assertRaises(ValueError, Seq.complement, seq)
+        dna = Seq.complement(seq)
+        self.assertEqual("TACTTTGAC", dna)
+        rna = Seq.complement_rna(seq)
+        self.assertEqual("UACUUUGAC", rna)
 
     def test_complement_of_rna(self):
         seq = "AUGAAACUG"
-        # new approach
         rna = Seq.complement_rna(seq)
-        self.assertEqual("UACUUUGAC", rna)
-        # old approach
-        with self.assertWarns(BiopythonDeprecationWarning):
-            rna = Seq.complement(seq)
         self.assertEqual("UACUUUGAC", rna)
 
     def test_complement_of_dna(self):
@@ -982,18 +941,14 @@ class TestReverseComplement(unittest.TestCase):
 
     def test_reverse_complement_of_mixed_dna_rna(self):
         seq = "AUGAAACTG"  # U and T
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=BiopythonDeprecationWarning)
-            self.assertRaises(ValueError, Seq.reverse_complement, seq)
+        dna = Seq.reverse_complement(seq)
+        self.assertEqual("CAGTTTCAT", dna)
+        rna = Seq.reverse_complement_rna(seq)
+        self.assertEqual("CAGUUUCAU", rna)
 
     def test_reverse_complement_of_rna(self):
-        # old approach
         seq = "AUGAAACUG"
-        with self.assertWarns(BiopythonDeprecationWarning):
-            rna = Seq.reverse_complement(seq)
-        self.assertEqual("CAGUUUCAU", rna)
-        # new approach
-        dna = Seq.reverse_complement(seq, inplace=False)  # TODO: remove inplace=False
+        dna = Seq.reverse_complement(seq)
         self.assertEqual("CAGTTTCAT", dna)
 
     def test_reverse_complement_of_dna(self):

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     numpy = None
 
-from Bio import BiopythonWarning, BiopythonDeprecationWarning
+from Bio import BiopythonWarning
 from Bio import Seq
 from Bio.Data.IUPACData import (
     ambiguous_dna_complement,


### PR DESCRIPTION
This PR removes deprecated code from Bio.Seq.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
