### PR TITLE
Update PDB server to HTTPS from FTP

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -54,6 +54,15 @@ A function called ``Bio.Phylo.to_igraph`` has been added to convert a
 ``Bio.Phylo.Tree`` into an ``igraph.Graph`` graph, in parallel to the existing
 function to convert the same object into a ``networkx`` graph.
 
+The PDB module no longer uses the PDB FTP server by default.
+Instead, the PDB module uses the HTTPS server in most cases.
+For ``get_all_assemblies``, the PDB module now uses the
+`RCSB PDB Search API <https://search.rcsb.org/#search-api>`_ to get all the
+assemblies.
+The wwPDB organization announced that they plan to deprecate the FTP
+server by the end of the year. See the announcement
+`here <https://www.wwpdb.org/news/news?year=2023#65562f0ad78e004e766a96c1>`_.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 


### PR DESCRIPTION
## Acknowledgements

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

## Description

In this pull request, I update the `PDBList` class to use the HTTPS PDB file download server instead of the FTP server. The FTP server is on the deprecation path ([announcement link](https://www.rcsb.org/news/636151b266d6046810db7f0f)), so it seems best to use the HTTPS server instead.

Most of the methods continue to work without any significant changes. However, for `get_all_assemblies`, I had to make significant changes to make the method work. First, I tried using the HTTPS endpoint https://files.wwpdb.org/pub/pdb/data/assemblies/mmCIF/all/. However, this endpoint returns HTML, and we want to avoid parsing HTML.

After some exploration, I determined that the next best option is to use the [RCSB search API](https://search.rcsb.org/index.html#search-api) to get all of the assemblies as a JSON object. I implement this option in this pull request, and I avoid any breaking changes to the existing implementation of `get_all_assemblies`.

## Testing

To test `get_all_assemblies`, in Python, I made a set of the assemblies returned by the existing implementation and a set of assemblies returned by my new implementation. I confirmed that the symmetric set difference is empty. I also confirmed that the count of the two lists of assemblies are the same. However, there may be a difference in the order of the assemblies returned by the different implementations.

For the other methods, I am relying on the existing unit tests to test that the methods are still working properly. If the existing unit tests do not give enough confidence that everything is working, I am happy to work more on testing the other methods. The tests in `test_PDBList.py` are passing locally for me.
