### PR TITLE
In chain files, print score as integer if possible

### DIFF
--- a/Bio/Align/bed.py
+++ b/Bio/Align/bed.py
@@ -112,7 +112,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             score = alignment.score
         except AttributeError:
             score = 0
-        fields.append(str(score))
+        fields.append(format(score, "g"))
         if bedN == 5:
             return "\t".join(fields) + "\n"
         fields.append(strand)
@@ -243,9 +243,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 score = float(score)
             except ValueError:
                 pass
-            else:
-                if score.is_integer():
-                    score = int(score)
             alignment.score = score
             if bedN <= 6:
                 return alignment

--- a/Bio/Align/chain.py
+++ b/Bio/Align/chain.py
@@ -59,15 +59,10 @@ class AlignmentWriter(interfaces.AlignmentWriter):
         tSize = len(target)
         qSize = len(query)
         lines = []
-        words = [None] * 12
-        words[0] = "chain"
         try:
             score = alignment.score
         except AttributeError:
             score = 0
-        words[1] = str(score)
-        words[2] = tName
-        words[3] = str(tSize)
         if coordinates[0, 0] > coordinates[0, -1]:
             tStrand = "-"
             coordinates = coordinates.copy()
@@ -80,25 +75,16 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             coordinates[1, :] = qSize - coordinates[1, :]
         else:
             qStrand = "+"
-        words[4] = tStrand
         tStart = coordinates[0, 0]
         tEnd = coordinates[0, -1]
         qStart = coordinates[1, 0]
         qEnd = coordinates[1, -1]
-        words[5] = str(tStart)
-        words[6] = str(tEnd)
-        words[7] = qName
-        words[8] = str(qSize)
-        words[9] = qStrand
-        words[10] = str(qStart)
-        words[11] = str(qEnd)
         try:
             chainID = alignment.annotations["id"]
         except (AttributeError, KeyError):
-            pass
+            line = f"chain {score:g} {tName} {tSize} {tStrand} {tStart} {tEnd} {qName} {qSize} {qStrand} {qStart} {qEnd}"
         else:
-            words.append(chainID)
-        line = " ".join(words)
+            line = f"chain {score:g} {tName} {tSize} {tStrand} {tStart} {tEnd} {qName} {qSize} {qStrand} {qStart} {qEnd} {chainID}"
         lines.append(line)
         # variable names follow those in the UCSC chain file format description
         tStart, qStart = coordinates[:, 0]
@@ -179,7 +165,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
     Each chain block in the file contains one pairwise alignment, which are
     loaded and returned incrementally.  The alignment score is scored as an
