### PR TITLE
Double the SeqXML parser block size for libexpat 2.6.0

### DIFF
--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -441,7 +441,8 @@ class SeqXmlIterator(SequenceIterator):
     method calls.
     """
 
-    BLOCK = 1024
+    # Small block size can be a problem with libexpat 2.6.0 onwards:
+    BLOCK = 2048
 
     def __init__(self, stream_or_path, namespace=None):
         """Create the object and initialize the XML parser."""

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -442,7 +442,7 @@ class SeqXmlIterator(SequenceIterator):
     """
 
     # Small block size can be a problem with libexpat 2.6.0 onwards:
-    BLOCK = 2048
+    BLOCK = 4096
 
     def __init__(self, stream_or_path, namespace=None):
         """Create the object and initialize the XML parser."""


### PR DESCRIPTION
If this works, it closes #4640 and confirms my hunch that the root cause of the failure under libexpat 2.6.x was CPython issue 115133 due to a CVE security fix.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
