### PR TITLE
Handle all blank continuation lines in Medline

### DIFF
--- a/Bio/Medline/__init__.py
+++ b/Bio/Medline/__init__.py
@@ -166,21 +166,20 @@ def parse(handle):
     key = ""
     record = Record()
     for line in handle:
-        orig_line = line
-        line = line.rstrip()
+        if line[:6] == "      ":  # continuation line
+            line = line.rstrip()
+            if line == "":
+                # All blank continuation lines should be considered a new line.
+                # See issue #4557
+                line = "      \n"
 
-        if line == "" and orig_line[:6] == "      ":
-            # All blank continuation lines should be considered a new line. See
-            # issue #4557
-            line = "      \n"
-
-        if orig_line[:6] == "      ":  # continuation line
             if key in ["MH", "AD"]:
                 # Multi-line MESH term, want to append to last entry in list
                 record[key][-1] += line[5:]  # including space using line[5:]
             else:
                 record[key].append(line[6:])
-        elif line:
+        elif line != "\n" and line != "\r\n":
+            line = line.rstrip()
             key = line[:4].rstrip()
             if key not in record:
                 record[key] = []

--- a/Bio/Medline/__init__.py
+++ b/Bio/Medline/__init__.py
@@ -166,8 +166,15 @@ def parse(handle):
     key = ""
     record = Record()
     for line in handle:
+        orig_line = line
         line = line.rstrip()
-        if line[:6] == "      ":  # continuation line
+
+        if line == "" and orig_line[:6] == "      ":
+            # All blank continuation lines should be considered a new line. See
+            # issue #4557
+            line = "      \n"
+
+        if orig_line[:6] == "      ":  # continuation line
             if key in ["MH", "AD"]:
                 # Multi-line MESH term, want to append to last entry in list
                 record[key][-1] += line[5:]  # including space using line[5:]
@@ -179,6 +186,7 @@ def parse(handle):
                 record[key] = []
             record[key].append(line[6:])
         elif record:
+            # End of the record
             # Join each list of strings into one string.
             for key in record:
                 if key in textkeys:

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -236,6 +236,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Maximilian Peters <maximili.peters at mail.huji.ac.il>
 - Melissa Gymrek <https://github.com/mgymrek>
 - Michael Hoffman <https://github.com/michaelmhoffman>
+- Michael M. <https://github.com/michaelfm1211>
 - Michael R. Crusoe <https://orcid.org/0000-0002-2961-9670>
 - Michal Kurowski <michal at domain genesilico.pl>
 - Michał J. Gajda <https://github.com/mgajda>


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4557

Currently, while parsing Medline files Biopython will `.rstip()` each line. This is good for removing trailing whitespace, but if the line is entirely whitespace and a valid continuation line, then `.rstip()` will turn that line into an empty string causing it to be interpreted as the end of a record instead of a continuation line.

This PR does two things:
- Check for continuation lines on the original, non-stripped, string.
- Transform all blank continuation lines into new lines. Without this, the new line is stripped so all blank continuation lines are invisible to the user.