### PR TITLE
Alignments list

### DIFF
--- a/Bio/Align/interfaces.py
+++ b/Bio/Align/interfaces.py
@@ -165,11 +165,14 @@ class AlignmentIterator(AlignmentsAbstractBaseClass):
         alignments = Alignments()
         stream = self._stream
         stream.seek(0)
+        # Read the header information and store it on the new alignments object:
         read_header(alignments, stream)
-        self._index = 0
-        for alignment in self:
-            alignments.append(alignment)
+        # Rewind the iterator to initialize it correctly for iteration:
+        self.rewind()
+        alignments.extend(self)
+        # May as well store the number of alignments while we are at it:
         self._len = self._index
+        # Return the alignments iterator to its original position:
         self.rewind()
         while self._index < index:
             next(self)

--- a/Bio/Align/interfaces.py
+++ b/Bio/Align/interfaces.py
@@ -16,7 +16,7 @@ from abc import abstractmethod
 from typing import Optional
 
 from Bio import StreamModeError
-from Bio.Align import AlignmentsAbstractBaseClass
+from Bio.Align import Alignments, AlignmentsAbstractBaseClass
 
 
 class AlignmentIterator(AlignmentsAbstractBaseClass):
@@ -62,6 +62,7 @@ class AlignmentIterator(AlignmentsAbstractBaseClass):
             else:
                 raise ValueError(f"Unknown mode '{self.mode}'") from None
             self._stream = source
+        self._index = 0
         self._read_header(self._stream)
 
     def __next__(self):
@@ -72,7 +73,9 @@ class AlignmentIterator(AlignmentsAbstractBaseClass):
             raise StopIteration from None
         alignment = self._read_next_alignment(stream)
         if alignment is None:
+            self._len = self._index
             raise StopIteration
+        self._index += 1
         return alignment
 
     def __len__(self):
@@ -86,15 +89,13 @@ class AlignmentIterator(AlignmentsAbstractBaseClass):
         try:
             length = self._len
         except AttributeError:
-            counter = 0
-            for alignment in self:
-                counter += 1
+            index = self._index
             self.rewind()
             length = 0
             for alignment in self:
                 length += 1
             self.rewind()
-            for i in range(length - counter):
+            while self._index < index:
                 next(self)
             self._len = length
         return length
@@ -111,6 +112,69 @@ class AlignmentIterator(AlignmentsAbstractBaseClass):
             stream.close()
         del self._stream
 
+    def __getitem__(self, index):
+        """Return the alignments as an Alignments object (which inherits from list).
+
+        Only an index of the form [:] (i.e., a full slice) is supported.
+        The file stream is returned to its zero position, and the file header
+        is read and stored in an Alignments object. Next, we iterate over the
+        alignments and store them in the Alignments object.  The iterator
+        is then returned to its original position in the file, and the
+        Alignments object is returned. The Alignments object contains the exact
+        same information as the Alignment iterator self, but stores the
+        alignments in a list instead of as an iterator, allowing indexing.
+
+        Typical usage is
+
+        >>> from Bio import Align
+        >>> alignments = Align.parse("Blat/dna_rna.psl", "psl")
+        >>> alignments.metadata
+        {'psLayout version': '3'}
+
+        As `alignments` is an iterator and not a list, we cannot retrieve an
+        alignment by its index:
+
+        >>> alignment = alignments[2]  # doctest:+ELLIPSIS
+        Traceback (most recent call last):
+          ...
+        KeyError: 'only [:] (a full slice) can be used as the index'
+
+        So we use the iterator to create a list-like Alignments object:
+
+        >>> alignments = alignments[:]
+
+        While `alignments` is a list-like object, it has the same `metadata`
+        attribute representing the information stored in the file header:
+
+        >>> alignments.metadata
+        {'psLayout version': '3'}
+
+        Now we can index individual alignments:
+
+        >>> len(alignments)
+        4
+        >>> alignment = alignments[2]
+        >>> alignment.target.id, alignment.query.id
+        ('chr3', 'NR_111921.1')
+
+        """
+        if index != slice(None, None, None):
+            raise KeyError("only [:] (a full slice) can be used as the index")
+        read_header = type(self)._read_header
+        index = self._index
+        alignments = Alignments()
+        stream = self._stream
+        stream.seek(0)
+        read_header(alignments, stream)
+        self._index = 0
+        for alignment in self:
+            alignments.append(alignment)
+        self._len = self._index
+        self.rewind()
+        while self._index < index:
+            next(self)
+        return alignments
+
     def _read_header(self, stream):
         """Read the file header and store it in metadata."""
         return
