### PR TITLE
Deprecate information_content and ic_vector in AlignInfo

### DIFF
--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -387,6 +387,31 @@ class SummaryInfo:
         content is calculated.
 
         """
+        warnings.warn(
+            "The `informatton_content` method and `ic_vector` attribute of the "
+            "`SummaryInfo` class are deprecated and will be removed in a "
+            "future release of Biopython. As an alternative, you can convert "
+            "the multiple sequence alignment object to a new-style Alignment "
+            "object by via its `.alignment` property, and use the "
+            "`information_content` attribute of the Alignment obecjt. "
+            "For example, for a multiple sequence alignment `msa` of "
+            "DNA nucleotides, you would do: "
+            "\n"
+            ">>> alignment = msa.alignment\n"
+            ">>> from Bio.motifs import Motif\n"
+            ">>> motif = Motif('ACGT', alignment)\n"
+            ">>> information_content = motif.information_content\n"
+            "\n"
+            "The `information_content` object contains the same values as the "
+            "`ic_vector` attribute of the `SummaryInfo` object. Its sum is "
+            "equal to the value return by the `information_content` method. "
+            "\n"
+            "If your multiple sequence alignment object was obtained using "
+            "Bio.AlignIO, then you can obtain a new-style Alignment object "
+            "directly by using Bio.Align.read instead of Bio.AlignIO.read, "
+            "or Bio.Align.parse instead of Bio.AlignIO.parse.",
+            BiopythonDeprecationWarning,
+        )
         # if no end was specified, then we default to the end of the sequence
         if end is None:
             end = len(self.alignment[0].seq)

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -582,11 +582,13 @@ class Motif:
                 frequencies = frequencies[mask] / total[mask]
                 values[mask] += frequencies * np.log2(frequencies / background[letter])
         else:
-            total = len(self.alignment) + sum(pseudocounts.values())
+            total = np.zeros(length)
+            for letter, frequencies in counts.items():
+                total += np.array(frequencies) + pseudocounts[letter]
             for letter, frequencies in counts.items():
                 frequencies = np.array(frequencies) + pseudocounts[letter]
                 mask = frequencies > 0
-                frequencies = frequencies[mask] / total
+                frequencies = frequencies[mask] / total[mask]
                 values[mask] += frequencies * np.log2(frequencies / background[letter])
         return values
 

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -77,9 +77,16 @@ The ``counts`` object contains the same information as the PSSM returned by
 >>> counts[letter][i] == pssm[index][letter]
 True
 
+The ``information_content`` method and the ``ic_vector`` attribute of the
+``SummaryInfo`` class were deprecated in release 1.82. As an alternative,
+please use the ``relative_entropy`` attribute of the ``motif`` instance (see
+above); it contains the same values as the ``ic_vector`` attribute, while
+``sum(relative_entropy)`` is equal to the value returned by
+``information_content``.
+
 The ``replacement_dictionary`` method of the ``SummaryInfo`` class was
 deprecated in release 1.82. As an alternative, please use the ``alignment``
-property of the ``MultipleSeqAlignment`` object to obtains a new-style
+property of the ``MultipleSeqAlignment`` object to obtain a new-style
 ``Alignment`` object, and use its ``substitutions`` attribute to obtain the
 replacement dictionary:
 

--- a/Doc/Tutorial/chapter_msa.tex
+++ b/Doc/Tutorial/chapter_msa.tex
@@ -1084,7 +1084,7 @@ First, we need to use our alignment to get an alignment summary object, which we
 >>> info_content  # doctest:+ELLIPSIS
 6.3910647...
 \end{minted}
-Now, \verb|info_content| will contain the relative information content over the region [2:6[ in relation to the expected frequencies.
+Now, \verb|info_content| will contain the relative information content over the region [2:6] in relation to the expected frequencies.
 
 The value return is calculated using base 2 as the logarithm base in the formula above. You can modify this by passing the parameter \verb|log_base| as the base you want:
 

--- a/Doc/examples/clustal_run.py
+++ b/Doc/examples/clustal_run.py
@@ -17,7 +17,6 @@ import sys
 import subprocess
 
 # biopython
-from Bio.Align.Applications import ClustalwCommandline
 from Bio import AlignIO
 from Bio.Align import AlignInfo
 from Bio.motifs import Motif
@@ -25,40 +24,33 @@ from Bio.motifs import Motif
 # create the command line to run clustalw
 # this assumes you've got clustalw somewhere on your path, otherwise
 # you need to pass the full path of the executable to this via cmd="..."
-cline = ClustalwCommandline(infile="opuntia.fasta", outfile="test.aln")
+command = "clustalw -infile=opuntia.fasta -outfile=test.aln"
 
 # actually perform the alignment
-return_code = subprocess.call(str(cline), shell=(sys.platform != "win32"))
+return_code = subprocess.call(command, shell=(sys.platform != "win32"))
 assert return_code == 0, "Calling ClustalW failed"
 
 # Parse the output
 msa = AlignIO.read("test.aln", "clustal")
+alignment = msa.alignment
 
-print(msa)
+print(alignment)
 
-print("first description: %s" % msa[0].description)
-print("first sequence: %s" % msa[0].seq)
+print("first description: %s" % alignment.sequences[0].description)
+print("first sequence: %s" % alignment.sequences[0].seq)
 
 # get the length of the alignment
-print("length %i" % msa.get_alignment_length())
-
-print(msa)
+print("length %i" % alignment.length)
 
 # print out interesting information about the alignment
 summary_align = AlignInfo.SummaryInfo(msa)
-
 consensus = summary_align.dumb_consensus()
 print("consensus %s" % consensus)
 
-alignment = msa.alignment
 motif = Motif("ACGT", alignment)
 counts = motif.counts
 print(counts)
 
-expect_freq = {"A": 0.3, "G": 0.2, "T": 0.3, "C": 0.2}
-
-info_content = summary_align.information_content(
-    5, 30, chars_to_ignore=["N"], e_freq_table=expect_freq
-)
-
-print("relative info content: %f" % info_content)
+motif.background = {"A": 0.3, "G": 0.2, "T": 0.3, "C": 0.2}
+relative_entropy = motif.relative_entropy
+print("relative entropy for columns [5:30]: %f" % sum(relative_entropy[5:30]))

--- a/Doc/examples/clustal_run.py
+++ b/Doc/examples/clustal_run.py
@@ -20,6 +20,7 @@ import subprocess
 from Bio.Align.Applications import ClustalwCommandline
 from Bio import AlignIO
 from Bio.Align import AlignInfo
+from Bio.motifs import Motif
 
 # create the command line to run clustalw
 # this assumes you've got clustalw somewhere on your path, otherwise
@@ -31,26 +32,28 @@ return_code = subprocess.call(str(cline), shell=(sys.platform != "win32"))
 assert return_code == 0, "Calling ClustalW failed"
 
 # Parse the output
-alignment = AlignIO.read("test.aln", "clustal")
+msa = AlignIO.read("test.aln", "clustal")
 
-print(alignment)
+print(msa)
 
-print("first description: %s" % alignment[0].description)
-print("first sequence: %s" % alignment[0].seq)
+print("first description: %s" % msa[0].description)
+print("first sequence: %s" % msa[0].seq)
 
 # get the length of the alignment
-print("length %i" % alignment.get_alignment_length())
+print("length %i" % msa.get_alignment_length())
 
-print(alignment)
+print(msa)
 
 # print out interesting information about the alignment
-summary_align = AlignInfo.SummaryInfo(alignment)
+summary_align = AlignInfo.SummaryInfo(msa)
 
 consensus = summary_align.dumb_consensus()
 print("consensus %s" % consensus)
 
-my_pssm = summary_align.pos_specific_score_matrix(consensus, chars_to_ignore=["N"])
-print(my_pssm)
+alignment = msa.alignment
+motif = Motif("ACGT", alignment)
+counts = motif.counts
+print(counts)
 
 expect_freq = {"A": 0.3, "G": 0.2, "T": 0.3, "C": 0.2}
 

--- a/Tests/test_AlignIO.py
+++ b/Tests/test_AlignIO.py
@@ -291,9 +291,10 @@ class TestAlignIO_reading(unittest.TestCase):
         e_freq = 1.0 / len(letters)
         ambiguous_letters = ambiguous_letters.upper() + ambiguous_letters.lower()
         e_freq_table = dict.fromkeys(ambiguous_letters, e_freq)
-        info_content = summary.information_content(
-            e_freq_table=e_freq_table, chars_to_ignore=chars_to_ignore
-        )
+        with self.assertWarns(BiopythonDeprecationWarning):
+            info_content = summary.information_content(
+                e_freq_table=e_freq_table, chars_to_ignore=chars_to_ignore
+            )
         motif.background = e_freq_table
         relative_entropy = sum(motif.relative_entropy)
         self.assertAlmostEqual(info_content, relative_entropy)
@@ -326,9 +327,10 @@ class TestAlignIO_reading(unittest.TestCase):
         e_freq = 1.0 / len(letters)
         all_letters = letters.upper() + letters.lower()
         e_freq_table = dict.fromkeys(all_letters, e_freq)
-        info_content = summary.information_content(
-            e_freq_table=e_freq_table, chars_to_ignore=["-"]
-        )
+        with self.assertWarns(BiopythonDeprecationWarning):
+            info_content = summary.information_content(
+                e_freq_table=e_freq_table, chars_to_ignore=["-"]
+            )
         relative_entropy = sum(motif.relative_entropy)
         self.assertAlmostEqual(info_content, relative_entropy)
 

--- a/Tests/test_AlignInfo.py
+++ b/Tests/test_AlignInfo.py
@@ -65,7 +65,10 @@ N  0.0 2.0 1.0 0.0
         )
 
         # provide the frequencies and chars to ignore explicitly.
-        ic = summary.information_content(e_freq_table=expected, chars_to_ignore=["-"])
+        with self.assertWarns(BiopythonDeprecationWarning):
+            ic = summary.information_content(
+                e_freq_table=expected, chars_to_ignore=["-"]
+            )
         self.assertAlmostEqual(ic, 7.32029999423075)
         ic = sum(motif.relative_entropy)
         self.assertAlmostEqual(ic, 7.32029999423075)
@@ -144,9 +147,10 @@ X  0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
 
         base_freq = 1.0 / len(letters)
         e_freq_table = {letter: base_freq for letter in letters}
-        ic = s.information_content(
-            e_freq_table=e_freq_table, chars_to_ignore=["-", "*"]
-        )
+        with self.assertWarns(BiopythonDeprecationWarning):
+            ic = s.information_content(
+                e_freq_table=e_freq_table, chars_to_ignore=["-", "*"]
+            )
         self.assertAlmostEqual(ic, 133.061475107)
         ic = sum(motif.relative_entropy)
         self.assertAlmostEqual(ic, 133.061475107)
@@ -169,9 +173,10 @@ X  0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0
 
         summary = SummaryInfo(msa)
         expected = {"A": 0.325, "G": 0.175, "T": 0.325, "C": 0.175}
-        ic = summary.information_content(
-            e_freq_table=expected, log_base=math.exp(1), pseudo_count=1
-        )
+        with self.assertWarns(BiopythonDeprecationWarning):
+            ic = summary.information_content(
+                e_freq_table=expected, log_base=math.exp(1), pseudo_count=1
+            )
         self.assertAlmostEqual(ic, 7.546369561463767)
         ic_vector = [
             0.11112361,

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -909,11 +909,15 @@ A  7.0 0.0 0.0 0.0
         value = align_info.information_content(
             5, 50, chars_to_ignore=["N"], e_freq_table=e_freq_table
         )
-        self.assertAlmostEqual(value, 88.42309908538343)
+        self.assertAlmostEqual(value, 88.42309908538343)  # MultipleSeqAlignment
+        value = sum(motif[5:50].relative_entropy)
+        self.assertAlmostEqual(value, 88.42309908538343)  # Alignment
         value = align_info.information_content(
             e_freq_table=e_freq_table, chars_to_ignore=["N"]
         )
-        self.assertAlmostEqual(value, 287.55, places=2)
+        self.assertAlmostEqual(value, 287.54558448976394)  # MultipleSeqAlignment
+        value = sum(motif.relative_entropy)
+        self.assertAlmostEqual(value, 287.54558448976394)  # Alignment
         self.assertEqual(align_info.get_column(1), "AAAAAAA")
         self.assertAlmostEqual(align_info.ic_vector[1], 2.00, places=2)
         self.assertEqual(align_info.get_column(7), "TTTATTT")

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -906,15 +906,17 @@ A  7.0 0.0 0.0 0.0
 """,
         )
         e_freq_table = {"G": 0.25, "C": 0.25, "A": 0.25, "T": 0.25}
