### PR TITLE
Deprecating Bio.MarkovModel

### DIFF
--- a/Bio/MarkovModel.py
+++ b/Bio/MarkovModel.py
@@ -22,6 +22,16 @@ Classes:
 MarkovModel     Holds the description of a markov model
 """
 
+import warnings
+from Bio import BiopythonDeprecationWarning
+
+warnings.warn(
+    "The 'Bio.markovModel' module is deprecated and will be removed in a "
+    "future release of Biopython. Consider using the hmmlearn pacage instead.",
+    BiopythonDeprecationWarning,
+)
+
+
 try:
     import numpy as np
 except ImportError:

--- a/Bio/MarkovModel.py
+++ b/Bio/MarkovModel.py
@@ -26,8 +26,8 @@ import warnings
 from Bio import BiopythonDeprecationWarning
 
 warnings.warn(
-    "The 'Bio.markovModel' module is deprecated and will be removed in a "
-    "future release of Biopython. Consider using the hmmlearn pacage instead.",
+    "The 'Bio.MarkovModel' module is deprecated and will be removed in a "
+    "future release of Biopython. Consider using the hmmlearn package instead.",
     BiopythonDeprecationWarning,
 )
 

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -74,9 +74,10 @@ Bio.MaxEntropy
 --------------
 Deprecated in release 1.82, consider using scikit-learn instead.
 
-Bio.MarkoveModel
-----------------
-Deprecated in release 1.82, consider using hmmlearn instead.
+Bio.MarkovModel
+---------------
+Deprecated in release 1.82, consider using hmmlearn
+(https://pypi.org/project/hmmlearn/) instead.
 
 Bio.Data.SCOPData
 -----------------

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -74,6 +74,10 @@ Bio.MaxEntropy
 --------------
 Deprecated in release 1.82, consider using scikit-learn instead.
 
+Bio.MarkoveModel
+----------------
+Deprecated in release 1.82, consider using hmmlearn instead.
+
 Bio.Data.SCOPData
 -----------------
 Declared obsolete in release 1.80, and removed in release 1.82. Please use

--- a/Tests/test_MarkovModel.py
+++ b/Tests/test_MarkovModel.py
@@ -29,10 +29,13 @@ except ImportError:
         "Install NumPy if you want to use Bio.MarkovModel."
     ) from None
 
+from Bio import BiopythonDeprecationWarning
+
 with warnings.catch_warnings():
     # Silence this warning:
     # For optimal speed, please update to Numpy version 1.3 or later
     warnings.simplefilter("ignore", UserWarning)
+    warnings.simplefilter("ignore", category=BiopythonDeprecationWarning)
     from Bio import MarkovModel
 
 


### PR DESCRIPTION
This PR deprecates Bio.MarkovModel, suggesting to use hmmlearn instead.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