-    attribute of the alignment; the ID is stored as an attribute.
+    attribute of the alignment; the ID is stored under the key "id" in the
+    dictionary referred to by the annotations attribute of the alignment.
     """
 
     fmt = "chain"

--- a/Bio/Align/chain.py
+++ b/Bio/Align/chain.py
@@ -196,8 +196,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 "expected first line of chain block to start with 'chain '"
             )
         score = float(words[1])
-        if score.is_integer():
-            score = int(score)
         tName = words[2]
         tSize = int(words[3])
         tStrand = words[4]

--- a/Bio/Align/sam.py
+++ b/Bio/Align/sam.py
@@ -323,7 +323,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
         except AttributeError:
             pass
         else:
-            field = "AS:i:%d" % int(round(score))
+            field = "AS:i:%.0f" % score
             fields.append(field)
         try:
             annotations = alignment.annotations

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -1986,7 +1986,7 @@ Now we can print the alignment in BED and PSL format:
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(format(alignment, "bed"))  # doctest: +NORMALIZE_WHITESPACE
-gi|330443520|ref|NC_001136.10|	1318045	1319275	gi|296143771|ref|NM_001180731.1| 6146.0	-	1318045	1319275	0	3	1226,3,1,	0,1226,1229,
+gi|330443520|ref|NC_001136.10|	1318045	1319275	gi|296143771|ref|NM_001180731.1| 6146	-	1318045	1319275	0	3	1226,3,1,	0,1226,1229,
 <BLANKLINE>
 >>> print(format(alignment, "psl"))  # doctest: +NORMALIZE_WHITESPACE
 1230	0	0	0	0	0	0	0	-	gi|296143771|ref|NM_001180731.1|	1230	0	1230	gi|330443520|ref|NC_001136.10|	1319275	1318045	1319275	3	1226,3,1,	0,1226,1229,	1318045,1319271,1319274,
@@ -2009,7 +2009,7 @@ The second alignment already has the target on the forward strand and the query 
 array([[1318045, 1318174, 1318177, 1319275],
        [   1230,    1101,    1098,       0]])
 >>> print(format(alignment, "BED"))  # doctest: +NORMALIZE_WHITESPACE
-gi|330443520|ref|NC_001136.10|	1318045	1319275	gi|296143771|ref|NM_001180731.1| 6146.0	-	1318045	1319275	0	3	129,3,1098,	0,129,132,
+gi|330443520|ref|NC_001136.10|	1318045	1319275	gi|296143771|ref|NM_001180731.1| 6146	-	1318045	1319275	0	3	129,3,1098,	0,129,132,
 <BLANKLINE>
 \end{minted}
 The third alignment contains a long gap:
@@ -2046,7 +2046,7 @@ As the target sequence (and also the query sequence) is on the forward strand, w
 %cont-doctest
 \begin{minted}{pycon}
 >>> print(format(alignment, "BED"))  # doctest: +NORMALIZE_WHITESPACE
-gi|330443688|ref|NC_001145.3|	85010	667216	gi|296143771|ref|NM_001180731.1| 518.0	+	85010	667216	0	34	11,15,4,1,8,17,4,8,3,33,7,102,14,10,5,10,4,20,15,5,4,20,6,12,5,7,1,12,75,6,4,2,3,41,	0,11,26,30,31,39,168964,168969,168977,168980,169015,169023,265949,265965,265975,265982,265992,265997,266017,266033,266038,388160,388185,582030,582044,582049,582058,582060,582072,582147,582153,582158,582161,582165,
+gi|330443688|ref|NC_001145.3|	85010	667216	gi|296143771|ref|NM_001180731.1| 518	+	85010	667216	0	34	11,15,4,1,8,17,4,8,3,33,7,102,14,10,5,10,4,20,15,5,4,20,6,12,5,7,1,12,75,6,4,2,3,41,	0,11,26,30,31,39,168964,168969,168977,168980,169015,169023,265949,265965,265975,265982,265992,265997,266017,266033,266038,388160,388185,582030,582044,582049,582058,582060,582072,582147,582153,582158,582161,582165,
 <BLANKLINE>
 \end{minted}
 
@@ -3077,7 +3077,7 @@ The alignment score (field 5) and information stored in fields 7-9 (referred to 
 %cont-doctest
 \begin{minted}{pycon}
 >>> alignment.score
-900
+900.0
 >>> alignment.thickStart
 2300
 >>> alignment.thickEnd
@@ -3900,7 +3900,7 @@ Check the alignment score and chain ID (the first and last number, respectively,
 %cont-doctest
 \begin{minted}{pycon}
 >>> alignment.score
-41
+41.0
 >>> alignment.annotations["id"]
 '7'
 \end{minted}

--- a/Doc/Tutorial/chapter_pairwise.tex
+++ b/Doc/Tutorial/chapter_pairwise.tex
@@ -721,7 +721,7 @@ target            0 AAAACCC 7
 query             0 --AACC- 4
 <BLANKLINE>
 >>> print(alignments[0].format("bed"))  # doctest: +NORMALIZE_WHITESPACE
-target   2   6   query   4.0   +   2   6   0   1   4,   0,
+target   2   6   query   4   +   2   6   0   1   4,   0,
 <BLANKLINE>
 >>> alignments = aligner.align(target, reverse_complement(query), strand="-")
 >>> len(alignments)
@@ -732,7 +732,7 @@ target            0 AAAACCC 7
 query             4 --AACC- 0
 <BLANKLINE>
 >>> print(alignments[0].format("bed"))  # doctest: +NORMALIZE_WHITESPACE
-target   2   6   query   4.0   -   2   6   0   1   4,   0,
+target   2   6   query   4   -   2   6   0   1   4,   0,
 <BLANKLINE>
 >>> alignments = aligner.align(target, query, strand="-")
 >>> len(alignments)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4412,7 +4412,7 @@ query            26 -ATACTTT-CGAGC------ 38
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	10	73	query	19.0	+	10	73	0	5	10,3,12,7,5,	0,10,24,50,58,
+target	10	73	query	19	+	10	73	0	5	10,3,12,7,5,	0,10,24,50,58,
 """,
         )
         self.assertEqual(
@@ -4449,7 +4449,7 @@ query            12 -ATACTTT-CGAGC------  0
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	10	73	query	19.0	-	10	73	0	5	10,3,12,7,5,	0,10,24,50,58,
+target	10	73	query	19	-	10	73	0	5	10,3,12,7,5,	0,10,24,50,58,
 """,
         )
         self.assertEqual(
@@ -4486,7 +4486,7 @@ query             0 CCCCACGTAGCATCAGC 17
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	0	13	query	13.0	+	0	13	0	1	13,	0,
+target	0	13	query	13	+	0	13	0	1	13,	0,
 """,
         )
         self.assertEqual(
@@ -4519,7 +4519,7 @@ query            17 CCCCACGTAGCATCAGC  0
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	0	13	query	13.0	-	0	13	0	1	13,	0,
+target	0	13	query	13	-	0	13	0	1	13,	0,
 """,
         )
         self.assertEqual(
@@ -4550,7 +4550,7 @@ query             0 ----ACGTAGCATCAGC 13
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	4	17	query	13.0	+	4	17	0	1	13,	0,
+target	4	17	query	13	+	4	17	0	1	13,	0,
 """,
         )
         self.assertEqual(
@@ -4583,7 +4583,7 @@ query            13 ----ACGTAGCATCAGC  0
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	4	17	query	13.0	-	4	17	0	1	13,	0,
+target	4	17	query	13	-	4	17	0	1	13,	0,
 """,
         )
         self.assertEqual(
@@ -4613,7 +4613,7 @@ query             0 ACGTAGCATCAGCGGGG 17
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	0	13	query	13.0	+	0	13	0	1	13,	0,
+target	0	13	query	13	+	0	13	0	1	13,	0,
 """,
         )
         self.assertEqual(
@@ -4645,7 +4645,7 @@ query            17 ACGTAGCATCAGCGGGG  0
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	0	13	query	13.0	-	0	13	0	1	13,	0,
+target	0	13	query	13	-	0	13	0	1	13,	0,
 """,
         )
         self.assertEqual(
@@ -4676,7 +4676,7 @@ query             0 ACGTAGCATCAGC---- 13
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	0	13	query	13.0	+	0	13	0	1	13,	0,
+target	0	13	query	13	+	0	13	0	1	13,	0,
 """,
         )
         self.assertEqual(
@@ -4709,7 +4709,7 @@ query            13 ACGTAGCATCAGC----  0
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	0	13	query	13.0	-	0	13	0	1	13,	0,
+target	0	13	query	13	-	0	13	0	1	13,	0,
 """,
         )
         self.assertEqual(
@@ -4750,7 +4750,7 @@ query             0 ACGATCGAGCNGCTACG 17
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	6	23	query	13.0	+	6	23	0	1	17,	0,
+target	6	23	query	13	+	6	23	0	1	17,	0,
 """,
         )
         self.assertEqual(
@@ -4780,7 +4780,7 @@ query            22 ACGATCGAGCNGCTACG  5
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	6	23	query	13.0	-	6	23	0	1	17,	0,
+target	6	23	query	13	-	6	23	0	1	17,	0,
 """,
         )
         self.assertEqual(
@@ -4811,7 +4811,7 @@ query             0 ACGATCGAGCNGCTACG 17
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	6	23	query	13.0	+	6	23	0	1	17,	0,
+target	6	23	query	13	+	6	23	0	1	17,	0,
 """,
         )
         self.assertEqual(
@@ -4843,7 +4843,7 @@ query            22 ACGATCGAGCNGCTACG  5
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	6	23	query	13.0	-	6	23	0	1	17,	0,
+target	6	23	query	13	-	6	23	0	1	17,	0,
 """,
         )
         self.assertEqual(
@@ -4877,7 +4877,7 @@ query             0 ------ACGATCGAGCNGCTACGCCCNC 22
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	6	23	query	13.0	+	6	23	0	1	17,	0,
+target	6	23	query	13	+	6	23	0	1	17,	0,
 """,
         )
         self.assertEqual(
@@ -4907,7 +4907,7 @@ query            22 ------ACGATCGAGCNGCTACGCCCNC  0
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	6	23	query	13.0	-	6	23	0	1	17,	0,
+target	6	23	query	13	-	6	23	0	1	17,	0,
 """,
         )
         self.assertEqual(
@@ -4938,7 +4938,7 @@ query             0 ------ACGATCGAGCNGCTACGCCCNC 22
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	6	23	query	13.0	+	6	23	0	1	17,	0,
+target	6	23	query	13	+	6	23	0	1	17,	0,
 """,
         )
         self.assertEqual(
@@ -4970,7 +4970,7 @@ query            22 ------ACGATCGAGCNGCTACGCCCNC  0
         self.assertEqual(
             alignment.format("bed"),
             """\
-target	6	23	query	13.0	-	6	23	0	1	17,	0,
+target	6	23	query	13	-	6	23	0	1	17,	0,
 """,
         )
         self.assertEqual(


### PR DESCRIPTION
In `Bio.Align.chain`, print the alignment score as an integer if possible by using the `'e'` format code. This also abrogates the need to store the score as an integer on the alignment.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
