### PR TITLE
Now also parsing the age (AG) and date (DT) fields.

### DIFF
--- a/Bio/ExPASy/cellosaurus.py
+++ b/Bio/ExPASy/cellosaurus.py
@@ -87,9 +87,9 @@ class Record(dict):
 
     Each record contains the following keys:
 
-     ---------  ---------------------------     ----------------------
+     ---------  ------------------------------  -----------------------
      Line code  Content                         Occurrence in an entry
-     ---------  ---------------------------     ----------------------
+     ---------  ------------------------------  -----------------------
      ID         Identifier (cell line name)     Once; starts an entry
      AC         Accession (CVCL_xxxx)           Once
      AS         Secondary accession number(s)   Optional; once
@@ -98,13 +98,15 @@ class Record(dict):
      RX         References identifiers          Optional: once or more
      WW         Web pages                       Optional; once or more
      CC         Comments                        Optional; once or more
-     ST         STR profile data                Optional; once or more
+     ST         STR profile data                Optional; twice or more
      DI         Diseases                        Optional; once or more
      OX         Species of origin               Once or more
      HI         Hierarchy                       Optional; once or more
      OI         Originate from same individual  Optional; once or more
-     SX         Sex (gender) of cell            Optional; once
+     SX         Sex of cell                     Optional; once
+     AG         Age of donor at sampling        Optional; once
      CA         Category                        Once
+     DT         Date (entry history)            Once
      //         Terminator                      Once; ends an entry
 
     """
@@ -126,7 +128,9 @@ class Record(dict):
         self["HI"] = []
         self["OI"] = []
         self["SX"] = ""
+        self["AG"] = ""
         self["CA"] = ""
+        self["DT"] = ""
 
     def __repr__(self):
         """Return the canonical string representation of the Record object."""
@@ -154,7 +158,9 @@ class Record(dict):
         output += " HI: " + repr(self["HI"])
         output += " OI: " + repr(self["OI"])
         output += " SX: " + self["SX"]
+        output += " AG: " + self["AG"]
         output += " CA: " + self["CA"]
+        output += " DT: " + self["DT"]
         return output
 
 
@@ -169,12 +175,10 @@ def __read(handle):
         if key == "ID":
             record = Record()
             record["ID"] = value
-        elif key in ["AC", "AS", "SY", "SX", "CA"]:
+        elif key in ["AC", "AS", "SY", "SX", "AG", "CA", "DT"]:
             record[key] += value
         elif key in [
-            "AC",
-            "AS",
-            "SY",
+            # just append to the fields defined as lists, not to strings
             "RX",
             "WW",
             "CC",
@@ -183,8 +187,6 @@ def __read(handle):
             "OX",
             "HI",
             "OI",
-            "SX",
-            "CA",
         ]:
             record[key].append(value)
         elif key == "DR":

--- a/Bio/ExPASy/cellosaurus.py
+++ b/Bio/ExPASy/cellosaurus.py
@@ -87,27 +87,28 @@ class Record(dict):
 
     Each record contains the following keys:
 
-     ---------  ------------------------------  -----------------------
-     Line code  Content                         Occurrence in an entry
-     ---------  ------------------------------  -----------------------
-     ID         Identifier (cell line name)     Once; starts an entry
-     AC         Accession (CVCL_xxxx)           Once
-     AS         Secondary accession number(s)   Optional; once
-     SY         Synonyms                        Optional; once
-     DR         Cross-references                Optional; once or more
-     RX         References identifiers          Optional: once or more
-     WW         Web pages                       Optional; once or more
-     CC         Comments                        Optional; once or more
-     ST         STR profile data                Optional; twice or more
-     DI         Diseases                        Optional; once or more
-     OX         Species of origin               Once or more
-     HI         Hierarchy                       Optional; once or more
-     OI         Originate from same individual  Optional; once or more
-     SX         Sex of cell                     Optional; once
-     AG         Age of donor at sampling        Optional; once
-     CA         Category                        Once
-     DT         Date (entry history)            Once
-     //         Terminator                      Once; ends an entry
+    =========  ==============================  =======================
+    Line code  Content                         Occurrence in an entry
+    =========  ==============================  =======================
+    ID         Identifier (cell line name)     Once; starts an entry
+    AC         Accession (CVCL_xxxx)           Once
+    AS         Secondary accession number(s)   Optional; once
+    SY         Synonyms                        Optional; once
+    DR         Cross-references                Optional; once or more
+    RX         References identifiers          Optional: once or more
+    WW         Web pages                       Optional; once or more
+    CC         Comments                        Optional; once or more
+    ST         STR profile data                Optional; twice or more
+    DI         Diseases                        Optional; once or more
+    OX         Species of origin               Once or more
+    HI         Hierarchy                       Optional; once or more
+    OI         Originate from same individual  Optional; once or more
+    SX         Sex of cell                     Optional; once
+    AG         Age of donor at sampling        Optional; once
+    CA         Category                        Once
+    DT         Date (entry history)            Once
+    //         Terminator                      Once; ends an entry
+    =========  ==============================  =======================
 
     """
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -191,6 +191,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - João D Ferreira <https://github.com/jdferreira>
 - João Rodrigues <https://github.com/joaorodrigues>
 - João Vitor F Cavalcante <https://github.com/jvfe>
