### PR TITLE
Fix Bio.Align.bigBed for NEP50

### DIFF
--- a/Bio/Align/bigbed.py
+++ b/Bio/Align/bigbed.py
@@ -442,7 +442,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             regions = []
             rezoomedList = []
             trees = _RangeTree.generate(chromUsageList, alignments)
-            scale = initialReduction["scale"]
+            scale = int(initialReduction["scale"])
             doubleReductionSize = scale * _ZoomLevels.bbiResIncrement
             for tree in trees:
                 start = -sys.maxsize
@@ -1279,7 +1279,7 @@ class _ZoomLevels(list):
 
     def reduce(self, summaries, initialReduction, buffer, blockSize, itemsPerSlot):
         zoomCount = initialReduction["size"]
-        reduction = initialReduction["scale"] * _ZoomLevels.bbiResIncrement
+        reduction = int(initialReduction["scale"]) * _ZoomLevels.bbiResIncrement
         output = buffer.output
         formatter = _RTreeFormatter()
         for zoomLevels in range(1, _ZoomLevels.bbiMaxZoomLevels):


### PR DESCRIPTION
NEP50 (https://numpy.org/neps/nep-0050-scalar-promotion.html#nep50) changes the promotion rules for Python scalars. This PR modifies Bio.Align.bigbed to be consistent with these new promotion rules, which appeared in numpy 2.0.


- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