@@ -122,6 +186,7 @@ class AlignmentIterator(AlignmentsAbstractBaseClass):
     def rewind(self):  # noqa: D102
         self._stream.seek(0)
         self._read_header(self._stream)
+        self._index = 0
 
 
 class AlignmentWriter(ABC):
@@ -270,3 +335,9 @@ class AlignmentWriter(ABC):
             if stream is not self._target:
                 stream.close()
         return count
+
+
+if __name__ == "__main__":
+    from Bio._utils import run_doctest
+
+    run_doctest()

--- a/Doc/Tutorial/chapter_align.tex
+++ b/Doc/Tutorial/chapter_align.tex
@@ -16,7 +16,7 @@ The \verb|Alignment| class is defined in \verb|Bio.Align|. Usually you would get
 \label{subsec:align_sequences_coordinates}
 
 Suppose you have three sequences:
-%doctest ../Tests/Blat lib:numpy
+%doctest ../Tests lib:numpy
 \begin{minted}{pycon}
 >>> seqA = "CCGGTTTTT"
 >>> seqB = "AGTTTAA"
@@ -693,7 +693,7 @@ The map method can also be used to lift over an alignment between different geno
 %cont-doctest
 \begin{minted}{pycon}
 >>> from Bio import Align
->>> chain = Align.read("panTro5ToPanTro6.over.chain", "chain")
+>>> chain = Align.read("Blat/panTro5ToPanTro6.over.chain", "chain")
 >>> chain.sequences[0].id
 'chr1'
 >>> len(chain.sequences[0].seq)
@@ -711,7 +711,7 @@ The map method can also be used to lift over an alignment between different geno
 showing that the range 122250000:122909835 of chr1 on chimpanzee genome assembly panTro5 aligns to range 111776384:112019978 of chr1 of chimpanzee genome assembly panTro6. See section \ref{subsec:align_chain} for more information about the chain file format.
 %cont-doctest
 \begin{minted}{pycon}
->>> transcript = Align.read("est.panTro5.psl", "psl")
+>>> transcript = Align.read("Blat/est.panTro5.psl", "psl")
 >>> transcript.sequences[0].id
 'chr1'
 >>> len(transcript.sequences[0].seq)
@@ -773,7 +773,7 @@ Consider a multiple alignment of genomic sequences of chimpanzee, human, macaque
 %cont-doctest
 \begin{minted}{pycon}
 >>> from Bio import Align
->>> path = "panTro5.maf"
+>>> path = "Blat/panTro5.maf"
 >>> genome_alignment = Align.read(path, "maf")
 >>> for record in genome_alignment.sequences:
 ...     print(record.id, len(record.seq))
@@ -825,12 +825,12 @@ To lift over the genome assembly for each species, we read in the corresponding 
 %cont-doctest
 \begin{minted}{pycon}
 >>> paths = [
-...     "panTro5ToPanTro6.chain",
-...     "hg19ToHg38.chain",
-...     "rheMac8ToRheMac10.chain",
-...     "calJac3ToCalJac4.chain",
-...     "mm10ToMm39.chain",
-...     "rn6ToRn7.chain",
+...     "Blat/panTro5ToPanTro6.chain",
+...     "Blat/hg19ToHg38.chain",
+...     "Blat/rheMac8ToRheMac10.chain",
+...     "Blat/calJac3ToCalJac4.chain",
+...     "Blat/mm10ToMm39.chain",
+...     "Blat/rn6ToRn7.chain",
 ... ]
 >>> liftover_alignments = [Align.read(path, "chain") for path in paths]
 >>> for liftover_alignment in liftover_alignments:
@@ -975,9 +975,122 @@ Output from sequence alignment software such as Clustal can be parsed into \verb
 \subsection{Reading alignments}
 \label{subsec:align_reading}
 
-The alignments iterator returned by \verb|Bio.Align.parse| inherits from the \verb|AlignmentsAbstractBaseClass| base class. This class defines a \verb|rewind| method that resets the iterator to let it loop over the alignments from the beginning. You can also call \verb|len| on the alignments to obtain the number of alignments. Depending on the file format, the number of alignments may be explicitly stored in the file (for example in the case of bigBed, bigPsl, and bigMaf files), or otherwise the number of alignments is counted by looping over them once (and returning the iterator to its original position). If the file is large, it may therefore take a considerable amount of time for \verb|len| to return. As the number of alignments is cached, subsequent calls to \verb|len| will return quickly.
+Use \verb|Bio.Align.parse| to parse a file of sequence alignments. For example, the file \verb|ucsc_mm9_chr10.maf| contains 48 multiple sequence alignments in the MAF (Multiple Alignment Format) format (see section \ref{subsec:align_maf}):
 
-Depending on the file format, the alignments object returned by \verb|Bio.Align.parse| may contain attributes that store metadata found in the file, such as the version number of the software that was used to create the alignments. The specific attributes stored for each file format are described in Section~\ref{sec:alignformats}.
+%cont-doctest
+\begin{minted}{pycon}
+>>> from Bio import Align
+>>> alignments = Align.parse("MAF/ucsc_mm9_chr10.maf", "maf")
+>>> alignments  # doctest: +ELLIPSIS
+<Bio.Align.maf.AlignmentIterator object at 0x...>
+\end{minted}
+where \verb|"maf"| is the file format.
+The alignments object returned by \verb|Bio.Align.parse| may contain attributes that store metadata found in the file, such as the version number of the software that was used to create the alignments. The specific attributes stored for each file format are described in Section~\ref{sec:alignformats}. For MAF files, we can obtain the file format version and the scoring scheme that was used:
+%cont-doctest
+\begin{minted}{pycon}
+>>> alignments.metadata
+{'MAF Version': '1', 'Scoring': 'autoMZ.v1'}
+\end{minted}
+
+As alignment files can be very large, \verb|Align.parse| returns an iterator over the alignments, so you won't have to store all alignments in memory at the same time. You can iterate over these alignments and print out, for example, the number of aligned sequences in each alignment:
+%cont-doctest
+\begin{minted}{pycon}
+>>> for a in alignments:
+...     print(len(a.sequences))  # doctest: +ELLIPSIS
+...
+2
+4
+5
+6
+...
+15
+14
+7
+6
+\end{minted}
+At this point, the iterator is exhausted, meaning that it has reached the end of the file and cannot retrieve any further alignments. Running the \verb|for|-loop again will therefore not print anything:
+%cont-doctest
+\begin{minted}{pycon}
+>>> for a in alignments:
+...     print(len(a.sequences))
+...
+>>>
+\end{minted}
+However, you can use the \verb|rewind| method to reset the iterator to the beginning of the file, letting you to loop over the alignments from the beginning:
+%cont-doctest
+\begin{minted}{pycon}
+>>> alignments.rewind()
+>>> for a in alignments:
+...     print(len(a.sequences))  # doctest: +ELLIPSIS
+...
+2
+4
+5
+6
+...
+15
+14
+7
+6
+\end{minted}
+You can also call \verb|len| on the alignments to obtain the number of alignments.
+%cont-doctest
+\begin{minted}{pycon}
+>>> len(alignments)
+48
+\end{minted}
+Depending on the file format, the number of alignments may be explicitly stored in the file (for example in the case of bigBed, bigPsl, and bigMaf files), or otherwise the number of alignments is counted by looping over them once (and returning the iterator to its original position).  If the file is large, it may therefore take a considerable amount of time for \verb|len| to return. However, as the number of alignments is cached, subsequent calls to \verb|len| will return quickly.
+
+If the number of alignments is not excessively large and will fit in memory, you can convert the alignments iterator to a list of alignments. To do so, you could call \verb|list| on the \verb|alignments| (after rewinding if needed):
+%cont-doctest
+\begin{minted}{pycon}
+>>> alignments.rewind()
+>>> alignment_list = list(alignments)
+>>> len(alignment_list)
+48
+>>> alignment_list[27]  # doctest: +ELLIPSIS
+<Alignment object (3 rows x 91 columns) at 0x...>
+>>> print(alignment_list[27])
+mm9.chr10   3019377 CCCCAGCATTCTGGCAGACACAGTG-AAAAGAGACAGATGGTCACTAATAAAATCTGT-A
+felCat3.s     46845 CCCAAGTGTTCTGATAGCTAATGTGAAAAAGAAGCATGTGCCCACCAGTAAGCTTTGTGG
+canFam2.c  47545247 CCCAAGTGTTCTGATTGCCTCTGTGAAAAAGAAACATGGGCCCGCTAATAagatttgcaa
+<BLANKLINE>
+mm9.chr10   3019435 TAAATTAG-ATCTCAGAGGATGGATGGACCA  3019465
+felCat3.s     46785 TGAACTAGAATCTCAGAGGATG---GGACTC    46757
+canFam2.c  47545187 tgacctagaatctcagaggatg---ggactc 47545159
+<BLANKLINE>
+\end{minted}
+But this will lose the metadata information:
+%cont-doctest
+\begin{minted}{pycon}
+>>> alignment_list.metadata  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+  ...
+AttributeError: 'list' object has no attribute 'metadata'
+\end{minted}
+Instead, you can ask for a full slice of the alignments:
+%cont-doctest
+\begin{minted}{pycon}
+>>> type(alignments)
+<class 'Bio.Align.maf.AlignmentIterator'>
+>>> alignments = alignments[:]
+>>> type(alignments)
+<class 'Bio.Align.Alignments'>
+\end{minted}
+This returns a \verb|Bio.Align.Alignments| object, which can be used as a list, while keeping the metadata information:
+%cont-doctest
+\begin{minted}{pycon}
+>>> len(alignments)
+48
+>>> print(alignments[11])
+mm9.chr10   3014742 AAGTTCCCTCCATAATTCCTTCCTCCCACCCCCACA 3014778
+calJac1.C      6283 AAATGTA-----TGATCTCCCCATCCTGCCCTG---    6311
+otoGar1.s    175262 AGATTTC-----TGATGCCCTCACCCCCTCCGTGCA  175231
+loxAfr1.s      9317 AGGCTTA-----TG----CCACCCCCCACCCCCACA    9290
+<BLANKLINE>
+>>> alignments.metadata
+{'MAF Version': '1', 'Scoring': 'autoMZ.v1'}
+\end{minted}
 
 \subsection{Writing alignments}
 \label{subsec:align_writing}