-        value = align_info.information_content(
-            5, 50, chars_to_ignore=["N"], e_freq_table=e_freq_table
-        )
+        with self.assertWarns(BiopythonDeprecationWarning):
+            value = align_info.information_content(
+                5, 50, chars_to_ignore=["N"], e_freq_table=e_freq_table
+            )
         self.assertAlmostEqual(value, 88.42309908538343)  # MultipleSeqAlignment
         value = sum(motif[5:50].relative_entropy)
         self.assertAlmostEqual(value, 88.42309908538343)  # Alignment
-        value = align_info.information_content(
-            e_freq_table=e_freq_table, chars_to_ignore=["N", "-"]
-        )
+        with self.assertWarns(BiopythonDeprecationWarning):
+            value = align_info.information_content(
+                e_freq_table=e_freq_table, chars_to_ignore=["N", "-"]
+            )
         self.assertAlmostEqual(value, 306.2080592664532)  # MultipleSeqAlignment
         value = sum(motif.relative_entropy)
         self.assertAlmostEqual(value, 306.2080592664532)  # Alignment

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -913,15 +913,17 @@ A  7.0 0.0 0.0 0.0
         value = sum(motif[5:50].relative_entropy)
         self.assertAlmostEqual(value, 88.42309908538343)  # Alignment
         value = align_info.information_content(
-            e_freq_table=e_freq_table, chars_to_ignore=["N"]
+            e_freq_table=e_freq_table, chars_to_ignore=["N", "-"]
         )
