### PR TITLE
Restore SeqFeature's .strand etc

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1,6 +1,6 @@
 # Copyright 2000-2003 Jeff Chang.
 # Copyright 2001-2008 Brad Chapman.
-# Copyright 2005-2016 by Peter Cock.
+# Copyright 2005-2024 by Peter Cock.
 # Copyright 2006-2009 Michiel de Hoon.
 # All rights reserved.
 #
@@ -65,6 +65,7 @@ import re
 import warnings
 from abc import ABC, abstractmethod
 
+from Bio import BiopythonDeprecationWarning
 from Bio import BiopythonParserWarning
 from Bio.Seq import MutableSeq
 from Bio.Seq import reverse_complement
@@ -223,6 +224,92 @@ class SeqFeature:
             self.qualifiers.update(qualifiers)
         if sub_features is not None:
             raise TypeError("Rather than sub_features, use a CompoundLocation")
+
+    def _get_strand(self):
+        """Get function for the strand property (PRIVATE)."""
+        warnings.warn(
+            "Please use .location.strand rather than .strand",
+            BiopythonDeprecationWarning,
+        )
+        return self.location.strand
+
+    def _set_strand(self, value):
+        """Set function for the strand property (PRIVATE)."""
+        warnings.warn(
+            "Please use .location.strand rather than .strand",
+            BiopythonDeprecationWarning,
+        )
+        try:
+            self.location.strand = value
+        except AttributeError:
+            if self.location is None:
+                if value is not None:
+                    raise ValueError("Can't set strand without a location.") from None
+            else:
+                raise
+
+    strand = property(
+        fget=_get_strand,
+        fset=_set_strand,
+        doc="Alias for the location's strand (DEPRECATED).",
+    )
+
+    def _get_ref(self):
+        """Get function for the reference property (PRIVATE)."""
+        warnings.warn(
+            "Please use .location.ref rather than .ref",
+            BiopythonDeprecationWarning,
+        )
+        try:
+            return self.location.ref
+        except AttributeError:
+            return None
+
+    def _set_ref(self, value):
+        """Set function for the reference property (PRIVATE)."""
+        warnings.warn(
+            "Please use .location.ref rather than .ref",
+            BiopythonDeprecationWarning,
+        )
+        try:
+            self.location.ref = value
+        except AttributeError:
+            if self.location is None:
+                if value is not None:
+                    raise ValueError("Can't set ref without a location.") from None
+            else:
+                raise
+
+    ref = property(
+        fget=_get_ref,
+        fset=_set_ref,
+        doc="Alias for the location's ref (DEPRECATED).",
+    )
+
+    def _get_ref_db(self):
+        """Get function for the database reference property (PRIVATE)."""
+        warnings.warn(
+            "Please use .location.ref_db rather than .ref_db",
+            BiopythonDeprecationWarning,
+        )
+        try:
+            return self.location.ref_db
+        except AttributeError:
+            return None
+
+    def _set_ref_db(self, value):
+        """Set function for the database reference property (PRIVATE)."""
+        warnings.warn(
+            "Please use .location.ref_db rather than .ref_db",
+            BiopythonDeprecationWarning,
+        )
+        self.location.ref_db = value
+
+    ref_db = property(
+        fget=_get_ref_db,
+        fset=_set_ref_db,
+        doc="Alias for the location's ref_db (DEPRECATED).",
+    )
 
     def __eq__(self, other):
         """Check if two SeqFeature objects should be considered equal."""

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -356,6 +356,11 @@ removed in release 1.82. Please use the ``Bio.PDB.qcprot`` module instead.
 
 Bio.SeqFeature
 --------------
+
+Release 1.82 unfortunately removed the ``.strand``, ``.ref``, and ``.ref_db``
+attributes of the ``SeqFeature`` without a deprecation period. Release 1.83
+restored but deprecated them. Please use ``.location.strand`` etc instead.
+
 With the introduction of the CompoundLocation in Release 1.62, the SeqFeature
 attribute sub_features was deprecated. It was removed in Release 1.68.
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -21,6 +21,11 @@ Our main documentation, the Biopython Tutorial and Cookbook, has been
 converted from LaTeX to reStructuredText, and combined with the existing API
 documentation, into a single more modern and navigable HTML output.
 
+This release reverts the removal of the ``.strand``, ``.ref``, and ``.ref_db``
+attributes of the ``SeqFeature`` which was done without a deprecation period.
+They are again aliases for ``.location.strand`` etc, but trigger deprecation
+warnings.
+
 Bio.Blast contains a new parser for BLAST XML output as a replacement for the
 old parser in Bio.Blast.NCBIXML. The main differences between the parsers is
 as follows:
@@ -62,6 +67,11 @@ possible, especially the following contributors:
 
 This release of Biopython supports Python 3.8, 3.9, 3.10, 3.11 and 3.12. It
 has also been tested on PyPy3.8 v7.3.11.
