### PR TITLE
Update PDBIO.py PDBIO.save with parameter write_ter

### DIFF
--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -294,7 +294,7 @@ class PDBIO(StructureIO):
             return _PQR_ATOM_FORMAT_STRING % args
 
     # Public methods
-    def save(self, file, select=_select, write_end=True, preserve_atom_numbering=False):
+    def save(self, file, select=_select, write_end=True, preserve_atom_numbering=False, write_ter = True):
         """Save structure to a file.
 
         :param file: output file
@@ -395,7 +395,7 @@ class PDBIO(StructureIO):
                             # inconsequential if preserve_atom_numbering is True
                             atom_number += 1
 
-                if chain_residues_written:
+                if chain_residues_written and write_ter:
                     fhandle.write(
                         _TER_FORMAT_STRING
                         % (atom_number, resname, chain_id, resseq, icode)


### PR DESCRIPTION
added write_ter = True as parameter of PDBIO.save to have a way to decide to get or not TER at the end of pdb 

corrected order of parameter in def save to have backward compatibility  

and 

As per the automated checks, style wise just use if chain_residues_written and write_ter:

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