-        self.assertAlmostEqual(value, 287.54558448976394)  # MultipleSeqAlignment
+        self.assertAlmostEqual(value, 306.2080592664532)  # MultipleSeqAlignment
         value = sum(motif.relative_entropy)
-        self.assertAlmostEqual(value, 287.54558448976394)  # Alignment
+        self.assertAlmostEqual(value, 306.2080592664532)  # Alignment
         self.assertEqual(align_info.get_column(1), "AAAAAAA")
-        self.assertAlmostEqual(align_info.ic_vector[1], 2.00, places=2)
+        self.assertAlmostEqual(align_info.ic_vector[1], 2.00)
+        self.assertAlmostEqual(motif.relative_entropy[1], 2.00)
         self.assertEqual(align_info.get_column(7), "TTTATTT")
-        self.assertAlmostEqual(align_info.ic_vector[7], 1.41, places=2)
+        self.assertAlmostEqual(align_info.ic_vector[7], 1.4083272214176725)
+        self.assertAlmostEqual(motif.relative_entropy[7], 1.4083272214176725)
         handle = StringIO()
         AlignInfo.print_info_content(align_info, fout=handle)
         self.assertEqual(
@@ -983,16 +985,16 @@ A  7.0 0.0 0.0 0.0
 53 A 2.000
 54 T 2.000
 55 A 2.000
-56 - 0.682
-57 - 0.682
-58 - 0.333
-59 - 0.333
-60 - -0.115
-61 - -0.115
-62 - -0.115
-63 - -0.115
-64 - -0.115
-65 - -0.115
+56 - 2.000
+57 - 2.000
+58 - 2.000
+59 - 2.000
+60 - 2.000
+61 - 2.000
+62 - 2.000
+63 - 2.000
+64 - 2.000
+65 - 2.000
 66 A 2.000
 67 T 2.000
 68 A 2.000
@@ -1375,7 +1377,8 @@ XX
         )
         self.assertAlmostEqual(sum(motif[5:50].relative_entropy), 88.42309908538343)
         relative_entropy = motif.relative_entropy
-        self.assertAlmostEqual(sum(relative_entropy), 287.54558448976394)
+        self.assertAlmostEqual(sum(relative_entropy[5:50]), 88.42309908538343)
+        self.assertAlmostEqual(sum(relative_entropy), 306.20805926645323)
         self.assertEqual(alignment[:, 1], "AAAAAAA")
         self.assertAlmostEqual(motif.relative_entropy[1], 2.0)
         self.assertEqual(alignment[:, 7], "TTTATTT")


### PR DESCRIPTION
This PR deprecates the `information_content` method and the `ic_vector` attribute of the `SummaryInfo` class in `Bio.Align.AlignInfo`.

As a replacement, users can create a `Motif` instance from the alignment, and use its `relative_entropy` attribute. It contains the same values as the `ic_vector` attribute. Summing these values gives the value returned by `information_content`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

