### PR TITLE
deprecating Bio.HMM submodules

### DIFF
--- a/Bio/HMM/DynamicProgramming.py
+++ b/Bio/HMM/DynamicProgramming.py
@@ -12,6 +12,18 @@ algorithms that can be used generally.
 """
 
 
+import warnings
+
+from Bio import BiopythonDeprecationWarning
+
+warnings.warn(
+    "The 'Bio.HMM.DynamicProgramming' module is deprecated and will "
+    "be removed in a future release of Biopython. Consider using the "
+    "hmmlearn package instead.",
+    BiopythonDeprecationWarning,
+)
+
+
 class AbstractDPAlgorithms:
     """An abstract class to calculate forward and backward probabilities.
 

--- a/Bio/HMM/MarkovModel.py
+++ b/Bio/HMM/MarkovModel.py
@@ -11,8 +11,17 @@ import copy
 import math
 import random
 from collections import defaultdict
+import warnings
 
 from Bio.Seq import Seq
+from Bio import BiopythonDeprecationWarning
+
+warnings.warn(
+    "The 'Bio.HMM.MarkovModule' module is deprecated and will be "
+    "removed in a future release of Biopython. Consider using the "
+    "hmmlearn package instead.",
+    BiopythonDeprecationWarning,
+)
 
 
 def _gen_random_array(n):

--- a/Bio/HMM/Trainer.py
+++ b/Bio/HMM/Trainer.py
@@ -26,6 +26,18 @@ import math
 from .DynamicProgramming import ScaledDPAlgorithms
 
 
+import warnings
+
+from Bio import BiopythonDeprecationWarning
+
+warnings.warn(
+    "The 'Bio.HMM.Trainer' module is deprecated and will be removed "
+    "in a future release of Biopython. Consider using the hmmlearn "
+    "package instead.",
+    BiopythonDeprecationWarning,
+)
+
+
 class TrainingSequence:
     """Hold a training sequence with emissions and optionally, a state path."""
 

--- a/Bio/HMM/Trainer.py
+++ b/Bio/HMM/Trainer.py
@@ -21,12 +21,10 @@ This aims to estimate two parameters:
 """
 # standard modules
 import math
+import warnings
 
 # local stuff
 from .DynamicProgramming import ScaledDPAlgorithms
-
-
-import warnings
 
 from Bio import BiopythonDeprecationWarning
 

--- a/Bio/HMM/Utilities.py
+++ b/Bio/HMM/Utilities.py
@@ -12,6 +12,19 @@ dealing with HMMs.
 """
 
 
+import warnings
+
+from Bio import BiopythonDeprecationWarning
+
+
+warnings.warn(
+    "The 'Bio.HMM.Utilities' module is deprecated and will be "
+    "removed in a future release of Biopython. Consider using the "
+    "hmmlearn package instead.",
+    BiopythonDeprecationWarning,
+)
+
+
 def pretty_print_prediction(
     emissions,
     real_state,

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -125,6 +125,13 @@ Bio.MarkovModel
 Deprecated in release 1.82, consider using hmmlearn
 (https://pypi.org/project/hmmlearn/) instead.
 
+Bio.HMM
+-------
+The `Bio.HMM.DynamicProgramming`, `Bio.HMM.Trainer`, `Bio.HMM.MarkovModel`, and
+`Bio.HMM.Utilities` modules were deprecated in release 1.82. Consider using
+hmmlearn (https://pypi.org/project/hmmlearn/) instead.
+
+
 Bio.Data.SCOPData
 -----------------
 Declared obsolete in release 1.80, and removed in release 1.82. Please use

--- a/Tests/test_HMMCasino.py
+++ b/Tests/test_HMMCasino.py
@@ -22,11 +22,16 @@ loaded dice is .05 and the probability of switching from loaded to fair is
 # standard modules
 import random
 import unittest
+import warnings
 
-# HMM stuff we are testing
-from Bio.HMM import MarkovModel
-from Bio.HMM import Trainer
-from Bio.HMM import Utilities
+from Bio import BiopythonDeprecationWarning
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", category=BiopythonDeprecationWarning)
+    # HMM stuff we are testing
+    from Bio.HMM import MarkovModel
+    from Bio.HMM import Trainer
+    from Bio.HMM import Utilities
 
 
 # whether we should print everything out. Set this to zero for

--- a/Tests/test_HMMGeneral.py
+++ b/Tests/test_HMMGeneral.py
@@ -13,15 +13,19 @@ Also tests Training methods.
 
 import unittest
 import math
+import warnings
 
 # biopython
 from Bio.Seq import Seq
+from Bio import BiopythonDeprecationWarning
 
 
-# stuff we are testing
-from Bio.HMM import MarkovModel
-from Bio.HMM import DynamicProgramming
-from Bio.HMM import Trainer
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", category=BiopythonDeprecationWarning)
+    # stuff we are testing
+    from Bio.HMM import MarkovModel
+    from Bio.HMM import DynamicProgramming
+    from Bio.HMM import Trainer
 
 
 # create some simple alphabets


### PR DESCRIPTION
This PR deprecates the Bio.HMM submodules, suggesting to use hmmlearn (https://github.com/hmmlearn/hmmlearn) instead.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