@@ -988,7 +1101,7 @@ To write alignments to a file, use
 >>> target = "myfile.txt"
 >>> Align.write(alignments, target, "clustal")
 \end{minted}
-where \verb|alignments| is either a single alignment or a list of alignments, \verb|target| is a file name or an open file-like object, and \verb|"clustal"| is the file format to be used. As some file formats allow or require metadata to be stored with the alignments, you may want to use the \verb|Alignments| (plural) class instead of a plain list of alignments (see Section~\ref{sec:alignments}), alloing you to store a metadata dictionary as an attribute on the \verb|alignments| object:
+where \verb|alignments| is either a single alignment or a list of alignments, \verb|target| is a file name or an open file-like object, and \verb|"clustal"| is the file format to be used. As some file formats allow or require metadata to be stored with the alignments, you may want to use the \verb|Alignments| (plural) class instead of a plain list of alignments (see Section~\ref{sec:alignments}), allowing you to store a metadata dictionary as an attribute on the \verb|alignments| object:
 \begin{minted}{pycon}
 >>> from Bio import Align
 >>> alignments = Align.Alignments(alignments)

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -17,9 +17,34 @@ This release of Biopython supports Python 3.8, 3.9, 3.10, 3.11 and 3.12. It
 has also been tested on PyPy3.9 v7.3.13. Python 3.8 is approaching end of
 life, our support for it is now deprecated.
 