+- Judith Bernett <https://github.com/JudithBernett>
 - Jun Aruga <https://github.com/junaruga>
 - Juraj Szász <https:/github.com/sars1492>
 - Kai Blin <https://github.com/kblin>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -77,6 +77,7 @@ possible, especially the following contributors:
 
 - Anil Tuncel (first contribution)
 - Fabio Zanini (first contribution)
+- Judith Bernett (first contribution)
 - Michael M. (first contribution)
 - Michiel de Hoon
 - Peter Cock

--- a/Tests/Cellosaurus/cell_lines_1.txt
+++ b/Tests/Cellosaurus/cell_lines_1.txt
@@ -1,14 +1,22 @@
 ID   #15310-LN
 AC   CVCL_E548
-SY   15310-LN; TER461
+SY   15310-LN; TER461; TER-461; Ter 461; TER479; TER-479; Ter 479; Extract 519
 DR   dbMHC; 48439
 DR   ECACC; 94050311
-DR   IHW; IHW9326
-DR   IMGT/HLA; 10074
-WW   http://bioinformatics.hsanmartino.it/ecbr/cl326.html
+DR   IHW; IHW09326
+DR   IPD-IMGT/HLA; 10074
+DR   Wikidata; Q54398957
+WW   http://pathology.ucla.edu/workfiles/360cx.pdf
+WW   http://pathology.ucla.edu/workfiles/370cx.pdf
 CC   Part of: 12th International Histocompatibility Workshop (12IHW) cell line panel.
-CC   Transformant: EBV.
-OX   NCBI_TaxID=9606; ! Homo sapiens
+CC   Population: Caucasian; French Canadian.
+CC   HLA typing: A*03,25; B*37:01:01:01,47:01:01:03; C*06; DPA1*01; DPB1*04:01:01; DQA1*01:01:01:01,01:03:01; DQB1*05:01:01;06:03:01:02; DRB1*01:01:01,14:17; DRB3*01:01 (IPD-IMGT/HLA=10074).
+CC   Transformant: NCBI_TaxID; 10376; Epstein-Barr virus (EBV).
+CC   Derived from site: In situ; Peripheral blood; UBERON=UBERON_0000178.
+CC   Cell type: B-cell; CL=CL_0000236.
+OX   NCBI_TaxID=9606; ! Homo sapiens (Human)
 SX   Female
+AG   Age unspecified
 CA   Transformed cell line
+DT   Created: 22-10-12; Last updated: 30-01-24; Version: 18
 //

--- a/Tests/Cellosaurus/cell_lines_2.txt
+++ b/Tests/Cellosaurus/cell_lines_2.txt
@@ -1,28 +1,54 @@
 ID   XP3OS
 AC   CVCL_3245
 AS   CVCL_F511
-SY   XP30S; GM04314
+SY   Xeroderma Pigmentosum 3 OSaka; GM04314; GM04314B; GM4314
 DR   CLO; CLO_0019557
 DR   Coriell; GM04314
+DR   GEO; GSM1338611
 DR   JCRB; JCRB0303
 DR   JCRB; KURB1002
 DR   JCRB; KURB1003
 DR   JCRB; KURB1004
+DR   Wikidata; Q54994928
+RX   CelloPub=CLPUB00447;
+RX   PubMed=832273;
 RX   PubMed=1372102;
