### PR TITLE
In bigbed parsing, avoid copying data

### DIFF
--- a/Bio/Align/bigbed.py
+++ b/Bio/Align/bigbed.py
@@ -834,11 +834,17 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 data = stream.read(node.dataSize)
                 if self._compressed > 0:
                     data = zlib.decompress(data)
-                while data:
+                i = 0
+                n = len(data)
+                while i < n:
+                    j = i + size
                     child_chromIx, child_chromStart, child_chromEnd = formatter.unpack(
-                        data[:size]
+                        data[i:j]
                     )
-                    rest, data = data[size:].split(b"\00", 1)
+                    i = j
+                    j = data.index(b"\00", i)
+                    rest = data[i:j]
+                    i = j + 1
                     if child_chromIx != chromIx:
                         continue
                     if end <= child_chromStart or child_chromEnd <= start:


### PR DESCRIPTION
In Bio.Align.bigbed parsing, data chunks can be large, so avoid copying data as it wastes a lot of time.
See #4656 .

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

