### PR TITLE
Remove deprecated title2ids argument

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -16,7 +16,6 @@ import warnings
 
 from typing import Callable, Optional, Tuple
 
-from Bio import BiopythonDeprecationWarning
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
@@ -147,18 +146,12 @@ class FastaIterator(SequenceIterator):
         self,
         source: _TextIOSource,
         alphabet: None = None,
-        title2ids: Optional[Callable[[str], Tuple[str, str, str]]] = None,
     ) -> None:
         """Iterate over Fasta records as SeqRecord objects.
 
         Arguments:
          - source - input stream opened in text mode, or a path to a file
          - alphabet - optional alphabet, not used. Leave as None.
-         - title2ids (DEPRECATED) - A function that, when given the title of
-           the FASTA file (without the beginning >), will return the id, name
-           and description (in that order) for the record as a tuple of strings.
-           If this is not given, then the entire title line will be used
-           as the description, and the first word as the id and name.
 
         By default this will act like calling Bio.SeqIO.parse(handle, "fasta")
         with no custom handling of the title lines:
@@ -173,22 +166,8 @@ class FastaIterator(SequenceIterator):
         alpha
         delta
 
-        However, you can supply a title2ids function to alter this (DEPRECATED):
-
-        >>> def take_upper(title):
-        ...     return title.split(None, 1)[0].upper(), "", title
-        >>> with open("Fasta/dups.fasta") as handle:
-        ...     for record in FastaIterator(handle, title2ids=take_upper):
-        ...         print(record.id)
-        ...
-        ALPHA
-        BETA
-        GAMMA
-        ALPHA
-        DELTA
-
-        Instead of title2ids, please use a generator function to modify the
-        records:
+        If you want to modify the records before writing, for example to change
+        the ID of each record, you can use a generator function as follows:
 
         >>> def modify_records(records):
         ...     for record in records:
@@ -208,26 +187,6 @@ class FastaIterator(SequenceIterator):
         """
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
-        if title2ids is not None:
-            warnings.warn(
-                "The title2ids argument is deprecated. Instead, please use a "
-                "generator function to modify records returned by the parser. "
-                "For example, to change the record IDs to uppercase, and "
-                "delete the description attribute, use\n"
-                "\n"
-                ">>> def modify_records(records):\n"
-                "...     for record in records:\n"
-                "...         record.id = record.id.upper()\n"
-                "...         del record.description\n"
-                "...         yield record\n"
-                "...\n"
-                ">>> with open('Fasta/dups.fasta') as handle:\n"
-                "...     for record in modify_records(FastaIterator(handle)):\n"
-                "...         print(record)\n"
-                "\n",
-                BiopythonDeprecationWarning,
-            )
-        self.title2ids = title2ids
         super().__init__(source, mode="t", fmt="Fasta")
 
     def parse(self, handle):
@@ -237,22 +196,16 @@ class FastaIterator(SequenceIterator):
 
     def iterate(self, handle):
         """Parse the file and generate SeqRecord objects."""
-        title2ids = self.title2ids
-        if title2ids:
-            for title, sequence in SimpleFastaParser(handle):
-                id, name, descr = title2ids(title)
-                yield SeqRecord(Seq(sequence), id=id, name=name, description=descr)
-        else:
-            for title, sequence in SimpleFastaParser(handle):
-                try:
-                    first_word = title.split(None, 1)[0]
-                except IndexError:
-                    assert not title, repr(title)
-                    # Should we use SeqRecord default for no ID?
-                    first_word = ""
-                yield SeqRecord(
-                    Seq(sequence), id=first_word, name=first_word, description=title
-                )
+        for title, sequence in SimpleFastaParser(handle):
+            try:
+                first_word = title.split(None, 1)[0]
+            except IndexError:
+                assert not title, repr(title)
+                # Should we use SeqRecord default for no ID?
+                first_word = ""
+            yield SeqRecord(
+                Seq(sequence), id=first_word, name=first_word, description=title
+            )
 
 
 class FastaTwoLineIterator(SequenceIterator):

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -410,7 +410,8 @@ list(SimpleFastaParser(handle)) from Bio.SeqIO.FastaIO instead (but
 ideally convert your code to using an iterator approach).
 
 The 'title2ids' argument to FastaIterator in Bio.SeqIO.FastaIO and
