### PR TITLE
Add similarity string extraction for hmmer3-text

### DIFF
--- a/Bio/SearchIO/HmmerIO/hmmer3_text.py
+++ b/Bio/SearchIO/HmmerIO/hmmer3_text.py
@@ -405,7 +405,9 @@ class Hmmer3TextParser:
                 # should strip from the beginning of the line. We can't call `strip()`
                 # since the similarity string might start with empty characters.
                 elif aln_prefix_len is not None:
-                    similarity = self.line[aln_prefix_len:-1]
+                    similarity = (
+                        self.line[aln_prefix_len:].removesuffix("\n").removesuffix("\r")
+                    )
                     if "similarity" not in annot:
                         annot["similarity"] = similarity
                     else:

--- a/Bio/SearchIO/HmmerIO/hmmer3_text.py
+++ b/Bio/SearchIO/HmmerIO/hmmer3_text.py
@@ -341,6 +341,7 @@ class Hmmer3TextParser:
             hmmseq = ""
             aliseq = ""
             annot = {}
+            aln_prefix_len = None
             self.line = self.handle.readline()
 
             # parse all the alignment blocks in the hsp
@@ -352,6 +353,12 @@ class Hmmer3TextParser:
                 # to anticipate special cases where query id == hit id
                 regx = re.search(_HRE_ID_LINE, self.line)
                 if regx:
+                    # Try to capture the block prefix len, to parse the similarity
+                    # string later.
+                    if aln_prefix_len is None:
+                        aln_prefix_len = len(regx.group(1))
+                    else:
+                        assert aln_prefix_len == len(regx.group(1))
                     # the first hit/query self.line we encounter is the hmmseq
                     if len(hmmseq) == len(aliseq):
                         hmmseq += regx.group(2)
@@ -377,11 +384,12 @@ class Hmmer3TextParser:
                     hmmseq = ""
                     aliseq = ""
                     annot = {}
+                    aln_prefix_len = None
+                    similarity = ""
                     break
-                # otherwise check if it's an annotation line and parse it
+                # check if it's an annotation line and parse it
                 # len(hmmseq) is only != len(aliseq) when the cursor is parsing
-                # the similarity character. Since we're not parsing that, we
-                # check for when the condition is False (i.e. when it's ==)
+                # the similarity character.
                 elif len(hmmseq) == len(aliseq):
                     regx = re.search(_HRE_ANNOT_LINE, self.line)
                     if regx:
@@ -390,6 +398,19 @@ class Hmmer3TextParser:
                             annot[annot_name] += regx.group(2)
                         else:
                             annot[annot_name] = regx.group(2)
+                # otherwise, assume we are seeing the similarity string (the string
+                # between the two alignments). We do that by checking if we have
+                # defined the aln_prefix_len variable, which is the length of string
+                # from the beginning of the line to the start of the actual alignment
+                # (sans the IDs). We need this string to see how many characters we
+                # should strip from the beginning of the line. We can't call `strip()`
+                # since the similarity string might start with empty characters.
+                elif aln_prefix_len is not None:
+                    similarity = self.line[aln_prefix_len:-1]
+                    if "similarity" not in annot:
+                        annot["similarity"] = similarity
+                    else:
+                        annot["similarity"] += similarity
 
                 self.line = self.handle.readline()
 

--- a/Bio/SearchIO/HmmerIO/hmmer3_text.py
+++ b/Bio/SearchIO/HmmerIO/hmmer3_text.py
@@ -385,7 +385,6 @@ class Hmmer3TextParser:
                     aliseq = ""
                     annot = {}
                     aln_prefix_len = None
-                    similarity = ""
                     break
                 # check if it's an annotation line and parse it
                 # len(hmmseq) is only != len(aliseq) when the cursor is parsing

--- a/Bio/SearchIO/HmmerIO/hmmer3_text.py
+++ b/Bio/SearchIO/HmmerIO/hmmer3_text.py
@@ -7,7 +7,7 @@
 
 import re
 
-from Bio.SearchIO._utils import read_forward
+from Bio.SearchIO._utils import read_forward, removesuffix
 from Bio.SearchIO._model import QueryResult, Hit, HSP, HSPFragment
 
 from ._base import _BaseHmmerTextIndexer
