### PR TITLE
make blast list conversion more robust

### DIFF
--- a/Doc/Tutorial/chapter_blast.rst
+++ b/Doc/Tutorial/chapter_blast.rst
@@ -567,9 +567,14 @@ and store them:
 If your BLAST file is huge though, you may run into memory problems
 trying to save them all in a list.
 
-Be careful not to iterate over the records *before* using ``blast_records`` as
-a list, as any record already iterated over will be missing from the list (it is
-fine to iterate over the records afterwards).
+If you start iterating over the records *before* using ``blast_records`` as
+a list, the parser will first reset the file stream to the beginning of the
+data to ensure that all records are neing read. Note that this will fail if the
+stream cannot be reset to the beginning, for example if the data are being
+read remotely (e.g. by qblast; see subsection :ref:`sec:running-www-blast`).
+In those cases, you can explicitly read the records into a list by calling
+``blast_records = blast_records[:]`` before iterating over them. After reading
+in the records, it is safe to iterate over them or use them as a list.
 
 Instead of opening the file yourself, you can just provide the file
 name:
@@ -681,13 +686,11 @@ The BLAST Records and Record classes
 The BLAST Records class
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-A single BLAST output file can contain output from multiple BLAST
-queries. In Biopython, the information in a BLAST output file is stored
-in an ``Bio.Blast.Records`` object. This is an iterator returning one
-``Bio.Blast.Record`` object (see subsection
-:ref:`subsec:blast-record`) for each query. The
-``Bio.Blast.Records`` object has the following attributes describing the
-BLAST run:
+A single BLAST output file can contain output from multiple BLAST queries. In
+Biopython, the information in a BLAST output file is stored in an
+``Bio.Blast.Records`` object. This is an iterator returning one
+``Bio.Blast.Record`` object (see subsection :ref:`subsec:blast-record`) for
+each query. The ``Bio.Blast.Records`` object has the following attributes describing the BLAST run:
 
 -  ``source``: The input data from which the ``Bio.Blast.Records``
    object was constructed (this could be a file name or path, or a

--- a/Tests/test_Blast_parser.py
+++ b/Tests/test_Blast_parser.py
@@ -114,15 +114,11 @@ Program: BLASTP 2.2.18+
    Hits: 0
 """,
         )
-
-    def check_xml_2218L_blastp_001_str(self, records):
-        self.assertEqual(
-            str(records),
-            """\
-Program: blastp 2.2.18 [Mar-02-2008]
-     db: /Users/pjcock/Downloads/Software/blast-2.2.18/data/nr
-""",
-        )
+        # check if converting the records to a list does not lose the header:
+        with open(datafile, "rb") as handle:
+            records = Blast.parse(handle)
+            records = records[:]
+        self.check_xml_2218_blastp_002_header(records)
 
     def test_xml_2218L_blastp_001(self):
         """Parsing blastp 2.2.18 [Mar-02-2008] (xml_2218L_blastp_001.xml)."""
@@ -143,6 +139,17 @@ Program: blastp 2.2.18 [Mar-02-2008]
 
         record = Blast.read(datafile)
         self.check_xml_2218L_blastp_001_record(record)
+
+    def check_xml_2218L_blastp_001_str(self, records):
+        self.assertEqual(
+            str(records),
+            """\
+Program: blastp 2.2.18 [Mar-02-2008]
+     db: /Users/pjcock/Downloads/Software/blast-2.2.18/data/nr
+
+   Hits: 0
+""",
+        )
 
     def check_xml_2218L_blastp_001_records(self, records):
         self.assertEqual(records.program, "blastp")


### PR DESCRIPTION
With this PR, the Blast iterator in `Bio.Blast` can be used as a list without losing records already iterated over.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

