### PR TITLE
Make SeqIO's import of MultipleSeqAlignment lazy.

### DIFF
--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2006-2018 by Peter Cock.  All rights reserved.
+# Copyright 2006-2024 by Peter Cock.  All rights reserved.
 # This file is part of the Biopython distribution and governed by your
 # choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
 # Please see the LICENSE file that should have been included as part of this
@@ -374,7 +374,6 @@ making up each alignment as SeqRecords.
 
 from typing import Callable, Dict, Iterable, Union
 
-from Bio.Align import MultipleSeqAlignment
 from Bio.File import as_handle
 from Bio.SeqIO import AbiIO
 from Bio.SeqIO import AceIO
@@ -540,6 +539,9 @@ def write(
     if format in AlignIO._FormatToWriter:
         # Try and turn all the records into a single alignment,
         # and write that using Bio.AlignIO
+        # Using a lazy import as most users won't need this loaded:
+        from Bio.Align import MultipleSeqAlignment
+
         alignment = MultipleSeqAlignment(sequences)
         alignment_count = AlignIO.write([alignment], handle, format)
         if alignment_count != 1:


### PR DESCRIPTION
If the file system is being slow (e.g. our cluster under heavy load), then the overhead of importing MultipleSeqAlignment from Bio.Align is noticeable if using Bio.SeqIO - but it is rarely needed.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

