### PR TITLE
In Bio.Align, deprecate infer_coordinates, and use parse_printed_alignment instead

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -970,7 +970,7 @@ class MultipleSeqAlignment:
         records = [copy.copy(record) for record in self._records]
         if records:
             lines = [bytes(record.seq) for record in records]
-            seqdata, coordinates = Alignment.parse_alignment_block(lines)
+            seqdata, coordinates = Alignment.parse_printed_alignment(lines)
             for record, seqrow in zip(records, seqdata):
                 if record.letter_annotations:
                     indices = [i for i, c in enumerate(record.seq) if c != "-"]
@@ -1043,18 +1043,17 @@ class Alignment:
         >>> alignment = Alignment(sequences, coordinates)
         """
         lines = [line.encode() for line in lines]
-        seqdata, coordinates = cls.parse_alignment_block(lines)
+        seqdata, coordinates = cls.parse_printed_alignment(lines)
         return coordinates
 
     @classmethod
-    def parse_alignment_block(cls, lines):
+    def parse_printed_alignment(cls, lines):
         """Parse an alignment block."""
-        seqdata = [line.replace(b"-", b"") for line in lines]
-        sequences, coordinates = _parser.parse_alignment_block(lines)
+        sequences, coordinates = _parser.parse_printed_alignment(lines)
         shape = coordinates.shape
         coordinates = np.frombuffer(coordinates, int)
         coordinates.shape = shape
-        return seqdata, coordinates
+        return sequences, coordinates
 
     def __init__(self, sequences, coordinates=None):
         """Initialize a new Alignment object.
@@ -1879,7 +1878,7 @@ class Alignment:
                 ) from None
             line = line.encode()
             lines.append(line)
-        seqdata, coordinates = self.parse_alignment_block(lines)
+        seqdata, coordinates = self.parse_printed_alignment(lines)
         for i, sequence in enumerate(sequences):
             line = seqdata[i]
             try:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -35,6 +35,7 @@ except ImportError:
         "See http://www.numpy.org/"
     ) from None
 
+from Bio.Align import _parser  # type: ignore
 from Bio.Align import _pairwisealigner  # type: ignore
 from Bio.Align import _codonaligner  # type: ignore
 from Bio.Align import substitution_matrices
@@ -1076,6 +1077,10 @@ class Alignment:
             path.append(indices)
         coordinates = np.array(path).transpose()
         seqdata = [line.replace(b"-", b"") for line in lines]
+        coordinates = _parser.parse_alignment_block(lines)
+        shape = coordinates.shape
+        coordinates = np.frombuffer(coordinates, int)
+        coordinates.shape = shape
         return seqdata, coordinates
 
     def __init__(self, sequences, coordinates=None):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1049,33 +1049,6 @@ class Alignment:
     @classmethod
     def parse_alignment_block(cls, lines):
         """Parse an alignment block."""
-        n = len(lines)
-        m = len(lines[0])
-        for line in lines:
-            assert m == len(line)
-        path = []
-        dash = ord(b"-")
-        if m > 0:
-            indices = [0] * n
-            current_state = [None] * n
-            for i in range(m):
-                next_state = [line[i] != dash for line in lines]
-                if next_state == current_state:
-                    step += 1  # noqa: F821
-                else:
-                    indices = [
-                        index + step if state else index
-                        for index, state in zip(indices, current_state)
-                    ]
-                    path.append(indices)
-                    step = 1
-                    current_state = next_state
-            indices = [
-                index + step if state else index
-                for index, state in zip(indices, current_state)
-            ]
-            path.append(indices)
-        coordinates = np.array(path).transpose()
         seqdata = [line.replace(b"-", b"") for line in lines]
         coordinates = _parser.parse_alignment_block(lines)
         shape = coordinates.shape

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1050,7 +1050,7 @@ class Alignment:
     def parse_alignment_block(cls, lines):
         """Parse an alignment block."""
         seqdata = [line.replace(b"-", b"") for line in lines]
-        coordinates = _parser.parse_alignment_block(lines)
+        sequences, coordinates = _parser.parse_alignment_block(lines)
         shape = coordinates.shape
         coordinates = np.frombuffer(coordinates, int)
         coordinates.shape = shape

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -7,6 +7,7 @@
 
 
 #include <Python.h>
