### PR TITLE
Programmatic UniProt search

### DIFF
--- a/Bio/UniProt/__init__.py
+++ b/Bio/UniProt/__init__.py
@@ -4,7 +4,7 @@
 # choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
 # Please see the LICENSE file that should have been included as part of this
 # package.
-"""Code for dealing with assorted UniProt file formats.
+"""Code for dealing with assorted UniProt file formats and interacting with the UniProt database.
 
 This currently include parsers for the GAF, GPA and GPI formats
 from UniProt-GOA as the module Bio.UniProt.GOA.
@@ -15,3 +15,139 @@ the legacy plain text sequence format still used in UniProt.
 See also Bio.SeqIO.SwissIO for the "uniprot-xml" support in
 Bio.SeqIO.
 """
+
+import json
+import re
+import urllib.parse
+from http.client import HTTPResponse
+
+from typing import Optional, List
+from urllib.request import urlopen
+
+
+_re_next_link = re.compile(r'<(.+)>; rel="next"')
+
+
+def _get_next_link(response: HTTPResponse) -> Optional[str]:
+    headers = response.headers
+
+    if "Link" in headers:
+        match = _re_next_link.match(headers["Link"])
+        if match:
+            return match.group(1)
+
+    return None
+
+
+def _get_results(response: HTTPResponse) -> List[dict]:
+    return json.loads(response.read().decode())["results"]
+
+
+def _get_search_result_count(response: HTTPResponse) -> int:
+    return int(response.headers["x-total-results"])
+
+
+class _UniProtSearchResults:
+    """A sequence over the results of a UniProt search.
+
+    Do not use this class directly. Instead, use the :meth:`UniProt.search` method.
+    """
+
+    def _fetch_next_batch(self) -> HTTPResponse:
+        assert self.next_url is not None  # type: ignore
+        with urlopen(self.next_url) as response:  # type: ignore
+            self.results_cache += _get_results(response)
+            self.next_url = _get_next_link(response)
+            return response
+
+    def __init__(self, first_url: str):
+        self.next_url = first_url
+        self.results_cache: List[dict] = []
+        self.next_result_index = 0
+        response = self._fetch_next_batch()
+        self.search_result_count = _get_search_result_count(response)
+
+    def __iter__(self):
+        return self
+
+    def __len__(self) -> int:
+        """Return the total number of search results, regardless of the batch size."""
+        return self.search_result_count
+
+    def _fetch_for(self, index: int) -> None:
+        """Fetch batches until the given index is in the cache."""
+        assert index in range(len(self))
+        while index >= len(self.results_cache):
+            self._fetch_next_batch()
+
+    def __next__(self) -> dict:
+        if self.next_result_index < len(self):
+            self._fetch_for(self.next_result_index)
+            try:
+                next_result = self.results_cache[self.next_result_index]
+                self.next_result_index += 1
+                return next_result
+            except IndexError:
+                raise StopIteration
+        else:
+            raise StopIteration
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            start, stop, step = index.indices(len(self))
+            # The assertions below should be guaranteed by the indices method
+            assert 0 <= start < len(self) and 0 <= stop <= len(self)
+            if step > 0:
+                if start <= stop and stop > 0:
+                    self._fetch_for(stop - 1)
+            else:
+                # If start is 0 and step is negative, the slice is empty
+                if start >= stop and start > 0:
+                    self._fetch_for(start)
+        elif isinstance(index, int):
+            if index not in range(-len(self), len(self)):
+                raise IndexError("Index out of bounds.")
+            self._fetch_for(index % len(self))
+        return self.results_cache[index]
+
+
+def search(
+    query: str, fields: Optional[List[str]] = None, batch_size: int = 500
+) -> _UniProtSearchResults:
+    """Search the UniProt database.
+
+    Consider using `query syntax <https://www.uniprot.org/help/text-search>`_ and
+    `query fields <https://www.uniprot.org/help/query-fields>`_ to refine your search.
+
+    See the API details `here <https://www.uniprot.org/help/api_queries>`_.
+
+    >>> from Bio import UniProt
+    >>> from itertools import islice
+    >>> # Get the first 10 results
+    >>> results = UniProt.search("(organism_id:2697049) AND (reviewed:true)")[:10]
+
+    :param query: The query string to search UniProt with
+    :type query: str
+    :param fields: The columns to retrieve in the results, defaults to all fields
+    :type fields: List[str], optional
+    :param batch_size: The number of results to retrieve in each batch, defaults to 500
+    :type batch_size: int
+    :return: An iterator over the search results
+    :rtype: _UniProtSearchResults
+    """
+    parameters = {
+        "query": query,
+        "size": batch_size,
+        "format": "json",
+    }
+    if fields:
+        parameters["fields"] = ",".join(fields)
+    url = f"https://rest.uniprot.org/uniprotkb/search?{urllib.parse.urlencode(parameters)}"
+
+    return _UniProtSearchResults(url)
+
+
+if __name__ == "__main__":
+    from Bio._utils import run_doctest
+
+    run_doctest()

--- a/Doc/Tutorial/chapter_uniprot.rst
+++ b/Doc/Tutorial/chapter_uniprot.rst
@@ -514,14 +514,53 @@ numbers:
    ...     records.append(record)
    ...
 
-Searching Swiss-Prot
-~~~~~~~~~~~~~~~~~~~~
+Searching with UniProt
+~~~~~~~~~~~~~~~~~~~~~~
 
 Now, you may remark that I knew the records’ accession numbers
 beforehand. Indeed, ``get_sprot_raw()`` needs either the entry name or
-an accession number. When you don’t have them handy, right now you could
-use https://www.uniprot.org/ but we do not have a Python wrapper for
-searching this from a script. Perhaps you could contribute here?
+an accession number. When you don't have them handy, you can use
+`UniProt <https://www.uniprot.org/>`_ to search for them.
+You can also use the UniProt package to programmatically search for proteins.
+
+For example, let's search for proteins from a specific organism (organism ID: 2697049)
+that have been reviewed. We can do this with the following code:
+
+.. code:: pycon
+
+   >>> from Bio import UniProt
+
+   >>> query = "(organism_id:2697049) AND (reviewed:true)"
+   >>> results = list(UniProt.search(query))
+
+The ``UniProt.search`` method returns an iterator over the search results.
+The iterator returns one result at a time, fetching more results from UniProt as needed until all results are returned.
+We can efficiently create a list from this iterator for this specific query
+because this query only returns a few results (17 at the time of writing).
+
+Let's try a search that returns more results.
+At the time of writing, there are 5,147 results for the query "Insulin AND (reviewed:true)".
+We can use slicing to get a list of the first 50 results.
+
+.. code:: pycon
+
+   >>> from Bio import UniProt
+   >>> from itertools import islice
+
+   >>> query = "Insulin AND (reviewed:true)"
+   >>> results = UniProt.search(query, batch_size=50)[:50]
+
+You can get the total number of search results (regardless of the batch size)
+with the ``len`` method:
+
+.. code:: pycon
+
+   >>> from Bio import UniProt
+
+   >>> query = "Insulin AND (reviewed:true)"
+   >>> result_iterator = UniProt.search(query, batch_size=0)
+   >>> len(result_iterator)
+   5147
 
 Retrieving Prosite and Prosite documentation records
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -68,6 +68,10 @@ Assembly (GFA) files with the formats ``gfa1`` and ``gfa2`` (for GFA 1.x and
 GFA 2.0 files respectively). All data outside of segment lines are ignored, such
 as linkage information.
 
+The UniProt package now includes a method to search UniProt programmatically.
+The tutorial has been updated with examples of how to use the search method.
+See the chapter on Swiss-Prot and ExPASy in the tutorial for more information.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -55,6 +55,7 @@ ONLINE_DOCTEST_MODULES = [
     "Bio.ExPASy",
     "Bio.ExPASy.cellosaurus",
     "Bio.TogoWS",
+    "Bio.UniProt",
 ]
 
 # Silently ignore any doctests for modules requiring numpy!

--- a/Tests/test_UniProt.py
+++ b/Tests/test_UniProt.py
@@ -1,0 +1,87 @@
+"""Tests for the UniProt module."""
+
+import requires_internet
+import unittest
+
+from Bio import UniProt
+from itertools import islice
+
+requires_internet.check()
+
+
+class SearchTests(unittest.TestCase):
+    def test_search_result_count(self):
+        query = "(organism_id:2697049) AND (reviewed:true)"
+        results = UniProt.search(query)
+        search_result_count = len(results)
+
+        self.assertIsInstance(search_result_count, int)
+        self.assertGreaterEqual(search_result_count, 1)
+        self.assertEqual(search_result_count, len(list(results)))
+
+    def test_search_all_fields(self):
+        query = "Insulin AND (reviewed:true)"
+        results = list(islice(UniProt.search(query, batch_size=50), 50))
+        self.assertEqual(len(results), 50)
+
+        for result in results:
+            self.assertIsInstance(result, dict)
+            self.assertGreater(len(result), 0)
+
+    def test_search_with_fields(self):
+        query = "Insulin AND (reviewed:true)"
+        fields = ["id", "accession"]
+        results = list(islice(UniProt.search(query, fields=fields, batch_size=50), 50))
+        self.assertEqual(len(results), 50)
+        expected_keys = {"entryType", "primaryAccession", "uniProtkbId"}
+
+        for result in results:
+            self.assertIsInstance(result, dict)
+            self.assertGreater(len(result), 0)
+            self.assertEqual(set(result.keys()), expected_keys)
+
+    def test_search_results_slicing(self):
+        query = "Insulin AND (reviewed:true)"
+        results = UniProt.search(query, batch_size=25)
+        results_sliced = results[:50]
+        self.assertEqual(50, len(results_sliced))
+        results_list = list(islice(results, 50))
+        self.assertEqual(50, len(results_list))
+        self.assertEqual(results_sliced, results_list)
+
+        # We need to fetch the results again to reset the iterator
+        results = UniProt.search(query, batch_size=25)
+        results_sliced = results[49:30:-1]
+        self.assertEqual(19, len(results_sliced))
+        results_list = list(islice(results, 50))[49:30:-1]
+        self.assertEqual(19, len(results_list))
+        self.assertEqual(results_sliced, results_list)
+
+        results_sliced = results[0:0]
+        self.assertEqual(0, len(results_sliced))
+
+        # This query should return less than 500 results.
+        query = "(organism_id:2697049) AND (reviewed:true)"
+        results = UniProt.search(query)
+        results_sliced = results[-10:-5]
+        self.assertEqual(5, len(results_sliced))
+        results_list = list(results)[-10:-5]
+        self.assertEqual(5, len(results_list))
+        self.assertEqual(results_sliced, results_list)
+
+        results = UniProt.search(query)
+        results_sliced = results[-1_000_001:1_000_000]
+        self.assertEqual(len(results), len(results_sliced))
+        results_list = list(results)[-1_000_001:1_000_000]
+        self.assertEqual(len(results_list), len(results))
+        self.assertEqual(results_sliced, results_list)
+
+    def test_search_results_indexing(self):
+        query = "(organism_id:2697049) AND (reviewed:true)"
+        results = UniProt.search(query)
+        self.assertIsInstance(results[0], dict)
+        self.assertIsInstance(results[-1], dict)
+        with self.assertRaises(IndexError):
+            _ = results[1_000_000]
+        with self.assertRaises(IndexError):
+            _ = results[-1_000_000]

--- a/Tests/test_UniProt_Parser.py
+++ b/Tests/test_UniProt_Parser.py
@@ -14,7 +14,7 @@ from Bio.SeqRecord import SeqRecord
 from seq_tests_common import SeqRecordTestBaseClass
 
 
-class TestUniprot(SeqRecordTestBaseClass):
+class ParserTests(SeqRecordTestBaseClass):
     """Tests Uniprot XML parser."""
 
     def test_uni001(self):


### PR DESCRIPTION
### Acknowledgements

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

### Description

This pull request adds functionality to search the UniProt database programmatically using the [UniProt query API](https://www.uniprot.org/help/api_queries). I update the tutorial to demonstrate how to use the new functionality, and I update the NEWS file to mention the new functionality.

Here is a basic example of the functionality:

```python

from Bio.UniProt import UniProt

query = "(organism_id:2697049) AND (reviewed:true)"
results = list(UniProt.search(query))
```

### Testing

I added unit tests that do some basic checks. These unit tests require an internet connection. I ran the tests locally and they passed.

For the documentation changes (the tutorial and the API docs), I manually built and inspected the documentation.

I manually tested the examples in the tutorial in the Python console.