### PR TITLE
Deprecate replacement_dictionary

### DIFF
--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -190,6 +190,25 @@ class SummaryInfo:
            will raise a ValueError
          - letters - An iterable (e.g. a string or list of characters to include.
         """
+        warnings.warn(
+            "The `replacement_dictionary` method is deprecated and will be "
+            "removed in a future release of Biopython. As an alternative, you "
+            "can convert the multiple sequence alignment object to a new-style "
+            "Alignment object by via its `.alignment` property, and then "
+            "use the `.substitutions` property  of the `Alignment` object. "
+            "For example, for a multiple sequence alignment `msa` of DNA "
+            "nucleotides, you would do: "
+            "\n"
+            ">>> alignment = msa.alignment\n"
+            ">>> dictionary = alignment.substitutions\n"
+            "\n"
+            "If your multiple sequence alignment object was obtained using "
+            "Bio.AlignIO, then you can obtain a new-style Alignment object "
+            "directly by using Bio.Align.read instead of Bio.AlignIO.read, "
+            "or Bio.Align.parse instead of Bio.AlignIO.parse.",
+            BiopythonDeprecationWarning,
+        )
+
         if skip_chars is not None:
             raise ValueError(
                 "argument skip_chars has been deprecated; instead, please use 'letters' to specify the characters you want to include"

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -77,6 +77,15 @@ The ``counts`` object contains the same information as the PSSM returned by
 >>> counts[letter][i] == pssm[index][letter]
 True
 
+The ``replacement_dictionary`` method of the ``SummaryInfo`` class was
+deprecated in release 1.82. As an alternative, please use the ``alignment``
+property of the ``MultipleSeqAlignment`` object to obtains a new-style
+``Alignment`` object, and use its ``substitutions`` attribute to obtain the
+replacement dictionary:
+
+>>> alignment = msa.alignment
+>>> dictionary = alignment.substitutions
+
 If the multiple sequence alignment object ``msa`` was obtained using
 ``Bio.AlignIO``, then you can obtain a new-style ``Alignment`` object directly
 by using ``Bio.Align.read`` instead of ``Bio.AlignIO.read``, or

--- a/Tests/test_AlignIO.py
+++ b/Tests/test_AlignIO.py
@@ -280,7 +280,9 @@ class TestAlignIO_reading(unittest.TestCase):
                 else:
                     self.assertAlmostEqual(count, 0.0)
             j += 1
-        rep_dict = summary.replacement_dictionary(skip_chars=None, letters=letters)
+        with self.assertWarns(BiopythonDeprecationWarning):
+            rep_dict = summary.replacement_dictionary(skip_chars=None, letters=letters)
+        rep_dict = alignment.substitutions
         e_freq = 1.0 / len(letters)
         ambiguous_letters = ambiguous_letters.upper() + ambiguous_letters.lower()
         e_freq_table = dict.fromkeys(ambiguous_letters, e_freq)
@@ -310,7 +312,9 @@ class TestAlignIO_reading(unittest.TestCase):
                 else:
                     self.assertAlmostEqual(count, 0.0)
             j += 1
-        rep_dict = summary.replacement_dictionary(skip_chars=None, letters=letters)
+        with self.assertWarns(BiopythonDeprecationWarning):
+            rep_dict = summary.replacement_dictionary(skip_chars=None, letters=letters)
+        rep_dict = alignment.substitutions
         e_freq = 1.0 / len(letters)
         all_letters = letters.upper() + letters.lower()
         e_freq_table = dict.fromkeys(all_letters, e_freq)

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -345,7 +345,10 @@ gi|671626|emb|CAA85685.1|           -
             consensus,
             "TATACATTAAAGXAGGGGGATGCGGATAAATGGAAAGGCGAAAGAAAGAATATATATATATATATAATATATTTCAAATTXCCTTATATATCCAAATATAAAAATATCTAATAAATTAGATGAATATCAAAGAATCTATTGATTTAGTGTACCAGA",
         )
-        dictionary = align_info.replacement_dictionary(skip_chars=None, letters="ACGT")
+        with self.assertWarns(BiopythonDeprecationWarning):
+            dictionary = align_info.replacement_dictionary(
+                skip_chars=None, letters="ACGT"
+            )
         self.assertEqual(len(dictionary), 16)
         self.assertAlmostEqual(dictionary[("A", "A")], 1395.0, places=1)
         self.assertAlmostEqual(dictionary[("A", "C")], 3.0, places=1)
@@ -363,10 +366,30 @@ gi|671626|emb|CAA85685.1|           -
         self.assertAlmostEqual(dictionary[("T", "C")], 12.0, places=1)
         self.assertAlmostEqual(dictionary[("T", "G")], 0, places=1)
         self.assertAlmostEqual(dictionary[("T", "T")], 874.0, places=1)
+        alignment = msa.alignment
+        dictionary = alignment.substitutions
+        self.assertEqual(len(dictionary), 4)
+        self.assertEqual(dictionary.shape, (4, 4))
+        self.assertEqual(len(dictionary.keys()), 16)
+        self.assertAlmostEqual(dictionary[("A", "A")], 1395)
+        self.assertAlmostEqual(dictionary[("A", "C")], 3)
+        self.assertAlmostEqual(dictionary[("A", "G")], 13)
+        self.assertAlmostEqual(dictionary[("A", "T")], 6)
+        self.assertAlmostEqual(dictionary[("C", "A")], 3)
+        self.assertAlmostEqual(dictionary[("C", "C")], 271)
+        self.assertAlmostEqual(dictionary[("C", "G")], 0)
+        self.assertAlmostEqual(dictionary[("C", "T")], 16)
+        self.assertAlmostEqual(dictionary[("G", "A")], 5)
+        self.assertAlmostEqual(dictionary[("G", "C")], 0)
+        self.assertAlmostEqual(dictionary[("G", "G")], 480)
+        self.assertAlmostEqual(dictionary[("G", "T")], 0)
+        self.assertAlmostEqual(dictionary[("T", "A")], 6)
+        self.assertAlmostEqual(dictionary[("T", "C")], 12)
+        self.assertAlmostEqual(dictionary[("T", "G")], 0)
+        self.assertAlmostEqual(dictionary[("T", "T")], 874)
         with self.assertWarns(BiopythonDeprecationWarning):
             matrix = align_info.pos_specific_score_matrix(consensus, ["N", "-"])
 
-        alignment = msa.alignment
         motif = motifs.Motif("ACGT", alignment)
         counts = motif.counts
         for i in range(alignment.length):


### PR DESCRIPTION
This PR deprecates the `replacement_dictionary` method of the `SummaryInfo` class in `Bio.Align.AlignInfo`.
The alternative is to convert the `MultipleSeqAlignment` object to an `Alignment` object using the `alignment` property, and then using the `substitutions` property of the `Alignment` object.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
