### PR TITLE
Bio.Genbank.Record: alias attribute .name to .locus

### DIFF
--- a/Bio/GenBank/Record.py
+++ b/Bio/GenBank/Record.py
@@ -135,6 +135,7 @@ class Record:
        (will be replaced by the dblink cross-references in 2009).
      - dblinks - The genome sequencing project number(s) and other links.
        (will replace the project information in 2009).
+     - name - An alias of the locus attribute
 
     """
 
@@ -241,6 +242,16 @@ class Record:
         output += self._contig_line()
         output += "//"
         return output
+
+    @property
+    def name(self):
+        """Make the name attribute is an alias for the locus attribute."""
+        return self.locus
+
+    @name.setter
+    def name(self, value):
+        """Make the name attribute is an alias for the locus attribute."""
+        self.locus = value
 
     def _locus_line(self):
         """Provide the output string for the LOCUS line (PRIVATE)."""


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4579

The Genbank parser uses different record classes when different abstractions are used. For example, when invoking `Bio.GenBank.read` directly, `Bio.GenBank.Record` is used, but when `Bio.SeqIO.read` is called on a GenBank file, `Bio.SeqRecord` is used.

However, these different record classes don't all have the same attributes. `Bio.GenBank.Record` has a `.locus` attribute that stores the LOCUS line from a GenBank file, however, the data from that line is stored in a `.name` attribute when using `Bio.SeqRecord`. This recently caused a problem in issue #4579 where some code in the GenBank parser assumed the `.name` attribute was present (probably because the author was only consider the `Bio.SeqIO` abstraction).

To fix this issue and to make life a bit less counterintuitive, this PR adds a new `.name` attribute to `Bio.GenBank.Record` and aliases it to the `.locus` attribute (through getters and setters).