### PR TITLE
In PDBList, only create "obsolete" directory if necessary

### DIFF
--- a/Tests/test_PDBList.py
+++ b/Tests/test_PDBList.py
@@ -148,6 +148,17 @@ class TestPDBListGetStructure(unittest.TestCase):
         self.check(structure, os.path.join("a", f"{structure}.cif"), "mmCif", pdir="a")
         self.check(structure, os.path.join("b", f"{structure}.cif"), "mmCif", pdir="b")
 
+    def test_invalid_file_format(self):
+        pdb_list = PDBList()
+        with self.assertRaises(ValueError) as context:
+            pdb_list.retrieve_pdb_file("127d", file_format="invalid")
+
+        self.assertEqual(
+            "Specified file_format invalid does not exist or is not supported. Please use one of the "
+            "following: pdb, mmCif, xml, mmtf, bundle.",
+            str(context.exception),
+        )
+
 
 class TestPDBListGetAssembly(unittest.TestCase):
     """Test methods responsible for getting assemblies."""


### PR DESCRIPTION
### Acknowledgements

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

### Description

In this pull request, I update PDBList so that it only creates an "obsolete" directory if obsolete files are downloaded. Prior to this change, PDBList would create an "obsolete" directory during instance initialization. This leads to a surprising behavior where an empty "obsolete" directory is present even when files have not been downloaded.

In addition to modifying the initialization method, I modify `retrieve_pdb_file` and `update_pdb` to create the "obsolete" directory when needed.

### Testing

I tested `retrieve_pdb_file` manually.

```python
import os
>>> if os.path.isdir("obsolete"):
...     os.rmdir("obsolete")
...     
... from Bio.PDB import PDBList
... pdbl = PDBList()
... pdbl.retrieve_pdb_file("14PS", obsolete=True)
... assert os.path.isdir("obsolete")
WARNING: The default download format has changed from PDB to PDBx/mmCif
Downloading PDB structure '14ps'...
```

```python
>>> import os
... if os.path.isdir("obsolete"):
...     os.rmdir("obsolete")
...
... from Bio.PDB import PDBList
... pdbl = PDBList()
... pdbl.retrieve_pdb_file("2DSP")
... assert not os.path.isdir("obsolete")
WARNING: The default download format has changed from PDB to PDBx/mmCif
Downloading PDB structure '2dsp'...
```

I tested `update_pdb` manually as well. I modified the method slightly in order to test it by commenting out the part that handles new additions and modifications and by manually setting the `obsolete` list to a few obsolete entry codes since last week only one entry was made obsolete.

```python
>>> import os
... assert not os.path.isdir("obsolete")
... pdbl = PDBList()
... assert not os.path.isdir("obsolete")
... pdbl.update_pdb()
... assert os.path.isdir("obsolete")
WARNING: The default download format has changed from PDB to PDBx/mmCif
Could not move /Users/willtyler/Desktop/biopython/ad/pdb1ada.mmCif to obsolete folder
Could not move /Users/willtyler/Desktop/biopython/ad/pdb1adh.mmCif to obsolete folder
Could not move /Users/willtyler/Desktop/biopython/ad/pdb1adk.mmCif to obsolete folder
Could not move /Users/willtyler/Desktop/biopython/ao/pdb2aok.mmCif to obsolete folder
```