### PR TITLE
Add method to resolve polytomies in Phylo.BaseTree

### DIFF
--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -720,6 +720,51 @@ class TreeMixin:
             clade = clade_cls(name=base_name + str(i), branch_length=branch_length)
             self.root.clades.append(clade)
 
+    def resolve_polytomies(self, shuffle=False, recursive=True):
+        """Resolve polytomies/multifurcations into zero-length bifurcations.
+
+        Polytomies are nodes with more than two child nodes. Some tools expect
+        trees to be strictly bifurcating. This function converts polytomies
+        into a series of bifurcations with branch length of zero.
+
+        :Parameters:
+            shuffle : bool
+                Randomly shuffle the order of child nodes when creating
+                bifurcations; otherwise, add in the order encountered.
+            recursive : bool
+                Resolve polytomies in all descendant clades; otherwise resolve
+                this node only.
+        """
+        if recursive:
+            for clade in self.get_nonterminals():
+                if len(clade.clades) > 2:
+                    clade._resolve_polytomy(shuffle=shuffle)
+        else:
+            try:
+                self._resolve_polytomy(shuffle=shuffle)
+            except AttributeError as e:
+                # self is a Tree object, start from its root instead
+                self.root._resolve_polytomy(shuffle=shuffle)
+
+    def _resolve_polytomy(self, shuffle=False):
+        """Resolve single polytomy into zero-length bifurcations (PRIVATE)."""
+        children = self.clades[:]  # shallow copy
+        if shuffle:
+            random.shuffle(children)
+        self.clades = []
+
+        def _recurse_add_branch(node, to_add):
+            if len(to_add) == 2:
+                node.clades = to_add
+                return
+            else:
+                new_clade = Clade(branch_length=0.0)
+                node.clades.append(to_add[0])
+                node.clades.append(new_clade)
+                return _recurse_add_branch(new_clade, to_add[1:])
+
+        _recurse_add_branch(self, children)
+
 
 class Tree(TreeElement, TreeMixin):
     """A phylogenetic tree, containing global info for the phylogeny.

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -72,6 +72,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Brad Chapman <https://github.com/chapmanb>
 - Brandon Carter  <https://github.com/b-carter>
 - Brandon Invergo <https://github.com/brandoninvergo>
+- Brandon Seah <https://github.com/kbseah/>
 - Brian Osborne <https://github.com/bosborne>
 - Bryan Lunt <https://github.com/bryan-lunt>
 - Caio Fontes <https://github.com/Caiofcas>

--- a/Tests/test_Phylo.py
+++ b/Tests/test_Phylo.py
@@ -497,6 +497,15 @@ class MixinTests(unittest.TestCase):
             self.assertEqual(clade.name, name)
             self.assertEqual(clade.branch_length, blen)
 
+    def test_resolve_polytomies(self):
+        """TreeMixin: resolve_polytomies() method."""
+        tree = list(Phylo.parse(EX_NEXUS, "nexus"))[2]
+        # tree1 = (1,(2,(4,(5,6,(7,(8,(9,3)))))));
+        #                   ^ ^ ^ multifurcation
+        self.assertFalse(tree.is_bifurcating())
+        tree.resolve_polytomies(shuffle=False, recursive=True)
+        self.assertTrue(tree.is_bifurcating())
+
 
 # ---------------------------------------------------------
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Add a method to resolve polytomies (multifurcations) in phylogenetic trees, by converting them to a series of bifurcations with branch length zero. Some phylogenetic tools require strictly bifurcating trees, while others may produce polytomies (e.g. Fasttree); this gives users the option of resolving polytomies with a simple Biopython wrapper script.

A unit test has been added, which checks the output of `.is_bifurcating()` before and after applying the method. I also manually tested a few simple trees and checked the output visually.