@@ -405,8 +405,8 @@ class Hmmer3TextParser:
                 # should strip from the beginning of the line. We can't call `strip()`
                 # since the similarity string might start with empty characters.
                 elif aln_prefix_len is not None:
-                    similarity = (
-                        self.line[aln_prefix_len:].removesuffix("\n").removesuffix("\r")
+                    similarity =  removesuffix(
+                        removesuffix(self.line[aln_prefix_len:], "\n"), "\r",
                     )
                     if "similarity" not in annot:
                         annot["similarity"] = similarity

--- a/Bio/SearchIO/HmmerIO/hmmer3_text.py
+++ b/Bio/SearchIO/HmmerIO/hmmer3_text.py
@@ -405,8 +405,9 @@ class Hmmer3TextParser:
                 # should strip from the beginning of the line. We can't call `strip()`
                 # since the similarity string might start with empty characters.
                 elif aln_prefix_len is not None:
-                    similarity =  removesuffix(
-                        removesuffix(self.line[aln_prefix_len:], "\n"), "\r",
+                    similarity = removesuffix(
+                        removesuffix(self.line[aln_prefix_len:], "\n"),
+                        "\r",
                     )
                     if "similarity" not in annot:
                         annot["similarity"] = similarity

--- a/Bio/SearchIO/_utils.py
+++ b/Bio/SearchIO/_utils.py
@@ -176,7 +176,7 @@ def removesuffix(string, suffix):
     # 3.8 is already the oldest supported version.
     major, minor, *_ = sys.version_info
     if major == 3 and minor == 8:
-        if string.endswith(suffix):
+        if suffix and string.endswith(suffix):
             return string[: -len(suffix)]
         return string
     return string.removesuffix(suffix)

--- a/Bio/SearchIO/_utils.py
+++ b/Bio/SearchIO/_utils.py
@@ -5,6 +5,8 @@
 # package.
 """Common SearchIO utility functions."""
 
+import sys
+
 
 def getattr_str(obj, attr, fmt=None, fallback="?"):
     """Return string of the given object's attribute.
@@ -165,3 +167,16 @@ def fragcascade(attr, seq_type, doc=""):
             setattr(seq, attr, value)
 
     return property(fget=getter, fset=setter, doc=doc)
+
+
+def removesuffix(string, suffix):
+    """Remove the suffix from the string, if it exists."""
+    # This method is a compatibility wrapper for Python 3.8. It should be
+    # removed when support for Python 3.8 is dropped. At the time of writing,
+    # 3.8 is already the oldest supported version.
+    major, minor, *_ = sys.version_info
+    if major == 3 and minor == 8:
+        if string.endswith(suffix):
+            return string[: -len(suffix)]
+        return string
+    return string.removesuffix(suffix)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -31,6 +31,11 @@ the ``Bio.codonalign`` module, but uses the standard ``Alignment`` class, and
 does not rely on regular expression searching to align a nucleotide sequence to
 an amino acid sequence.
 
+The ``hmmer3-text`` SearchIO format now also extracts the similarity string of
+the parsed alignments. This value is available under the 'similarity' key of
+the ``aln_annotation`` attribute of each HSP, the same as how it is done in
+other SearchIO formats.
+
 HMMER results with the full path to the hmmer executable in the banner are
 now parsed correctly. This should help Windows users and users with python
 installations in non-default locations.
@@ -111,6 +116,7 @@ possible, especially the following contributors:
 - Rob Miller
 - Thomas Holder
 - Vladislav Kuznetsov (first contribution)
+- Wibowo Arindrarto
 - Yiming Qu (first contribution)
 
 12 February 2023: Biopython 1.81

--- a/Tests/test_SearchIO_hmmer3_text.py
+++ b/Tests/test_SearchIO_hmmer3_text.py
@@ -97,6 +97,10 @@ class HmmscanCases(unittest.TestCase):
             "67899******************************************************************96",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "++ ++ele+fak +kq+ri+Lg+tqadvg +lg+l+Gk+fsqttIcrFEalqLslknmckL+pllekW+eea+",
+            hsp.aln_annotation["similarity"],
+        )
 
         # last hit
         hit = qresult[4]
@@ -138,6 +142,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(
             "345666667778888899************************99..9999999988876554",
             hsp.aln_annotation["PP"],
+        )
+        self.assertEqual(
+            "+ +++ + +++++   +++ ++l cP  sl++++++a++l  +k    v+++ +  r+  ++",
+            hsp.aln_annotation["similarity"],
         )
 
         # test if we've properly finished iteration
@@ -217,6 +225,10 @@ class HmmscanCases(unittest.TestCase):
             "5789*********************************************************************...6899***********************999998",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+++lv   w+kv+a+++ +g+e+l rlfk +p+t ++F kf+ l+  +++k s+++k+h+++vl al+ ++k+   ++ ++a++k l+++Ha+++ ++ ++ + ++e++",
+            hsp.aln_annotation["similarity"],
+        )
 
         # test third result
         qresult = next(qresults)
@@ -273,6 +285,10 @@ class HmmscanCases(unittest.TestCase):
             "8************************99..78888888****************************************9",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "kP++s++psp+v+sggnv L+C ++     + +s +     +++   +++++ ++ss +++++ +v+++ +  Y+C+a",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("Ig_2", hit.id)
@@ -312,6 +328,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(
             "799998885779*************85.899***9988655554443320...134455543444669************88443344588888888766",
             hsp.aln_annotation["PP"],
+        )
+        self.assertEqual(
+            "kp+l+a+p +vv++g nv L+C ++    + +++ k+g +e +      +            + +  vs++    Y+C+a    + +e++ +s+ +el v",
+            hsp.aln_annotation["similarity"],
         )
 
         # test fourth result
@@ -370,6 +390,10 @@ class HmmscanCases(unittest.TestCase):
             "89******************************************************99..79*********************************99*****************************************8889*********************8",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+++++ l+++++e++++e+p++Wp+++ +l  l++++++++el++ iL++l+e++++f  ++l  +rr++++++l++++++i+++ll+ l+++v+k+               ++++  a+L++l+ +++w+++++i +++  ll++l+ lLn++el+  A+ecL",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(2, hsp.domain_index)
@@ -392,6 +416,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("swvswidiglivnspllsllfqlLndpe", hsp.hit.seq)
         self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", hsp.query.seq)
         self.assertEqual("899*********98.8888899998776", hsp.aln_annotation["PP"])
+        self.assertEqual("s+v+w  ++l+++s +++ +f+ Ln++e", hsp.aln_annotation["similarity"])
 
         hit = qresult[-1]
         self.assertEqual("IBN_N", hit.id)
@@ -437,6 +462,10 @@ class HmmscanCases(unittest.TestCase):
             "56788886699*********.6555899******************........999999****99999887",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            " ++++++  P ++++ l+++ +k+    vR++++++L++ ++ +W+         ++  ek +++n++ +l+",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(2, hsp.domain_index)
@@ -459,6 +488,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("qqlpeeekelIrnnllnll", hsp.hit.seq)
         self.assertEqual("QTLPPQRRRDIQQTLTQNM", hsp.query.seq)
         self.assertEqual("6899*******99998865", hsp.aln_annotation["PP"])
+        self.assertEqual("q+lp++ + +I ++l + +", hsp.aln_annotation["similarity"])
 
         # test fifth result
         qresult = next(qresults)
@@ -515,6 +545,10 @@ class HmmscanCases(unittest.TestCase):
             "67899******************************************************************96",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "++ ++ele+fak +kq+ri+Lg+tqadvg +lg+l+Gk+fsqttIcrFEalqLslknmckL+pllekW+eea+",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[1]
         self.assertEqual("Homeobox", hit.id)
@@ -558,6 +592,10 @@ class HmmscanCases(unittest.TestCase):
             "79****************************************************997",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+rkRt++++     Le +F k+++ps ++++++A++lgL++++V+vWF+NrR+k k+",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[2]
         self.assertEqual("HTH_31", hit.id)
@@ -592,6 +630,9 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(
             "6999***********************************99", hsp.aln_annotation["PP"]
         )
+        self.assertEqual(
+            "+++ +L++ R + G tq++v+  lg      +S++t++r E", hsp.aln_annotation["similarity"]
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -613,6 +654,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("rgrpsaavlaalaralgldpaera", hsp.hit.seq)
         self.assertEqual("CPKPSLQQITHIANQLGLEKDVVR", hsp.query.seq)
         self.assertEqual("678**************9988765", hsp.aln_annotation["PP"])
+        self.assertEqual("++ ps+++++ +a+ lgl+ + ++", hsp.aln_annotation["similarity"])
 
         hit = qresult[3]
         self.assertEqual("Homeobox_KN", hit.id)
@@ -645,6 +687,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("hnPYPskevkeelakqTglsrkqidnWFiNaRr", hsp.hit.seq)
         self.assertEqual("KCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQ", hsp.query.seq)
         self.assertEqual("56779*************************996", hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "+ P Ps +++  +a+q gl  + +  WF N R ",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[4]
         self.assertEqual("DUF521", hit.id)
@@ -685,6 +731,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(
             "345666667778888899************************99..9999999988876554",
             hsp.aln_annotation["PP"],
+        )
+        self.assertEqual(
+            "+ +++ + +++++   +++ ++l cP  sl++++++a++l  +k    v+++ +  r+  ++",
+            hsp.aln_annotation["similarity"],
         )
 
         # test if we've properly finished iteration
@@ -774,6 +824,10 @@ class HmmscanCases(unittest.TestCase):
             "5789*********************************************************************...6899***********************999998",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+++lv   w+kv+a+++ +g+e+l rlfk +p+t ++F kf+ l+  +++k s+++k+h+++vl al+ ++k+   ++ ++a++k l+++Ha+++ ++ ++ + ++e++",
+            hsp.aln_annotation["similarity"],
+        )
 
         # test if we've properly finished iteration
         self.assertRaises(StopIteration, next, qresults)
@@ -840,6 +894,10 @@ class HmmscanCases(unittest.TestCase):
             "8************************99..78888888****************************************9",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "kP++s++psp+v+sggnv L+C ++     + +s +     +++   +++++ ++ss +++++ +v+++ +  Y+C+a",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("Ig_2", hit.id)
@@ -879,6 +937,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(
             "799998885779*************85.899***9988655554443320...134455543444669************88443344588888888766",
             hsp.aln_annotation["PP"],
+        )
+        self.assertEqual(
+            "kp+l+a+p +vv++g nv L+C ++    + +++ k+g +e +      +            + +  vs++    Y+C+a    + +e++ +s+ +el v",
+            hsp.aln_annotation["similarity"],
         )
 
         # test if we've properly finished iteration
@@ -947,6 +1009,10 @@ class HmmscanCases(unittest.TestCase):
             "89******************************************************99..79*********************************99*****************************************8889*********************8",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+++++ l+++++e++++e+p++Wp+++ +l  l++++++++el++ iL++l+e++++f  ++l  +rr++++++l++++++i+++ll+ l+++v+k+               ++++  a+L++l+ +++w+++++i +++  ll++l+ lLn++el+  A+ecL",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(2, hsp.domain_index)
@@ -969,6 +1035,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("swvswidiglivnspllsllfqlLndpe", hsp.hit.seq)
         self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", hsp.query.seq)
         self.assertEqual("899*********98.8888899998776", hsp.aln_annotation["PP"])
+        self.assertEqual("s+v+w  ++l+++s +++ +f+ Ln++e", hsp.aln_annotation["similarity"])
 
         hit = qresult[-1]
         self.assertEqual("IBN_N", hit.id)
@@ -1014,6 +1081,10 @@ class HmmscanCases(unittest.TestCase):
             "56788886699*********.6555899******************........999999****99999887",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            " ++++++  P ++++ l+++ +k+    vR++++++L++ ++ +W+         ++  ek +++n++ +l+",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(2, hsp.domain_index)
@@ -1036,6 +1107,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("qqlpeeekelIrnnllnll", hsp.hit.seq)
         self.assertEqual("QTLPPQRRRDIQQTLTQNM", hsp.query.seq)
         self.assertEqual("6899*******99998865", hsp.aln_annotation["PP"])
+        self.assertEqual("q+lp++ + +I ++l + +", hsp.aln_annotation["similarity"])
 
         # test if we've properly finished iteration
         self.assertRaises(StopIteration, next, qresults)
@@ -1102,6 +1174,10 @@ class HmmscanCases(unittest.TestCase):
             "67899******************************************************************96",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "++ ++ele+fak +kq+ri+Lg+tqadvg +lg+l+Gk+fsqttIcrFEalqLslknmckL+pllekW+eea+",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[1]
         self.assertEqual("Homeobox", hit.id)
@@ -1145,6 +1221,10 @@ class HmmscanCases(unittest.TestCase):
             "79****************************************************997",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+rkRt++++     Le +F k+++ps ++++++A++lgL++++V+vWF+NrR+k k+",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[2]
         self.assertEqual("HTH_31", hit.id)
@@ -1179,6 +1259,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(
             "6999***********************************99", hsp.aln_annotation["PP"]
         )
+        self.assertEqual(
+            "+++ +L++ R + G tq++v+  lg      +S++t++r E",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -1200,6 +1284,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("rgrpsaavlaalaralgldpaera", hsp.hit.seq)
         self.assertEqual("CPKPSLQQITHIANQLGLEKDVVR", hsp.query.seq)
         self.assertEqual("678**************9988765", hsp.aln_annotation["PP"])
+        self.assertEqual("++ ps+++++ +a+ lgl+ + ++", hsp.aln_annotation["similarity"])
 
         hit = qresult[3]
         self.assertEqual("Homeobox_KN", hit.id)
@@ -1232,6 +1317,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("hnPYPskevkeelakqTglsrkqidnWFiNaRr", hsp.hit.seq)
         self.assertEqual("KCPKPSLQQITHIANQLGLEKDVVRVWFCNRRQ", hsp.query.seq)
         self.assertEqual("56779*************************996", hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "+ P Ps +++  +a+q gl  + +  WF N R ",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[4]
         self.assertEqual("DUF521", hit.id)
@@ -1272,6 +1361,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual(
             "345666667778888899************************99..9999999988876554",
             hsp.aln_annotation["PP"],
+        )
+        self.assertEqual(
+            "+ +++ + +++++   +++ ++l cP  sl++++++a++l  +k    v+++ +  r+  ++",
+            hsp.aln_annotation["similarity"],
         )
 
         # test if we've properly finished iteration
@@ -1528,6 +1621,10 @@ class HmmscanCases(unittest.TestCase):
             "89******************************************************99..79*********************************99*****************************************8889*********************8",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+++++ l+++++e++++e+p++Wp+++ +l  l++++++++el++ iL++l+e++++f  ++l  +rr++++++l++++++i+++ll+ l+++v+k+               ++++  a+L++l+ +++w+++++i +++  ll++l+ lLn++el+  A+ecL",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(2, hsp.domain_index)
@@ -1550,6 +1647,10 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("swvswidiglivnspllsllfqlLndpe", hsp.hit.seq)
         self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", hsp.query.seq)
         self.assertEqual("899*********98.8888899998776", hsp.aln_annotation["PP"])
+        self.assertEqual(
+            "s+v+w  ++l+++s +++ +f+ Ln++e",
+            hsp.aln_annotation["similarity"],
+        )
 
         hit = qresult[-1]
         self.assertEqual("IBN_N", hit.id)
@@ -1595,6 +1696,10 @@ class HmmscanCases(unittest.TestCase):
             "56788886699*********.6555899******************........999999****99999887",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            " ++++++  P ++++ l+++ +k+    vR++++++L++ ++ +W+         ++  ek +++n++ +l+",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[-1]
         self.assertEqual(2, hsp.domain_index)
@@ -1617,6 +1722,7 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("qqlpeeekelIrnnllnll", hsp.hit.seq)
         self.assertEqual("QTLPPQRRRDIQQTLTQNM", hsp.query.seq)
         self.assertEqual("6899*******99998865", hsp.aln_annotation["PP"])
+        self.assertEqual("q+lp++ + +I ++l + +", hsp.aln_annotation["similarity"])
 
         # test if we've properly finished iteration
         self.assertRaises(StopIteration, next, qresults)
@@ -1897,6 +2003,10 @@ class HmmersearchCases(unittest.TestCase):
             "67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+ell+ lG+Gs+GkV+ ++k   ++ g+ +A+K+lkk + k + + +++ E  il++++Hp+ivkl+ +f+t+ +lyl+l++++ggdlf+ l+ke  ++ee++k+++ +++ +l++lH  gii+rDLKpeNiLld++g++ki+DFGl+k+++ +++++++++gt eYmAPEv++ ++++t+++D+Ws+Gv+++e+ltg+lpf+g+   d++e+++ ilk kl  ++  s    +e+++l++ l++++p +Rl      +eei++hp++",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -1930,6 +2040,10 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(
             "7899***********************************98......9*******99**************************************************************************98544444888**********************************.***************************************************************************************7",
             hsp.aln_annotation["PP"],
+        )
+        self.assertEqual(
+            "ye++e +G Gs+++++++++k t  ++AvKi++k++++ ++      E++il +  +Hpni++l +v+ + +++ylv+e+++gg+l d + +++++se+e+ +++++i++ ++ylHs+g++HrDLKp+NiL  +++      +i+DFG+ak+l  +++ l t + t +++APEvl+ +++y++++DvWslG++ly++l g +pf +  +++ +e++++i ++k+  +  +++s s+ +kd+++k+l+ dp++Rlta ++lkhpw+",
+            hsp.aln_annotation["similarity"],
         )
 
         hit = qresult[-1]
@@ -1979,6 +2093,10 @@ class HmmersearchCases(unittest.TestCase):
             "67899**********8888876655455****************999999****************************************************************************************************9***********************.******************************...999999999999988888866....9******************9888888999999886",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+ell+ lG+GsfGkV+ +kk + ++    +A+K+lkk + k + + +++ E  il +++Hp+ivkl+ +f+t+ +lyl+l++++ggdlf+ l+ke  ++ee++k+++ +++ +l++lHs gii+rDLKpeNiLld++g++k++DFGl+k+   +++k+++++gt eYmAPEv++ ++++t+++D+Ws+Gv+++e+ltg+lpf+g+   d++e++ +ilk kl  ++  s    +e+++l++ l++++pa+Rl      +eei++h+++",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -2012,6 +2130,10 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(
             "7899***********************************88......9*******99**********************************9***************************************98554444888**********************************.***************************************************************************************7",
             hsp.aln_annotation["PP"],
+        )
+        self.assertEqual(
+            "ye++e +G Gs+++++++++k t+ ++AvKi++k++++ ++      E++il +  +Hpni++l +v+ + +++y+v+e+++gg+l d + +++ +se+e+  ++ +i + +eylH +g++HrDLKp+NiL  +++      +i+DFG+ak+l  +++ l t + t +++APEvl+ +++y++++D+WslGv+ly++ltg +pf +  +++ +e++++i ++k + +   ++s s+++kdl++k+l+ dp++Rlta+ +l+hpw+",
+            hsp.aln_annotation["similarity"],
         )
 
         # test if we've properly finished iteration
@@ -2205,6 +2327,10 @@ class HmmersearchCases(unittest.TestCase):
             "67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+ell+ lG+Gs+GkV+ ++k   ++ g+ +A+K+lkk + k + + +++ E  il++++Hp+ivkl+ +f+t+ +lyl+l++++ggdlf+ l+ke  ++ee++k+++ +++ +l++lH  gii+rDLKpeNiLld++g++ki+DFGl+k+++ +++++++++gt eYmAPEv++ ++++t+++D+Ws+Gv+++e+ltg+lpf+g+   d++e+++ ilk kl  ++  s    +e+++l++ l++++p +Rl      +eei++hp++",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -2238,6 +2364,10 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(
             "7899***********************************98......9*******99**************************************************************************98544444888**********************************.***************************************************************************************7",
             hsp.aln_annotation["PP"],
+        )
+        self.assertEqual(
+            "ye++e +G Gs+++++++++k t  ++AvKi++k++++ ++      E++il +  +Hpni++l +v+ + +++ylv+e+++gg+l d + +++++se+e+ +++++i++ ++ylHs+g++HrDLKp+NiL  +++      +i+DFG+ak+l  +++ l t + t +++APEvl+ +++y++++DvWslG++ly++l g +pf +  +++ +e++++i ++k+  +  +++s s+ +kd+++k+l+ dp++Rlta ++lkhpw+",
+            hsp.aln_annotation["similarity"],
         )
 
         hit = qresult[-1]
@@ -2287,6 +2417,10 @@ class HmmersearchCases(unittest.TestCase):
             "67899**********8888876655455****************999999****************************************************************************************************9***********************.******************************...999999999999988888866....9******************9888888999999886",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+ell+ lG+GsfGkV+ +kk + ++    +A+K+lkk + k + + +++ E  il +++Hp+ivkl+ +f+t+ +lyl+l++++ggdlf+ l+ke  ++ee++k+++ +++ +l++lHs gii+rDLKpeNiLld++g++k++DFGl+k+   +++k+++++gt eYmAPEv++ ++++t+++D+Ws+Gv+++e+ltg+lpf+g+   d++e++ +ilk kl  ++  s    +e+++l++ l++++pa+Rl      +eei++h+++",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -2320,6 +2454,10 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(
             "7899***********************************88......9*******99**********************************9***************************************98554444888**********************************.***************************************************************************************7",
             hsp.aln_annotation["PP"],
+        )
+        self.assertEqual(
+            "ye++e +G Gs+++++++++k t+ ++AvKi++k++++ ++      E++il +  +Hpni++l +v+ + +++y+v+e+++gg+l d + +++ +se+e+  ++ +i + +eylH +g++HrDLKp+NiL  +++      +i+DFG+ak+l  +++ l t + t +++APEvl+ +++y++++D+WslGv+ly++ltg +pf +  +++ +e++++i ++k + +   ++s s+++kdl++k+l+ dp++Rlta+ +l+hpw+",
+            hsp.aln_annotation["similarity"],
         )
 
         # test if we've properly finished iteration
@@ -2403,6 +2541,10 @@ class HmmersearchCases(unittest.TestCase):
             "67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+ell+ lG+Gs+GkV+ ++k   ++ g+ +A+K+lkk + k + + +++ E  il++++Hp+ivkl+ +f+t+ +lyl+l++++ggdlf+ l+ke  ++ee++k+++ +++ +l++lH  gii+rDLKpeNiLld++g++ki+DFGl+k+++ +++++++++gt eYmAPEv++ ++++t+++D+Ws+Gv+++e+ltg+lpf+g+   d++e+++ ilk kl  ++  s    +e+++l++ l++++p +Rl      +eei++hp++",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -2436,6 +2578,10 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(
             "7899***********************************98......9*******99**************************************************************************98544444888**********************************.***************************************************************************************7",
             hsp.aln_annotation["PP"],
+        )
+        self.assertEqual(
+            "ye++e +G Gs+++++++++k t  ++AvKi++k++++ ++      E++il +  +Hpni++l +v+ + +++ylv+e+++gg+l d + +++++se+e+ +++++i++ ++ylHs+g++HrDLKp+NiL  +++      +i+DFG+ak+l  +++ l t + t +++APEvl+ +++y++++DvWslG++ly++l g +pf +  +++ +e++++i ++k+  +  +++s s+ +kd+++k+l+ dp++Rlta ++lkhpw+",
+            hsp.aln_annotation["similarity"],
         )
 
         hit = qresult[-1]
@@ -2485,6 +2631,10 @@ class HmmersearchCases(unittest.TestCase):
             "67899**********8888876655455****************999999****************************************************************************************************9***********************.******************************...999999999999988888866....9******************9888888999999886",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+ell+ lG+GsfGkV+ +kk + ++    +A+K+lkk + k + + +++ E  il +++Hp+ivkl+ +f+t+ +lyl+l++++ggdlf+ l+ke  ++ee++k+++ +++ +l++lHs gii+rDLKpeNiLld++g++k++DFGl+k+   +++k+++++gt eYmAPEv++ ++++t+++D+Ws+Gv+++e+ltg+lpf+g+   d++e++ +ilk kl  ++  s    +e+++l++ l++++pa+Rl      +eei++h+++",
+            hsp.aln_annotation["similarity"],
+        )
 
         hsp = hit.hsps[1]
         self.assertEqual(2, hsp.domain_index)
@@ -2518,6 +2668,10 @@ class HmmersearchCases(unittest.TestCase):
         self.assertEqual(
             "7899***********************************88......9*******99**********************************9***************************************98554444888**********************************.***************************************************************************************7",
             hsp.aln_annotation["PP"],
+        )
+        self.assertEqual(
+            "ye++e +G Gs+++++++++k t+ ++AvKi++k++++ ++      E++il +  +Hpni++l +v+ + +++y+v+e+++gg+l d + +++ +se+e+  ++ +i + +eylH +g++HrDLKp+NiL  +++      +i+DFG+ak+l  +++ l t + t +++APEvl+ +++y++++D+WslGv+ly++ltg +pf +  +++ +e++++i ++k + +   ++s s+++kdl++k+l+ dp++Rlta+ +l+hpw+",
+            hsp.aln_annotation["similarity"],
         )
 
         # test if we've properly finished iteration
@@ -2589,6 +2743,10 @@ class PhmmerCases(unittest.TestCase):
             "89***************************************************************************************",
             hsp.aln_annotation["PP"][:89],
         )
+        self.assertEqual(
+            "mafsaedvlkeydrrrrmealllslyypndrklldykewspprvqvecpkapvewnnppsekglivghfsgikykgekaqasevdvnkm",
+            hsp.aln_annotation["similarity"][:89],
+        )
 
         # last query, last hit
         qresult = qresults[-1]
@@ -2637,6 +2795,10 @@ class PhmmerCases(unittest.TestCase):
         self.assertEqual("cpqswygspqlereivckmsgaphypnyyp", hsp.query.seq)
         self.assertEqual("YPDCSYGMSQLERSIVVACEGSPYVPVHFD", hsp.hit.seq)
         self.assertEqual("68889******************9887764", hsp.aln_annotation["PP"])
+        self.assertEqual(
+            " p   yg  qler iv    g+p+ p ++ ",
+            hsp.aln_annotation["similarity"],
+        )
 
 
 if __name__ == "__main__":

--- a/Tests/test_SearchIO_hmmer3_text.py
+++ b/Tests/test_SearchIO_hmmer3_text.py
@@ -416,7 +416,9 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("swvswidiglivnspllsllfqlLndpe", hsp.hit.seq)
         self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", hsp.query.seq)
         self.assertEqual("899*********98.8888899998776", hsp.aln_annotation["PP"])
-        self.assertEqual("s+v+w  ++l+++s +++ +f+ Ln++e", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "s+v+w  ++l+++s +++ +f+ Ln++e", hsp.aln_annotation["similarity"]
+        )
 
         hit = qresult[-1]
         self.assertEqual("IBN_N", hit.id)
@@ -631,7 +633,8 @@ class HmmscanCases(unittest.TestCase):
             "6999***********************************99", hsp.aln_annotation["PP"]
         )
         self.assertEqual(
-            "+++ +L++ R + G tq++v+  lg      +S++t++r E", hsp.aln_annotation["similarity"]
+            "+++ +L++ R + G tq++v+  lg      +S++t++r E",
+            hsp.aln_annotation["similarity"],
         )
 
         hsp = hit.hsps[1]
@@ -1035,7 +1038,9 @@ class HmmscanCases(unittest.TestCase):
         self.assertEqual("swvswidiglivnspllsllfqlLndpe", hsp.hit.seq)
         self.assertEqual("SFVQWEAMTLFLES-VITQMFRTLNREE", hsp.query.seq)
         self.assertEqual("899*********98.8888899998776", hsp.aln_annotation["PP"])
-        self.assertEqual("s+v+w  ++l+++s +++ +f+ Ln++e", hsp.aln_annotation["similarity"])
+        self.assertEqual(
+            "s+v+w  ++l+++s +++ +f+ Ln++e", hsp.aln_annotation["similarity"]
+        )
 
         hit = qresult[-1]
         self.assertEqual("IBN_N", hit.id)

--- a/Tests/test_SearchIO_hmmer3_text.py
+++ b/Tests/test_SearchIO_hmmer3_text.py
@@ -1807,6 +1807,10 @@ class HmmersearchCases(unittest.TestCase):
             "67899**********7666611155667*****************99999****************************************************************************************************************************.******************************...999999999999999998866....99******************9999999*****997",
             hsp.aln_annotation["PP"],
         )
+        self.assertEqual(
+            "+ell+ lG+Gs+GkV+ ++k   ++ g+ +A+K+lkk + k + + +++ E  il++++Hp+ivkl+ +f+t+ +lyl+l++++ggdlf+ l+ke  ++ee++k+++ +++ +l++lH  gii+rDLKpeNiLld++g++ki+DFGl+k+++ +++++++++gt eYmAPEv++ ++++t+++D+Ws+Gv+++e+ltg+lpf+g+   d++e+++ ilk kl  ++  s    +e+++l++ l++++p +Rl      +eei++hp++",
+            hsp.aln_annotation["similarity"],
+        )
 
     def test_30_hmmsearch_001(self):
         """Parsing hmmersearch 3.0 (text_30_hmmsearch_001)."""


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This PR updates the `hmmer3-text` SearchIO parsing to also extract the similarity string of the HSP alignments. I have also updated the tests to ensure that we can indeed extract the string from all existing test files we have.

Closes #4494