### PR TITLE
Add dna-2 binary encoding scheme

### DIFF
--- a/Bio/codecs/__init__.py
+++ b/Bio/codecs/__init__.py
@@ -1,0 +1,24 @@
+"""Registers a search function for codecs in this module."""
+
+
+import codecs
+import importlib
+
+from typing import Union
+
+
+def _search_function(encoding_name: str) -> Union[codecs.CodecInfo, None]:
+    try:
+        module = importlib.import_module(f"Bio.codecs.{encoding_name}")
+        codec = module.Codec()
+
+        return codecs.CodecInfo(
+            name=encoding_name,
+            encode=codec.encode,
+            decode=codec.decode,
+        )
+    except ModuleNotFoundError:
+        return None
+
+
+codecs.register(_search_function)

--- a/Bio/codecs/dna_2.py
+++ b/Bio/codecs/dna_2.py
@@ -1,0 +1,150 @@
+"""
+This module defines the dna-2 encoding scheme.
+
+The dna-2 encoding scheme is experimental and subject to change or removal.
+
+Do not import this module directly. Instead, import Bio.codecs.
+
+Classes:
+ - Codec - Defines the dna-2 encoding scheme.
+
+Usage:
+>>> import Bio.codecs
+>>> "GATGCGATCGTAGCTGAT".encode("dna-2").decode("dna-2")
+'GATGCGATCGTAGCTGAT'
+"""
+
+import Bio._utils
+import codecs
+import math
+
+from typing import Union
+
+_nucleotide_characters = set("ATCGatcg")
+
+
+def _count_nucleotide_characters(string: str, should_error: bool) -> int:
+    nucleotide_count = 0
+
+    for character in string:
+        if character in _nucleotide_characters:
+            nucleotide_count += 1
+        elif should_error:
+            raise ValueError(f"Unexpected character '{character}'")
+
+    return nucleotide_count
+
+
+def _encode_nucleotide(nucleotide: str) -> int:
+    assert len(nucleotide) == 1
+    assert nucleotide in _nucleotide_characters
+
+    if nucleotide in "Tt":
+        return 0b00
+    elif nucleotide in "Cc":
+        return 0b01
+    elif nucleotide in "Aa":
+        return 0b10
+    else:
+        assert nucleotide in "Gg"
+        return 0b11
+
+
+def _decode_nucleotide(byte: int) -> str:
+    return {
+        0b00: "T",
+        0b01: "C",
+        0b10: "A",
+        0b11: "G",
+    }[byte]
+
+
+def _encode_nucleotides_into_byte(nucleotides: Union[list[str], str]) -> int:
+    nucleotide_count = len(nucleotides)
+    assert nucleotide_count <= 4
+    for nucleotide in nucleotides:
+        assert nucleotide in _nucleotide_characters
+
+    bit_shifts = [6, 4, 2, 0][0:nucleotide_count]
+    result = 0
+
+    for nucleotide_index, bit_shift in enumerate(bit_shifts):
+        nucleotide = nucleotides[nucleotide_index]
+        result |= _encode_nucleotide(nucleotide) << bit_shift
+
+    if nucleotide_count < 4:
+        result |= nucleotide_count
+
+    assert 0x0 <= result <= 0xFF
+
+    return result
+
+
+def _decode_nucleotides_from_byte(byte: int, is_last_byte: bool = False) -> str:
+    assert 0x0 <= byte <= 0xFF
+    nucleotide_count = byte & 0b11 if is_last_byte else 4
+    assert 0 <= nucleotide_count <= 4
+
+    nucleotides = []
+    bit_shifts = [6, 4, 2, 0][0:nucleotide_count]
+
+    for bit_shift in bit_shifts:
+        nucleotide = _decode_nucleotide(byte >> bit_shift & 0b11)
+        nucleotides.append(nucleotide)
+
+    return "".join(nucleotides)
+
+
+class Codec(codecs.Codec):
+    """Defines the dna-2 encoding scheme."""
+
+    def encode(self, input, errors="strict"):
+        """Encode the input string representing a DNA sequence into binary using the dna-2 encoding scheme."""
+        assert isinstance(input, str)
+        assert errors in {"strict", "ignore"}
+
+        nucleotide_count = _count_nucleotide_characters(
+            input, should_error=errors == "strict"
+        )
+        bit_count = 2 * (nucleotide_count + 1)
+        byte_count: int = math.ceil(bit_count / 8)
+
+        result = bytearray(byte_count)
+        byte_index = 0
+        nucleotides = []
+
+        for character in input:
+            assert len(nucleotides) <= 4
+            if character not in _nucleotide_characters:
+                continue
+
+            nucleotide = character
+            nucleotides.append(nucleotide)
+
+            if len(nucleotides) == 4:
+                result[byte_index] = _encode_nucleotides_into_byte(nucleotides)
+                byte_index += 1
+                nucleotides = []
+
+        assert byte_index == byte_count - 1
+        result[byte_index] = _encode_nucleotides_into_byte(nucleotides)
+
+        return bytes(result), len(input)
+
+    def decode(self, input, errors="strict"):
+        """Decode the input bytes into a string according to the dna-2 encoding scheme."""
+        assert (
+            isinstance(input, bytes)
+            or isinstance(input, bytearray)
+            or isinstance(input, memoryview)
+        )
+
+        strings = [_decode_nucleotides_from_byte(byte) for byte in input[0:-1]] + [
+            _decode_nucleotides_from_byte(input[-1], is_last_byte=True)
+        ]
+
+        return "".join(strings), len(input)
+
+
+if __name__ == "__main__":
+    Bio._utils.run_doctest()

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -335,6 +335,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Walter Gillett <https://github.com/wgillett>
 - Wayne Decatur <https://github.com/fomightez>
 - Wibowo Arindrarto <https://github.com/bow>
