### PR TITLE
Enable ruff check --fix, and pre-commit.ci autofix PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     # Run the Ruff linter.
     -   id: ruff
         args: [
+            '--fix',
             '--extend-select=B,C4,D,ISC,UP',
             '--extend-ignore=E501,F401,F841,D105,D2,D4',
             '--extend-ignore=B007,B009,B010,B018,B028,B904,UP031',
@@ -90,7 +91,7 @@ repos:
         files: \.(rst|tex)$
 ci:
     # Settings for the https://pre-commit.ci/ continuous integration service
-    autofix_prs: false
+    autofix_prs: true
     # Default message is more verbose
     autoupdate_commit_msg: '[pre-commit.ci] autoupdate'
     # Default is weekly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,6 @@ repos:
     -   id: end-of-file-fixer
         files: \.py$
     -   id: mixed-line-ending
--   repo: https://github.com/psf/black
-    rev: 24.2.0
-    hooks:
-    -   id: black
-        args: [--check,--target-version,py38]
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.3.1
     hooks:
@@ -30,6 +25,11 @@ repos:
             '--extend-per-file-ignores=Tests/*.py:D101,Tests/*.py:D102,Tests/*.py:D103',
             '--extend-per-file-ignores=Tests/*.py:B015',
         ]
+-   repo: https://github.com/psf/black
+    rev: 24.2.0
+    hooks:
+    -   id: black
+        args: [--check,--target-version,py38]
 -   repo: https://github.com/PyCQA/flake8
     rev: 7.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,10 +24,12 @@ repos:
     # Run the Ruff linter.
     -   id: ruff
         args: [
-        '--extend-select=B,C4,D,ISC,UP',
-        '--extend-ignore=E501,F401,F841,D105,D2,D4,B007,B009,B010,B018,B028,B904,UP031',
-        '--extend-per-file-ignores=Tests/*.py:D101,Tests/*.py:D102,Tests/*.py:D103,Tests/*.py:B015',
-    ]
+            '--extend-select=B,C4,D,ISC,UP',
+            '--extend-ignore=E501,F401,F841,D105,D2,D4',
+            '--extend-ignore=B007,B009,B010,B018,B028,B904,UP031',
+            '--extend-per-file-ignores=Tests/*.py:D101,Tests/*.py:D102,Tests/*.py:D103',
+            '--extend-per-file-ignores=Tests/*.py:B015',
+        ]
 -   repo: https://github.com/PyCQA/flake8
     rev: 7.0.0
     hooks:


### PR DESCRIPTION
This means when run locally, ruff will apply fixes where possible. The order is changed so that black is now run afterwards for any style fix needed on top. I find this helpful when working at the command line.

Next, this will also happen on the pre-commit.ci service, and if changes are made it will update the associated pull request.

i.e. If anyone submits a minor edit on GitHub via their browser which doesn't follow the style checks, then their PR is automatically updated for them - very easy.

If you are working at the command line (or in an editor) with the pre-commit hook setup as per CONTRIBUTING.rst, again very little changes except you don't have to run black or ruff check by hand.

The only potential for surprise is if you bypass the pre-commit hooks: your online branch will have the fixes, leaving your local branch out of date. You would then have to pull the changes, or make equivalent fixes locally and force push your version online overriding the automatic fixes.

This will become more valuable if/when we include isort as per #4662 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
