### PR TITLE
remove references to blast-text from Bio.SearchIO

### DIFF
--- a/Bio/SearchIO/BlastIO/__init__.py
+++ b/Bio/SearchIO/BlastIO/__init__.py
@@ -39,7 +39,6 @@ Bio.SearchIO.BlastIO supports the following BLAST+ output formats:
 
   - XML        - 'blast-xml'  - parsing, indexing, writing
   - Tabular    - 'blast-tab'  - parsing, indexing, writing
-  - Plain text - 'blast-text' - parsing
 
 
 blast-xml
@@ -316,89 +315,6 @@ well:
 |              +---------------+----------------------------+
 |              | version       | BLAST version              |
 +--------------+---------------+----------------------------+
-
-
-blast-text
-==========
-The BLAST plain text output format has been known to change considerably between
-BLAST versions. NCBI itself has recommended that users not rely on the plain
-text output for parsing-related work.
-
-However, in some cases parsing the plain text output may still be useful.
-SearchIO provides parsing support for the plain text output, but guarantees only
-a minimum level of support. Writing a parser that fully supports plain text
-output for all BLAST versions is not a priority at the moment.
-
-If you do have a BLAST plain text file that can not be parsed and would like to
-submit a patch, we are more than happy to accept it.
-
-The blast-text parser provides the following object attributes:
-
-+-----------------+-------------------------+----------------------------------+
-| Object          | Attribute               | Value                            |
-+=================+=========================+==================================+
-| QueryResult     | description             | query sequence description       |
-|                 +-------------------------+----------------------------------+
-|                 | id                      | query sequence ID                |
-|                 +-------------------------+----------------------------------+
-|                 | program                 | BLAST flavor                     |
-|                 +-------------------------+----------------------------------+
-|                 | seq_len                 | full length of query sequence    |
-|                 +-------------------------+----------------------------------+
-|                 | target                  | target database of the search    |
-|                 +-------------------------+----------------------------------+
-|                 | version                 | BLAST version                    |
-+-----------------+-------------------------+----------------------------------+
-| Hit             | evalue                  | hit-level evalue, from the hit   |
-|                 |                         | table                            |
-|                 +-------------------------+----------------------------------+
-|                 | id                      | hit sequence ID                  |
-|                 +-------------------------+----------------------------------+
-|                 | description             | hit sequence description         |
-|                 +-------------------------+----------------------------------+
-|                 | score                   | hit-level score, from the hit    |
-|                 |                         | table                            |
-|                 +-------------------------+----------------------------------+
-|                 | seq_len                 | full length of hit sequence      |
-+-----------------+-------------------------+----------------------------------+
-| HSP             | evalue                  | hsp-level evalue                 |
-|                 +-------------------------+----------------------------------+
-|                 | bitscore                | hsp-level bit score              |
-|                 +-------------------------+----------------------------------+
-|                 | bitscore_raw            | hsp-level score                  |
-|                 +-------------------------+----------------------------------+
-|                 | gap_num                 | number of gaps in alignment      |
-|                 +-------------------------+----------------------------------+
-|                 | ident_num               | number of identical residues     |
-|                 |                         | in alignment                     |
-|                 +-------------------------+----------------------------------+
-|                 | pos_num                 | number of positive matches in    |
-|                 |                         | alignment                        |
-+-----------------+-------------------------+----------------------------------+
-| HSPFragment     | aln_annotation          | alignment similarity string      |
-| (also via       +-------------------------+----------------------------------+
-| HSP)            | aln_span                | length of alignment fragment     |
-|                 +-------------------------+----------------------------------+
-|                 | hit                     | hit sequence                     |
-|                 +-------------------------+----------------------------------+
-|                 | hit_end                 | hit sequence end coordinate      |
-|                 +-------------------------+----------------------------------+
-|                 | hit_frame               | hit sequence reading frame       |
-|                 +-------------------------+----------------------------------+
-|                 | hit_start               | hit sequence start coordinate    |
-|                 +-------------------------+----------------------------------+
-|                 | hit_strand              | hit sequence strand              |
-|                 +-------------------------+----------------------------------+
-|                 | query                   | query sequence                   |
-|                 +-------------------------+----------------------------------+
-|                 | query_end               | query sequence end coordinate    |
-|                 +-------------------------+----------------------------------+
-|                 | query_frame             | query sequence reading frame     |
-|                 +-------------------------+----------------------------------+
-|                 | query_start             | query sequence start coordinate  |
-|                 +-------------------------+----------------------------------+
-|                 | query_strand            | query sequence strand            |
-+-----------------+-------------------------+----------------------------------+
 
 
 .. [*] may be modified

--- a/Bio/SearchIO/__init__.py
+++ b/Bio/SearchIO/__init__.py
@@ -132,9 +132,7 @@ Sequence coordinate order
 -------------------------
 
 Some search output formats reverse the start and end coordinate sequences
-according to the sequence's strand. For example, in BLAST plain text
-format if the matching strand lies in the minus orientation, then the
-start coordinate will always be bigger than the end coordinate.
+according to the sequence's strand.
 
 In SearchIO, start coordinates are always smaller than the end
 coordinates, regardless of their originating strand. This ensures
@@ -187,7 +185,6 @@ Support for parsing and indexing:
 
 Support for parsing:
 
- - blast-text       - BLAST+ plain text output.
  - hhsuite2-text    - HHSUITE plain text output.
 
 Each of these formats have different keyword arguments available for use with
@@ -207,7 +204,6 @@ __all__ = ("read", "parse", "to_dict", "index", "index_db", "write", "convert")
 # dictionary of supported formats for parse() and read()
 _ITERATOR_MAP = {
     "blast-tab": ("BlastIO", "BlastTabParser"),
-    "blast-text": ("BlastIO", "BlastTextParser"),
     "blast-xml": ("BlastIO", "BlastXmlParser"),
     "blat-psl": ("BlatIO", "BlatPslParser"),
     "exonerate-cigar": ("ExonerateIO", "ExonerateCigarParser"),


### PR DESCRIPTION
Remove references to blast-text (which has now been removed) from Bio.SearchIO docstrings.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
