### PR TITLE
In Bio.Blast, allow Records to be used as a list

### DIFF
--- a/Bio/Blast/__init__.py
+++ b/Bio/Blast/__init__.py
@@ -445,6 +445,10 @@ class Records(UserList):
             # Read all records and store them
             for record in self:
                 self._records.append(record)
+            stream = self._stream
+            if stream is not self.source:
+                stream.close()
+            del self._stream
             self._loaded = True
         return self._records
 

--- a/Bio/Blast/__init__.py
+++ b/Bio/Blast/__init__.py
@@ -27,6 +27,7 @@ import warnings
 
 import time
 
+from collections import UserList
 from urllib.parse import urlencode
 from urllib.request import build_opener, install_opener
 from urllib.request import urlopen
@@ -194,7 +195,7 @@ class Record(list):
         self.query = None
 
 
-class Records:
+class Records(UserList):
     """Stores the BLAST results of a single BLAST run.
 
     A ``Bio.Blast.Records`` object is an iterator. Iterating over it returns
@@ -290,6 +291,45 @@ class Records:
     ...
     StopIteration
 
+    You can also use the records as a list, for example by extracting a record
+    by index, or by calling ``len`` or ``print`` on the records. The parser
+    will then automatically iterate over the records and store them:
+
+    >>> records = Blast.parse("Blast/wnts.xml")
+    >>> record = records[3]  # this causes all records to be read in and stored
+    >>> record.query.id
+    'Query_4'
+    >>> len(records)
+    5
+
+    After the records have been read in, you can still iterate over them:
+
+    >>> for i, record in enumerate(records):
+    ...     print(i, record.query.id)
+    ...
+    0 Query_1
+    1 Query_2
+    2 Query_3
+    3 Query_4
+    4 Query_5
+
+    However, be careful not to iterate over the records *before* using them as
+    a list, as any records already iterated over will be missing:
+
+    >>> records = Blast.parse("Blast/wnts.xml")
+    >>> record = next(records)
+    >>> record.query.id
+    'Query_1'
+    >>> len(records)
+    4
+    >>> for i in range(4):
+    ...     print(i, records[i].query.id)
+    ...
+    0 Query_2
+    1 Query_3
+    2 Query_4
+    3 Query_5
+
     """  # noqa: RST201, RST203, RST301
 
     def __init__(self, source):
@@ -349,6 +389,8 @@ class Records:
             if stream is not source:
                 stream.close()
             raise
+        self._records = []  # for when we want to use Records as a list
+        self._loaded = False
 
     def __enter__(self):
         return self
@@ -363,6 +405,8 @@ class Records:
         del self._stream
 
     def __iter__(self):
+        if self._loaded is True:
+            return iter(self.data)
         return self
 
     def __next__(self):
@@ -393,6 +437,16 @@ class Records:
                 parser.Parse(data, False)
             except expat.ExpatError as e:
                 raise CorruptedXMLError(e) from None
+
+    @property
+    def data(self):
+        """Overrides the data attribute of UserList."""
+        if self._loaded is False:
+            # Read all records and store them
+            for record in self:
+                self._records.append(record)
+            self._loaded = True
+        return self._records
 
 
 def parse(source):

--- a/Bio/Blast/__init__.py
+++ b/Bio/Blast/__init__.py
@@ -406,7 +406,7 @@ class Records(UserList):
 
     def __iter__(self):
         if self._loaded is True:
-            return iter(self.data)
+            return iter(self._records)
         return self
 
     def __next__(self):

--- a/Doc/Tutorial/chapter_blast.rst
+++ b/Doc/Tutorial/chapter_blast.rst
@@ -551,39 +551,42 @@ are interested in.
 Alternatively, you can use ``blast_records`` as a list, for example by
 extracting one record by index, or by calling ``len`` or ``print`` on
 ``blast_records``. The parser will then automatically iterate over the records
-and store them.
+and store them:
+
+.. doctest ../Tests/Blast
 
 .. code:: pycon
 
    >>> from Bio import Blast
