### PR TITLE
deprecate Bio.MaxEntropy

### DIFF
--- a/Bio/MaxEntropy.py
+++ b/Bio/MaxEntropy.py
@@ -11,6 +11,7 @@ Uses Improved Iterative Scaling.
 # TODO Define terminology
 
 from functools import reduce
+import warnings
 
 try:
     import numpy as np
@@ -21,6 +22,15 @@ except ImportError:
         "Please install NumPy if you want to use Bio.MaxEntropy. "
         "See http://www.numpy.org/"
     ) from None
+
+
+from Bio import BiopythonDeprecationWarning
+
+warnings.warn(
+    "The 'Bio.MaxEntropy' module is deprecated and will be removed in a future "
+    "release of Biopython. Consider using scikit-learn instead.",
+    BiopythonDeprecationWarning,
+)
 
 
 class MaxEntropy:

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -66,6 +66,10 @@ Bio.LogisticRegression
 ----------------------
 Deprecated in release 1.82, consider using scikit-learn instead.
 
+Bio.MaxEntropy
+--------------
+Deprecated in release 1.82, consider using scikit-learn instead.
+
 Bio.Data.SCOPData
 -----------------
 Declared obsolete in release 1.80, and removed in release 1.82. Please use


### PR DESCRIPTION
This PR deprecates Bio.MaxEntropy, as this functionality is better handled by scikit-learn.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

