### PR TITLE
Add module to interact with AlphaFold DB

### DIFF
--- a/Bio/PDB/alphafold_db.py
+++ b/Bio/PDB/alphafold_db.py
@@ -1,0 +1,114 @@
+"""A module for interacting with the AlphaFold Protein Structure Database.
+
+See the `database website <https://alphafold.com/>`_ and the `API docs <https://alphafold.com/api-docs/>`_.
+"""
+
+import json
+import os
+from os import PathLike
+
+from Bio.PDB import MMCIFParser
+from Bio.PDB.Structure import Structure as PDBStructure
+from typing import Iterator, Union, Optional
+from urllib.request import urlopen
+
+
+def get_predictions(qualifier: str) -> Iterator[dict]:
+    """Get all AlphaFold predictions for a UniProt accession.
+
+    :param qualifier: A UniProt accession, e.g. P00520
+    :type qualifier: str
+    :return: The AlphaFold predictions
+    :rtype: Iterator[dict]
+    """
+    url = f"https://alphafold.com/api/prediction/{qualifier}"
+    # Retrieve the AlphaFold predictions with urllib
+    with urlopen(url) as response:
+        yield from json.loads(response.read().decode())
+
+
+def _get_mmcif_file_path_for(
+    prediction: dict, directory: Optional[Union[str, bytes, PathLike]] = None
+) -> str:
+    """Get the path to the mmCIF file for an AlphaFold prediction.
+
+    :param prediction: An AlphaFold prediction
+    :type prediction: dict
+    :param directory: The directory that stores the mmCIF file, defaults to the current working directory
+    :type directory: Union[int, str, bytes, PathLike], optional
+    :return: The path to the mmCIF file
+    :rtype: str
+    """
+    if directory is None:
+        directory = os.getcwd()
+
+    cif_url = prediction["cifUrl"]
+    # Get the file name from the URL
+    file_name = cif_url.split("/")[-1]
+    return os.path.join(directory, file_name)
+
+
+def download_cif_for(
+    prediction: dict, directory: Optional[Union[str, bytes, PathLike]] = None
+) -> str:
+    """Download the mmCIF file for an AlphaFold prediction.
+
+    Downloads the file to the current working directory if no destination is specified.
+
+    :param prediction: An AlphaFold prediction
+    :type prediction: dict
+    :param directory: The directory to write the mmCIF data to, defaults to the current working directory
+    :type directory: Union[int, str, bytes, PathLike], optional
+    :return: The path to the mmCIF file
+    :rtype: str
+    """
+    if directory is None:
+        directory = os.getcwd()
+
+    cif_url = prediction["cifUrl"]
+    # Create the directory in case it does not exist
+    os.makedirs(directory, exist_ok=True)
+    file_path = _get_mmcif_file_path_for(prediction, directory)
+
+    if os.path.exists(file_path):
+        print(f"File {file_path} already exists, skipping download.")
+    else:
+        with urlopen(cif_url) as response:
+            data = response.read()
+        # Write the data to destination
+        with open(file_path, "wb") as file:
+            file.write(data)
+
+    return file_path
+
+
+def get_pdb_structures_for(
+    qualifier: str,
+    mmcif_parser: Optional[MMCIFParser] = None,
+    directory: Optional[Union[str, bytes, PathLike]] = None,
+) -> Iterator[PDBStructure]:
+    """Get the PDB structures for a UniProt accession.
+
+    Downloads the mmCIF files to the directory if they are not present.
+
+    :param qualifier: A UniProt accession, e.g. P00520
+    :type qualifier: str
+    :param mmcif_parser: The mmCIF parser to use, defaults to ``MMCIFParser()``
+    :type mmcif_parser: MMCIFParser, optional
+    :param directory: The directory to store the mmCIF data, defaults to the current working directory
+    :type directory: Union[int, str, bytes, PathLike], optional
+    :return: An iterator over the PDB structures
+    :rtype: Iterator[PDBStructure]
+    """
+    if mmcif_parser is None:
+        mmcif_parser = MMCIFParser()
+    if directory is None:
+        directory = os.getcwd()
+
+    for prediction in get_predictions(qualifier):
+        mmcif_path = _get_mmcif_file_path_for(prediction, directory)
+
+        if not os.path.exists(mmcif_path):
+            mmcif_path = download_cif_for(prediction, directory)
+
+        yield mmcif_parser.get_structure(qualifier, mmcif_path)

--- a/Bio/PDB/alphafold_db.py
+++ b/Bio/PDB/alphafold_db.py
@@ -7,7 +7,7 @@ import json
 import os
 from os import PathLike
 
-from Bio.PDB import MMCIFParser
+from Bio.PDB.MMCIFParser import MMCIFParser
 from Bio.PDB.Structure import Structure as StructuralModel
 from typing import Iterator, Union, Optional
 from urllib.request import urlopen