+
+[NOTE: This release unfortunately removed the ``.strand``, ``.ref``, and
+``.ref_db`` attributes of the ``SeqFeature`` without a deprecation period.
+This has been addressed in Biopython 1.83, which restores them but starts
+the formal deprecation cycle.]
 
 The ``inplace`` argument of ``complement`` and ``reverse_complement`` in
 ``Bio.Seq`` now always default to ``False`` both for ``Seq`` and ``MutableSeq``

--- a/Tests/seq_tests_common.py
+++ b/Tests/seq_tests_common.py
@@ -5,7 +5,9 @@
 """Common code for SeqRecord object tests."""
 
 import unittest
+import warnings
 
+from Bio import BiopythonDeprecationWarning
 from Bio.Seq import UndefinedSequenceError
 from Bio.SeqUtils.CheckSum import seguid
 from Bio.SeqFeature import ExactPosition, UnknownPosition
@@ -63,6 +65,12 @@ class SeqRecordTestBaseClass(unittest.TestCase):
         self.assertEqual(old_f.location.strand, new_f.location.strand)
         self.assertEqual(old_f.location.ref, new_f.location.ref)
         self.assertEqual(old_f.location.ref_db, new_f.location.ref_db)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=BiopythonDeprecationWarning)
+            self.assertEqual(old_f.location.strand, new_f.strand)
+            self.assertEqual(old_f.location.ref, new_f.ref)
+            self.assertEqual(old_f.location.ref_db, new_f.ref_db)
+
         # TODO - BioSQL does not store/retrieve feature's id (Bug 2526)
         if new_f.id != "<unknown id>":
             self.assertEqual(old_f.id, new_f.id)

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -11,6 +11,7 @@ import warnings
 from copy import deepcopy
 from os import path
 
+from Bio import BiopythonDeprecationWarning
 from Bio import Seq
 from Bio import SeqIO
 from Bio import SeqRecord
@@ -202,6 +203,19 @@ class TestSeqFeature(unittest.TestCase):
         f.qualifiers["transl_table"] = [11]
         with self.assertRaises(TranslationError):
             f.translate(seq)
+
+    def test_location_aliases(self):
+        f = SeqFeature(None, type="CDS")
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("ignore", BiopythonDeprecationWarning)
+            with self.assertRaisesRegex(
+                AttributeError,
+                # "The .strand alias is only available when .location is defined.",
+                "'NoneType' object has no attribute 'strand'",
+            ):
+                f.strand
+            self.assertEqual(None, f.ref)
+            self.assertEqual(None, f.ref_db)
 
 
 class TestLocations(unittest.TestCase):

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -9,9 +9,11 @@ and confirms they are consistent using our different parsers.
 """
 import os
 import unittest
+import warnings
 
 from io import StringIO
 
+from Bio import BiopythonDeprecationWarning
 from Bio import SeqIO
 from Bio.Data.CodonTable import TranslationError
 from Bio.Seq import MutableSeq
@@ -91,8 +93,15 @@ class SeqIOFeatureTestBaseClass(SeqIOTestBaseClass):
         self.assertEqual(old.location.start, new.location.start, msg=msg)
         if old.location.strand is not None:
             self.assertEqual(old.location.strand, new.location.strand, msg=msg)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=BiopythonDeprecationWarning)
+                self.assertEqual(old.location.strand, new.strand)
         self.assertEqual(old.location.ref, new.location.ref, msg=msg)
         self.assertEqual(old.location.ref_db, new.location.ref_db, msg=msg)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=BiopythonDeprecationWarning)
+            self.assertEqual(old.location.ref, new.ref)
+            self.assertEqual(old.location.ref_db, new.ref_db)
         self.assertEqual(
             getattr(old.location, "operator", None),
             getattr(new.location, "operator", None),

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -13,6 +13,7 @@ import warnings
 
 from io import StringIO
 
+from Bio import BiopythonWarning
 from Bio import BiopythonDeprecationWarning
 from Bio import SeqIO
 from Bio.Data.CodonTable import TranslationError
@@ -1237,7 +1238,10 @@ class TestWriteRead(SeqIOFeatureTestBaseClass):
 
     def test_dbsource_wrap(self):
         """Write and read back dbsource_wrap.gb."""
-        self.write_read(os.path.join("GenBank", "dbsource_wrap.gb"), "gb", ["gb"])
+        with warnings.catch_warnings():
+            # Ignore warning about over long DBSOURCE line
+            warnings.simplefilter("ignore", category=BiopythonWarning)
+            self.write_read(os.path.join("GenBank", "dbsource_wrap.gb"), "gb", ["gb"])
         # Protein so can't convert this to EMBL format
 
     def test_blank_seq(self):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->


The ``SeqFeature`` attributes ``.strand``, ``.ref`` and ``.ref_db`` were wrongly removed in Biopython 1.82 without deprecation in #4503.

~~This restores the aliases but read only with deprecation warnings, and only a pending deprecation warning for the ``.strand`` in particular.~~

~~*Update: This restores the aliases using the original code but with deprecation warnings, and only a pending deprecation warning for the ``.strand`` in particular.*~~

*Update: This restores the aliases using the original code but with deprecation warnings.*


Closes #4563.

I think we should try to release Biopython 1.83 soon to include this fix.