### PR TITLE
Deprecate PSSM in Bio.Align.AlignInfo

### DIFF
--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -14,8 +14,10 @@ be put into classes in this module.
 
 import math
 import sys
+import warnings
 from collections import Counter
 
+from Bio import BiopythonDeprecationWarning
 from Bio.Seq import Seq
 
 
@@ -256,6 +258,33 @@ class SummaryInfo:
 
         """
         # determine all of the letters we have to deal with
+        warnings.warn(
+            "The `pos_specific_score_matrix` method is deprecated and will be "
+            "removed in a future release of Biopython. As an alternative, you "
+            "can convert the multiple sequence alignment object to a new-style "
+            "Alignment object by via its `.alignment` property, and then "
+            "create a Motif object. For example, for a multiple sequence "
+            "alignment `msa` of DNA nucleotides, you would do: "
+            "\n"
+            ">>> alignment = msa.alignment\n"
+            ">>> from Bio.motifs import Motif\n"
+            ">>> motif = Motif('ACGT', alignment)\n"
+            ">>> counts = motif.counts\n"
+            "\n"
+            "The `counts` object contains the same information as the PSSM "
+            "returned by `pos_specific_score_matrix`, but note that the "
+            "indices are reversed:\n"
+            "\n"
+            ">>> counts[letter][i] == pssm[index][letter]\n"
+            "True\n"
+            "\n"
+            "If your multiple sequence alignment object was obtained using "
+            "Bio.AlignIO, then you can obtain a new-style Alignment object "
+            "directly by using Bio.Align.read instead of Bio.AlignIO.read, "
+            "or Bio.Align.parse instead of Bio.AlignIO.parse.",
+            BiopythonDeprecationWarning,
+        )
+
         all_letters = self._get_all_letters()
         if not all_letters:
             raise ValueError("_get_all_letters returned empty string")
@@ -558,6 +587,32 @@ class PSSM:
         from the example above, the first few list[0]s would be GTAT...
         list[1] - A dictionary with the letter substitutions and counts.
         """
+        warnings.warn(
+            "The `PSSM` class is deprecated and will be removed in a future "
+            "release of Biopython. As an alternative, you can convert the "
+            "multiple sequence alignment object to a new-style Alignment "
+            "object by via its `.alignment` property, and then create a Motif "
+            "object. For example, for a multiple sequence alignment `msa` of "
+            "DNA nucleotides, you would do: "
+            "\n"
+            ">>> alignment = msa.alignment\n"
+            ">>> from Bio.motifs import Motif\n"
+            ">>> motif = Motif('ACGT', alignment)\n"
+            ">>> counts = motif.counts\n"
+            "\n"
+            "The `counts` object contains the same information as the PSSM "
+            "returned by `pos_specific_score_matrix`, but note that the "
+            "indices are reversed:\n"
+            "\n"
+            ">>> counts[letter][i] == pssm[index][letter]\n"
+            "True\n"
+            "\n"
+            "If your multiple sequence alignment object was obtained using "
+            "Bio.AlignIO, then you can obtain a new-style Alignment object "
+            "directly by using Bio.Align.read instead of Bio.AlignIO.read, "
+            "or Bio.Align.parse instead of Bio.AlignIO.parse.",
+            BiopythonDeprecationWarning,
+        )
         self.pssm = pssm
 
     def __getitem__(self, pos):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -977,7 +977,11 @@ class MultipleSeqAlignment:
                     record.letter_annotations.clear()
                     record.seq = record.seq.replace("-", "")
                     for key, value in letter_annotations.items():
-                        value = "".join([value[i] for i in indices])
+                        if isinstance(value, str):
+                            value = "".join([value[i] for i in indices])
+                        else:  # list, tuple
+                            cls = type(value)
+                            value = cls(value[i] for i in indices)
                         letter_annotations[key] = value
                     record.letter_annotations = letter_annotations
                 else:

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -58,6 +58,31 @@ was deprecated as of Release 1.70.
 Biopython modules, methods, functions
 =====================================
 
