### PR TITLE
Remove deprecated code from Bio.Align

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -35,7 +35,6 @@ except ImportError:
         "See http://www.numpy.org/"
     ) from None
 
-from Bio import BiopythonDeprecationWarning
 from Bio.Align import _pairwisealigner  # type: ignore
 from Bio.Align import _codonaligner  # type: ignore
 from Bio.Align import substitution_matrices
@@ -1523,31 +1522,6 @@ class Alignment:
             if left < right:
                 return False
         return True
-
-    @property
-    def path(self):
-        """Return the path through the trace matrix."""
-        warnings.warn(
-            "The path attribute is deprecated; please use the coordinates "
-            "attribute instead. The coordinates attribute is a NumPy array "
-            "containing the same values as the path attributes, after "
-            "transposition.",
-            BiopythonDeprecationWarning,
-            stacklevel=2,
-        )
-        return tuple(tuple(row) for row in self.coordinates.transpose())
-
-    @path.setter
-    def path(self, value):
-        warnings.warn(
-            "The path attribute is deprecated; please use the coordinates "
-            "attribute instead. The coordinates attribute is a NumPy array "
-            "containing the same values as the path attributes, after "
-            "transposition.",
-            BiopythonDeprecationWarning,
-            stacklevel=2,
-        )
-        self.coordinates = np.array(value).transpose()
 
     def _get_row(self, index):
         """Return self[index], where index is an integer (PRIVATE).
@@ -3985,41 +3959,6 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             self.mismatch_score = state["mismatch_score"]
         else:
             self.substitution_matrix = substitution_matrix
-
-
-class PairwiseAlignment(Alignment):
-    """Represents a pairwise sequence alignment.
-
-    Internally, the pairwise alignment is stored as the path through
-    the traceback matrix, i.e. a tuple of pairs of indices corresponding
-    to the vertices of the path in the traceback matrix.
-    """
-
-    def __init__(self, target, query, path, score):
-        """Initialize a new PairwiseAlignment object.
-
-        Arguments:
-         - target  - The first sequence, as a plain string, without gaps.
-         - query   - The second sequence, as a plain string, without gaps.
-         - path    - The path through the traceback matrix, defining an
-                     alignment.
-         - score   - The alignment score.
-
-        You would normally obtain a PairwiseAlignment object by iterating
-        over a PairwiseAlignments object.
-        """
-        warnings.warn(
-            "The PairwiseAlignment class is deprecated; please use the "
-            "Alignment class instead.  Note that the coordinates attribute of "
-            "an Alignment object is a NumPy array and the transpose of the "
-            "path attribute of a PairwiseAlignment object.",
-            BiopythonDeprecationWarning,
-            stacklevel=2,
-        )
-        sequences = [target, query]
-        coordinates = np.array(path).transpose()
-        super().__init__(sequences, coordinates)
-        self.score = score
 
 
 class CodonAligner(_codonaligner.CodonAligner):

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -474,8 +474,8 @@ reversed in Release 1.79.
 The ``__format__`` method of the Array class in Bio.Align.substitution_matrices
 was deprecated in Release 1.79.
 
-The PairwiseAlignment class was deprecated in Release 1.80; please use the new
-Alignment class instead.
+The PairwiseAlignment class was deprecated in Release 1.80, and removed in
+Release 1.82. Please use the new Alignment class instead.
 
 Bio.Align.Generic
 -----------------


### PR DESCRIPTION
Removing the PairwiseAlignment class and the path attribute from Bio.Align.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