-ST   Source(s): JCRB
+RX   PubMed=1702221;
+RX   PubMed=2570806;
+RX   PubMed=7000335;
+RX   PubMed=7830260;
+RX   PubMed=9671271;
+RX   PubMed=27197874;
+CC   Population: Japanese.
+CC   Sequence variation: Mutation; HGNC; 12814; XPA; Simple; c.390-1G>C (IVS3-1G>C); ClinVar=VCV000264684; Zygosity=Homozygous; Note=Splice acceptor mutation (PubMed=1702221; PubMed=9671271; PubMed=27197874).
+CC   Omics: Deep exome analysis.
+CC   Misspelling: XP30S; Note=Occasionally.
+CC   Derived from site: In situ; Skin; UBERON=UBERON_0002097.
+CC   Cell type: Fibroblast of skin; CL=CL_0002620.
+ST   Source(s): JCRB; PubMed=27197874
 ST   Amelogenin: X
 ST   CSF1PO: 10,11
 ST   D13S317: 9,11
 ST   D16S539: 9,12
+ST   D18S51: 13
+ST   D21S11: 29,30
+ST   D3S1358: 15,16
 ST   D5S818: 10,11
 ST   D7S820: 11,12
+ST   D8S1179: 13,15
+ST   FGA: 22,23
+ST   Penta D: 9
+ST   Penta E: 14,17
 ST   TH01: 7
 ST   TPOX: 8,11
 ST   vWA: 14,16
 DI   NCIt; C3965; Xeroderma pigmentosum, complementation group A
-OX   NCBI_TaxID=9606; ! Homo sapiens
+DI   ORDO; Orphanet_910; Xeroderma pigmentosum
+OX   NCBI_TaxID=9606; ! Homo sapiens (Human)
 SX   Female
+AG   5Y
 CA   Finite cell line
+DT   Created: 04-04-12; Last updated: 29-06-23; Version: 20
 //
 ID   1-5c-4
 AC   CVCL_2260
@@ -37,12 +63,18 @@ DR   BioSample; SAMN03151673
 DR   ECACC; 88021103
 DR   IZSLER; BS CL 93
 DR   KCLB; 10020.2
+DR   Wikidata; Q54399838
+RX   DOI=10.1007/BF02618370;
 RX   PubMed=566722;
 RX   PubMed=19630270;
 RX   PubMed=20143388;
-WW   http://iclac.org/wp-content/uploads/Cross-Contaminations-v7_2.pdf
-CC   Problematic cell line: Contaminated. Shown to be a HeLa derivative (PubMed 566722, PubMed 20143388).
-CC   Omics: Transcriptome analysis.
+WW   https://iclac.org/wp-content/uploads/Cross-Contaminations_v12_distribution.xlsx
+CC   Problematic cell line: Contaminated. Shown to be a HeLa derivative (PubMed=566722; PubMed=20143388). Originally thought to originate from the conjunctiva of a child.
+CC   Registration: International Cell Line Authentication Committee, Register of Misidentified Cell Lines; ICLAC-00298.
+CC   Population: African American.
+CC   Transformant: NCBI_TaxID; 333761; Human papillomavirus type 18 (HPV18).
+CC   Omics: Transcriptome analysis by microarray.
+CC   Derived from site: In situ; Uterus, cervix; UBERON=UBERON_0000002.
 ST   Source(s): ATCC; KCLB
 ST   Amelogenin: X
 ST   CSF1PO: 9,10
@@ -55,9 +87,11 @@ ST   FGA: 18,21
 ST   TH01: 7
 ST   TPOX: 8,12
 ST   vWA: 16,18
-DI   NCIt; C4029; Cervical adenocarcinoma
-OX   NCBI_TaxID=9606; ! Homo sapiens
+DI   NCIt; C27677; Human papillomavirus-related cervical adenocarcinoma
+OX   NCBI_TaxID=9606; ! Homo sapiens (Human)
 HI   CVCL_0030 ! HeLa
 SX   Female
+AG   30Y6M
 CA   Cancer cell line
+DT   Created: 04-04-12; Last updated: 05-10-23; Version: 25
 //

--- a/Tests/Cellosaurus/cell_lines_3.txt
+++ b/Tests/Cellosaurus/cell_lines_3.txt
@@ -2,8 +2,18 @@ ID   ZZ-R 127
 AC   CVCL_5418
 SY   ZZ-R
 DR   CCLV; CCLV-RIE 0127