+Bio.AlignInfo
+-------------
+The ``pos_specific_score_matrix`` method of the ``SummaryInfo`` class and the
+``PSSM`` class were deprecated in release 1.82. As an alternative, please use
+the ``alignment`` property of a ``MultipleSeqAlignment`` object to obtains a
+new-style ``Alignment`` object, and use it to create a ``Bio.motifs.Motif``
+object. For example,
+
+>>> alignment = msa.alignment
+>>> from Bio.motifs import Motif
+>>> motif = Motif('ACGT', alignment)
+>>> counts = motif.counts
+
+The ``counts`` object contains the same information as the PSSM returned by
+``pos_specific_score_matrix``, but note that the indices are reversed:
+
+>>> counts[letter][i] == pssm[index][letter]
+True
+
+If the multiple sequence alignment object ``msa`` was obtained using
+``Bio.AlignIO``, then you can obtain a new-style ``Alignment`` object directly
+by using ``Bio.Align.read`` instead of ``Bio.AlignIO.read``, or
+``Bio.Align.parse`` instead of ``Bio.AlignIO.parse``.
+
+
 Bio.kNN
 -------
 Deprecated in release 1.82, consider using scikit-learn instead.

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -21,7 +21,7 @@ motif finders, but it is not a part of Biopython and has some restrictions
 on commercial use.
 
 \section{Motif objects}
-\label{sec:object}
+\label{sec:motif_object}
 
 Since we are interested in motif analysis, we need to take a look at
 \verb|Motif| objects in the first place. For that we need to import
@@ -38,6 +38,7 @@ obtain a \verb+Motif+ object by parsing a file from a motif database
 or motif finding software.
 
 \subsection{Creating a motif from instances}
+\label{subsec:creating_motif}
 
 Suppose we have these instances of a DNA motif:
 