+- Will Tyler <https://github.com/Will-Tyler>
 - Wolfgang Schueler <wolfgang at domain proceryon.at>
 - Xiaoyu Zhuo <https://github.com/xzhuo>
 - Yair Benita <Y.Benita at domain pharm.uu.nl>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -20,6 +20,7 @@ Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
 - Peter Cock
+- Will Tyler (first contribution)
 
 22 December 2023: Biopython 1.82
 ================================

--- a/Tests/test_Codecs_dna_2.py
+++ b/Tests/test_Codecs_dna_2.py
@@ -1,0 +1,39 @@
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+
+"""Tests for dna-2 encoding scheme."""
+
+import importlib
+import itertools
+import unittest
+
+_nucleotides = set("ATCG")
+
+
+class TestCodec(unittest.TestCase):
+    def setUp(self):
+        importlib.import_module("Bio.codecs")
+
+    def test_encode_and_decode(self):
+        for length in range(1, 10):
+            for sequence in itertools.product(_nucleotides, repeat=length):
+                sequence = "".join(sequence)
+                decoded = sequence.encode("dna-2").decode("dna-2")
+                self.assertEqual(sequence, decoded)
+                decoded = sequence.lower().encode("dna-2").decode("dna-2")
+                self.assertEqual(sequence, decoded)
+
+    def test_strict_errors(self):
+        def encode_bad_sequence() -> None:
+            """Call encode with a bad DNA sequence."""
+            "actgatcgatcgatgctagctdacatgcttagct".encode("dna-2")
+
+        self.assertRaises(ValueError, encode_bad_sequence)
+
+    def test_ignore_errors(self):
+        sequence = "actgatcgatcgatgctagctdacatgcttagct"
+        expected = "actgatcgatcgatgctagctacatgcttagct".upper()
+        decoded = sequence.encode("dna-2", errors="ignore").decode("dna-2")
+
+        self.assertEqual(expected, decoded)

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ PACKAGES = [
     "Bio.Blast",
     "Bio.CAPS",
     "Bio.Cluster",
+    "Bio.codecs",
     "Bio.codonalign",
     "Bio.Compass",
     "Bio.Data",


### PR DESCRIPTION
## Agreements

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

## Description

In this pull request, I add a memory-efficient binary encoding scheme for DNA sequence data, which I call "dna-2". dna-2 uses two bits to represent each nucleotide and is four times more memory efficient than ASCII.

dna-2 supports two error modes: strict and ignore. In strict mode, the encoder raises an error if a non-nucleotide letter is found in the string representing the DNA sequence. In ignore mode, the encoder ignores characters that do not correspond to a nucleotide. Strict mode is the default error mode.

### The dna-2 Binary Encoding Scheme
dna-2 encodes nucleotides in binary according to the following relation:
|Nucleotide|Binary Representation|
|---|---|
|Thymine (T)|``00``|
|Cytosine (C)|``01``|
|Adenine (A)|``10``|
|Guanine (G)|``11``|

The relation is the same as the one used in the UCSC 2bit file format. See [here](https://genome.ucsc.edu/FAQ/FAQformat.html#format7).

dna-2 encodes DNA sequences from left to right according to the relation above. A single byte can represent a sequence of four nucleotides. For example, the DNA sequence TCAG would be encoded as ``00011011``. (dna-2 would actually use an additional byte to terminate this example sequence. This is described below.)

Computers operate with bytes, so all byte sequences have a bit count that is a multiple of eight. This means that the number of pairs of bits is a multiple of four. But not all DNA sequences have a nucleotide count that is a multiple of four. To correct for this, dna-2 interprets the last byte in the byte sequence differently.

For bytes that are not the last byte in the sequence, dna-2 interprets the pairs of bits according to the relation in the table above. However, in the last byte, dna-2 uses the last two bits of the byte to store the number of nucleotides contained in the final byte. Let us consider some examples:

|Example Number|Last Byte|Last Two Bits|DNA Sequence|
|---|---|---|---|
|1|``00000000``|``00``||
|2|``10000001``|``01``|A|
|3|``01110111``|``11``|CGC|

In Example 1, the last two bits of the last byte indicate that there are no nucleotides represented in the last byte. The decoder ignores the first six bits of this byte. This situation occurs when the total number of nucleotides in the sequence is a multiple of four.

In Example 2, the last two bits of the last byte indicate that there is one nucleotide represented in the last byte. The decoder interprets the first two bits as a nucleotide according to the relation in the first table and ignores the middle four bytes.

In Example 3, the last two bits of the last byte indicate that there are three nucleotides represented in the last byte. The decoder interprets the first six bits as nucleotides according to the relation in the first table.

Thus, dna-2 is able to efficiently encode arbitrary sequences of DNA in binary.

### Example Usage
```python
>>> import Bio.codecs
>>> dna_sequence = "actgatcgtactagtcagtcgtgatgctgagtcgatgctacgtagctg"
>>> len(dna_sequence.encode("ascii"))
48
>>> len(dna_sequence.encode("dna-2"))
13
```

The example below demonstrates strict mode.
```python
>>> import Bio.codecs
>>> dna_sequence = "actgdgtac"
>>> dna_sequence.encode("dna-2")
Traceback (most recent call last):
  File "/Users/willtyler/Desktop/biopython/Bio/Codecs/dna_2.py", line 98, in encode
    nucleotide_count = _count_nucleotide_characters(
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/willtyler/Desktop/biopython/Bio/Codecs/dna_2.py", line 25, in _count_nucleotide_characters
    raise ValueError(f"Unexpected character '{character}'")
ValueError: Unexpected character 'd'
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/Users/willtyler/Applications/PyCharm Community Edition.app/Contents/plugins/python-ce/helpers/pydev/pydevconsole.py", line 364, in runcode
    coro = func()
           ^^^^^^
  File "<input>", line 1, in <module>
ValueError: encoding with 'dna-2' codec failed (ValueError: Unexpected character 'd')
```

The example below demonstrates the ignore mode.
```python
>>> import Bio.codecs
>>> dna_sequence = "actgdgtac"
>>> dna_sequence.encode("dna-2", errors="ignore").decode("dna-2")
'ACTGGTAC'
```

## Testing
I added some unit tests.

## Future Work
If this code is merged, then I plan to use dna-2 in other parts of the package, such as the ``Seq`` and ``SeqIO`` modules.

I also want to create encoding schemes for RNA and protein sequences.
