### PR TITLE
Flipping origin-spanning locations with strand=None

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1641,7 +1641,7 @@ class CompoundLocation(Location):
     def _flip(self, length):
         """Return a copy of the locations after the parent is reversed (PRIVATE).
 
-        Note that the order of the parts is NOT reversed too. Consider a CDS
+        Note that the order of the parts is NOT reversed if strand!= None. Consider a CDS
         on the forward strand with exons small, medium and large (in length).
         Once we change the frame of reference to the reverse complement strand,
         the start codon is still part of the small exon, and the stop codon
@@ -1709,7 +1709,16 @@ class CompoundLocation(Location):
         versions of Biopython which would have given join{[5:29](-), [37:52](-)}
         and the translation would have wrongly been "EXAMPLE*SILLY" instead.
 
+        When strand is None, the parts are reversed. In principle this does not
+        change the meaning of the location, but improves the representation of
+        locations spanning the origin in circular molecules. For more details,
+        see https://github.com/biopython/biopython/issues/4611
+
         """
+        if all(loc.strand is None for loc in self.parts):
+            return CompoundLocation(
+                [loc._flip(length) for loc in self.parts[::-1]], self.operator
+            )
         return CompoundLocation(
             [loc._flip(length) for loc in self.parts], self.operator
         )

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -1641,11 +1641,13 @@ class CompoundLocation(Location):
     def _flip(self, length):
         """Return a copy of the locations after the parent is reversed (PRIVATE).
 
-        Note that the order of the parts is NOT reversed if strand!= None. Consider a CDS
-        on the forward strand with exons small, medium and large (in length).
-        Once we change the frame of reference to the reverse complement strand,
-        the start codon is still part of the small exon, and the stop codon
-        still part of the large exon - so the part order remains the same!
+        Note that the order of the parts is NOT reversed unless all parts
+        have strand=None, since the order has meaning for stranded features.
+        Consider a CDS on the forward strand with exons small, medium
+        and large (in length). Once we change the frame of reference
+        to the reverse complement strand, the start codon is still part of
+        the small exon, and the stop codon still part of the large exon -
+        so the part order remains the same!
 
         Here is an artificial example, were the features map to the two upper
         case regions and the lower case runs of n are not used:
@@ -1709,19 +1711,27 @@ class CompoundLocation(Location):
         versions of Biopython which would have given join{[5:29](-), [37:52](-)}
         and the translation would have wrongly been "EXAMPLE*SILLY" instead.
 
-        When strand is None, the parts are reversed. In principle this does not
-        change the meaning of the location, but improves the representation of
-        locations spanning the origin in circular molecules. For more details,
-        see https://github.com/biopython/biopython/issues/4611
+        When all the parts have strand None, the order of the parts is reversed.
+        In principle this does not change the meaning of the location, but improves
+        the representation of feature locations spanning the origin in circular
+        molecules.
 
+        >>> loc = SimpleLocation(4, 6, None) + SimpleLocation(0, 1, None)
+        >>> print(loc)
+        join{[4:6], [0:1]}
+        >>> print(loc._flip(6))
+        join{[5:6], [0:2]}
+
+        join{[0:2], [5:6]} would not be properly represented in SnapGene, Benchling, etc.
         """
         if all(loc.strand is None for loc in self.parts):
             return CompoundLocation(
                 [loc._flip(length) for loc in self.parts[::-1]], self.operator
             )
-        return CompoundLocation(
-            [loc._flip(length) for loc in self.parts], self.operator
-        )
+        else:
+            return CompoundLocation(
+                [loc._flip(length) for loc in self.parts], self.operator
+            )
 
     @property
     def start(self):

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -80,6 +80,10 @@ The UniProt package now includes a method to search UniProt programmatically.
 The tutorial has been updated with examples of how to use the search method.
 See the chapter on Swiss-Prot and ExPASy in the tutorial for more information.
 
+Now when "flipping" compound locations with ``_flip()`` in ``Bio.SeqFeature``,
+if the strand is ``None``, the order of the sublocations is reversed, to improve
+the representation of origin-spanning locations. See issue #4611.
+
 As in recent releases, more of our code is now explicitly available under
 either our original "Biopython License Agreement", or the very similar but
 more commonly used "3-Clause BSD License".  See the ``LICENSE.rst`` file for

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -80,8 +80,8 @@ The UniProt package now includes a method to search UniProt programmatically.
 The tutorial has been updated with examples of how to use the search method.
 See the chapter on Swiss-Prot and ExPASy in the tutorial for more information.
 
-Now when "flipping" compound locations with ``_flip()`` in ``Bio.SeqFeature``,
-if the strand is ``None``, the order of the sublocations is reversed, to improve
+Now when reverse complementing a ``SeqRecord`` containing unstranded features
+with compound locations the order of the sublocations is reversed, to improve
 the representation of origin-spanning locations. See issue #4611.
 
 As in recent releases, more of our code is now explicitly available under

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -590,6 +590,18 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
             self.assertEqual(_get_location_string(f._flip(200), 200), "101..200")
             self.assertEqual(f._flip(100).location.strand, f.location.strand)
 
+        # Test for compound locations (see https://github.com/biopython/biopython/issues/4611)
+
+        # flip with +1/-1 strands does not invert the order in compound locations
+        loc = SimpleLocation(4, 6, 1) + SimpleLocation(0, 1, 1)
+        self.assertEqual(str(loc._flip(6)), "join{[0:2](-), [5:6](-)}")
+        loc = SimpleLocation(4, 6, -1) + SimpleLocation(0, 1, -1)
+        self.assertEqual(str(loc._flip(6)), "join{[0:2](+), [5:6](+)}")
+
+        # flip with None strand inverts the order in compound locations
+        loc = SimpleLocation(4, 6, None) + SimpleLocation(0, 1, None)
+        self.assertEqual(str(loc._flip(6)), "join{[5:6], [0:2]}")
+
     def test_between(self):
         """GenBank/EMBL write/read simple between locations."""
         # Note we don't use the BetweenPosition any more!


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4611
