### PR TITLE
Remove doctest that depends on endianness

### DIFF
--- a/Doc/Tutorial/chapter_align.rst
+++ b/Doc/Tutorial/chapter_align.rst
@@ -706,11 +706,16 @@ string) characters by using ``dtype='U'``:
 .. code:: pycon
 
    >>> align_array = np.array(alignment, dtype="U")
+
+.. code:: pycon
+
    >>> align_array  # doctest: +NORMALIZE_WHITESPACE
    array([['C', 'G', 'G', 'T', 'T', 'T', 'T', 'T'],
           ['A', 'G', '-', 'T', 'T', 'T', '-', '-'],
           ['A', 'G', 'G', 'T', 'T', 'T', '-', '-']], dtype='<U1')
 
+(the printed ``dtype`` will be '<U1' or '>U1' depending on whether your system
+is little-endian or big-endian, respectively).
 Note that the ``alignment`` object and the NumPy array ``align_array``
 are separate objects in memory - editing one will not update the other!
 


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

See issue  #4658 