### PR TITLE
Deprecate version parameter in Bio.motifs.Motif's weblogo method

### DIFF
--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -592,10 +592,12 @@ class Motif:
                 values[mask] += frequencies * np.log2(frequencies / background[letter])
         return values
 
-    def weblogo(self, fname, fmt="PNG", version="2.8.2", **kwds):
+    def weblogo(self, fname, fmt="PNG", version=None, **kwds):
         """Download and save a weblogo using the Berkeley weblogo service.
 
         Requires an internet connection.
+
+        The version parameter is deprecated and has no effect.
 
         The parameters from ``**kwds`` are passed directly to the weblogo server.
 
@@ -639,6 +641,12 @@ class Motif:
             'color4': '',
 
         """
+        if version is not None:
+            warnings.warn(
+                "The version parameter is deprecated and has no effect.",
+                BiopythonDeprecationWarning,
+            )
+
         if set(self.alphabet) == set("ACDEFGHIKLMNPQRSTVWY"):
             alpha = "alphabet_protein"
         elif set(self.alphabet) == set("ACGU"):

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -164,6 +164,9 @@ The ``search`` method of the ``Instances`` class in ``Bio.motifs`` was
 deprecated in release 1.82. Instead of ``instances.search(sequence)``,
 ``sequence.search(instances)`` can be used, where sequence is a Seq object.
 This allows instances to have different lengths.
+The ``version`` parameter of the ``weblogo`` method of the ``Motif`` class in
+``Bio.motifs`` was deprecated in release 1.83. Using the parameter has no
+effect.
 
 The ``Instances`` class and the ``instances`` argument of the ``Motif`` class
 initializer in ``Bio.motifs`` were deprecated in release 1.82. Instead of

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -75,9 +75,6 @@ attributes of the ``SeqFeature`` which was done without a deprecation period.
 They are again aliases for ``.location.strand`` etc, but trigger deprecation
 warnings.
 
-The unused ``version`` parameter to the ``weblogo`` method of
-``Bio.motifs.Motif`` is also now deprecated.
-
 22 December 2023: Biopython 1.82
 ================================
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -75,6 +75,9 @@ attributes of the ``SeqFeature`` which was done without a deprecation period.
 They are again aliases for ``.location.strand`` etc, but trigger deprecation
 warnings.
 
+The unused ``version`` parameter to the ``weblogo`` method of
+``Bio.motifs.Motif`` is also now deprecated.
+
 22 December 2023: Biopython 1.82
 ================================
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4576

This PR implements @peterjc's suggestions from the discussion of issue #4576. The title of the PR should also be fairly self-explanatory.

(PS: on the linked issue there seemed to have been another offer to write up the deprecation, however, I couldn't find any associated PRs and it looked abandoned)