### PR TITLE
Improve docs

### DIFF
--- a/.circleci/requirements-sphinx.txt
+++ b/.circleci/requirements-sphinx.txt
@@ -13,3 +13,4 @@ sphinxcontrib-devhelp<=1.0.2
 sphinxcontrib-qthelp<=1.0.3
 sphinxcontrib.htmlhelp<=2.0.4
 sphinxcontrib.serializinghtml<=1.1.9
+chardet

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -337,6 +337,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Walter Gillett <https://github.com/wgillett>
 - Wayne Decatur <https://github.com/fomightez>
 - Wibowo Arindrarto <https://github.com/bow>
+- Will Tyler <https://github.com/Will-Tyler>
 - Wolfgang Schueler <wolfgang at domain proceryon.at>
 - Xiaoyu Zhuo <https://github.com/xzhuo>
 - Yair Benita <Y.Benita at domain pharm.uu.nl>

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -21,5 +21,7 @@ help:
 
 clean:
 	-rm -f api/Bio*.rst
-	-rm -rf _build/html
 	-rm -rf _build/doctrees
+	-rm -rf _build/html
+	-rm -rf _build/latex
+

--- a/Doc/README.rst
+++ b/Doc/README.rst
@@ -1,8 +1,29 @@
 Contributing to the Biopython Tutorial
 ======================================
 
-Installing the tools you need
------------------------------
+Installing the requirements
+---------------------------
+
+In the Biopython directory, install the required packages for building the documentation with::
+
+    pip install -r .circleci/requirements-sphinx.txt
+
+ReStructered Text Markup Language
+---------------------------------
+
+The tutorials are written in `ReStructered Text <https://en.m.wikipedia.org/wiki/ReStructuredText>`_ format.
+Read the `Sphix reST Primer <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#hyperlinks>`_ to learn how to use this format.
+
+Building the documentation
+--------------------------
+
+Build the documentation in HTML by running ``make html`` in the Docs folder.
+Make sure that you have installed necessary requirements (see instructions above).
+
+To view the generated documentation, open ``Doc/_build/html/index.html`` in your browser.
+
+Build a PDF of the documentation using ``make latexpdf``.
+This command depends on `Latexmk <https://mg.readthedocs.io/latexmk.html>`_ and LaTeX tooling.
 
 On Ubuntu, you can install these with the following commands::
 
@@ -13,61 +34,9 @@ On Fedora (tested for Workstation 33)::
     dnf install texlive-scheme-basic texlive-preprint \
                 texlive-comment texlive-minted hevea
 
-Formatting code examples
+Testing code examples
 ------------------------
 
-Code examples should be formatted using minted. Also, the Biopython tutorial
-uses its own system for testing code examples, which is located in
-``test_Tutorial.py``. You can read more about this system in the testing
+The Biopython tutorial uses its own system for testing code examples, which is located in
+``Tests/test_Tutorial.py``. You can read more about this system in the testing
 chapter of the Biopython Tutorial.
-
-Here is an example of Python code that uses the console to show output::
-
-    %doctest path-to-folder
-    \begin{minted}{pycon}
-    >>> from Bio import SeqIO
-    \end{minted}
-
-These examples should use %doctest to verify that the output is correct.
-
-Here is an example of Python code that does not show output::
-
-    \begin{minted}{python}
-    from Bio import SeqIO
-    \end{minted}
-
-
-Formatting text
----------------
-
-Format headings as follows:
-
-Chapter titles::
-
-    \chapter{Title of Chapter}
-    \label{chapter:chapterlabel}
-
-Section titles::
-
-    \section{Title of Section}
-    \label{sec:sectionlabel}
-
-Subsection titles::
-
-    \subsection{Title of Subsection}
-
-When referring to code in the middle of a paragraph, format it as follows::
-
-    \verb|variable_name|
-
-This will render ``variable_name`` in a monospace font. Within the pipe
-characters, underscores will be interpreted literally, so they do not need
-to be escaped.
-
-Building the documentation
---------------------------
-
-Build the documentation by running "make" in the Docs folder.
-
-Once the documentation has been generated, you can inspect either Tutorial.pdf
-or Tutorial.html in the Docs directory to see if the output is correct.

--- a/Doc/Tutorial/chapter_seq_objects.rst
+++ b/Doc/Tutorial/chapter_seq_objects.rst
@@ -354,21 +354,24 @@ Before talking about transcription, I want to try to clarify the strand
 issue. Consider the following (made up) stretch of double stranded DNA
 which encodes a short peptide:
 
-== ========================================================== ==
-\  DNA coding strand (aka Crick strand, strand :math:`+1`)    
-5’ ``ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG``                3’
-\  ``|||||||||||||||||||||||||||||||||||||||``                
-3’ ``TACCGGTAACATTACCCGGCGACTTTCCCACGGGCTATC``                5’
-\  DNA template strand (aka Watson strand, strand :math:`-1`) 
-\                                                             
-\  :math:`|`                                                  
-\  Transcription                                              
-\  :math:`\downarrow`                                         
-\                                                             
-5’ ``AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG``                3’
-\  Single stranded messenger RNA                              
-\                                                             
-== ========================================================== ==
+.. math::
+
+   \begin{gathered}
+       \text{DNA coding strand (aka Crick strand, strand } +1 \text{)} \\
+       \text{5'} \qquad \texttt{ATGGCCATTGTAATGGGCCGCTGAAAGGGTGCCCGATAG} \qquad \text{3'} \\
+       \texttt{|||||||||||||||||||||||||||||||||||||||} \\
+       \text{3'} \qquad \texttt{TACCGGTAACATTACCCGGCGACTTTCCCACGGGCTATC} \qquad \text{5'} \\
+       \text{DNA template strand (aka Watson strand, strand } -1 \text{)}
+   \end{gathered}
+
+Transcription of this DNA sequence produces the following RNA sequence:
+
+.. math::
+
+   \begin{gathered}
+       \text{5'} \qquad \texttt{AUGGCCAUUGUAAUGGGCCGCUGAAAGGGUGCCCGAUAG} \qquad \text{3'} \\
+       \text{Single-stranded messenger RNA}
+   \end{gathered}
 
 The actual biological transcription process works from the template
 strand, doing a reverse complement (TCAG :math:`\rightarrow` CUGA) to

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -61,6 +61,7 @@ possible, especially the following contributors:
 - Fabio Zanini (first contribution)
 - Michiel de Hoon
 - Peter Cock
+- Will Tyler (first contribution)
 
 10 January 2024: Biopython 1.83
 ===============================


### PR DESCRIPTION
## Acknowledgements

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

## Description

In this pull request, I improve the display of the transcription example in the Seq objects tutorial chapter. The issue with the transcription example is described [here](https://mailman.open-bio.org/pipermail/biopython-announce/2024-January/000188.html).

While making these changes, I noticed that the README in the Doc folder is out-of-date, so I updated it as best as I could. I added a `doc-requirements.txt` file to keep track of the Python packages that are required to build the documentation.

## Testing

I built the documentation on my machine and opened the generated documentation to verify that the transcription example is improved.