+DR   Wikidata; Q54996143
 RX   PubMed=19656987;
 RX   PubMed=19941903;
-OX   NCBI_TaxID=9925; ! Capra hircus
+RX   PubMed=26082457;
+RX   PubMed=27795464;
+RX   PubMed=32851014;
+RX   PubMed=34737324;
+CC   Virology: Susceptible to infection by foot-and-mouth disease virus.
+CC   Derived from site: In situ; Fetal oral cavity, tongue; UBERON=UBERON_0010056.
+OX   NCBI_TaxID=9925; ! Capra hircus (Goat)
+SX   Sex unspecified
+AG   Fetus
 CA   Spontaneously immortalized cell line
+DT   Created: 04-04-12; Last updated: 29-06-23; Version: 15
 //

--- a/Tests/test_cellosaurus.py
+++ b/Tests/test_cellosaurus.py
@@ -17,23 +17,46 @@ class TestCellosaurus(unittest.TestCase):
             record = cellosaurus.read(handle)
         self.assertEqual(record["ID"], "#15310-LN")
         self.assertEqual(record["AC"], "CVCL_E548")
-        self.assertEqual(record["SY"], "15310-LN; TER461")
+        self.assertEqual(record["SY"], "15310-LN; TER461; TER-461; Ter 461; TER479; TER-479; Ter 479; Extract 519")
         self.assertEqual(record["DR"][0], ("dbMHC", "48439"))
         self.assertEqual(record["DR"][1], ("ECACC", "94050311"))
-        self.assertEqual(record["DR"][2], ("IHW", "IHW9326"))
-        self.assertEqual(record["DR"][3], ("IMGT/HLA", "10074"))
+        self.assertEqual(record["DR"][2], ("IHW", "IHW09326"))
+        self.assertEqual(record["DR"][3], ("IPD-IMGT/HLA", "10074"))
+        self.assertEqual(record["DR"][4], ("Wikidata", "Q54398957"))
         self.assertEqual(
-            record["WW"][0], "http://bioinformatics.hsanmartino.it/ecbr/cl326.html"
+            record["WW"][0], "http://pathology.ucla.edu/workfiles/360cx.pdf"
+        )
+        self.assertEqual(
+            record["WW"][1], "http://pathology.ucla.edu/workfiles/370cx.pdf"
         )
         self.assertEqual(
             record["CC"][0],
             "Part of: 12th International Histocompatibility Workshop (12IHW) "
             "cell line panel.",
         )
-        self.assertEqual(record["CC"][1], "Transformant: EBV.")
-        self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens")
+        self.assertEqual(
+            record["CC"][1],
+            "Population: Caucasian; French Canadian."
+        )
+        self.assertEqual(
+            record["CC"][2],
+            "HLA typing: A*03,25; B*37:01:01:01,47:01:01:03; C*06; DPA1*01; DPB1*04:01:01; DQA1*01:01:01:01,"
+            "01:03:01; DQB1*05:01:01;06:03:01:02; DRB1*01:01:01,14:17; DRB3*01:01 (IPD-IMGT/HLA=10074)."
+        )
+        self.assertEqual(record["CC"][3], "Transformant: NCBI_TaxID; 10376; Epstein-Barr virus (EBV).")
+        self.assertEqual(
+            record["CC"][4],
+            "Derived from site: In situ; Peripheral blood; UBERON=UBERON_0000178."
+        )
+        self.assertEqual(
+            record["CC"][5],
+            "Cell type: B-cell; CL=CL_0000236."
+        )
+        self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens (Human)")
         self.assertEqual(record["SX"], "Female")
+        self.assertEqual(record["AG"], "Age unspecified")
         self.assertEqual(record["CA"], "Transformed cell line")
+        self.assertEqual(record["DT"], "Created: 22-10-12; Last updated: 30-01-24; Version: 18")
 
     def test_parse(self):
         """Test parsing function."""
@@ -43,32 +66,57 @@ class TestCellosaurus(unittest.TestCase):
             self.assertEqual(record["ID"], "XP3OS")
             self.assertEqual(record["AC"], "CVCL_3245")
             self.assertEqual(record["AS"], "CVCL_F511")
