### PR TITLE
Deprecate Python 3.8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [pypy-3.8]
+        python-version: [pypy-3.9]
 
     steps:
     - uses: actions/checkout@v4

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -12,7 +12,7 @@ First supported in release 1.79, although it was mostly working in 1.78.
 
 Python 3.8
 ----------
-First supported in release 1.75.
+First supported in release 1.75. Support deprecated as of Release 1.83.
 
 Python 3.7
 ----------

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -14,8 +14,8 @@ The latest news is at the top of this file.
 ===============================================
 
 This release of Biopython supports Python 3.8, 3.9, 3.10, 3.11 and 3.12. It
-has also been tested on PyPy3.8 v7.3.11.
-Python 3.8 is approaching end-of-life, support for it is now deprecated.
+has also been tested on PyPy3.9 v7.3.13. Python 3.8 is approaching end of
+life, our support for it is now deprecated.
 
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -15,6 +15,7 @@ The latest news is at the top of this file.
 
 This release of Biopython supports Python 3.8, 3.9, 3.10, 3.11 and 3.12. It
 has also been tested on PyPy3.8 v7.3.11.
+Python 3.8 is approaching end-of-life, support for it is now deprecated.
 
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Python 3.8 support is EOL in October 2024.