+Bio.Blast contains a new parser for BLAST XML output as a replacement for the
+old parser in Bio.Blast.NCBIXML. The main differences between the parsers is
+as follows:
+- The old parser stores information in a Bio.Blast.NCBIXML.Blast object, with
+attribute names based on plain-text Blast output. The new parser stores
+information in a Bio.Blast.Record object. This class follows the DTD that
+describes the XML in terms of attribute names and dictionary key names, class
+structure, and object types. This makes it easier to find the detailed
+description of each field in the NCBI Blast documentation.
+- The old parser stores alignment information directly as seen in the BLAST XML
+output, i.e. as strings with dashes to represent gaps. The new parser stores
+the alignment information as a Bio.Align.Alignment object, which can then be
+used to e.g. print the alignment in a different format.
+
+Bio.Blast also contains a new qblast function as a replacement for the old
+qblast function in Bio.Blast.NCBIWWW. The main difference is that the old
+qblast function in Bio.Blast.NCBIWWW returns the BLAST search results as Python
+strings, while the new qblast returns bytes objects. Note that in Python, to
+parse an XML file it should be opened in binary mode, as the string encoding is
+specified in the XML data itself. The object returned by the new qblast
+function can therefore be passed directly to the BLAST parser. Also, this
+allows data to be downloaded in a binary format such as JSON2, which returns
+data in a zipped JSON format.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
+- Michiel de Hoon
 - Peter Cock
 
 22 December 2023: Biopython 1.82

--- a/Tests/test_Align_maf.py
+++ b/Tests/test_Align_maf.py
@@ -130,10 +130,7 @@ i oryCun1.scaffold_133159 N 0 N 0
 """,
         )
 
-    def test_reading_ucsc_mm9_chr10(self):
-        """Test parsing MAF file ucsc_mm9_chr10.maf."""
-        path = "MAF/ucsc_mm9_chr10.maf"
-        alignments = Align.parse(path, "maf")
+    def check_reading_ucsc_mm9_chr10(self, alignments):
         self.assertEqual(alignments.metadata["MAF Version"], "1")
         self.assertEqual(alignments.metadata["Scoring"], "autoMZ.v1")
         alignment = next(alignments)
@@ -10853,6 +10850,18 @@ np.array([['T', 'G', 'T', 'T', 'T', 'A', 'G', 'T', 'A', 'C', 'C', '-', '-',
             )
         )
         self.assertRaises(StopIteration, next, alignments)
+
+    def test_reading_ucsc_mm9_chr10(self):
+        """Test parsing MAF file ucsc_mm9_chr10.maf."""
+        path = "MAF/ucsc_mm9_chr10.maf"
+        alignments = Align.parse(path, "maf")
+        self.check_reading_ucsc_mm9_chr10(alignments)
+        self.assertRaises(StopIteration, next, alignments)
+        alignments.rewind()
+        self.check_reading_ucsc_mm9_chr10(alignments)
+        self.assertRaises(StopIteration, next, alignments)
+        alignments = alignments[:]
+        self.check_reading_ucsc_mm9_chr10(alignments)
 
     def test_reading_missing_signature(self):
         """Test parsing MAF file ucsc_mm9_chr10_big.maf with missing signature."""


### PR DESCRIPTION
Allow conversion of an Alignment iterator to a list-like Alignments object.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