-            self.assertEqual(record["SY"], "XP30S; GM04314")
+            self.assertEqual(record["SY"], "Xeroderma Pigmentosum 3 OSaka; GM04314; GM04314B; GM4314")
             self.assertEqual(record["DR"][0], ("CLO", "CLO_0019557"))
             self.assertEqual(record["DR"][1], ("Coriell", "GM04314"))
-            self.assertEqual(record["DR"][2], ("JCRB", "JCRB0303"))
-            self.assertEqual(record["DR"][3], ("JCRB", "KURB1002"))
-            self.assertEqual(record["DR"][4], ("JCRB", "KURB1003"))
-            self.assertEqual(record["DR"][5], ("JCRB", "KURB1004"))
-            self.assertEqual(record["RX"][0], "PubMed=1372102;")
-            self.assertEqual(len(record["ST"]), 10)
-            self.assertEqual(record["ST"][0], "Source(s): JCRB")
+            self.assertEqual(record["DR"][2], ("GEO", "GSM1338611"))
+            self.assertEqual(record["DR"][3], ("JCRB", "JCRB0303"))
+            self.assertEqual(record["DR"][4], ("JCRB", "KURB1002"))
+            self.assertEqual(record["DR"][5], ("JCRB", "KURB1003"))
+            self.assertEqual(record["DR"][6], ("JCRB", "KURB1004"))
+            self.assertEqual(record["DR"][7], ("Wikidata", "Q54994928"))
+            self.assertEqual(record["RX"][0], "CelloPub=CLPUB00447;")
+            self.assertEqual(record["RX"][1], "PubMed=832273;")
+            self.assertEqual(record["RX"][2], "PubMed=1372102;")
+            self.assertEqual(record["RX"][3], "PubMed=1702221;")
+            self.assertEqual(record["RX"][4], "PubMed=2570806;")
+            self.assertEqual(record["RX"][5], "PubMed=7000335;")
+            self.assertEqual(record["RX"][6], "PubMed=7830260;")
+            self.assertEqual(record["RX"][7], "PubMed=9671271;")
+            self.assertEqual(record["RX"][8], "PubMed=27197874;")
+            self.assertEqual(len(record["CC"]), 6)
+            self.assertEqual(len(record["ST"]), 17)
+            self.assertEqual(record["ST"][0], "Source(s): JCRB; PubMed=27197874")
             self.assertEqual(record["ST"][1], "Amelogenin: X")
             self.assertEqual(record["ST"][2], "CSF1PO: 10,11")
             self.assertEqual(record["ST"][3], "D13S317: 9,11")
             self.assertEqual(record["ST"][4], "D16S539: 9,12")
-            self.assertEqual(record["ST"][5], "D5S818: 10,11")
-            self.assertEqual(record["ST"][6], "D7S820: 11,12")
-            self.assertEqual(record["ST"][7], "TH01: 7")
-            self.assertEqual(record["ST"][8], "TPOX: 8,11")
-            self.assertEqual(record["ST"][9], "vWA: 14,16")
+            self.assertEqual(record["ST"][5], "D18S51: 13")
+            self.assertEqual(record["ST"][6], "D21S11: 29,30")
+            self.assertEqual(record["ST"][7], "D3S1358: 15,16")
+            self.assertEqual(record["ST"][8], "D5S818: 10,11")
+            self.assertEqual(record["ST"][9], "D7S820: 11,12")
+            self.assertEqual(record["ST"][10], "D8S1179: 13,15")
+            self.assertEqual(record["ST"][11], "FGA: 22,23")
+            self.assertEqual(record["ST"][12], "Penta D: 9")
+            self.assertEqual(record["ST"][13], "Penta E: 14,17")
+            self.assertEqual(record["ST"][14], "TH01: 7")
+            self.assertEqual(record["ST"][15], "TPOX: 8,11")
+            self.assertEqual(record["ST"][16], "vWA: 14,16")
             self.assertEqual(
                 record["DI"][0],
                 "NCIt; C3965; Xeroderma pigmentosum, complementation group A",
             )
-            self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens")
+            self.assertEqual(
+                record["DI"][1],
+                "ORDO; Orphanet_910; Xeroderma pigmentosum",
+            )
+            self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens (Human)")
             self.assertEqual(record["SX"], "Female")
+            self.assertEqual(record["AG"], "5Y")
             self.assertEqual(record["CA"], "Finite cell line")
