### PR TITLE
Drop use of hevea for HTML version of the Tutorial

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -1,7 +1,7 @@
 subdirs :=
 BP_VERSION := $(shell python -c "`grep ^__version__ ../Bio/__init__.py`; print('dev' if 'dev' in __version__ else __version__)")
 
-all:  Tutorial.html Tutorial.txt pdf $(subdirs)
+all:  pdf $(subdirs)
 pdf:  Tutorial.pdf biopdb_faq.pdf
 
 Tutorial.pdf: Tutorial.tex Tutorial/chapter_*.tex
@@ -13,12 +13,6 @@ biopdb_faq.pdf: biopdb_faq.tex
 	pdflatex biopdb_faq.tex
 	pdflatex biopdb_faq.tex
 	pdflatex biopdb_faq.tex
-
-Tutorial.html: Tutorial.tex Tutorial/chapter_*.tex version.sh
-	hevea -exec ./version.sh -exec xxdate.exe -fix Tutorial.tex
-
-Tutorial.txt: Tutorial.tex Tutorial/chapter_*.tex version.sh
-	hevea -exec ./version.sh -exec xxdate.exe -fix -text Tutorial.tex
 
 version.sh: version.in
 	sed "s/\@VERSION\@/${BP_VERSION}/g" version.in > version.sh

--- a/Doc/Tutorial.tex
+++ b/Doc/Tutorial.tex
@@ -45,7 +45,6 @@
 \documentclass{report}
 \usepackage{url}
 \usepackage{fullpage}
-\usepackage{hevea}
 \usepackage{graphicx}
 
 % For syntax coloring of python, pycon, bash etc in pdflatex:
@@ -59,42 +58,14 @@
 
 % Make links between references
 \usepackage{hyperref}
-\newif\ifpdf
-\ifx\pdfoutput\undefined
-  \pdffalse
-\else
-  \pdfoutput=1
-  \pdftrue
-\fi
-\ifpdf
-  \hypersetup{colorlinks=true, hyperindex=true, citecolor=red, urlcolor=blue}
-\fi
 
 \begin{document}
 
-\begin{htmlonly}
 \title{Biopython Tutorial and Cookbook}