--- a/Doc/Tutorial/chapter_msa.tex
+++ b/Doc/Tutorial/chapter_msa.tex
@@ -1018,7 +1018,7 @@ You can access any element of the PSSM by subscripting like \verb|your_pssm[sequ
 
 The structure of the PSSM class hopefully makes it easy both to access elements and to pretty print the matrix.
 
-Alternatively, you can convert the multiple sequence alignment object \verb|msa| to a new-style \verb|Alignment| object (see section \ref{sec:alignmentobject}) by using the \verb|alignment| attribute:
+Alternatively, you can convert the multiple sequence alignment object \verb|msa| to a new-style \verb|Alignment| object (see section \ref{sec:alignmentobject}) by using the \verb|alignment| attribute (see section \ref{sec:alignment_newstyle}):
 %cont-doctest
 \begin{minted}{pycon}
 >>> alignment = msa.alignment
@@ -1124,6 +1124,7 @@ P_{ij} = \frac{n_{ij} + k\times Q_{i}}{N_{j} + k}
 Well, now you are ready to calculate information content. If you want to try applying this to some real life problems, it would probably be best to dig into the literature on information content to get an idea of how it is used. Hopefully your digging won't reveal any mistakes made in coding this function!
 
 \section{Getting a new-style Alignment object}
+\label{sec:alignment_newstyle}
 
 Use the \verb+alignment+ property to create a new-style \verb+Alignment+ object (see section~\ref{sec:alignmentobject}) from an old-style \verb+MultipleSeqAlignment+ object:
 

--- a/Doc/Tutorial/chapter_msa.tex
+++ b/Doc/Tutorial/chapter_msa.tex
@@ -1018,6 +1018,33 @@ You can access any element of the PSSM by subscripting like \verb|your_pssm[sequ
 
 The structure of the PSSM class hopefully makes it easy both to access elements and to pretty print the matrix.
 
+Alternatively, you can convert the multiple sequence alignment object \verb|msa| to a new-style \verb|Alignment| object (see section \ref{sec:alignmentobject}) by using the \verb|alignment| attribute:
+%cont-doctest
+\begin{minted}{pycon}
+>>> alignment = msa.alignment
+\end{minted}
+You can then create a \verb|Motif| object (see section \ref{sec:motif_object}):
+%cont-doctest
+\begin{minted}{pycon}
+>>> from Bio.motifs import Motif
+>>> motif = Motif("ACGT", alignment)
+\end{minted}
+and obtain the counts of each nucleotide in each position:
+%cont-doctest
+\begin{minted}{pycon}
+>>> counts = motif.counts
+>>> print(counts)
+        0      1      2      3      4      5      6
+A:   2.00   1.00   0.00   1.00   0.00   0.00   2.00
+C:   1.00   3.00   0.00   2.00   4.00   0.00   1.00
+G:   0.00   0.00   0.00   0.00   0.00   0.00   0.00
+T:   1.00   0.00   4.00   0.00   0.00   4.00   0.00
+<BLANKLINE>
+>>> print(counts["T"][5])
+4
+\end{minted}
+
+
 \subsection{Information Content}
 \label{sec:getting_info_content}
 
@@ -1271,7 +1298,6 @@ By default ClustalW will generate an alignment and guide tree file with names
 based on the input FASTA file, in this case \texttt{opuntia.aln} and
 \texttt{opuntia.dnd}, but you can override this or make it explicit:
 
-%doctest
 \begin{minted}{pycon}
 >>> import subprocess
 >>> cmd = "clustalw2 -infile=opuntia.fasta"

--- a/Tests/test_AlignIO.py
+++ b/Tests/test_AlignIO.py
@@ -13,6 +13,7 @@ from Bio import SeqIO
 from Bio.Align import AlignInfo
 from Bio.Align import MultipleSeqAlignment
 from Bio.Data import IUPACData
+from Bio.motifs import Motif
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
@@ -245,37 +246,67 @@ class TestAlignIO_reading(unittest.TestCase):
         dumb_consensus = summary.dumb_consensus()
         # gap_consensus = summary.gap_consensus()
 
-    def check_summary(self, alignment, molecule_type):
+    def check_summary(self, msa, molecule_type):
         # Check AlignInfo.SummaryInfo likes the alignment; smoke test only
         if molecule_type == "DNA":
             letters = IUPACData.unambiguous_dna_letters
-            all_letters = IUPACData.ambiguous_dna_letters
+            ambiguous_letters = IUPACData.ambiguous_dna_letters
         elif molecule_type == "RNA":
             letters = IUPACData.unambiguous_rna_letters
-            all_letters = IUPACData.ambiguous_rna_letters
+            ambiguous_letters = IUPACData.ambiguous_rna_letters
         elif molecule_type == "protein":
             letters = IUPACData.protein_letters
-            all_letters = IUPACData.protein_letters
+            ambiguous_letters = IUPACData.protein_letters
         else:
             raise ValueError(f"Unknown molecule type '{molecule_type}'")
-        summary = AlignInfo.SummaryInfo(alignment)
+        summary = AlignInfo.SummaryInfo(msa)
+        alignment = msa.alignment  # New-style alignment
+        motif = Motif(letters, alignment)
+        counts = motif.counts
         dumb_consensus = summary.dumb_consensus()
         # gap_consensus = summary.gap_consensus()
         pssm = summary.pos_specific_score_matrix()
+        all_letters = summary._get_all_letters()
+        j = 0
+        for i in range(alignment.length):
+            while set(msa[:, j]) == set("-"):
+                j += 1
+            for letter in letters:
+                count = counts[letter][i]
+                if letter in all_letters:
+                    self.assertAlmostEqual(count, pssm[j][letter])
+                else:
+                    self.assertAlmostEqual(count, 0.0)
+            j += 1
         rep_dict = summary.replacement_dictionary(skip_chars=None, letters=letters)
         e_freq = 1.0 / len(letters)
-        all_letters = all_letters.upper() + all_letters.lower()
-        e_freq_table = dict.fromkeys(all_letters, e_freq)
+        ambiguous_letters = ambiguous_letters.upper() + ambiguous_letters.lower()
+        e_freq_table = dict.fromkeys(ambiguous_letters, e_freq)
         info_content = summary.information_content(
             e_freq_table=e_freq_table, chars_to_ignore=["N", "X"]
         )
 
-    def check_summary_pir(self, alignment):
+    def check_summary_pir(self, msa):
         letters = IUPACData.unambiguous_dna_letters
-        summary = AlignInfo.SummaryInfo(alignment)
+        summary = AlignInfo.SummaryInfo(msa)
         dumb_consensus = summary.dumb_consensus()
         # gap_consensus = summary.gap_consensus()
         pssm = summary.pos_specific_score_matrix()
+        all_letters = summary._get_all_letters()
+        alignment = msa.alignment
+        motif = Motif(letters, alignment)
+        counts = motif.counts
+        j = 0
+        for i in range(alignment.length):
+            while set(msa[:, j]) == set("-"):
+                j += 1
+            for letter in letters:
+                count = counts[letter][i]
+                if letter in all_letters:
+                    self.assertAlmostEqual(count, pssm[j][letter])
+                else:
+                    self.assertAlmostEqual(count, 0.0)
+            j += 1
         rep_dict = summary.replacement_dictionary(skip_chars=None, letters=letters)
         e_freq = 1.0 / len(letters)
         all_letters = letters.upper() + letters.lower()

--- a/Tests/test_AlignIO.py
+++ b/Tests/test_AlignIO.py
@@ -8,6 +8,7 @@ import warnings
 
 from io import StringIO
 
+from Bio import BiopythonDeprecationWarning
 from Bio import AlignIO
 from Bio import SeqIO
 from Bio.Align import AlignInfo
@@ -265,7 +266,8 @@ class TestAlignIO_reading(unittest.TestCase):
         counts = motif.counts
         dumb_consensus = summary.dumb_consensus()
         # gap_consensus = summary.gap_consensus()
-        pssm = summary.pos_specific_score_matrix()
+        with self.assertWarns(BiopythonDeprecationWarning):
+            pssm = summary.pos_specific_score_matrix()
         all_letters = summary._get_all_letters()
         j = 0
         for i in range(alignment.length):
@@ -291,7 +293,8 @@ class TestAlignIO_reading(unittest.TestCase):
         summary = AlignInfo.SummaryInfo(msa)
         dumb_consensus = summary.dumb_consensus()
         # gap_consensus = summary.gap_consensus()
-        pssm = summary.pos_specific_score_matrix()
+        with self.assertWarns(BiopythonDeprecationWarning):
+            pssm = summary.pos_specific_score_matrix()
         all_letters = summary._get_all_letters()
         alignment = msa.alignment
         motif = Motif(letters, alignment)

--- a/Tests/test_AlignInfo.py
+++ b/Tests/test_AlignInfo.py
@@ -6,6 +6,7 @@
 """Bio.Align.AlignInfo related tests."""
 import unittest
 
+from Bio import BiopythonDeprecationWarning
 from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
@@ -40,7 +41,8 @@ class AlignInfoTests(unittest.TestCase):
 
         expected = {"A": 0.25, "G": 0.25, "T": 0.25, "C": 0.25}
 
-        m = summary.pos_specific_score_matrix(chars_to_ignore=["-"], axis_seq=c)
+        with self.assertWarns(BiopythonDeprecationWarning):
+            m = summary.pos_specific_score_matrix(chars_to_ignore=["-"], axis_seq=c)
 
         counts = motif.counts
 
@@ -85,7 +87,8 @@ N  0.0 2.0 1.0 0.0
         c = s.gap_consensus(ambiguous="X")
         self.assertEqual(c, "MHXXIFIYQIGYXXLKSGYIQSIRSPEYXNWX")
 
-        m = s.pos_specific_score_matrix(chars_to_ignore=["-", "*"], axis_seq=c)
+        with self.assertWarns(BiopythonDeprecationWarning):
+            m = s.pos_specific_score_matrix(chars_to_ignore=["-", "*"], axis_seq=c)
         all_letters = s._get_all_letters()
         alignment = a.alignment
         motif = Motif(letters, alignment)

--- a/Tests/test_AlignInfo.py
+++ b/Tests/test_AlignInfo.py
@@ -12,6 +12,7 @@ from Bio.SeqRecord import SeqRecord
 from Bio import AlignIO
 from Bio.Align.AlignInfo import SummaryInfo
 from Bio.Data import IUPACData
+from Bio.motifs import Motif
 import math
 
 
@@ -26,8 +27,10 @@ class AlignInfoTests(unittest.TestCase):
     def test_nucleotides(self):
         filename = "GFF/multi.fna"
         fmt = "fasta"
-        alignment = AlignIO.read(filename, fmt)
-        summary = SummaryInfo(alignment)
+        msa = AlignIO.read(filename, fmt)
+        summary = SummaryInfo(msa)
+        alignment = msa.alignment
+        motif = Motif("ACGT", alignment)
 
         c = summary.dumb_consensus(ambiguous="N")
         self.assertEqual(c, "NNNNNNNN")
@@ -38,6 +41,13 @@ class AlignInfoTests(unittest.TestCase):
         expected = {"A": 0.25, "G": 0.25, "T": 0.25, "C": 0.25}
 
         m = summary.pos_specific_score_matrix(chars_to_ignore=["-"], axis_seq=c)
+
+        counts = motif.counts
+
+        for i in range(alignment.length):
+            for letter in "ACGT":
+                self.assertAlmostEqual(counts[letter][i], m[i][letter])
+
         self.assertEqual(
             str(m),
             """    A   C   G   T
@@ -57,6 +67,7 @@ N  0.0 2.0 1.0 0.0
         self.assertAlmostEqual(ic, 7.32029999423075, places=6)
 
     def test_proteins(self):
+        letters = IUPACData.protein_letters
         a = MultipleSeqAlignment(
             [
                 SeqRecord(Seq("MHQAIFIYQIGYP*LKSGYIQSIRSPEYDNW-"), id="ID001"),
@@ -75,6 +86,19 @@ N  0.0 2.0 1.0 0.0
         self.assertEqual(c, "MHXXIFIYQIGYXXLKSGYIQSIRSPEYXNWX")
 
         m = s.pos_specific_score_matrix(chars_to_ignore=["-", "*"], axis_seq=c)
+        all_letters = s._get_all_letters()
+        alignment = a.alignment
+        motif = Motif(letters, alignment)
+        counts = motif.counts
+        j = 0
+        for i in range(alignment.length):
+            for letter in letters:
+                count = counts[letter][i]
+                if letter in all_letters:
+                    self.assertAlmostEqual(count, m[j][letter])
+                else:
+                    self.assertAlmostEqual(count, 0.0)
+            j += 1
         self.assertEqual(
             str(m),
             """    A   D   E   F   G   H   I   K   L   M   N   P   Q   R   S   W   Y
@@ -113,7 +137,6 @@ X  0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
 """,
         )
 
-        letters = IUPACData.protein_letters
         base_freq = 1.0 / len(letters)
         e_freq_table = {letter: base_freq for letter in letters}
         ic = s.information_content(

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -18,9 +18,11 @@ Right now we've got tests for:
 # standard library
 import os
 import unittest
+import warnings
 from io import StringIO
 
 # biopython
+from Bio import BiopythonDeprecationWarning
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Align import AlignInfo
@@ -361,7 +363,8 @@ gi|671626|emb|CAA85685.1|           -
         self.assertAlmostEqual(dictionary[("T", "C")], 12.0, places=1)
         self.assertAlmostEqual(dictionary[("T", "G")], 0, places=1)
         self.assertAlmostEqual(dictionary[("T", "T")], 874.0, places=1)
-        matrix = align_info.pos_specific_score_matrix(consensus, ["N", "-"])
+        with self.assertWarns(BiopythonDeprecationWarning):
+            matrix = align_info.pos_specific_score_matrix(consensus, ["N", "-"])
 
         alignment = msa.alignment
         motif = motifs.Motif("ACGT", alignment)
@@ -533,7 +536,8 @@ A  7.0 0.0 0.0 0.0
 """,
         )
 
-        matrix = align_info.pos_specific_score_matrix(chars_to_ignore=["N", "-"])
+        with self.assertWarns(BiopythonDeprecationWarning):
+            matrix = align_info.pos_specific_score_matrix(chars_to_ignore=["N", "-"])
 
         alignment = msa.alignment
         motif = motifs.Motif("ACGT", alignment)
@@ -706,7 +710,8 @@ A  7.0 0.0 0.0 0.0
         )
 
         second_seq = msa[1].seq
-        matrix = align_info.pos_specific_score_matrix(second_seq, ["N", "-"])
+        with self.assertWarns(BiopythonDeprecationWarning):
+            matrix = align_info.pos_specific_score_matrix(second_seq, ["N", "-"])
 
         alignment = msa.alignment
         motif = motifs.Motif("ACGT", alignment)

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -362,6 +362,14 @@ gi|671626|emb|CAA85685.1|           -
         self.assertAlmostEqual(dictionary[("T", "G")], 0, places=1)
         self.assertAlmostEqual(dictionary[("T", "T")], 874.0, places=1)
         matrix = align_info.pos_specific_score_matrix(consensus, ["N", "-"])
+
+        alignment = msa.alignment
+        motif = motifs.Motif("ACGT", alignment)
+        counts = motif.counts
+        for i in range(alignment.length):
+            for letter in "ACGT":
+                self.assertAlmostEqual(counts[letter][i], matrix[i][letter])
+
         self.assertEqual(
             str(matrix),
             """\
@@ -526,6 +534,14 @@ A  7.0 0.0 0.0 0.0
         )
 
         matrix = align_info.pos_specific_score_matrix(chars_to_ignore=["N", "-"])
+
+        alignment = msa.alignment
+        motif = motifs.Motif("ACGT", alignment)
+        counts = motif.counts
+        for i in range(alignment.length):
+            for letter in "ACGT":
+                self.assertAlmostEqual(counts[letter][i], matrix[i][letter])
+
         self.assertEqual(
             str(matrix),
             """\
@@ -691,6 +707,14 @@ A  7.0 0.0 0.0 0.0
 
         second_seq = msa[1].seq
         matrix = align_info.pos_specific_score_matrix(second_seq, ["N", "-"])
+
+        alignment = msa.alignment
+        motif = motifs.Motif("ACGT", alignment)
+        counts = motif.counts
+        for i in range(alignment.length):
+            for letter in "ACGT":
+                self.assertAlmostEqual(counts[letter][i], matrix[i][letter])
+
         self.assertEqual(
             str(matrix),
             """\


### PR DESCRIPTION
This PR deprecates the `PSSM` class in `Bio.Align.AlignInfo`, and the `pos_specific_score_matrix` method of the `SummaryInfo` class in `Bio.Align.AlignInfo` that returns a `PSSM` instance.

The suggested alternatives are to

- call the `alignment` attribute of the `MultpleSeqAlignment` object to convert it to a new-style `Alignment` object;
- use `Bio.Align` to read/parse the alignment instead of `Bio.AlignIO` to get an `Alignment` object directly.

With the `Alignment` object, a `Bio.motifs.Motif` object can be created, which has a `pssm` attribute that returns a `PositionSpecificScoringMatrix` object (defined in `Bio.motifs.matrix`).

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