+            self.assertEqual(record["DT"], "Created: 04-04-12; Last updated: 29-06-23; Version: 20")
+
             record = next(records)
             self.assertEqual(record["ID"], "1-5c-4")
             self.assertEqual(record["AC"], "CVCL_2260")
@@ -77,7 +125,7 @@ class TestCellosaurus(unittest.TestCase):
                 "Clone 1-5c-4; Clone 1-5c-4 WKD of Chang Conjunctiva; "
                 "Wong-Kilbourne derivative of Chang conjunctiva; ChWK",
             )
-            self.assertEqual(len(record["DR"]), 10)
+            self.assertEqual(len(record["DR"]), 11)
             self.assertEqual(record["DR"][0], ("CLO", "CLO_0002500"))
             self.assertEqual(record["DR"][1], ("CLO", "CLO_0002501"))
             self.assertEqual(record["DR"][2], ("CLDB", "cl793"))
@@ -88,19 +136,22 @@ class TestCellosaurus(unittest.TestCase):
             self.assertEqual(record["DR"][7], ("ECACC", "88021103"))
             self.assertEqual(record["DR"][8], ("IZSLER", "BS CL 93"))
             self.assertEqual(record["DR"][9], ("KCLB", "10020.2"))
-            self.assertEqual(record["RX"][0], "PubMed=566722;")
-            self.assertEqual(record["RX"][1], "PubMed=19630270;")
-            self.assertEqual(record["RX"][2], "PubMed=20143388;")
+            self.assertEqual(record["DR"][10], ("Wikidata", "Q54399838"))
+            self.assertEqual(record["RX"][0], "DOI=10.1007/BF02618370;")
+            self.assertEqual(record["RX"][1], "PubMed=566722;")
+            self.assertEqual(record["RX"][2], "PubMed=19630270;")
+            self.assertEqual(record["RX"][3], "PubMed=20143388;")
             self.assertEqual(
                 record["WW"][0],
-                "http://iclac.org/wp-content/uploads/Cross-Contaminations-v7_2.pdf",
+                "https://iclac.org/wp-content/uploads/Cross-Contaminations_v12_distribution.xlsx",
             )
+            self.assertEqual(len(record["CC"]), 6)
             self.assertEqual(
                 record["CC"][0],
-                "Problematic cell line: Contaminated. "
-                "Shown to be a HeLa derivative (PubMed 566722, PubMed 20143388).",
+                "Problematic cell line: Contaminated. Shown to be a HeLa derivative (PubMed=566722; PubMed=20143388). "
+                "Originally thought to originate from the conjunctiva of a child.",
             )
-            self.assertEqual(record["CC"][1], "Omics: Transcriptome analysis.")
+            self.assertEqual(record["CC"][1], "Registration: International Cell Line Authentication Committee, Register of Misidentified Cell Lines; ICLAC-00298.")
             self.assertEqual(record["ST"][0], "Source(s): ATCC; KCLB")
             self.assertEqual(record["ST"][1], "Amelogenin: X")
             self.assertEqual(record["ST"][2], "CSF1PO: 9,10")
@@ -113,11 +164,13 @@ class TestCellosaurus(unittest.TestCase):
             self.assertEqual(record["ST"][9], "TH01: 7")
             self.assertEqual(record["ST"][10], "TPOX: 8,12")
             self.assertEqual(record["ST"][11], "vWA: 16,18")
-            self.assertEqual(record["DI"][0], "NCIt; C4029; Cervical adenocarcinoma")
-            self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens")
+            self.assertEqual(record["DI"][0], "NCIt; C27677; Human papillomavirus-related cervical adenocarcinoma")
+            self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens (Human)")
             self.assertEqual(record["HI"][0], "CVCL_0030 ! HeLa")
             self.assertEqual(record["SX"], "Female")
+            self.assertEqual(record["AG"], "30Y6M")
             self.assertEqual(record["CA"], "Cancer cell line")
+            self.assertEqual(record["DT"], "Created: 04-04-12; Last updated: 05-10-23; Version: 25")
             self.assertRaises(StopIteration, next, records)
 
     def test__str__(self):
