### PR TITLE
Remove type annotations from strictly_equals methods in Bio.PDB

### DIFF
--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -267,7 +267,7 @@ class Atom:
         diff = self.coord - other.coord
         return np.sqrt(np.dot(diff, diff))
 
-    def strictly_equals(self, other: "Atom", compare_coordinates: bool = False) -> bool:
+    def strictly_equals(self, other, compare_coordinates: bool = False) -> bool:
         """Compare this atom to the other atom using a strict definition of equality.
 
         Indicates whether the atoms have the same name, B factor, occupancy,

--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -201,16 +201,14 @@ class Entity(Generic[_Parent, _Child]):
         self._id = value
         self._reset_full_id()
 
-    def strictly_equals(
-        self, other: "Entity", compare_coordinates: bool = False
-    ) -> bool:
+    def strictly_equals(self, other, compare_coordinates: bool = False) -> bool:
         """Compare this entity to the other entity for equality.
 
         Recursively compare the children of this entity to the other entity's children.
         Compare most properties including names and IDs.
 
         :param other: The entity to compare this entity with
-        :type other: Entity
+        :type other: Entity or Atom
         :param compare_coordinates: Whether to compare atomic coordinates
         :type compare_coordinates: bool
         :return: Whether the two entities are strictly equal

--- a/Bio/PDB/Residue.py
+++ b/Bio/PDB/Residue.py
@@ -43,9 +43,7 @@ class Residue(Entity["Chain", "Atom"]):
         full_id = (resname, hetflag, resseq, icode)
         return "<Residue %s het=%s resseq=%s icode=%s>" % full_id
 
-    def strictly_equals(
-        self, other: "Residue", compare_coordinates: bool = False
-    ) -> bool:
+    def strictly_equals(self, other, compare_coordinates: bool = False) -> bool:
         """Compare this residue to the other residue using a strict definition of equality.
 
         The residues are equal if they have the same name, identifier,


### PR DESCRIPTION
For some reason, all checks passed on #4593 but after merging mypy started complaining. The issue seems to be overloading `strictly_equals` in Entity subclasses (and in Atom.py) violates some typing rule. I cannot figure out a way to handle this, so I simply removed the type annotation from these methods..
