### PR TITLE
Feat/add bgzf typing

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -16,6 +16,9 @@ warn_redundant_casts = True
 #warn_return_any = True
 warn_unused_configs = True
 
+[mypy-Bio.bgzf]
+strict = True
+
 [mypy-Bio/PDB/*]
 disallow_incomplete_defs = False
 

--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -699,7 +699,8 @@ class BgzfReader(tp.Generic[_BufferT]):
         self._handle = handle
         self.max_cache = max_cache
         self._buffers: dict[int, tuple[_BufferT, int]] = {}
-        self._block_start_offset: int
+        # Is there a safe default for a non-`None` integer?
+        self._block_start_offset: int = None  # type: ignore[assignment]
         self._block_raw_length: int
         self._buffer: _BufferT
         self._load_block(handle.tell())


### PR DESCRIPTION
- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

---

As discussed in https://github.com/biopython/biopython/pull/4651#issuecomment-1980850966, this is a conversion of `Bio.bgzf` to [`--strict`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-strict) static typing. Setting this as a draft PR for feedback.

Part of this required making some runtime changes, which are done in the following commits:
 - https://github.com/biopython/biopython/commit/45fd6093d8c46bf186a04f9ddb7570caa1e5ea22
 - https://github.com/biopython/biopython/commit/a83311c47301f28b27b6884e602642f76f285d5a
 - https://github.com/biopython/biopython/commit/6fba8bb98302921e498f2e525c24d8ac1adf89a0
 - https://github.com/biopython/biopython/commit/79c981b8cb864bdfaeb0278dfd6f665a87b70c8b

I *believe* these taken together are fully compatible with the usage of the module as given by the specifications, but this needs thorough review.