@@ -125,10 +178,12 @@ class TestCellosaurus(unittest.TestCase):
         with open("Cellosaurus/cell_lines_3.txt") as handle:
             record = cellosaurus.read(handle)
         text = (
-            "ID: ZZ-R 127 AC: CVCL_5418 AS:  SY: ZZ-R DR: [('CCLV', 'CCLV-RIE 0127')] "
-            "RX: ['PubMed=19656987;', 'PubMed=19941903;'] WW: [] CC: [] ST: [] DI: [] "
-            "OX: ['NCBI_TaxID=9925; ! Capra hircus'] HI: [] OI: [] SX:  CA: "
-            "Spontaneously immortalized cell line"
+            "ID: ZZ-R 127 AC: CVCL_5418 AS:  SY: ZZ-R DR: [('CCLV', 'CCLV-RIE 0127'), ('Wikidata', 'Q54996143')] RX: "
+            "['PubMed=19656987;', 'PubMed=19941903;', 'PubMed=26082457;', 'PubMed=27795464;', 'PubMed=32851014;', "
+            "'PubMed=34737324;'] WW: [] CC: ['Virology: Susceptible to infection by foot-and-mouth disease virus.', "
+            "'Derived from site: In situ; Fetal oral cavity, tongue; UBERON=UBERON_0010056.'] ST: [] DI: [] OX: ["
+            "'NCBI_TaxID=9925; ! Capra hircus (Goat)'] HI: [] OI: [] SX: Sex unspecified AG: Fetus CA: Spontaneously "
+            "immortalized cell line DT: Created: 04-04-12; Last updated: 29-06-23; Version: 15"
         )
         self.assertEqual(str(record), text)
 

--- a/Tests/test_cellosaurus.py
+++ b/Tests/test_cellosaurus.py
@@ -17,7 +17,10 @@ class TestCellosaurus(unittest.TestCase):
             record = cellosaurus.read(handle)
         self.assertEqual(record["ID"], "#15310-LN")
         self.assertEqual(record["AC"], "CVCL_E548")
-        self.assertEqual(record["SY"], "15310-LN; TER461; TER-461; Ter 461; TER479; TER-479; Ter 479; Extract 519")
+        self.assertEqual(
+            record["SY"],
+            "15310-LN; TER461; TER-461; Ter 461; TER479; TER-479; Ter 479; Extract 519",
+        )
         self.assertEqual(record["DR"][0], ("dbMHC", "48439"))
         self.assertEqual(record["DR"][1], ("ECACC", "94050311"))
         self.assertEqual(record["DR"][2], ("IHW", "IHW09326"))
@@ -34,29 +37,28 @@ class TestCellosaurus(unittest.TestCase):
             "Part of: 12th International Histocompatibility Workshop (12IHW) "
             "cell line panel.",
         )
-        self.assertEqual(
-            record["CC"][1],
-            "Population: Caucasian; French Canadian."
-        )
+        self.assertEqual(record["CC"][1], "Population: Caucasian; French Canadian.")
         self.assertEqual(
             record["CC"][2],
             "HLA typing: A*03,25; B*37:01:01:01,47:01:01:03; C*06; DPA1*01; DPB1*04:01:01; DQA1*01:01:01:01,"
-            "01:03:01; DQB1*05:01:01;06:03:01:02; DRB1*01:01:01,14:17; DRB3*01:01 (IPD-IMGT/HLA=10074)."
+            "01:03:01; DQB1*05:01:01;06:03:01:02; DRB1*01:01:01,14:17; DRB3*01:01 (IPD-IMGT/HLA=10074).",
         )
-        self.assertEqual(record["CC"][3], "Transformant: NCBI_TaxID; 10376; Epstein-Barr virus (EBV).")
+        self.assertEqual(
+            record["CC"][3],
+            "Transformant: NCBI_TaxID; 10376; Epstein-Barr virus (EBV).",
+        )
         self.assertEqual(
             record["CC"][4],
-            "Derived from site: In situ; Peripheral blood; UBERON=UBERON_0000178."
+            "Derived from site: In situ; Peripheral blood; UBERON=UBERON_0000178.",
         )
-        self.assertEqual(
-            record["CC"][5],
-            "Cell type: B-cell; CL=CL_0000236."
-        )
+        self.assertEqual(record["CC"][5], "Cell type: B-cell; CL=CL_0000236.")
         self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens (Human)")
         self.assertEqual(record["SX"], "Female")
         self.assertEqual(record["AG"], "Age unspecified")
         self.assertEqual(record["CA"], "Transformed cell line")
