### PR TITLE
Replace assorted flake8 plugins with ruff equivalents 

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -65,7 +65,6 @@ ignore =
     # by default... It is therefore recommended to use a stacklevel of
     # 2 or greater to provide more information to the user
     B902,
-    # blind except Exception: statement
     # =========================================
     # Optional ignores for local installations:
     # =========================================

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,21 +24,16 @@ repos:
     # Run the Ruff linter.
     -   id: ruff
         args: [
-        '--extend-select=D',
-        '--extend-ignore=E501,F401,F841,D105,D2,D4',
-        '--extend-per-file-ignores=Tests/*.py:D101,Tests/*.py:D102,Tests/*.py:D103',
+        '--extend-select=B,C4,D,ISC',
+        '--extend-ignore=E501,F401,F841,D105,D2,D4,B007,B009,B010,B018,B028,B904',
+        '--extend-per-file-ignores=Tests/*.py:D101,Tests/*.py:D102,Tests/*.py:D103,Tests/*.py:B015',
     ]
 -   repo: https://github.com/PyCQA/flake8
     rev: 7.0.0
     hooks:
     -   id: flake8
         additional_dependencies: [
-            'flake8-blind-except',
-            'flake8-bugbear',
-            'flake8-comprehensions',
-            'flake8-implicit-str-concat',
             'flake8-rst-docstrings>=0.2.3',
-            'pydocstyle>=6.0.0',
         ]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.8.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,8 +24,8 @@ repos:
     # Run the Ruff linter.
     -   id: ruff
         args: [
-        '--extend-select=B,C4,D,ISC',
-        '--extend-ignore=E501,F401,F841,D105,D2,D4,B007,B009,B010,B018,B028,B904',
+        '--extend-select=B,C4,D,ISC,UP',
+        '--extend-ignore=E501,F401,F841,D105,D2,D4,B007,B009,B010,B018,B028,B904,UP031',
         '--extend-per-file-ignores=Tests/*.py:D101,Tests/*.py:D102,Tests/*.py:D103,Tests/*.py:B015',
     ]
 -   repo: https://github.com/PyCQA/flake8

--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -229,9 +229,7 @@ class MMCIFParser:
                 # Non-existing residue ID
                 try:
                     msg_resseq = mmcif_dict["_atom_site.auth_seq_id"][i]
-                    msg = "Non-existing residue ID in chain '{}', residue '{}'".format(
-                        chainid, msg_resseq
-                    )
+                    msg = f"Non-existing residue ID in chain '{chainid}', residue '{msg_resseq}'"
                 except (KeyError, IndexError):
                     msg = f"Non-existing residue ID in chain '{chainid}'"
                 warnings.warn(
@@ -517,9 +515,7 @@ class FastMMCIFParser:
                 # Non-existing residue ID
                 try:
                     msg_resseq = mmcif_dict["_atom_site.auth_seq_id"][i]
-                    msg = "Non-existing residue ID in chain '{}', residue '{}'".format(
-                        chainid, msg_resseq
-                    )
+                    msg = f"Non-existing residue ID in chain '{chainid}', residue '{msg_resseq}'"
                 except (KeyError, IndexError):
                     msg = f"Non-existing residue ID in chain '{chainid}'"
                 warnings.warn(

--- a/Bio/PDB/PDBParser.py
+++ b/Bio/PDB/PDBParser.py
@@ -385,9 +385,7 @@ class PDBParser:
                 structure_builder.set_sigatm(sigatm_array)
             elif record_type not in allowed_records:
                 warnings.warn(
-                    "Ignoring unrecognized record '{}' at line {}".format(
-                        record_type, global_line_counter
-                    ),
+                    f"Ignoring unrecognized record '{record_type}' at line {global_line_counter}",
                     PDBConstructionWarning,
                 )
             local_line_counter += 1

--- a/Bio/PDB/internal_coords.py
+++ b/Bio/PDB/internal_coords.py
@@ -1739,12 +1739,7 @@ class IC_Chain:
         fp: TextIO, d: "Dihedron", hedraNdx: Dict, hedraSet: Set[EKT]
     ) -> None:
         fp.write(
-            "[ {:9.5f}, {}, {}, {}, ".format(
-                d.angle,
-                hedraNdx[d.h1key],
-                hedraNdx[d.h2key],
-                (1 if d.reverse else 0),
-            )
+            f"[ {d.angle:9.5f}, {hedraNdx[d.h1key]}, {hedraNdx[d.h2key]}, {1 if d.reverse else 0}, "
         )
         fp.write(
             f"{0 if d.h1key in hedraSet else 1}, "
@@ -1877,11 +1872,7 @@ class IC_Chain:
             hed = hedra[hk]
             fp.write("     [ ")
             fp.write(
-                "{:9.5f}, {:9.5f}, {:9.5f}".format(
-                    set_accuracy_95(hed.len12),
-                    set_accuracy_95(hed.angle),
-                    set_accuracy_95(hed.len23),
-                )
+                f"{set_accuracy_95(hed.len12):9.5f}, {set_accuracy_95(hed.angle):9.5f}, {set_accuracy_95(hed.len23):9.5f}"
             )
             atom_str = ""  # atom and bond state
             atom_done_str = ""  # create each only once

--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -652,7 +652,7 @@ class Confidence(float, PhyloElement):
 
     def __new__(cls, value, type="unknown"):
         """Create and return a Confidence object with the specified value and type."""
-        obj = super(Confidence, cls).__new__(cls, value)
+        obj = super().__new__(cls, value)
         obj.type = type
         return obj
 

--- a/Scripts/Restriction/rebase_update.py
+++ b/Scripts/Restriction/rebase_update.py
@@ -54,8 +54,8 @@ def get_files():
             print(e)
             print(
                 "Download of Rebase files failed. Please download the files "
-                '"emboss_e.{0}", "emboss_s.{0}", "emboss_r.{0}", and "bairoch.{0}" manually '
-                "from: ftp://ftp.neb.com/pub/rebase.".format(release_number)
+                f'"emboss_e.{release_number}", "emboss_s.{release_number}", "emboss_r.{release_number}", and "bairoch.{release_number}" manually '
+                "from: ftp://ftp.neb.com/pub/rebase."
             )
             return
 

--- a/Tests/run_tests.py
+++ b/Tests/run_tests.py
@@ -303,7 +303,7 @@ class TestRunner(unittest.TextTestRunner):
             # exception messages can be in loader.errors instead.
             sys.stderr.write(f"skipping. {msg}\n")
             return True
-        except Exception as msg:
+        except Exception as msg:  # noqa: BLE001
             # This happened during the import
             sys.stderr.write("ERROR\n")
             result.stream.write(result.separator1 + "\n")

--- a/Tests/test_align_substitution_matrices.py
+++ b/Tests/test_align_substitution_matrices.py
@@ -2427,7 +2427,7 @@ class TestLoading(unittest.TestCase):
         self.assertEqual(len(fname_matrix), 24)
         self.assertEqual(len(fname_matrix[0]), 24)
 
-        with open(matrix_path, "r") as handle:
+        with open(matrix_path) as handle:
             handle_matrix = substitution_matrices.read(handle)
             self.assertFalse(handle.closed)
         self.assertTrue(handle.closed)


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Follows on from discussion on #4655 and #4662.

Note drops flake8-blind-except but does not yet enable the ruff equivalent as that reports lots of issues...