### PR TITLE
Support escaped quotes in Newick trees

### DIFF
--- a/Bio/Phylo/NewickIO.py
+++ b/Bio/Phylo/NewickIO.py
@@ -143,7 +143,14 @@ class Parser:
 
             if token.startswith("'"):
                 # quoted label; add characters to clade name
-                current_clade.name = token[1:-1]
+                if not current_clade.name:
+                    # This is almost always the case
+                    current_clade.name = token[1:-1]
+                else:
+                    # Hack to support labels with escaped quotes. Escaped quotes
+                    # are two consequtive quotes. To the parser, this just looks
+                    # like two quoted labels next to each other. See issue #4537
+                    current_clade.name += token[:-1]
 
             elif token.startswith("["):
                 # comment
@@ -292,7 +299,7 @@ class Writer:
             if label:
                 unquoted_label = re.match(token_dict["unquoted node label"], label)
                 if (not unquoted_label) or (unquoted_label.end() < len(label)):
-                    label = "'%s'" % label.replace("\\", "\\\\").replace("'", "\\'")
+                    label = "'%s'" % label.replace("'", "''")
 
             if clade.is_terminal():  # terminal
                 return label + make_info_string(clade, terminal=True)

--- a/Tests/test_Phylo.py
+++ b/Tests/test_Phylo.py
@@ -173,6 +173,22 @@ class IOTests(unittest.TestCase):
         )
         self.assertEqual({leaf.name for leaf in tree.get_terminals()}, {"0", "1", "2"})
 
+    def test_newick_escaped_quote_parse(self):
+        """Parse a newick tree with an escaped quote in a label."""
+        newick_str = "('Node''Name':0.00000)Root:0.00000;"
+        tree = Phylo.read(StringIO(newick_str), "newick")
+        self.assertEqual(tree.get_terminals()[0].name, "Node'Name")
+
+    def test_newick_escaped_quote_write(self):
+        """Write a newick tree with an escaped quote in a label."""
+        tree = Phylo.BaseTree.Tree(root=Phylo.BaseTree.Clade(name="Root"))
+        clade_with_quote = Phylo.BaseTree.Clade(name="Node'Name")
+        tree.root.clades.append(clade_with_quote)
+        mem_file = StringIO()
+        Phylo.write(tree, mem_file, "newick")
+        mem_file.seek(0)
+        self.assertEqual(mem_file.read(), "('Node''Name':0.00000)Root:0.00000;\n")
+
 
 class TreeTests(unittest.TestCase):
     """Tests for methods on BaseTree.Tree objects."""


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4536 
Closes #4537 

As described in the linked issues, single quotes inside quoted labels on Newick trees are escaped by using two consecutive quotes, so the quoted label `'Node''Name'` is valid. Currently, Biopython doesn't recognize these labels, and when labels with quotes are written to a file, they are incorrectly escaped as `\'` instead of `''`.

Instead of modifying the tokenizer's RegEx, this PR lets the parser pick up the label as two separate tokens (ie `'Node''Name'` is tokenized as `'Node'` and `'Name'`), then when encountering a second label it just appends it to the first label. This is kind of a hack, but it avoids having to mess with any RegEx.