### PR TITLE
update deprecation warning in Bio.Nexus.Nexus

### DIFF
--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -671,8 +671,7 @@ class Nexus:
         warnings.warn(
             "The get_original_taxon_order method has been deprecated "
             "and will likely be removed from Biopython in the near "
-            "future. Please use the original_taxon_order attribute "
-            "instead.",
+            "future. Please use the taxlabels attribute instead.",
             BiopythonDeprecationWarning,
         )
         return self.taxlabels
@@ -682,8 +681,7 @@ class Nexus:
         warnings.warn(
             "The set_original_taxon_order method has been deprecated "
             "and will likely be removed from Biopython in the near "
-            "future. Please use the original_taxon_order attribute "
-            "instead.",
+            "future. Please use the taxlabels attribute instead.",
             BiopythonDeprecationWarning,
         )
         self.taxlabels = value


### PR DESCRIPTION
Fix the deprecation warning text to suggest to use the `taxlabels` attribute instead of the `original_taxon_order` attribute.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