-\end{htmlonly}
-\begin{latexonly}
-\title{
-%Hack to get the logo on the PDF front page:
-\includegraphics[width=\textwidth]{images/biopython_logo.pdf}\\
-%Hack to get some white space using a blank line:
-~\\
-Biopython Tutorial and Cookbook}
-\end{latexonly}
 
 \author{Jeff Chang, Brad Chapman, Iddo Friedberg, Thomas Hamelryck, \\
 Michiel de Hoon, Peter Cock, Tiago Antao, Eric Talevich, Bartek Wilczy\'{n}ski}
 \date{Last Update -- \today\ (Biopython \bpversion)}
-
-%Hack to get the logo at the start of the HTML front page:
-%(hopefully this isn't going to be too wide for most people)
-\begin{rawhtml}
-<P ALIGN="center">
-<IMG ALIGN="center" SRC="images/biopython_logo.svg" TITLE="Biopython Logo" ALT="[Biopython Logo]" width="450" height="300" />
-</p>
-\end{rawhtml}
 
 \maketitle
 \tableofcontents

--- a/Doc/Tutorial/chapter_blast.tex
+++ b/Doc/Tutorial/chapter_blast.tex
@@ -447,17 +447,7 @@ doing what you need to do!
 
 An important consideration for extracting information from a BLAST report is the type of objects that the information is stored in. In Biopython, the parsers return \verb|Record| objects, either \verb|Blast| or \verb|PSIBlast| depending on what you are parsing. These objects are defined in \verb|Bio.Blast.Record| and are quite complete.
 
-\begin{htmlonly}
-Here is my attempt at a UML class diagram for the \verb|Blast| record class:
 
-\imgsrc[width=650, height=750]{images/BlastRecord.png}
-
-The PSIBlast record object is similar, but has support for the rounds that are used in the iteration steps of PSIBlast:
-
-\imgsrc[width=650, height=750]{images/PSIBlastRecord.png}
-\end{htmlonly}
-
-\begin{latexonly}
 Figures~\ref{fig:blastrecord} and~\ref{fig:psiblastrecord} and are my attempts at UML class diagrams for the \verb|Blast| and \verb|PSIBlast| record classes.
 The PSIBlast record object is similar, but has support for the rounds that are used in the iteration steps of PSIBlast.
 
@@ -474,7 +464,6 @@ The PSIBlast record object is similar, but has support for the rounds that are u
 \caption{Class diagram for the PSIBlast Record class.}
 \label{fig:psiblastrecord}
 \end{figure}
-\end{latexonly}
 
 If you are good at UML and see mistakes/improvements that can be made, please let me know.
 

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1088,17 +1088,10 @@ pylab.show()
 %
 % Have a HTML version and a PDF version to display nicely...
 %
-\begin{htmlonly}
-\noindent That should pop up a new window containing the following graph:
-
-\imgsrc[width=600, height=450]{images/hist_plot.png}
-
-\end{htmlonly}
 %
 % Now the PDF equivalent where we cannot always expect the figure
 % to be positioned right next to the text, so will use a reference.
 %
-\begin{latexonly}
 \begin{figure}[htbp]
 \centering
 \includegraphics[width=0.8\textwidth]{images/hist_plot.png}
@@ -1107,7 +1100,6 @@ pylab.show()
 \end{figure}
 \noindent That should pop up a new window containing the graph
 shown in Figure~\ref{fig:seq-len-hist}.
-\end{latexonly}
 %
 % The text now continues...
 %
@@ -1157,17 +1149,10 @@ pylab.show()
 %
 % Have an HTML version and a PDF version to display nicely...
 %
-\begin{htmlonly}
-\noindent As in the previous example, that should pop up a new window containing a graph:
-
-\imgsrc[width=600, height=450]{images/gc_plot.png}
-
-\end{htmlonly}
 %
 % Now the PDF equivalent where we cannot always expect the figure
 % to be positioned right next to the text, so we'll use a reference.
 %
-\begin{latexonly}
 \begin{figure}[htbp]
 \centering
 \includegraphics[width=0.8\textwidth]{images/gc_plot.png}
@@ -1175,7 +1160,6 @@ pylab.show()
 \label{fig:seq-gc-plot}
 \end{figure}
 \noindent As in the previous example, that should pop up a new window with the graph shown in Figure~\ref{fig:seq-gc-plot}.
-\end{latexonly}
 %
 % The text now continues...
 %
@@ -1187,25 +1171,18 @@ A dot plot is a way of visually comparing two nucleotide sequences for similarit
 each other.  A sliding window is used to compare short sub-sequences to each other,
 often with a mismatch threshold.  Here for simplicity we'll only look for perfect
 matches (shown in black
-\begin{latexonly}
 in Figure~\ref{fig:nuc-dot-plot}).
-\end{latexonly}
-\begin{htmlonly}
-in the plot below).
-\end{htmlonly}
 
 %
 % Now the PDF equivalent where we cannot always expect the figure
 % to be positioned right next to the text, so we'll use a reference.
 %
-\begin{latexonly}
 \begin{figure}[htbp]
 \centering
 \includegraphics[width=0.8\textwidth]{images/dot_plot.png}
 \caption{Nucleotide dot plot of two orchid sequence lengths (using pylab's imshow function).}
 \label{fig:nuc-dot-plot}
 \end{figure}
-\end{latexonly}
 
 To start off, we'll need two sequences.  For the sake of argument, we'll just take
 the first two from our orchid FASTA file \href{https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/ls_orchid.fasta}{ls\_orchid.fasta}:
@@ -1259,15 +1236,7 @@ pylab.show()
 %
 % Have a HTML version and a PDF version to display nicely...
 %
-\begin{htmlonly}
-\noindent That should pop up a new window containing a graph like this:
-
-\imgsrc[width=600, height=450]{images/dot_plot.png}
-
-\end{htmlonly}
-\begin{latexonly}
 \noindent That should pop up a new window showing the graph in Figure~\ref{fig:nuc-dot-plot}.
-\end{latexonly}
 %
 % The text now continues...
 %
@@ -1335,13 +1304,6 @@ pylab.show()
 %
 % Have a HTML version and a PDF version to display nicely...
 %
-\begin{htmlonly}
-\noindent That should pop up a new window containing a graph like this:
-
-\imgsrc[width=600, height=450]{images/dot_plot_scatter.png}
-
-\end{htmlonly}
-\begin{latexonly}
 \noindent That should pop up a new window showing the graph in Figure~\ref{fig:nuc-dot-plot-scatter}.
 \begin{figure}[htbp]
 \centering
@@ -1349,7 +1311,6 @@ pylab.show()
 \caption{Nucleotide dot plot of two orchid sequence lengths (using pylab's scatter function).}
 \label{fig:nuc-dot-plot-scatter}
 \end{figure}
-\end{latexonly}
 Personally I find this second plot much easier to read!
 Again note that we have \emph{not} checked for reverse complement matches here
 -- you could extend this example to do this, and perhaps plot the forward
@@ -1397,7 +1358,6 @@ Solexa/Illumina FASTQ variant file formats instead.
 
 This example uses the \verb|pylab.savefig(...)| function instead of
 \verb|pylab.show(...)|, but as mentioned before both are useful.
-\begin{latexonly}
 \begin{figure}[htbp]
 \centering
 \includegraphics[width=0.8\textwidth]{images/SRR001666.png}
@@ -1405,14 +1365,6 @@ This example uses the \verb|pylab.savefig(...)| function instead of
 \label{fig:paired-end-qual-plot}
 \end{figure}
 The result is shown in Figure~\ref{fig:paired-end-qual-plot}.
-\end{latexonly}
-\begin{htmlonly}
-Here is the result:
-
-%Blank lines here are important!
-\imgsrc[width=600, height=600]{images/SRR001666.png}
-
-\end{htmlonly}
 
 
 \section{BioSQL -- storing sequences in a relational database}

--- a/Doc/Tutorial/chapter_cookbook.tex
+++ b/Doc/Tutorial/chapter_cookbook.tex
@@ -1085,13 +1085,6 @@ pylab.ylabel("Count")
 pylab.show()
 \end{minted}
 
-%
-% Have a HTML version and a PDF version to display nicely...
-%
-%
-% Now the PDF equivalent where we cannot always expect the figure
-% to be positioned right next to the text, so will use a reference.
-%
 \begin{figure}[htbp]
 \centering
 \includegraphics[width=0.8\textwidth]{images/hist_plot.png}
@@ -1100,9 +1093,6 @@ pylab.show()
 \end{figure}
 \noindent That should pop up a new window containing the graph
 shown in Figure~\ref{fig:seq-len-hist}.
-%
-% The text now continues...
-%
 Notice that most of these orchid sequences are about $740$ bp long, and there could be
 two distinct classes of sequence here with a subset of shorter sequences.
 
@@ -1146,13 +1136,6 @@ pylab.ylabel("GC%")
 pylab.show()
 \end{minted}
 
-%
-% Have an HTML version and a PDF version to display nicely...
-%
-%
-% Now the PDF equivalent where we cannot always expect the figure
-% to be positioned right next to the text, so we'll use a reference.
-%
 \begin{figure}[htbp]
 \centering
 \includegraphics[width=0.8\textwidth]{images/gc_plot.png}
@@ -1160,9 +1143,6 @@ pylab.show()
 \label{fig:seq-gc-plot}
 \end{figure}
 \noindent As in the previous example, that should pop up a new window with the graph shown in Figure~\ref{fig:seq-gc-plot}.
-%
-% The text now continues...
-%
 If you tried this on the full set of genes from one organism, you'd probably get a much
 smoother plot than this.
 
@@ -1173,10 +1153,6 @@ often with a mismatch threshold.  Here for simplicity we'll only look for perfec
 matches (shown in black
 in Figure~\ref{fig:nuc-dot-plot}).
 
-%
-% Now the PDF equivalent where we cannot always expect the figure
-% to be positioned right next to the text, so we'll use a reference.
-%
 \begin{figure}[htbp]
 \centering
 \includegraphics[width=0.8\textwidth]{images/dot_plot.png}
@@ -1233,13 +1209,7 @@ pylab.show()
 %pylab.savefig("dot_plot.png", dpi=75)
 %pylab.savefig("dot_plot.pdf")
 
-%
-% Have a HTML version and a PDF version to display nicely...
-%
 \noindent That should pop up a new window showing the graph in Figure~\ref{fig:nuc-dot-plot}.
-%
-% The text now continues...
-%
 As you might have expected, these two sequences are very similar with a
 partial line of window sized matches along the diagonal.  There are no off
 diagonal matches which would be indicative of inversions or other interesting
@@ -1301,9 +1271,7 @@ pylab.show()
 \end{minted}
 %pylab.savefig("dot_plot_scatter.png", dpi=75)
 %pylab.savefig("dot_plot_scatter.pdf")
-%
-% Have a HTML version and a PDF version to display nicely...
-%
+
 \noindent That should pop up a new window showing the graph in Figure~\ref{fig:nuc-dot-plot-scatter}.
 \begin{figure}[htbp]
 \centering

--- a/Doc/Tutorial/chapter_graphics.tex
+++ b/Doc/Tutorial/chapter_graphics.tex
@@ -127,12 +127,6 @@ for example:
 gd_diagram.write("plasmid_linear.png", "PNG")
 \end{minted}
 
-\begin{htmlonly}
-%The blank line below is important to start a new paragraph
-\imgsrc[width=550, height=400]{images/plasmid_linear.png}
-
-\end{htmlonly}
-\begin{latexonly}
 The expected output is shown in Figure~\ref{fig:plasmid_linear}.
 \begin{figure}[htbp]
 \centering
@@ -140,7 +134,6 @@ The expected output is shown in Figure~\ref{fig:plasmid_linear}.
 \caption{Simple linear diagram for \textit{Yersinia pestis biovar Microtus} plasmid pPCP1.}
 \label{fig:plasmid_linear}
 \end{figure}
-\end{latexonly}
 Notice that the \verb|fragments| argument which we set to four controls how
 many pieces the genome gets broken up into.
 
@@ -158,12 +151,6 @@ gd_diagram.draw(
 gd_diagram.write("plasmid_circular.pdf", "PDF")
 \end{minted}
 
-\begin{htmlonly}
-%The blank line below is important to start a new paragraph
-\imgsrc[width=400, height=400]{images/plasmid_circular.png}
-
-\end{htmlonly}
-\begin{latexonly}
 The expected output is shown in Figure~\ref{fig:plasmid_circular}.
 \begin{figure}[htbp]
 \centering
@@ -171,7 +158,6 @@ The expected output is shown in Figure~\ref{fig:plasmid_circular}.
 \caption{Simple circular diagram for \textit{Yersinia pestis biovar Microtus} plasmid pPCP1.}
 \label{fig:plasmid_circular}
 \end{figure}
-\end{latexonly}
 These figures are not very exciting, but we've only just got started.
 
 \subsection{A bottom up example}
@@ -253,12 +239,7 @@ gdd.draw(format="linear", pagesize=(15 * cm, 4 * cm), fragments=1, start=0, end=
 gdd.write("GD_labels_default.pdf", "pdf")
 \end{minted}
 
-\begin{htmlonly}
-The top part of the image in the next subsection shows the output
-\end{htmlonly}
-\begin{latexonly}
 The output is shown at the top of Figure~\ref{fig:gd_sigil_labels}
-\end{latexonly}
 (in the default feature color, pale green).
 
 Notice that we have used the \texttt{name} argument here to specify the
@@ -318,14 +299,6 @@ gd_feature_set.add_feature(
 
 \noindent Combining each of these three fragments with the complete example
 in the previous section should give something like
-\begin{htmlonly}
-this:
-
-%The blank lines above and below are important to trigger paragraph breaks
-\imgsrc[width=600, height=700]{images/GD_sigil_labels.png}
-
-\end{htmlonly}
-\begin{latexonly}
 the tracks in Figure~\ref{fig:gd_sigil_labels}.
 \begin{figure}[htbp]
 \centering
@@ -338,7 +311,6 @@ Section~\ref{sec:gd_feature_captions}).
 }
 \label{fig:gd_sigil_labels}
 \end{figure}
-\end{latexonly}
 
 We've not shown it here, but you can also set \texttt{label\_color} to
 control the label's color (used in Section~\ref{sec:gd_nice_example}).
@@ -380,22 +352,13 @@ gd_feature_set.add_feature(feature, sigil="BIGARROW")
 \end{minted}
 
 These are shown
-\begin{htmlonly}
-below.
-\end{htmlonly}
-\begin{latexonly}
 in Figure~\ref{fig:gd_sigils}.
-\end{latexonly}
 Most sigils fit into a bounding box (as given by the default BOX sigil),
 either above or below the axis for the forward or reverse strand, or
 straddling it (double the height) for strand-less features.
 The BIGARROW sigil is different, always straddling the axis with the
 direction taken from the feature's stand.
 
-\begin{htmlonly}
-\imgsrc[width=425, height=600]{images/GD_sigils.png}
-\end{htmlonly}
-\begin{latexonly}
 \begin{figure}[htbp]
 \centering
 \includegraphics[width=0.8\textwidth]{images/GD_sigils.png}
@@ -403,7 +366,6 @@ direction taken from the feature's stand.
 (see Section~\ref{sec:gd_sigils})}
 \label{fig:gd_sigils}
 \end{figure}
-\end{latexonly}
 
 \subsection{Arrow sigils}
 \label{sec:gd_arrow_sigils}
@@ -424,13 +386,6 @@ gd_feature_set.add_feature(
 )
 \end{minted}
 
-\begin{htmlonly}
-\noindent The results are shown below:
-
-\imgsrc[width=600, height=700]{images/GD_sigil_arrow_shafts.png}
-
-\end{htmlonly}
-\begin{latexonly}
 \noindent The results are shown in Figure~\ref{fig:gd_sigil_arrow_shafts}.
 \begin{figure}[htbp]
 \centering
@@ -439,7 +394,6 @@ gd_feature_set.add_feature(
 (see Section~\ref{sec:gd_arrow_sigils})}
 \label{fig:gd_sigil_arrow_shafts}
 \end{figure}
-\end{latexonly}
 
 Secondly, the length of the arrow head - given as a proportion of the height
 of the bounding box (defaulting to $0.5$, or $50\%$):
@@ -453,13 +407,6 @@ gd_feature_set.add_feature(feature, sigil="ARROW", color="orange", arrowhead_len
 gd_feature_set.add_feature(feature, sigil="ARROW", color="red", arrowhead_length=10000)
 \end{minted}
 
-\begin{htmlonly}
-\noindent The results are shown below:
-
-\imgsrc[width=600, height=700]{images/GD_sigil_arrow_heads.png}
-
-\end{htmlonly}
-\begin{latexonly}
 \noindent The results are shown in Figure~\ref{fig:gd_sigil_arrow_heads}.
 \begin{figure}[htbp]
 \centering
@@ -468,7 +415,6 @@ gd_feature_set.add_feature(feature, sigil="ARROW", color="red", arrowhead_length
 (see Section~\ref{sec:gd_arrow_sigils})}
 \label{fig:gd_sigil_arrow_heads}
 \end{figure}
-\end{latexonly}
 
 Biopython 1.61 adds a new \verb|BIGARROW| sigil which always straddles
 the axis, pointing left for the reverse strand or right otherwise:
@@ -558,15 +504,6 @@ gd_diagram.write("plasmid_circular_nice.eps", "EPS")
 gd_diagram.write("plasmid_circular_nice.svg", "SVG")
 \end{minted}
 
-\begin{htmlonly}
-\noindent And the output:
-
-\imgsrc[width=550, height=400]{images/plasmid_linear_nice.png}
-
-\imgsrc[width=591, height=591]{images/plasmid_circular_nice.png}
-
-\end{htmlonly}
-\begin{latexonly}
 \noindent The expected output is shown in Figures~\ref{fig:plasmid_linear_nice}
 and~\ref{fig:plasmid_circular_nice}.
 \begin{figure}[htbp]
@@ -585,7 +522,6 @@ pPCP1 showing selected restriction digest sites (see
 Section~\ref{sec:gd_nice_example}).}
 \label{fig:plasmid_circular_nice}
 \end{figure}
-\end{latexonly}
 
 \subsection{Multiple tracks}
 \label{sec:gd_multiple_tracks}
@@ -722,13 +658,6 @@ gd_diagram.write(name + ".eps", "EPS")
 gd_diagram.write(name + ".svg", "SVG")
 \end{minted}
 
-\begin{htmlonly}
-\noindent The result:
-
-\imgsrc[width=565, height=400]{images/three_track_simple.png}
-
-\end{htmlonly}
-\begin{latexonly}
 \noindent The expected output is shown in Figure~\ref{fig:three_track_simple}.
 \begin{figure}[htbp]
 \centering
@@ -739,7 +668,6 @@ gd_diagram.write(name + ".svg", "SVG")
 (see Section~\ref{sec:gd_multiple_tracks}).}
 \label{fig:three_track_simple}
 \end{figure}
-\end{latexonly}
 I did wonder why in the original manuscript there were no red or orange genes
 marked in the bottom phage. Another important point is here the phage are
 shown with different lengths - this is because they are all drawn to the same
@@ -884,13 +812,6 @@ is to use transparency in ReportLab, by using colors with their alpha channel se
 However, this kind of shaded color scheme combined with overlap transparency
 would be difficult to interpret.
 %Again, HTML and PDF versions for the figure
-\begin{htmlonly}
-\noindent The result:
-
-\imgsrc[width=565, height=400]{images/three_track_cl.png}
-
-\end{htmlonly}
-\begin{latexonly}
 \noindent The expected output is shown in Figure~\ref{fig:three_track_cl}.
 \begin{figure}[htbp]
 \centering
@@ -901,7 +822,6 @@ would be difficult to interpret.
 shaded by percentage identity (see Section~\ref{sec:gd_cross_links}).}
 \label{fig:three_track_cl}
 \end{figure}
-\end{latexonly}
 
 There is still a lot more that can be done within Biopython to help
 improve this figure. First of all, the cross links in this case are
@@ -917,13 +837,6 @@ are demonstrated in the example script
 \href{https://github.com/biopython/biopython/blob/master/Doc/examples/Proux_et_al_2002_Figure_6.py}{Proux\_et\_al\_2002\_Figure\_6.py}
 included in the \texttt{Doc/examples} folder of the Biopython source code.
 %TODO - Add a link get the file directly (for Windows users etc).
-\begin{htmlonly}
-\noindent The result:
-
-\imgsrc[width=565, height=400]{images/three_track_cl2a.png}
-
-\end{htmlonly}
-\begin{latexonly}
 \noindent The expected output is shown in Figure~\ref{fig:three_track_cl2}.
 \begin{figure}[htbp]
 \centering
@@ -934,7 +847,6 @@ included in the \texttt{Doc/examples} folder of the Biopython source code.
 shaded by percentage identity (see Section~\ref{sec:gd_cross_links}).}
 \label{fig:three_track_cl2}
 \end{figure}
-\end{latexonly}
 
 Beyond that, finishing touches you might want to do manually in a vector
 image editor include fine tuning the placement of gene labels, and adding
@@ -1015,7 +927,6 @@ There is an example in Jupe \textit{et al.} (2012) \cite{jupe2012}
 \subsection{Simple Chromosomes}
 Here is a very simple example - for which we'll use \textit{Arabidopsis thaliana}.
 
-\begin{latexonly}
 \begin{figure}[p]
 \centering
 \includegraphics[scale=0.45]{images/simple_chrom.pdf}
@@ -1028,7 +939,6 @@ Here is a very simple example - for which we'll use \textit{Arabidopsis thaliana
 \caption{Chromosome diagram for \textit{Arabidopsis thaliana} showing tRNA genes.}
 \label{fig:trnachromosome}
 \end{figure}
-\end{latexonly}
 
 You can skip this bit, but first I downloaded the five sequenced chromosomes
 as five individual FASTA files from the NCBI's FTP site
@@ -1103,16 +1013,7 @@ chr_diagram.draw("simple_chrom.pdf", "Arabidopsis thaliana")
 \end{minted}
 
 This should create a very simple PDF file, shown
-\begin{htmlonly}
-here:
-
-%The blank lines above and below are important to trigger paragraph breaks
-\imgsrc[width=650, height=460]{images/simple_chrom.png}
-
-\end{htmlonly}
-\begin{latexonly}
 in Figure~\ref{fig:simplechromosome}.
-\end{latexonly}
 This example is deliberately short and sweet. The next example shows the
 location of features of interest.
 
@@ -1183,13 +1084,4 @@ chr_diagram.draw("tRNA_chrom.pdf", "Arabidopsis thaliana")
 It might warn you about the labels being too close together - have a look
 at the forward strand (right hand side) of Chr I, but it should create a
 colorful PDF file, shown
-\begin{htmlonly}
-here:
-
-%The blank lines above and below are important to trigger paragraph breaks
-\imgsrc[width=650, height=460]{images/tRNA_chrom.png}
-
-\end{htmlonly}
-\begin{latexonly}
 in Figure~\ref{fig:simplechromosome}.
-\end{latexonly}

--- a/Doc/Tutorial/chapter_graphics.tex
+++ b/Doc/Tutorial/chapter_graphics.tex
@@ -811,8 +811,8 @@ we don't have any problems with overlapping cross-links. One way to tackle that
 is to use transparency in ReportLab, by using colors with their alpha channel set.
 However, this kind of shaded color scheme combined with overlap transparency
 would be difficult to interpret.
-%Again, HTML and PDF versions for the figure
-\noindent The expected output is shown in Figure~\ref{fig:three_track_cl}.
+The expected output is shown in Figure~\ref{fig:three_track_cl}.
+
 \begin{figure}[htbp]
 \centering
 \includegraphics[width=\textwidth]{images/three_track_cl.png}
@@ -837,7 +837,8 @@ are demonstrated in the example script
 \href{https://github.com/biopython/biopython/blob/master/Doc/examples/Proux_et_al_2002_Figure_6.py}{Proux\_et\_al\_2002\_Figure\_6.py}
 included in the \texttt{Doc/examples} folder of the Biopython source code.
 %TODO - Add a link get the file directly (for Windows users etc).
-\noindent The expected output is shown in Figure~\ref{fig:three_track_cl2}.
+The expected output is shown in Figure~\ref{fig:three_track_cl2}.
+
 \begin{figure}[htbp]
 \centering
 \includegraphics[width=\textwidth]{images/three_track_cl2a.png}

--- a/Doc/Tutorial/chapter_introduction.tex
+++ b/Doc/Tutorial/chapter_introduction.tex
@@ -116,9 +116,7 @@ file for other options.
   licensed under your choice of the \emph{Biopython License Agreement} or
   the \emph{BSD 3-Clause License}.
 
-\begin{latexonly}
   \includegraphics[width=6cm]{images/biopython_logo.pdf}\\
-\end{latexonly}
 \begin{rawhtml}
   <IMG ALIGN="center" SRC="images/biopython_logo.svg" TITLE="Biopython Logo (2017 onwards)" ALT="[New Biopython Logo]" width="300" height="200" />
   <IMG ALIGN="center" SRC="images/biopython_logo_old.jpg" TITLE="Old Biopython Logo (2003-2017)" ALT="[Old Biopython Logo]" width="512" height="144" />
@@ -128,9 +126,7 @@ file for other options.
   helix around the word ``BIOPYTHON'', designed by Henrik Vestergaard and
   Thomas Hamelryck in 2003 as part of an open competition.
 
-\begin{latexonly}
   \includegraphics[width=7cm]{images/biopython_logo_old.jpg}\\
-\end{latexonly}
 
   \item \emph{Do you have a change-log listing what's new in each release?} \\
   See the file \verb|NEWS.rst| included with the source code (originally called

--- a/Doc/Tutorial/chapter_introduction.tex
+++ b/Doc/Tutorial/chapter_introduction.tex
@@ -117,10 +117,6 @@ file for other options.
   the \emph{BSD 3-Clause License}.
 
   \includegraphics[width=6cm]{images/biopython_logo.pdf}\\
-\begin{rawhtml}
-  <IMG ALIGN="center" SRC="images/biopython_logo.svg" TITLE="Biopython Logo (2017 onwards)" ALT="[New Biopython Logo]" width="300" height="200" />
-  <IMG ALIGN="center" SRC="images/biopython_logo_old.jpg" TITLE="Old Biopython Logo (2003-2017)" ALT="[Old Biopython Logo]" width="512" height="144" />
-\end{rawhtml}
 
   Prior to this, the Biopython logo was two yellow snakes forming a double
   helix around the word ``BIOPYTHON'', designed by Henrik Vestergaard and

--- a/Doc/Tutorial/chapter_motifs.tex
+++ b/Doc/Tutorial/chapter_motifs.tex
@@ -861,8 +861,6 @@ TRANSFAC files are typically much more elaborate than this example, containing
 lots of additional information about the motif. Table \ref{table:transfaccodes}
 lists the two-letter field codes that are commonly found in TRANSFAC files:
 \begin{table}[h]
-\label{table:transfaccodes}
-\begin{center}
 \caption{Fields commonly found in TRANSFAC files}
 \begin{tabular}{|l|l||}
 \verb+AC+ & Accession number \\
@@ -886,7 +884,7 @@ lists the two-letter field codes that are commonly found in TRANSFAC files:
 \verb+TY+ & Type \\
 \verb+XX+ & Empty line; these are not stored in the Record. \\
 \end{tabular}
-\end{center}
+\label{table:transfaccodes}
 \end{table}
 
 Each motif also has an attribute \verb+.references+ containing the

--- a/Doc/Tutorial/chapter_pdb.tex
+++ b/Doc/Tutorial/chapter_pdb.tex
@@ -284,13 +284,8 @@ detect likely problems. We will give several examples of this in section
 \ref{sec:problem_structures}.
 
 \begin{figure}[htbp]
-\begin{htmlonly}
-\imgsrc[width=650, height=750]{images/smcra.png}
-\end{htmlonly}
-\begin{latexonly}
 \centering
 \includegraphics[width=0.8\textwidth]{images/smcra.png}
-\end{latexonly}
 \caption{UML diagram of SMCRA architecture of the \texttt{Structure} class used to represent a macromolecular structure.
 Full lines with diamonds denote aggregation, full lines with
 arrows denote referencing, full lines with triangles denote inheritance
@@ -1272,12 +1267,7 @@ plt.show()
 \end{minted}
 
 \begin{figure}[h!]
-\begin{htmlonly}
-\imgsrc[width=280, height=280]{images/1a8o-ca-plot.png}
-\end{htmlonly}
-\begin{latexonly}
 \includegraphics[width=0.3\textwidth]{images/1a8o-ca-plot.png}
-\end{latexonly}
 \caption{C$\alpha$ distance plot for PDB file 1A8O (HIV capsid C-terminal domain)}
 \label{fig:distanceplot}
 \end{figure}
@@ -1385,12 +1375,7 @@ across multiple protein structures, e.g. Figure~\ref{fig:phepairs}.
 
 \begin{figure}[htbp]
 \centering
-\begin{htmlonly}
-\imgsrc[width=360, height=360]{images/phe-pairs-3pbl.png}
-\end{htmlonly}
-\begin{latexonly}
 \includegraphics[width=0.7\textwidth]{images/phe-pairs-3pbl.png}
-\end{latexonly}
 \caption{Neighboring phenylalanine sidechains in PDB file 3PBL (human dopamine D3 receptor)}
 \label{fig:phepairs}
 \end{figure}

--- a/Doc/Tutorial/chapter_phylo.tex
+++ b/Doc/Tutorial/chapter_phylo.tex
@@ -103,11 +103,7 @@ tree using the \verb|draw| function.
 >>> Phylo.draw(tree)
 \end{minted}
 
-\begin{htmlonly}
-\imgsrc[width=666, height=530]{images/phylo-simple-draw.png}
-\end{htmlonly}
 
-\begin{latexonly}
 \begin{figure}[htb]
 \centering
 \includegraphics[width=0.7\textwidth]{images/phylo-simple-draw.png}
@@ -116,7 +112,6 @@ tree using the \verb|draw| function.
 \end{figure}
 
 See Figure~\ref{fig:phylo-simple-draw}.
-\end{latexonly}
 
 
 \subsection{Coloring branches within a tree}
@@ -205,11 +200,7 @@ Finally, show our work:
 >>> Phylo.draw(tree)
 \end{minted}
 
-\begin{htmlonly}
-\imgsrc[width=666, height=530]{images/phylo-color-draw.png}
-\end{htmlonly}
 
-\begin{latexonly}
 \begin{figure}[htb]
 \centering
 \includegraphics[width=0.7\textwidth]{images/phylo-color-draw.png}
@@ -218,7 +209,6 @@ Finally, show our work:
 \end{figure}
 
 See Figure~\ref{fig:phylo-color-draw}.
-\end{latexonly}
 
 Note that a clade's color includes the branch leading to that clade, as well as its
 descendents. The common ancestor of E and F turns out to be just under the root, and with this
@@ -400,11 +390,7 @@ customize the output.
 >>> Phylo.draw(tree, branch_labels=lambda c: c.branch_length)
 \end{minted}
 
-\begin{htmlonly}
-\imgsrc[width=701, height=465]{images/phylo-draw-example.png}
-\end{htmlonly}
 
-\begin{latexonly}
 \begin{figure}[tbp]
 \centering
 \includegraphics[width=0.7\textwidth]{images/phylo-draw-example.png}
@@ -413,7 +399,6 @@ customize the output.
 \end{figure}
 
 See Figure~\ref{fig:phylo-draw-example} for example.
-\end{latexonly}
 
 See the Phylo page on the Biopython wiki (\url{http://biopython.org/wiki/Phylo}) for
 descriptions and examples of the more advanced functionality in \verb|draw_ascii|,


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This is work extracted from #4371, which I will return to now that Biopython 1.82 is out with the goal of converting the LaTeX Tutorial into RST rendered with Sphinx.

In the short term this means the main branch will not be able to build an HTML version of the Tutorial (but installing hevea is increasingly painful).