### PR TITLE
Don't use record specific attributes in GenBank parser warning

### DIFF
--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1798,8 +1798,7 @@ class GenBankScanner(InsdcScanner):
                                     not in structured_comment_dict
                                 ):
                                     warnings.warn(
-                                        "Structured comment not parsed for %s. Is it malformed?"
-                                        % consumer.data.name,
+                                        f"Structured comment not parsed on malformed header line: {line}",
                                         BiopythonParserWarning,
                                     )
                                     continue

--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -7759,7 +7759,8 @@ KEYWORDS    """,
             record = SeqIO.read(path, "genbank")
             self.assertNotIn("structured_comment", record.annotations)
             self.assertIn(
-                "Structured comment not parsed for AYW00820.", str(caught[0].message)
+                "Structured comment not parsed on malformed header line",
+                str(caught[0].message),
             )
 
     def test_locus_line_topogoly(self):


### PR DESCRIPTION
See issue #4579

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4579

This PR changes a warning by the GenBank scanner to not use attributes of a record. Because the parser uses a scanner/consumer model, there's no guarantee on what attributes are present on the consumer's internal record data type. This caused a problem in the linked issue.

This PR uses @peterjc's idea from the linked issue and prints out the offending line. This also makes the warning look a bit more like the other warnings that the GenBank scanner gives.