-   >>> blast_records = Blast.parse("my_blast.xml")
+   >>> blast_records = Blast.parse("xml_2222_blastx_001.xml")
    >>> len(blast_records)  # this causes the parser to iterate over all records
-   3
-   >>> blast_records[2].query.id
-   something
+   7
+   >>> blast_records[2].query.description
+   'gi|5690369|gb|AF158246.1|AF158246 Cricetulus griseus glucose phosphate isomerase (GPI) gene, partial intron sequence'
 
-Now you can access each BLAST record in the list with an index as usual.
 If your BLAST file is huge though, you may run into memory problems
 trying to save them all in a list.
 
-Be careful not to iterate over the records before using ``blast_records`` as a
-list, as any record already iterated over will be missing from the list (it is
+Be careful not to iterate over the records *before* using ``blast_records`` as
+a list, as any record already iterated over will be missing from the list (it is
 fine to iterate over the records afterwards).
 
 Instead of opening the file yourself, you can just provide the file
 name:
 
+.. doctest examples
+
 .. code:: pycon
 
    >>> from Bio import Blast
-   >>> with Blast.parse("my_blast_xml") as blast_records:
+   >>> with Blast.parse("my_blast.xml") as blast_records:
    ...     for blast_record in blast_records:
    ...         pass  # Do something with blast_record
    ...
 
 In this case, Biopython opens the file for you, and closes it as soon as
 the file is not needed any more (while it is possible to simply use
-``blast_records = Blast.parse("my_blast_xml")``, it has the disadvantage
+``blast_records = Blast.parse("my_blast.xml")``, it has the disadvantage
 that the file may stay open longer than strictly necessary, thereby
 wasting resources).
 
@@ -609,7 +612,7 @@ or, equivalently,
 .. code:: pycon
 
    >>> from Bio import Blast
-   >>> blast_record = Blast.read("my_blast_xml")
+   >>> blast_record = Blast.read("my_blast.xml")
 
 (here, you don’t need to use a ``with`` block as ``Blast.read`` will
 read the whole file and close it immediately afterwards).

--- a/Doc/Tutorial/chapter_blast.rst
+++ b/Doc/Tutorial/chapter_blast.rst
@@ -546,16 +546,29 @@ Or, you can use a ``for``-loop:
 
 Note though that you can step through the BLAST records only once.
 Usually, from each BLAST record you would save the information that you
-are interested in. If you want to save all returned BLAST records, you
-can convert the iterator into a list:
+are interested in.
+
+Alternatively, you can use ``blast_records`` as a list, for example by
+extracting one record by index, or by calling ``len`` or ``print`` on
+``blast_records``. The parser will then automatically iterate over the records
+and store them.
 
 .. code:: pycon
 
-   >>> blast_records = list(blast_records)
+   >>> from Bio import Blast
+   >>> blast_records = Blast.parse("my_blast.xml")
+   >>> len(blast_records)  # this causes the parser to iterate over all records
+   3
+   >>> blast_records[2].query.id
+   something
 
 Now you can access each BLAST record in the list with an index as usual.
 If your BLAST file is huge though, you may run into memory problems
 trying to save them all in a list.
+
+Be careful not to iterate over the records before using ``blast_records`` as a
+list, as any record already iterated over will be missing from the list (it is
+fine to iterate over the records afterwards).
 
 Instead of opening the file yourself, you can just provide the file
 name:

--- a/Tests/test_Blast_parser.py
+++ b/Tests/test_Blast_parser.py
@@ -16,65 +16,86 @@ from Bio.SeqRecord import SeqRecord
 class TestBlastp(unittest.TestCase):
     """Test the Blast XML parser for blastp output."""
 
-    def test_xml_2218_blastp_002(self):
-        """Parsing BLASTP 2.2.18+ (xml_2218_blastp_002.xml)."""
+    def check_xml_2218_blastp_002_header(self, records):
+        self.assertEqual(records.program, "blastp")
+        self.assertEqual(records.version, "BLASTP 2.2.18+")
+        self.assertEqual(
+            records.reference,
+            'Altschul, Stephen F., Thomas L. Madden, Alejandro A. Schäffer, Jinghui Zhang, Zheng Zhang, Webb Miller, and David J. Lipman (1997), "Gapped BLAST and PSI-BLAST: a new generation of protein database search programs", Nucleic Acids Res. 25:3389-3402.',
+        )
+        self.assertEqual(records.db, "gpipe/9606/Previous/protein")
+        self.assertIsInstance(records.query, SeqRecord)
+        self.assertEqual(records.query.id, "gi|585505|sp|Q08386|MOPB_RHOCA")
+        self.assertEqual(
+            records.query.description,
+            "Molybdenum-pterin-binding protein mopB >gi|310278|gb|AAA71913.1| molybdenum-pterin-binding protein",
+        )
+        self.assertEqual(repr(records.query.seq), "Seq(None, length=270)")
+        self.assertEqual(len(records.param), 5)
+        self.assertEqual(records.param["matrix"], "BLOSUM62")
+        self.assertAlmostEqual(records.param["expect"], 0.01)
+        self.assertEqual(records.param["gap-open"], 11)
+        self.assertEqual(records.param["gap-extend"], 1)
+        self.assertEqual(records.param["filter"], "m L; R -d repeat/repeat_9606;")
+
+    def check_xml_2218_blastp_002_record_0(self, record):
+        self.assertIsInstance(record.query, SeqRecord)
+        self.assertEqual(record.query.id, "gi|585505|sp|Q08386|MOPB_RHOCA")
+        self.assertEqual(
+            record.query.description,
+            "Molybdenum-pterin-binding protein mopB >gi|310278|gb|AAA71913.1| molybdenum-pterin-binding protein",
+        )
+        self.assertEqual(repr(record.query.seq), "Seq(None, length=270)")
+        self.assertEqual(len(record.stat), 7)
+        self.assertEqual(record.stat["db-num"], 27252)
+        self.assertEqual(record.stat["db-len"], 13958303)
+        self.assertEqual(record.stat["hsp-len"], 0)
+        self.assertAlmostEqual(record.stat["eff-space"], 0.0)
+        self.assertAlmostEqual(record.stat["kappa"], 0.041)
+        self.assertAlmostEqual(record.stat["lambda"], 0.267)
+        self.assertAlmostEqual(record.stat["entropy"], 0.14)
+        self.assertEqual(len(record), 0)
+
+    def check_xml_2218_blastp_002_record_1(self, record):
+        self.assertIsInstance(record.query, SeqRecord)
+        self.assertEqual(record.query.id, "gi|129628|sp|P07175.1|PARA_AGRTU")
+        self.assertEqual(record.query.description, "Protein parA")
+        self.assertEqual(repr(record.query.seq), "Seq(None, length=222)")
+        self.assertEqual(len(record.stat), 7)
+        self.assertEqual(record.stat["db-num"], 27252)
+        self.assertEqual(record.stat["db-len"], 13958303)
+        self.assertEqual(record.stat["hsp-len"], 0)
+        self.assertAlmostEqual(record.stat["eff-space"], 0.0)
+        self.assertAlmostEqual(record.stat["kappa"], 0.041)
+        self.assertAlmostEqual(record.stat["lambda"], 0.267)
+        self.assertAlmostEqual(record.stat["entropy"], 0.14)
+        self.assertEqual(len(record), 0)
+
+    def test_xml_2218_blastp_002_iterator(self):
+        """Parsing BLASTP 2.2.18+ (xml_2218_blastp_002.xml) by iteration."""
         filename = "xml_2218_blastp_002.xml"
         datafile = os.path.join("Blast", filename)
         with open(datafile, "rb") as handle:
             records = Blast.parse(handle)
-            self.assertEqual(records.program, "blastp")
-            self.assertEqual(records.version, "BLASTP 2.2.18+")
-            self.assertEqual(
-                records.reference,
-                'Altschul, Stephen F., Thomas L. Madden, Alejandro A. Schäffer, Jinghui Zhang, Zheng Zhang, Webb Miller, and David J. Lipman (1997), "Gapped BLAST and PSI-BLAST: a new generation of protein database search programs", Nucleic Acids Res. 25:3389-3402.',
-            )
-            self.assertEqual(records.db, "gpipe/9606/Previous/protein")
-            self.assertIsInstance(records.query, SeqRecord)
-            self.assertEqual(records.query.id, "gi|585505|sp|Q08386|MOPB_RHOCA")
-            self.assertEqual(
-                records.query.description,
-                "Molybdenum-pterin-binding protein mopB >gi|310278|gb|AAA71913.1| molybdenum-pterin-binding protein",
-            )
-            self.assertEqual(repr(records.query.seq), "Seq(None, length=270)")
-            self.assertEqual(len(records.param), 5)
-            self.assertEqual(records.param["matrix"], "BLOSUM62")
-            self.assertAlmostEqual(records.param["expect"], 0.01)
-            self.assertEqual(records.param["gap-open"], 11)
-            self.assertEqual(records.param["gap-extend"], 1)
-            self.assertEqual(records.param["filter"], "m L; R -d repeat/repeat_9606;")
+            self.check_xml_2218_blastp_002_header(records)
             record = next(records)
-            self.assertIsInstance(record.query, SeqRecord)
-            self.assertEqual(record.query.id, "gi|585505|sp|Q08386|MOPB_RHOCA")
-            self.assertEqual(
-                record.query.description,
-                "Molybdenum-pterin-binding protein mopB >gi|310278|gb|AAA71913.1| molybdenum-pterin-binding protein",
-            )
-            self.assertEqual(repr(record.query.seq), "Seq(None, length=270)")
-
-            self.assertEqual(len(record.stat), 7)
-            self.assertEqual(record.stat["db-num"], 27252)
-            self.assertEqual(record.stat["db-len"], 13958303)
-            self.assertEqual(record.stat["hsp-len"], 0)
-            self.assertAlmostEqual(record.stat["eff-space"], 0.0)
-            self.assertAlmostEqual(record.stat["kappa"], 0.041)
-            self.assertAlmostEqual(record.stat["lambda"], 0.267)
-            self.assertAlmostEqual(record.stat["entropy"], 0.14)
-            self.assertEqual(len(record), 0)
+            self.check_xml_2218_blastp_002_record_0(record)
             record = next(records)
-            self.assertIsInstance(record.query, SeqRecord)
-            self.assertEqual(record.query.id, "gi|129628|sp|P07175.1|PARA_AGRTU")
-            self.assertEqual(record.query.description, "Protein parA")
-            self.assertEqual(repr(record.query.seq), "Seq(None, length=222)")
+            self.check_xml_2218_blastp_002_record_1(record)
 
-            self.assertEqual(len(record.stat), 7)
-            self.assertEqual(record.stat["db-num"], 27252)
-            self.assertEqual(record.stat["db-len"], 13958303)
-            self.assertEqual(record.stat["hsp-len"], 0)
-            self.assertAlmostEqual(record.stat["eff-space"], 0.0)
-            self.assertAlmostEqual(record.stat["kappa"], 0.041)
-            self.assertAlmostEqual(record.stat["lambda"], 0.267)
-            self.assertAlmostEqual(record.stat["entropy"], 0.14)
-            self.assertEqual(len(record), 0)
+    def test_xml_2218_blastp_002_list(self):
+        """Parsing BLASTP 2.2.18+ (xml_2218_blastp_002.xml) as a list."""
+        filename = "xml_2218_blastp_002.xml"
+        datafile = os.path.join("Blast", filename)
+        with open(datafile, "rb") as handle:
+            records = Blast.parse(handle)
+            record = records[0]
+            self.check_xml_2218_blastp_002_record_0(record)
+            record = records[1]
+            self.check_xml_2218_blastp_002_record_1(record)
+            # header should still be OK
+            self.check_xml_2218_blastp_002_header(records)
+            self.assertEqual(len(records), 2)
 
     def test_xml_2218L_blastp_001(self):
         """Parsing blastp 2.2.18 [Mar-02-2008] (xml_2218L_blastp_001.xml)."""


### PR DESCRIPTION
This PR lets Bio.Blast.Records be both an iterator and a list, by automatically iterating over the records when used as a list.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