-FastqPhredIterator in Bio.SeqIO.QualityIO was deprecated in Release 1.80.
+FastqPhredIterator in Bio.SeqIO.QualityIO was deprecated in Release 1.80, and
+removed in Release 1.82.
 Please use a generator function to modify the records returned by the parser.
 
 Function Tm_staluc in Bio.SeqUtils.MeltingTemp was deprecated in Release 1.78,

--- a/Tests/test_SeqIO_FastaIO.py
+++ b/Tests/test_SeqIO_FastaIO.py
@@ -87,41 +87,11 @@ class TitleFunctions(unittest.TestCase):
         """Test parsing single record FASTA files."""
         msg = f"Test failure parsing file {filename}"
         title, seq = read_title_and_seq(filename)  # crude parser
-        idn, name, descr = title_to_ids(title)
-        # First check using Bio.SeqIO.FastaIO directly with title2ids function.
-        # (DEPRECATED)
-        with self.assertWarns(BiopythonDeprecationWarning):
-            records = FastaIterator(filename, title2ids=title_to_ids)
-        record = next(records)
-        with self.assertRaises(StopIteration):
-            next(records)
-        self.assertEqual(record.id, idn, msg=msg)
-        self.assertEqual(record.name, name, msg=msg)
-        self.assertEqual(record.description, descr, msg=msg)
-        self.assertEqual(record.seq, seq, msg=msg)
-        # Now check using Bio.SeqIO (default settings)
         record = SeqIO.read(filename, "fasta")
         self.assertEqual(record.id, title.split()[0], msg=msg)
         self.assertEqual(record.name, title.split()[0], msg=msg)
         self.assertEqual(record.description, title, msg=msg)
         self.assertEqual(record.seq, seq, msg=msg)
-        # Uncomment this for testing the methods are calling the right files:
-        # print("{%s done}" % filename)
-
-    def multi_check(self, filename):
-        """Test parsing multi-record FASTA files."""
-        msg = f"Test failure parsing file {filename}"
-        # title2ids is deprecated
-        with self.assertWarns(BiopythonDeprecationWarning):
-            re_titled = list(FastaIterator(filename, title2ids=title_to_ids))
-        default = list(SeqIO.parse(filename, "fasta"))
-        self.assertEqual(len(re_titled), len(default), msg=msg)
-        for old, new in zip(default, re_titled):
-            idn, name, descr = title_to_ids(old.description)
-            self.assertEqual(new.id, idn, msg=msg)
-            self.assertEqual(new.name, name, msg=msg)
-            self.assertEqual(new.description, descr, msg=msg)
-            self.assertEqual(new.seq, old.seq, msg=msg)
         # Uncomment this for testing the methods are calling the right files:
         # print("{%s done}" % filename)
 
@@ -150,12 +120,6 @@ class TitleFunctions(unittest.TestCase):
         for path in paths:
             self.simple_check(path)
 
-    def test_multi_dna_files(self):
-        """Test Fasta files containing multiple nucleotide sequences."""
-        paths = ("Quality/example.fasta",)
-        for path in paths:
-            self.multi_check(path)
-
     def test_single_proteino_files(self):
         """Test Fasta files containing a single protein sequence."""
         paths = (
@@ -166,12 +130,6 @@ class TitleFunctions(unittest.TestCase):
         )
         for path in paths:
             self.simple_check(path)
-
-    def test_multi_protein_files(self):
-        """Test Fasta files containing multiple protein sequences."""
-        paths = ("Fasta/f002", "Fasta/fa01")
-        for path in paths:
-            self.multi_check(path)
 
 
 class TestSimpleFastaParsers(unittest.TestCase):

--- a/Tests/test_SeqIO_FastaIO.py
+++ b/Tests/test_SeqIO_FastaIO.py
@@ -8,7 +8,6 @@ import unittest
 
 from io import StringIO
 
-from Bio import BiopythonDeprecationWarning
 from Bio import SeqIO
 from Bio.SeqIO.FastaIO import FastaIterator
 from Bio.SeqIO.FastaIO import FastaTwoLineParser


### PR DESCRIPTION
This PR removes the deprecated title2ids argument from Bio/SeqIO/FastaIO.py and Bio/SeqIO/QualityIO.py.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
