### PR TITLE
deprecate Bio.NaiveBayes

### DIFF
--- a/Bio/NaiveBayes.py
+++ b/Bio/NaiveBayes.py
@@ -5,7 +5,7 @@
 # Please see the LICENSE file that should have been included as part of this
 # package.
 
-"""General Naive Bayes learner.
+"""General Naive Bayes learner (DEPRECATED).
 
 Naive Bayes is a supervised classification algorithm that uses Bayes
 rule to compute the fit between a new observation and some previously
@@ -27,6 +27,16 @@ Functions:
  - classify  - Classify an observation into a class.
 
 """
+
+
+import warnings
+from Bio import BiopythonDeprecationWarning
+
+warnings.warn(
+    "The 'Bio.NaiveBayes' module is deprecated and will be removed in a future "
+    "release of Biopython. Consider using scikit-learn instead.",
+    BiopythonDeprecationWarning,
+)
 
 
 try:

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -66,6 +66,10 @@ Bio.LogisticRegression
 ----------------------
 Deprecated in release 1.82, consider using scikit-learn instead.
 
+Bio.NaiveBayes
+--------------
+Deprecated in release 1.82, consider using scikit-learn instead.
+
 Bio.Data.SCOPData
 -----------------
 Declared obsolete in release 1.80, and removed in release 1.82. Please use

--- a/Tests/test_NaiveBayes.py
+++ b/Tests/test_NaiveBayes.py
@@ -7,8 +7,13 @@
 
 import copy
 import unittest
+import warnings
 
-from Bio import NaiveBayes
+from Bio import BiopythonDeprecationWarning
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", category=BiopythonDeprecationWarning)
+    from Bio import NaiveBayes
 
 # Importing NaiveBayes will itself raise MissingPythonDependencyError
 # if NumPy is unavailable.


### PR DESCRIPTION
Same as Bio.kNN and Bio.LogisticRegression. This stuff is handled better by scikit-learn.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