@@ -45,7 +45,7 @@ def _get_mmcif_file_path_for(
     cif_url = prediction["cifUrl"]
     # Get the file name from the URL
     file_name = cif_url.split("/")[-1]
-    return os.path.join(directory, file_name)
+    return str(os.path.join(directory, file_name))
 
 
 def download_cif_for(

--- a/Bio/PDB/alphafold_db.py
+++ b/Bio/PDB/alphafold_db.py
@@ -8,7 +8,7 @@ import os
 from os import PathLike
 
 from Bio.PDB import MMCIFParser
-from Bio.PDB.Structure import Structure as PDBStructure
+from Bio.PDB.Structure import Structure as StructuralModel
 from typing import Iterator, Union, Optional
 from urllib.request import urlopen
 
@@ -82,11 +82,11 @@ def download_cif_for(
     return file_path
 
 
-def get_pdb_structures_for(
+def get_structural_models_for(
     qualifier: str,
     mmcif_parser: Optional[MMCIFParser] = None,
     directory: Optional[Union[str, bytes, PathLike]] = None,
-) -> Iterator[PDBStructure]:
+) -> Iterator[StructuralModel]:
     """Get the PDB structures for a UniProt accession.
 
     Downloads the mmCIF files to the directory if they are not present.

--- a/Tests/test_PDB_alphafold_db.py
+++ b/Tests/test_PDB_alphafold_db.py
@@ -1,0 +1,23 @@
+"""Tests for the alphafold_db module."""
+import requires_internet
+import unittest
+
+from Bio.PDB import alphafold_db
+
+requires_internet.check()
+
+
+class AlphafoldDBTests(unittest.TestCase):
+    def test_get_predictions(self):
+        predictions = alphafold_db.get_predictions("P00520")
+
+        for prediction in predictions:
+            self.assertIsInstance(prediction, dict)
+            self.assertGreater(len(prediction), 0)
+
+    def test_get_mmcif_file_path_for(self):
+        prediction = {
+            "cifUrl": "https://alphafold.ebi.ac.uk/files/AF-P00520-F1-model_v4.cif",
+        }
+        file_path = alphafold_db._get_mmcif_file_path_for(prediction, "test")
+        self.assertEqual(file_path, "test/AF-P00520-F1-model_v4.cif")

--- a/Tests/test_PDB_alphafold_db.py
+++ b/Tests/test_PDB_alphafold_db.py
@@ -1,4 +1,5 @@
 """Tests for the alphafold_db module."""
+
 import requires_internet
 import unittest
 


### PR DESCRIPTION
## Acknowledgements

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

## Description

In this pull request, I add a module to interact with the AlphaFold Protein Structure Database. This is useful for downloading computed structure models. AlphaFold has released 200 million protein structure predictions, whereas there are only several hundred thousand experimentally determined structures (available via PDB).

The module includes three methods:
- `get_predictions`,
- `download_cif_for(prediction, ...)`,
- `get_pdb_structures_for(prediction, ...)`.

Given a UniProt accession, `get_predictions` returns the AlphaFold prediction objects using the AlphaFold API.

Given an AlphaFold prediction, `download_cif_for(prediction, ...)` downloads the CIF file associated with the prediction.

Given an AlphaFold prediction, `get_pdb_structures_for(prediction, ...)` downloads the CIF file if necessary and yields a PDB structure.

## Testing

I added some basic unit tests. The unit tests test `get_predictions`.

For the other two new methods, I tested them manually.

```python
from Bio.PDB import alphafold_db
import os

assert not os.path.exists("AF-P00520-F1-model_v4.cif")
prediction = next(alphafold_db.get_predictions("P00520"))
alphafold_db.download_cif_for(prediction)
assert os.path.exists("AF-P00520-F1-model_v4.cif")
```

```python
from Bio.PDB import alphafold_db
import os

assert not os.path.exists("test/AF-P00520-F1-model_v4.cif")
prediction = next(alphafold_db.get_predictions("P00520"))
alphafold_db.download_cif_for(prediction, "test")
assert os.path.exists("test/AF-P00520-F1-model_v4.cif")
```

```python
from Bio.PDB import alphafold_db
from Bio.PDB.Structure import Structure
import os

# In this test case, the file has not been downloaded yet. `get_pdb_structures_for` downloads the file.
assert not os.path.exists("AF-P00520-F1-model_v4.cif")
structure = next(alphafold_db.get_pdb_structures_for("P00520"))
assert os.path.exists("AF-P00520-F1-model_v4.cif")
assert isinstance(structure, Structure)
```

```python
from Bio.PDB import alphafold_db
from Bio.PDB.Structure import Structure
import os

# In this test case, the file has not been downloaded yet. `get_pdb_structures_for` downloads the file.
assert not os.path.exists("test/AF-P00520-F1-model_v4.cif")
structure = next(alphafold_db.get_pdb_structures_for("P00520", directory="test"))
assert os.path.exists("test/AF-P00520-F1-model_v4.cif")
assert isinstance(structure, Structure)
```

```python
from Bio.PDB import alphafold_db
from Bio.PDB.Structure import Structure
import os

# In this test case, the file is already downloaded.
assert os.path.exists("AF-P00520-F1-model_v4.cif")
structure = next(alphafold_db.get_pdb_structures_for("P00520"))
assert os.path.exists("AF-P00520-F1-model_v4.cif")
assert isinstance(structure, Structure)
```

For the API documentation, I built the documentation locally and inspected it.