-        self.assertEqual(record["DT"], "Created: 22-10-12; Last updated: 30-01-24; Version: 18")
+        self.assertEqual(
+            record["DT"], "Created: 22-10-12; Last updated: 30-01-24; Version: 18"
+        )
 
     def test_parse(self):
         """Test parsing function."""
@@ -66,7 +68,9 @@ class TestCellosaurus(unittest.TestCase):
             self.assertEqual(record["ID"], "XP3OS")
             self.assertEqual(record["AC"], "CVCL_3245")
             self.assertEqual(record["AS"], "CVCL_F511")
-            self.assertEqual(record["SY"], "Xeroderma Pigmentosum 3 OSaka; GM04314; GM04314B; GM4314")
+            self.assertEqual(
+                record["SY"], "Xeroderma Pigmentosum 3 OSaka; GM04314; GM04314B; GM4314"
+            )
             self.assertEqual(record["DR"][0], ("CLO", "CLO_0019557"))
             self.assertEqual(record["DR"][1], ("Coriell", "GM04314"))
             self.assertEqual(record["DR"][2], ("GEO", "GSM1338611"))
@@ -115,7 +119,9 @@ class TestCellosaurus(unittest.TestCase):
             self.assertEqual(record["SX"], "Female")
             self.assertEqual(record["AG"], "5Y")
             self.assertEqual(record["CA"], "Finite cell line")
-            self.assertEqual(record["DT"], "Created: 04-04-12; Last updated: 29-06-23; Version: 20")
+            self.assertEqual(
+                record["DT"], "Created: 04-04-12; Last updated: 29-06-23; Version: 20"
+            )
 
             record = next(records)
             self.assertEqual(record["ID"], "1-5c-4")
@@ -151,7 +157,10 @@ class TestCellosaurus(unittest.TestCase):
                 "Problematic cell line: Contaminated. Shown to be a HeLa derivative (PubMed=566722; PubMed=20143388). "
                 "Originally thought to originate from the conjunctiva of a child.",
             )
-            self.assertEqual(record["CC"][1], "Registration: International Cell Line Authentication Committee, Register of Misidentified Cell Lines; ICLAC-00298.")
+            self.assertEqual(
+                record["CC"][1],
+                "Registration: International Cell Line Authentication Committee, Register of Misidentified Cell Lines; ICLAC-00298.",
+            )
             self.assertEqual(record["ST"][0], "Source(s): ATCC; KCLB")
             self.assertEqual(record["ST"][1], "Amelogenin: X")
             self.assertEqual(record["ST"][2], "CSF1PO: 9,10")
@@ -164,13 +173,18 @@ class TestCellosaurus(unittest.TestCase):
             self.assertEqual(record["ST"][9], "TH01: 7")
             self.assertEqual(record["ST"][10], "TPOX: 8,12")
             self.assertEqual(record["ST"][11], "vWA: 16,18")
-            self.assertEqual(record["DI"][0], "NCIt; C27677; Human papillomavirus-related cervical adenocarcinoma")
+            self.assertEqual(
+                record["DI"][0],
+                "NCIt; C27677; Human papillomavirus-related cervical adenocarcinoma",
+            )
             self.assertEqual(record["OX"][0], "NCBI_TaxID=9606; ! Homo sapiens (Human)")
             self.assertEqual(record["HI"][0], "CVCL_0030 ! HeLa")
             self.assertEqual(record["SX"], "Female")
             self.assertEqual(record["AG"], "30Y6M")
             self.assertEqual(record["CA"], "Cancer cell line")
-            self.assertEqual(record["DT"], "Created: 04-04-12; Last updated: 05-10-23; Version: 25")
+            self.assertEqual(
+                record["DT"], "Created: 04-04-12; Last updated: 05-10-23; Version: 25"
+            )
             self.assertRaises(StopIteration, next, records)
 
     def test__str__(self):


### PR DESCRIPTION
Also fixed a "bug" that would never occur since the fields just occur once per entry. In this bug, the reader would try to append to a field defined as string, which is not possible as append can just be called on lists.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [ x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4323 - now able to parse all fields, including the age (AG) and date (DT) fields. 
I've also fixed a "bug" that would never occur since the fields in question just occur once per entry. In this bug, the reader would try to append to a field defined as a string, which is impossible because append can only be called on lists.
