### PR TITLE
Add strand, start, end properties to SeqFeature

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -286,6 +286,32 @@ class SeqFeature:
             qualifiers=self.qualifiers.copy(),
         )
 
+    @property
+    def start(self):
+        """Start location - left most (minimum) value, regardless of strand.
+
+        Read only, returns an integer like position object, possibly a fuzzy position.
+        `feature.start` is shorthand for `feature.location.start`.
+        """
+        return self.location.start
+
+    @property
+    def end(self):
+        """End location - right most (maximum) value, regardless of strand.
+
+        Read only, returns an integer like position object, possibly a fuzzy position.
+        `feature.end` is shorthand for `feature.location.end`.
+        """
+        return self.location.end
+
+    @property
+    def strand(self):
+        """Strand of the location (+1, -1, 0 or None).
+
+        `feature.strand` is shorthand for `feature.location.strand`.
+        """
+        return self.location.strand
+
     def extract(self, parent_sequence, references=None):
         """Extract the feature's sequence from supplied parent sequence.
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

___

This PR adds strand, start, end properties (read only) to the SeqFeature class.

In the BioPython v1.82 update, the strand property of SeqFeature was removed and the change from `feature.strand` to `feature.location.strand` is required (#4503). I think that `feature.strand` was a relatively commonly used property by users, so the impact of this breaking change seems a bit large. Therefore, I think it is better to keep the strand property of SeqFeature for backward compatibility. I also think that usability would be improved if the start and end properties were added to SeqFeature as well.