+#include <string.h>
 
 
 typedef struct {
@@ -147,7 +148,8 @@ parse_printed_alignment(PyObject* module, PyObject* args)
     Py_ssize_t i, j, k, n, m, p;
     const char* s;
     char** destination = NULL;
-    Py_ssize_t index, previous, step;
+    Py_ssize_t index, previous;
+    long step;
     Py_ssize_t* indices = NULL;
     Py_ssize_t length;
     Py_ssize_t* lengths = NULL;

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -199,7 +199,7 @@ parse_printed_alignment(PyObject* module, PyObject* args)
         if (index == m) break;
         for (i = 0; i < n; i++) {
             if (indices[i] == index) {
-                s = &lines[i].buf[index];
+                s = lines[i].buf + index;
                 if (*s == '-') {
                     for (j = index+1; j < m; j++) if (*(++s) != '-') break;
                 }
@@ -244,13 +244,13 @@ parse_printed_alignment(PyObject* module, PyObject* args)
         for (i = 0; i < n; i++) {
             if (index == indices[i]) {
                 length = lengths[i];
-                s = &lines[i].buf[index];
+                s = lines[i].buf + index;
                 if (*s == '-') {
                     for (j = index+1; j < m; j++) if (*(++s) != '-') break;
                 }
                 else {
                     for (j = index+1; j < m; j++) if (*(++s) == '-') break;
-                    s = &lines[i].buf[index];
+                    s = lines[i].buf + index;
                     memcpy(destination[i]+length, s, j - index);
                     lengths[i] += j - index;
                 }

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -235,8 +235,8 @@ parse_printed_alignment(PyObject* module, PyObject* args)
     coordinates->shape[0] = n;
     coordinates->shape[1] = p;
 
-    bzero(indices, n * sizeof(Py_ssize_t));
-    bzero(lengths, n * sizeof(Py_ssize_t));
+    memset(indices, '\0', n * sizeof(Py_ssize_t));
+    memset(lengths, '\0', n * sizeof(Py_ssize_t));
     k = 1;
     index = 0;
     do {
@@ -250,7 +250,8 @@ parse_printed_alignment(PyObject* module, PyObject* args)
                 }
                 else {
                     for (j = index+1; j < m; j++) if (*(++s) == '-') break;
-                    memcpy(destination[i]+length, &lines[i].buf[index], j - index);
+                    s = &lines[i].buf[index];
+                    memcpy(destination[i]+length, s, j - index);
                     lengths[i] += j - index;
                 }
                 indices[i] = j;

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -199,7 +199,7 @@ parse_printed_alignment(PyObject* module, PyObject* args)
         if (index == m) break;
         for (i = 0; i < n; i++) {
             if (indices[i] == index) {
-                s = lines[i].buf + index;
+                s = ((const char*)(lines[i].buf)) + index;
                 if (*s == '-') {
                     for (j = index+1; j < m; j++) if (*(++s) != '-') break;
                 }
@@ -244,13 +244,13 @@ parse_printed_alignment(PyObject* module, PyObject* args)
         for (i = 0; i < n; i++) {
             if (index == indices[i]) {
                 length = lengths[i];
-                s = lines[i].buf + index;
+                s = ((const char*)(lines[i].buf)) + index;
                 if (*s == '-') {
                     for (j = index+1; j < m; j++) if (*(++s) != '-') break;
                 }
                 else {
                     for (j = index+1; j < m; j++) if (*(++s) == '-') break;
-                    s = lines[i].buf + index;
+                    s = ((const char*)(lines[i].buf)) + index;
                     memcpy(destination[i]+length, s, j - index);
                     lengths[i] += j - index;
                 }

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -1,0 +1,292 @@
+/* Copyright 2024 by Michiel de Hoon.  All rights reserved.
+ * This file is part of the Biopython distribution and governed by your
+ * choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+ * Please see the LICENSE file that should have been included as part of this
+ * package.
+ */
+
+
+#include <Python.h>
+
+
+typedef struct {
+    PyObject_HEAD
+    long *data;
+    Py_ssize_t shape[2];
+} Coordinates;
+
+/* Destructor function */
+static void
+Coordinates_dealloc(Coordinates *self)
+{
+    if (self->data != NULL) {
+        PyMem_Free(self->data);
+    }
+    Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+/* Buffer protocol getbuffer function */
+static int
+Coordinates_getbuffer(PyObject *obj, Py_buffer *view, int flags)
+{
+    Coordinates *self = (Coordinates *)obj;
+
+    if (view == NULL) {
+        PyErr_SetString(PyExc_BufferError, "NULL view in getbuffer");
+        return -1;
+    }
+
+    view->obj = obj;
+    view->buf = self->data;
+    view->len = self->shape[0] * self->shape[1] * sizeof(long);
+    view->readonly = 0;
+    view->itemsize = sizeof(long);
+    view->format = "l";
+    view->ndim = 2;
+    view->shape = self->shape;
+    view->strides = NULL;
+    view->suboffsets = NULL;
+    view->internal = NULL;
+
+    Py_INCREF(obj);
+
+    return 0;
+}
+
+static PyBufferProcs Coordinates_as_buffer = {
+    .bf_getbuffer = Coordinates_getbuffer,
+};
+
+static PyObject*
+Coordinates_get_shape(Coordinates* self, void* closure)
+{
+    return Py_BuildValue("ll", self->shape[0], self->shape[1]);
+}
+
+static PyGetSetDef Coordinates_getset[] = {
+    {"shape", (getter)Coordinates_get_shape,
+     NULL, "return the shape of the coordinates matrix", NULL,
+    },
+    {NULL, NULL, 0, NULL}  /* Sentinel */
+};
+
+
+static PyTypeObject CoordinatesType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "_parser.Coordinates",
+    .tp_doc = "Coordinates objects",
+    .tp_basicsize = sizeof(Coordinates),
+    .tp_itemsize = 0,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_dealloc = (destructor)Coordinates_dealloc,
+    .tp_as_buffer = &Coordinates_as_buffer,
+    .tp_getset = Coordinates_getset,
+};
+
+static int
+converter(PyObject* argument, void* pointer)
+{
+    Py_buffer* lines;
+    Py_ssize_t i, n;
+    PyObject* item;
+    PyObject** items;
+    int status;
+
+    argument = PySequence_Fast(argument,
+                               "argument must be a tuple, list, or any other "
+                               "object supporting the sequence protocol");
+    if (!argument) return 0;
+    n = PySequence_Fast_GET_SIZE(argument);
+    items = PySequence_Fast_ITEMS(argument);
+    lines = PyMem_Calloc(n+1, sizeof(Py_buffer));  /* one more as sentinel */
+    if (!lines) {
+        Py_DECREF(argument);
+        return 0;
+    }
+    *((Py_buffer**)pointer) = lines;
+    for (i = 0; i < n; i++) {
+        item = items[i];
+        if (PyObject_GetBuffer(item, &lines[i], PyBUF_CONTIG_RO) == 0) {
+            if (lines[i].itemsize == 1 && lines[i].ndim == 1) continue;
+            PyErr_Format(PyExc_ValueError,
+                         "line [%zi] does not contain a one-dimensional array "
+                         "of single bytes.", i);
+        }
+        else {
+            PyErr_Clear();
+            item = PyUnicode_AsASCIIString(item);
+            if (item) {
+                status = PyObject_GetBuffer(item, &lines[i], PyBUF_CONTIG_RO);
+                Py_DECREF(item);
+                if (status == 0) continue;
+                PyErr_Format(PyExc_RuntimeError,
+                             "failed to obtain a buffer after converting "
+                             "line [%zi] to a bytes-like object.", i);
+            }
+            else {
+                PyErr_Format(PyExc_ValueError,
+                             "line [%zi] is neither a bytes-like object "
+                             "nor an ASCII string", i);
+            }
+        }
+        n = i;
+        for (i = 0; i < n; i++) PyBuffer_Release(&lines[i]);
+        Py_DECREF(argument);
+        return 0;
+    }
+    Py_DECREF(argument);
+    return 1;
+}
+
+
+static PyObject*
+parse_alignment_block(PyObject* module, PyObject* args)
+{
+    Py_buffer* lines;
+    Py_ssize_t i, j, k, n, m, p;
+    const char* s;
+    Py_ssize_t index, previous, step;
+    Py_ssize_t* indices = NULL;
+    Coordinates *coordinates = NULL;
+
+    PyObject* result = NULL;
+
+    if (!PyArg_ParseTuple(args, "O&:parse_alignment_block", converter, &lines))
+        return NULL;
+
+    if (lines[0].buf == NULL) {
+        PyMem_Free(lines);
+        return Py_BuildValue("()()");
+    }
+    m = lines[0].shape[0];
+    n = 1;
+    for (i = 1; lines[i].buf; i++) {
+        if (lines[i].shape[0] != m) {
+            PyErr_Format(PyExc_ValueError,
+                         "all lines must have the same length "
+                         "(first line has length %zi, "
+                         "line [%zi] has length %zi).",
+                         m, i, lines[i].shape[0]);
+            goto exit;
+        }
+        n++;
+    }
+    indices = PyMem_Calloc(n, sizeof(Py_ssize_t));
+    if (!indices) goto exit;
+    p = 0;
+    while (1) {
+        index = m;
+        for (i = 0; i < n; i++) if (indices[i] < index) index = indices[i];
+        p++;
+        if (index == m) break;
+        for (i = 0; i < n; i++) {
+            if (indices[i] == index) {
+                s = &lines[i].buf[index];
+                if (*s == '-') {
+                    for (j = index+1; j < m; j++) if (*(++s) != '-') break;
+                }
+                else {
+                    for (j = index+1; j < m; j++) if (*(++s) == '-') break;
+                }
+                indices[i] = j;
+            }
+        }
+    }
+    coordinates = (Coordinates *)PyType_GenericAlloc(&CoordinatesType, 0);
+    if (coordinates == NULL) goto exit;
+    coordinates->data = PyMem_Malloc(n*p*sizeof(long));
+    if (!coordinates->data) goto exit;
+    for (i = 0; i < n; i++) coordinates->data[i*p] = 0;
+    coordinates->shape[0] = n;
+    coordinates->shape[1] = p;
+
+    bzero(indices, n * sizeof(Py_ssize_t));
+    k = 1;
+    index = 0;
+    while (1) {
+        for (i = 0; i < n; i++) {
+            s = &lines[i].buf[index];
+            if (*s == '-') {
+                for (j = index+1; j < m; j++) if (*(++s) != '-') break;
+            }
+            else {
+                for (j = index+1; j < m; j++) if (*(++s) == '-') break;
+            }
+            indices[i] = j;
+        }
+        previous = index;
+        index = m;
+        for (i = 0; i < n; i++) if (indices[i] < index) index = indices[i];
+        step = index - previous;
+        for (i = 0; i < n; i++) {
+            s = lines[i].buf;
+            if (s[previous] == '-') {
+                coordinates->data[i*p+k] = coordinates->data[i*p+k-1];
+            }
+            else {
+                coordinates->data[i*p+k] = coordinates->data[i*p+k-1] + step;
+            }
+        }
+        k++;
+        if (index == m) break;
+    }
+
+    result = Py_BuildValue("O", coordinates);
+exit:
+    Py_XDECREF(coordinates);
+    if (indices) PyMem_Free(indices);
+    for (i = 0; i < n; i++) PyBuffer_Release(&lines[i]);
+    PyMem_Free(lines);
+    return result;
+}
+
+static char parse_alignment_block__doc__[] =
+"Infer the coordinates from a printed alignment."
+"\n"
+"This method is primarily employed by the alignment parsers in Bio.Align,\n"
+"though it may be useful for other purposes.\n"
+"\n"
+"For an alignment consisting of N sequences, printed as N lines with the same\n"
+"number of columns, where gaps are represented by dashes, this method\n"
+"calculates the sequence coordinates that define the alignment.\n"
+"This function returns a tuple of the sequences and the coordinates.\n"
+"The sequences object is a tuple of bytes objects containing the sequence\n"
+"data after removing the dashes. The coordinates object returned supports\n"
+"the buffer protocol, allowing the coordinates to be converted into a NumPy\n"
+"array of integers without copying.\n";
+
+
+static struct PyMethodDef methods[] = {
+    {"parse_alignment_block",
+     (PyCFunction)parse_alignment_block,
+     METH_VARARGS,
+     parse_alignment_block__doc__
+    },                             
+    {NULL, NULL, 0, NULL}  /* Sentinel */
+};
+
+/* Module initialization function */
+static PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "_parser",
+    .m_doc = "fast C implementation of utility functions for alignment parsing",
+    .m_size = -1,
+    .m_methods = methods,
+};
+
+PyMODINIT_FUNC
+PyInit__parser(void)
+{
+    PyObject *module;
+
+    if (PyType_Ready(&CoordinatesType) < 0)
+        return NULL;
+
+    module = PyModule_Create(&moduledef);
+    if (module == NULL)
+        return NULL;
+
+    Py_INCREF(&CoordinatesType);
+    PyModule_AddObject(module, "Coordinates", (PyObject *)&CoordinatesType);
+    return module;
+}

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -171,7 +171,9 @@ parse_printed_alignment(PyObject* module, PyObject* args)
         coordinates->shape[0] = 0;
         coordinates->shape[1] = 0;
         PyMem_Free(lines);
-        return Py_BuildValue("[]O", coordinates);
+        result = Py_BuildValue("[]O", coordinates);
+        Py_DECREF(coordinates);
+        return result;
     }
     m = lines[0].shape[0];
     n = 1;
@@ -227,8 +229,6 @@ parse_printed_alignment(PyObject* module, PyObject* args)
         }
         PyList_SET_ITEM(sequences, i, sequence);
     }
-    coordinates = (Coordinates *)PyType_GenericAlloc(&CoordinatesType, 0);
-    if (coordinates == NULL) goto exit;
     coordinates->data = PyMem_Malloc(n*p*sizeof(long));
     if (!coordinates->data) goto exit;
     for (i = 0; i < n; i++) coordinates->data[i*p] = 0;

--- a/Bio/Align/a2m.py
+++ b/Bio/Align/a2m.py
@@ -109,7 +109,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                     raise Exception("Unexpected letter '%s' in alignment" % c)
         for i, line in enumerate(lines):
             lines[i] = line.upper().replace(".", "-").encode()
-        seqdata, coordinates = Alignment.parse_alignment_block(lines)
+        seqdata, coordinates = Alignment.parse_printed_alignment(lines)
         records = []
         for name, description, seqrow in zip(names, descriptions, seqdata):
             sequence = Seq(seqrow)

--- a/Bio/Align/a2m.py
+++ b/Bio/Align/a2m.py
@@ -108,12 +108,11 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 else:
                     raise Exception("Unexpected letter '%s' in alignment" % c)
         for i, line in enumerate(lines):
-            lines[i] = line.upper().replace(".", "-")
-        coordinates = Alignment.infer_coordinates(lines)
+            lines[i] = line.upper().replace(".", "-").encode()
+        seqdata, coordinates = Alignment.parse_alignment_block(lines)
         records = []
-        for name, description, line in zip(names, descriptions, lines):
-            line = line.replace("-", "")
-            sequence = Seq(line)
+        for name, description, seqrow in zip(names, descriptions, seqdata):
+            sequence = Seq(seqrow)
             record = SeqRecord(sequence, name, description=description)
             records.append(record)
         alignment = Alignment(records, coordinates)

--- a/Bio/Align/clustal.py
+++ b/Bio/Align/clustal.py
@@ -233,7 +233,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 if i == n:
                     i = 0
         aligned_seqs = [s.encode() for s in aligned_seqs]
-        seqs, coordinates = Alignment.parse_alignment_block(aligned_seqs)
+        seqs, coordinates = Alignment.parse_printed_alignment(aligned_seqs)
         records = [
             SeqRecord(Seq(seq), id=seqid, description="")
             for (seqid, seq) in zip(ids, seqs)

--- a/Bio/Align/clustal.py
+++ b/Bio/Align/clustal.py
@@ -135,7 +135,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         # identifier (not a good idea - but seems possible), then this
         # dictionary based parser will merge their sequences.  Fix this?
         ids = []
-        seqs = []
         aligned_seqs = []
         consensus = ""
         index = None  # Used to extract the consensus
@@ -161,8 +160,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 seqid, aligned_seq = fields[:2]
                 ids.append(seqid)
                 aligned_seqs.append(aligned_seq)
-                seq = aligned_seq.replace("-", "")
-                seqs.append(seq)
 
                 # Record the sequence position to get the consensus
                 if index is None:
@@ -171,15 +168,15 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 if len(fields) == 3:
                     # This MAY be an old style file with a letter count...
                     try:
-                        letters = int(fields[2])
+                        count = int(fields[2])
                     except ValueError:
                         raise ValueError(
-                            "Could not parse line, bad sequence number:\n%s" % line
+                            "Could not parse line, bad sequence count:\n%s" % line
                         ) from None
-                    if len(seq) != letters:
+                    if len(aligned_seq) - aligned_seq.count("-") != count:
                         raise ValueError(
-                            "Could not parse line, invalid sequence number:\n%s" % line
-                        )
+                            "Could not parse line, incorrect sequence count:\n%s" % line
+                        ) from None
             else:
                 # no consensus line
                 if index:
@@ -196,7 +193,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         if consensus:
             assert len(consensus) == length
 
-        n = len(seqs)
+        n = len(aligned_seqs)
         i = 0
         # Loop over any remaining blocks...
         for line in stream:
@@ -219,30 +216,28 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 assert seqid == fields[0]
                 aligned_seq = fields[1]
                 aligned_seqs[i] += aligned_seq
-                seq = aligned_seq.replace("-", "")
-                seqs[i] += seq
 
                 if len(fields) == 3:
                     # This MAY be an old style file with a letter count...
                     try:
-                        letters = int(fields[2])
+                        count = int(fields[2])
                     except ValueError:
                         raise ValueError(
                             "Could not parse line, bad sequence number:\n%s" % line
                         ) from None
-                    if len(seqs[i]) != letters:
+                    if len(aligned_seqs[i]) - aligned_seqs[i].count("-") != count:
                         raise ValueError(
-                            "Could not parse line, invalid sequence number:\n%s" % line
-                        )
+                            "Could not parse line, incorrect sequence count:\n%s" % line
+                        ) from None
                 i += 1
                 if i == n:
                     i = 0
-
+        aligned_seqs = [s.encode() for s in aligned_seqs]
+        seqs, coordinates = Alignment.parse_alignment_block(aligned_seqs)
         records = [
             SeqRecord(Seq(seq), id=seqid, description="")
             for (seqid, seq) in zip(ids, seqs)
         ]
-        coordinates = Alignment.infer_coordinates(aligned_seqs)
         alignment = Alignment(records, coordinates)
         if consensus:
             columns = alignment.length

--- a/Bio/Align/emboss.py
+++ b/Bio/Align/emboss.py
@@ -219,7 +219,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         aligned_sequences = [
             aligned_sequence.encode() for aligned_sequence in aligned_sequences
         ]
-        sequences, coordinates = Alignment.parse_alignment_block(aligned_sequences)
+        sequences, coordinates = Alignment.parse_printed_alignment(aligned_sequences)
         records = []
         n = len(sequences)
         for i in range(n):

--- a/Bio/Align/emboss.py
+++ b/Bio/Align/emboss.py
@@ -12,7 +12,7 @@ for example from the needle, water, and stretcher tools.
 
 from Bio.Align import Alignment
 from Bio.Align import interfaces
-from Bio.Seq import Seq, reverse_complement
+from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
 
@@ -216,24 +216,27 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 else:
                     assert column == len(aligned_sequences[index])
                 index += 1
-        coordinates = Alignment.infer_coordinates(aligned_sequences)
+        aligned_sequences = [
+            aligned_sequence.encode() for aligned_sequence in aligned_sequences
+        ]
+        sequences, coordinates = Alignment.parse_alignment_block(aligned_sequences)
         records = []
         n = len(sequences)
         for i in range(n):
             start = starts[i]
             end = ends[i]
-            if start < end:
+            data = sequences[i]
+            if start == 0:
+                sequence = Seq(data)
+            elif start < end:
                 coordinates[i, :] += start
-                data = sequences[i]
+                # create a partially defined sequence
+                sequence = Seq({start: data}, length=end)
             else:
                 start, end = end, start
                 coordinates[i, :] = end - coordinates[i, :]
-                data = reverse_complement(sequences[i])
-            if start == 0:
-                sequence = Seq(data)
-            else:
                 # create a partially defined sequence
-                sequence = Seq({start: data}, length=end)
+                sequence = Seq({0: data}, length=end).reverse_complement()
             record = SeqRecord(sequence, identifiers[i])
             records.append(record)
         alignment = Alignment(records, coordinates)

--- a/Bio/Align/fasta.py
+++ b/Bio/Align/fasta.py
@@ -76,7 +76,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 raise ValueError("Empty file.")
             return
         lines = [line.encode() for line in lines]
-        seqs, coordinates = Alignment.parse_alignment_block(lines)
+        seqs, coordinates = Alignment.parse_printed_alignment(lines)
         records = []
         for name, description, seq in zip(names, descriptions, seqs):
             sequence = Seq(seq)

--- a/Bio/Align/fasta.py
+++ b/Bio/Align/fasta.py
@@ -75,11 +75,11 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             if self._stream.tell() == 0:
                 raise ValueError("Empty file.")
             return
-        coordinates = Alignment.infer_coordinates(lines)
+        lines = [line.encode() for line in lines]
+        seqs, coordinates = Alignment.parse_alignment_block(lines)
         records = []
-        for name, description, line in zip(names, descriptions, lines):
-            line = line.replace("-", "")
-            sequence = Seq(line)
+        for name, description, seq in zip(names, descriptions, seqs):
+            sequence = Seq(seq)
             record = SeqRecord(sequence, id=name, description=description)
             records.append(record)
         alignment = Alignment(records, coordinates)

--- a/Bio/Align/hhr.py
+++ b/Bio/Align/hhr.py
@@ -85,7 +85,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             if n == 0:
                 return
             lines = [target_sequence.encode(), query_sequence.encode()]
-            seq_data, coordinates = Alignment.parse_alignment_block(lines)
+            seq_data, coordinates = Alignment.parse_printed_alignment(lines)
             target_seq_data, query_seq_data = seq_data
             coordinates[0, :] += target_start
             coordinates[1, :] += query_start

--- a/Bio/Align/hhr.py
+++ b/Bio/Align/hhr.py
@@ -84,13 +84,15 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             assert len(query_sequence) == n
             if n == 0:
                 return
-            coordinates = Alignment.infer_coordinates([target_sequence, query_sequence])
+            lines = [target_sequence.encode(), query_sequence.encode()]
+            seq_data, coordinates = Alignment.parse_alignment_block(lines)
+            target_seq_data, query_seq_data = seq_data
             coordinates[0, :] += target_start
             coordinates[1, :] += query_start
-            sequence = {query_start: query_sequence.replace("-", "")}
+            sequence = {query_start: query_seq_data}
             query_seq = Seq(sequence, length=query_length)
             query = SeqRecord(query_seq, id=self.query_name)
-            sequence = {target_start: target_sequence.replace("-", "")}
+            sequence = {target_start: target_seq_data}
             target_seq = Seq(sequence, length=target_length)
             target_annotations = {
                 "hmm_name": hmm_name,

--- a/Bio/Align/maf.py
+++ b/Bio/Align/maf.py
@@ -439,7 +439,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 raise ValueError(f"Error parsing alignment - unexpected line:\n{line}")
         else:
             self._aline = None
-        sequences, coordinates = Alignment.parse_alignment_block(aligned_sequences)
+        sequences, coordinates = Alignment.parse_printed_alignment(aligned_sequences)
         for start, size, sequence, record in zip(starts, sizes, sequences, records):
             srcSize = len(record.seq)
             if len(sequence) != size:

--- a/Bio/Align/maf.py
+++ b/Bio/Align/maf.py
@@ -343,6 +343,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
     def _create_alignment(self, aline, stream):
         records = []
+        starts = []
+        sizes = []
         strands = []
         aligned_sequences = []
         annotations = {}
@@ -379,19 +381,12 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 text = words[6]
                 for gap_char in ".=_":
                     text = text.replace(gap_char, "-")
-                aligned_sequences.append(text)
-                sequence = text.replace("-", "")
-                if len(sequence) != size:
-                    raise ValueError(
-                        "sequence size is incorrect (found %d, expected %d)"
-                        % (len(sequence), size)
-                    )
-                if strand == "-":
-                    sequence = reverse_complement(sequence)
-                    start = srcSize - start - size
-                seq = Seq({start: sequence}, length=srcSize)
+                aligned_sequences.append(text.encode())
+                seq = Seq(None, length=srcSize)
                 record = SeqRecord(seq, id=src, name="", description="")
                 records.append(record)
+                starts.append(start)
+                sizes.append(size)
                 strands.append(strand)
             elif line.startswith("i "):
                 words = line.strip().split()
@@ -444,10 +439,19 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 raise ValueError(f"Error parsing alignment - unexpected line:\n{line}")
         else:
             self._aline = None
-        coordinates = Alignment.infer_coordinates(aligned_sequences)
+        sequences, coordinates = Alignment.parse_alignment_block(aligned_sequences)
+        for start, size, sequence, record in zip(starts, sizes, sequences, records):
+            srcSize = len(record.seq)
+            if len(sequence) != size:
+                raise ValueError(
+                    "sequence size is incorrect (found %d, expected %d)"
+                    % (len(sequence), size)
+                )
+            record.seq = Seq({start: sequence}, length=srcSize)
         for record, strand, row in zip(records, strands, coordinates):
             if strand == "-":
                 row[:] = row[-1] - row[0] - row
+                record.seq = record.seq.reverse_complement()
             start = record.seq.defined_ranges[0][0]
             row += start
         alignment = Alignment(records, coordinates)

--- a/Bio/Align/mauve.py
+++ b/Bio/Align/mauve.py
@@ -217,7 +217,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 # There may be more data, but we've reached the end of this
                 # alignment
                 seqs = [seq.encode() for seq in seqs]
-                seqs, coordinates = Alignment.parse_alignment_block(seqs)
+                seqs, coordinates = Alignment.parse_printed_alignment(seqs)
                 records = []
                 for index, (description, seq) in enumerate(zip(descriptions, seqs)):
                     identifier, start, end, strand, comments = description

--- a/Bio/Align/mauve.py
+++ b/Bio/Align/mauve.py
@@ -216,24 +216,29 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             if line.startswith("="):
                 # There may be more data, but we've reached the end of this
                 # alignment
-                coordinates = Alignment.infer_coordinates(seqs)
+                seqs = [seq.encode() for seq in seqs]
+                seqs, coordinates = Alignment.parse_alignment_block(seqs)
                 records = []
                 for index, (description, seq) in enumerate(zip(descriptions, seqs)):
                     identifier, start, end, strand, comments = description
-                    seq = seq.replace("-", "")
                     assert len(seq) == end - start
                     if strand == "+":
                         pass
                     elif strand == "-":
-                        seq = reverse_complement(seq)
                         coordinates[index, :] = len(seq) - coordinates[index, :]
                     else:
                         raise ValueError("Unexpected strand '%s'" % strand)
                     coordinates[index] += start
                     if start == 0:
                         seq = Seq(seq)
+                        if strand == "-":
+                            seq = seq.reverse_complement()
                     else:
-                        seq = Seq({start: seq}, length=end)
+                        if strand == "+":
+                            seq = Seq({start: seq}, length=end)
+                        else:  # strand == "-"
+                            seq = Seq({0: seq}, length=end)
+                            seq = seq.reverse_complement()
                     record = SeqRecord(seq, id=identifier, description=comments)
                     records.append(record)
 

--- a/Bio/Align/msf.py
+++ b/Bio/Align/msf.py
@@ -224,7 +224,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             seqs[index] = seq
 
         seqs = [seq.encode() for seq in seqs]
-        seqs, coordinates = Alignment.parse_alignment_block(seqs)
+        seqs, coordinates = Alignment.parse_printed_alignment(seqs)
         records = [
             SeqRecord(
                 Seq(seq),

--- a/Bio/Align/msf.py
+++ b/Bio/Align/msf.py
@@ -223,11 +223,11 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 seq += "-" * (aln_length - len(seq))
             seqs[index] = seq
 
-        coordinates = Alignment.infer_coordinates(seqs)
-        seqs = (Seq(seq.replace("-", "")) for seq in seqs)
+        seqs = [seq.encode() for seq in seqs]
+        seqs, coordinates = Alignment.parse_alignment_block(seqs)
         records = [
             SeqRecord(
-                seq,
+                Seq(seq),
                 id=name,
                 name=name,
                 description=name,

--- a/Bio/Align/nexus.py
+++ b/Bio/Align/nexus.py
@@ -182,7 +182,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         else:
             annotations = None
         aligned_seqs = [bytes(n.matrix[name]) for name in n.taxlabels]
-        seqs, coordinates = Alignment.parse_alignment_block(aligned_seqs)
+        seqs, coordinates = Alignment.parse_printed_alignment(aligned_seqs)
         records = [
             SeqRecord(Seq(seq), id=name, annotations=annotations)
             for seq, name in zip(seqs, n.unaltered_taxlabels)

--- a/Bio/Align/nexus.py
+++ b/Bio/Align/nexus.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from Bio.Align import Alignment
 from Bio.Align import interfaces
+from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.Nexus import Nexus
 
@@ -180,18 +181,14 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             annotations = {"molecule_type": "protein"}
         else:
             annotations = None
-        aligned_seqs = [str(n.matrix[new_name]) for new_name in n.taxlabels]
+        aligned_seqs = [bytes(n.matrix[name]) for name in n.taxlabels]
+        seqs, coordinates = Alignment.parse_alignment_block(aligned_seqs)
         records = [
-            SeqRecord(
-                n.matrix[new_name].replace("-", ""),
-                id=old_name,
-                annotations=annotations,
-            )
-            for old_name, new_name in zip(n.unaltered_taxlabels, n.taxlabels)
+            SeqRecord(Seq(seq), id=name, annotations=annotations)
+            for seq, name in zip(seqs, n.unaltered_taxlabels)
         ]
-        coordinates = Alignment.infer_coordinates(aligned_seqs)
         # Remove columns consisting of gaps only
-        steps = (coordinates[:, 1:] - coordinates[:, :-1]).max(0)
+        steps = np.diff(coordinates, 1).max(0)
         indices = np.nonzero(steps == 0)[0] + 1
         coordinates = np.delete(coordinates, indices, 1)
         alignment = Alignment(records, coordinates)

--- a/Bio/Align/phylip.py
+++ b/Bio/Align/phylip.py
@@ -175,8 +175,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             if "." in seq:
                 raise ValueError("PHYLIP format no longer allows dots in sequence")
 
-        coordinates = Alignment.infer_coordinates(seqs)
-        seqs = [seq.replace("-", "") for seq in seqs]
+        seqs = [seq.encode() for seq in seqs]
+        seqs, coordinates = Alignment.parse_alignment_block(seqs)
         records = [
             SeqRecord(Seq(seq), id=name, description="")
             for (name, seq) in zip(names, seqs)

--- a/Bio/Align/phylip.py
+++ b/Bio/Align/phylip.py
@@ -176,7 +176,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 raise ValueError("PHYLIP format no longer allows dots in sequence")
 
         seqs = [seq.encode() for seq in seqs]
-        seqs, coordinates = Alignment.parse_alignment_block(seqs)
+        seqs, coordinates = Alignment.parse_printed_alignment(seqs)
         records = [
             SeqRecord(Seq(seq), id=name, description="")
             for (name, seq) in zip(names, seqs)

--- a/Bio/Align/stockholm.py
+++ b/Bio/Align/stockholm.py
@@ -321,7 +321,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 skipped_columns = np.nonzero((aligned_sequences == ord("-")).all(0))[0]
                 aligned_sequences = np.delete(aligned_sequences, skipped_columns, 1)
                 aligned_sequences = [row.tobytes() for row in aligned_sequences]
-                sequences, coordinates = Alignment.parse_alignment_block(
+                sequences, coordinates = Alignment.parse_printed_alignment(
                     aligned_sequences
                 )
                 for sequence, record in zip(sequences, records):

--- a/Bio/Align/stockholm.py
+++ b/Bio/Align/stockholm.py
@@ -320,10 +320,12 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 )
                 skipped_columns = np.nonzero((aligned_sequences == ord("-")).all(0))[0]
                 aligned_sequences = np.delete(aligned_sequences, skipped_columns, 1)
-                aligned_sequences = [
-                    row.tobytes().decode() for row in aligned_sequences
-                ]
-                coordinates = Alignment.infer_coordinates(aligned_sequences)
+                aligned_sequences = [row.tobytes() for row in aligned_sequences]
+                sequences, coordinates = Alignment.parse_alignment_block(
+                    aligned_sequences
+                )
+                for sequence, record in zip(sequences, records):
+                    record.seq = Seq(sequence)
                 alignment = Alignment(records, coordinates)
                 for index in sorted(skipped_columns, reverse=True):
                     del operations[index]  # noqa: F821
@@ -377,10 +379,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                         assert operations[i] != ord("D")
                         operations[i] = ord("I")  # insertion
                 aligned_sequence = aligned_sequence.replace(".", "-")
-                sequence = aligned_sequence.replace("-", "")
                 aligned_sequences.append(aligned_sequence)
-                seq = Seq(sequence)
-                record = SeqRecord(seq, id=seqname, description="")
+                record = SeqRecord(None, id=seqname, description="")
                 records.append(record)
             elif line.startswith("#=GF "):
                 # Generic per-File annotation, free text

--- a/Bio/Blast/_parser.py
+++ b/Bio/Blast/_parser.py
@@ -920,7 +920,7 @@ class XMLHandler:
         target_seq_aligned = hsp.hseq.encode()
         assert len(target_seq_aligned) == align_len
         (target_seq_data, query_seq_data), coordinates = (
-            Alignment.parse_alignment_block([target_seq_aligned, query_seq_aligned])
+            Alignment.parse_printed_alignment([target_seq_aligned, query_seq_aligned])
         )
         query = SeqRecord(None, query_id, description=query_description)
         query_start = hsp.query_from - 1

--- a/Bio/Blast/_parser.py
+++ b/Bio/Blast/_parser.py
@@ -915,14 +915,13 @@ class XMLHandler:
         query_id = query.id
         query_description = query.description
         query_length = len(query.seq)
-        query_seq_aligned = hsp.qseq
+        query_seq_aligned = hsp.qseq.encode()
         assert len(query_seq_aligned) == align_len
-        target_seq_aligned = hsp.hseq
+        target_seq_aligned = hsp.hseq.encode()
         assert len(target_seq_aligned) == align_len
-        coordinates = Alignment.infer_coordinates(
-            [target_seq_aligned, query_seq_aligned]
+        (target_seq_data, query_seq_data), coordinates = (
+            Alignment.parse_alignment_block([target_seq_aligned, query_seq_aligned])
         )
-        query_seq_data = query_seq_aligned.replace("-", "")
         query = SeqRecord(None, query_id, description=query_description)
         query_start = hsp.query_from - 1
         query_end = hsp.query_to
@@ -958,7 +957,6 @@ class XMLHandler:
         target_name = target.name
         target_description = target.description
         target_length = len(target.seq)
-        target_seq_data = target_seq_aligned.replace("-", "")
         target = SeqRecord(None, target_id, target_name, description=target_description)
         if program in ("blastn", "megablast"):
             try:
@@ -974,19 +972,24 @@ class XMLHandler:
                 target_start = hsp.hit_from - 1
                 target_end = hsp.hit_to
                 coordinates[0, :] += target_start
+                assert target_end - target_start == len(target_seq_data)
+                target_seq_data = {target_start: target_seq_data}
+                target.seq = Seq(target_seq_data, target_length)
             elif target_strand == "Minus":
                 target_start = hsp.hit_to - 1
                 target_end = hsp.hit_from
-                target_seq_data = reverse_complement(target_seq_data)
                 coordinates[0, :] = target_end - coordinates[0, :]
-            assert target_end - target_start == len(target_seq_data)
-            target_seq_data = {target_start: target_seq_data}
+                assert target_end - target_start == len(target_seq_data)
+                target_seq_data = {target_length - target_end: target_seq_data}
+                seq = Seq(target_seq_data, target_length)
+                target.seq = seq.reverse_complement()
         elif program in ("blastp", "blastx", "rpsblast"):
             target_start = hsp.hit_from - 1
             target_end = hsp.hit_to
             coordinates[0, :] += target_start
             assert target_end - target_start == len(target_seq_data)
             target_seq_data = {target_start: target_seq_data}
+            target.seq = Seq(target_seq_data, target_length)
         elif program in ("tblastn", "tblastx"):
             target_start = hsp.hit_from - 1
             target_end = hsp.hit_to
@@ -1002,9 +1005,9 @@ class XMLHandler:
             qualifiers = {"coded_by": coded_by}
             feature = SeqFeature(location, type="CDS", qualifiers=qualifiers)
             target.features.append(feature)
+            target.seq = Seq(target_seq_data, target_length)
         else:
             raise RuntimeError("Unexpected program name '%s'" % program)
-        target.seq = Seq(target_seq_data, target_length)
         sequences = [target, query]
         alignment = HSP(sequences, coordinates)
         alignment.num = hsp.num

--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -272,7 +272,7 @@ class Phylogeny(PhyloElement, BaseTree.Tree):
             lines.append(bytes(record.seq))
             records.append(record)
         if lines:
-            sequences, coordinates = Alignment.parse_alignment_block(lines)
+            sequences, coordinates = Alignment.parse_printed_alignment(lines)
             for sequence, record in zip(sequences, records):
                 record.seq = Seq(sequence)
         else:

--- a/Bio/Phylo/PhyloXML.py
+++ b/Bio/Phylo/PhyloXML.py
@@ -269,11 +269,12 @@ class Phylogeny(PhyloElement, BaseTree.Tree):
         lines = []
         for seq in seqs:
             record = seq.to_seqrecord()
-            lines.append(str(record.seq))
-            record.seq = record.seq.replace("-", "")
+            lines.append(bytes(record.seq))
             records.append(record)
         if lines:
-            coordinates = Alignment.infer_coordinates(lines)
+            sequences, coordinates = Alignment.parse_alignment_block(lines)
+            for sequence, record in zip(sequences, records):
+                record.seq = Seq(sequence)
         else:
             coordinates = None
         return Alignment(records, coordinates)

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -535,6 +535,11 @@ The Bio.SubsMat module was deprecated in Release 1.78, and removed in Release
 
 Bio.Align
 ---------
+The ``infer_coordinates`` class method of the ``Alignment`` class in
+``Bio.Align`` was deprecated in Release 1.84.  Instead,please use the
+``parse_printed_alignment`` method, which is much faster, and returns both the
+sequences after removing the gaps and the coordinates.
+
 The ``get_column`` method of the MultipleSeqAlignment was deprecated in
 Release 1.57 and removed in Release 1.69.
 

--- a/Doc/Tutorial/chapter_align.rst
+++ b/Doc/Tutorial/chapter_align.rst
@@ -126,7 +126,7 @@ Print the ``Alignment`` object to show the alignment explicitly:
 with the starting and end coordinate for each sequence are shown to the
 left and right, respectively, of the alignment.
 
-.. _`subsec:align_infer_coordinates`:
+.. _`subsec:align_parse_alignment_block`:
 
 Creating an Alignment object from aligned sequences
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Doc/Tutorial/chapter_align.rst
+++ b/Doc/Tutorial/chapter_align.rst
@@ -126,14 +126,14 @@ Print the ``Alignment`` object to show the alignment explicitly:
 with the starting and end coordinate for each sequence are shown to the
 left and right, respectively, of the alignment.
 
-.. _`subsec:align_parse_alignment_block`:
+.. _`subsec:align_parse_printed_alignment`:
 
 Creating an Alignment object from aligned sequences
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you start out with the aligned sequences, with dashes representing
 gaps, then you can calculate the coordinates using the
-``parse_alignment_block`` class method. This method is primarily employed in
+``parse_printed_alignment`` class method. This method is primarily employed in
 Biopython’s alignment parsers (see
 Section :ref:`sec:alignmentparsers`), but it may be useful for other
 purposes. For example, you can construct the ``Alignment`` object from
@@ -150,12 +150,9 @@ aligned sequences as follows:
    CGGTTTTT
    AG-TTT--
    AGGTTT--
-   >>> lines = [line.encode() for line in lines]  # convert to bytes
-   >>> lines
-   [b'CGGTTTTT', b'AG-TTT--', b'AGGTTT--']
-   >>> sequences, coordinates = Alignment.parse_alignment_block(lines)
+   >>> sequences, coordinates = Alignment.parse_printed_alignment(lines)
    >>> sequences
-   [b'CGGTTTTT', b'AGTTT', b'AGGTTT']
+   ['CGGTTTTT', 'AGTTT', 'AGGTTT']
    >>> coordinates
    array([[0, 2, 3, 6, 8],
           [0, 2, 2, 5, 5],
@@ -170,11 +167,8 @@ therefore missing here. But this is easy to fix:
 .. code:: pycon
 
    >>> from Bio.Seq import Seq
-   >>> sequences[0] = b"C" + sequences[0]
-   >>> sequences[1] = sequences[1] + b"AA"
-   >>> sequences
-   [b'CCGGTTTTT', b'AGTTTAA', b'AGGTTT']
-   >>> sequences = [sequence.decode() for sequence in sequences]
+   >>> sequences[0] = "C" + sequences[0]
+   >>> sequences[1] = sequences[1] + "AA"
    >>> sequences
    ['CCGGTTTTT', 'AGTTTAA', 'AGGTTT']
    >>> coordinates[0, :] += 1

--- a/Doc/Tutorial/chapter_align.rst
+++ b/Doc/Tutorial/chapter_align.rst
@@ -133,7 +133,7 @@ Creating an Alignment object from aligned sequences
 
 If you start out with the aligned sequences, with dashes representing
 gaps, then you can calculate the coordinates using the
-``infer_coordinates`` class method. This method is primarily employed in
+``parse_alignment_block`` class method. This method is primarily employed in
 Biopython’s alignment parsers (see
 Section :ref:`sec:alignmentparsers`), but it may be useful for other
 purposes. For example, you can construct the ``Alignment`` object from
@@ -143,13 +143,19 @@ aligned sequences as follows:
 
 .. code:: pycon
 
-   >>> aligned_sequences = ["CGGTTTTT", "AG-TTT--", "AGGTTT--"]
-   >>> sequences = [aligned_sequence.replace("-", "")
-   ...              for aligned_sequence in aligned_sequences]  # fmt: skip
+   >>> lines = ["CGGTTTTT", "AG-TTT--", "AGGTTT--"]
+   >>> for line in lines:
+   ...     print(line)
    ...
+   CGGTTTTT
+   AG-TTT--
+   AGGTTT--
+   >>> lines = [line.encode() for line in lines]  # convert to bytes
+   >>> lines
+   [b'CGGTTTTT', b'AG-TTT--', b'AGGTTT--']
+   >>> sequences, coordinates = Alignment.parse_alignment_block(lines)
    >>> sequences
-   ['CGGTTTTT', 'AGTTT', 'AGGTTT']
-   >>> coordinates = Alignment.infer_coordinates(aligned_sequences)
+   [b'CGGTTTTT', b'AGTTT', b'AGGTTT']
    >>> coordinates
    array([[0, 2, 3, 6, 8],
           [0, 2, 2, 5, 5],
@@ -163,8 +169,12 @@ therefore missing here. But this is easy to fix:
 
 .. code:: pycon
 
-   >>> sequences[0] = "C" + sequences[0]
-   >>> sequences[1] = sequences[1] + "AA"
+   >>> from Bio.Seq import Seq
+   >>> sequences[0] = b"C" + sequences[0]
+   >>> sequences[1] = sequences[1] + b"AA"
+   >>> sequences
+   [b'CCGGTTTTT', b'AGTTTAA', b'AGGTTT']
+   >>> sequences = [sequence.decode() for sequence in sequences]
    >>> sequences
    ['CCGGTTTTT', 'AGTTTAA', 'AGGTTT']
    >>> coordinates[0, :] += 1

--- a/setup.py
+++ b/setup.py
@@ -184,6 +184,7 @@ PACKAGES = [
 EXTENSIONS = [
     Extension("Bio.Align._codonaligner", ["Bio/Align/_codonaligner.c"]),
     Extension("Bio.Align._pairwisealigner", ["Bio/Align/_pairwisealigner.c"]),
+    Extension("Bio.Align._parser", ["Bio/Align/_parser.c"]),
     Extension("Bio.cpairwise2", ["Bio/cpairwise2module.c"]),
     Extension("Bio.Nexus.cnexus", ["Bio/Nexus/cnexus.c"]),
     Extension("Bio.motifs._pwm", ["Bio/motifs/_pwm.c"]),


### PR DESCRIPTION
`parse_printed_alignment` is implemented in C and is much faster than `infer_coordinates`, which was slow for long sequences.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
