### PR TITLE
Updating REBASE parser on Restriction Enzyme Dictionary creation script  

### DIFF
--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -284,6 +284,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Robert Ernst <https://github.com/rernst>
 - Robert Sawicki <https://github.com/Battlesheepu>
 - Rodrigo Dorantes-Gilardi <https://github.com/rodogi>
+- Rolando Rodriguez <https://github.com/Rolando-at-Arzeda>
 - Rona Costello <https://github.com/RonaCostello>
 - Rudolf Koopmann <https://github.com/koopmann>
 - Ryan Stecher <https://github.com/rystecher>

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -94,6 +94,8 @@ def read_enzyme_record(handle):
     for line in handle:
         key, value = line[:2], line[5:].rstrip()
         if key == "ID":
+            # Sync the replacement of "- and ." by "_" or enzyme will not be found in the bairoch list
+            value = value.replace("-", "_").replace(".", "_")
             record = {"ID": value}
         elif key == "AC":
             record["AC"] = value
@@ -452,7 +454,8 @@ class DictionaryBuilder:
             try:
                 enzyme_id = enzyme_id_dict[name]
             except KeyError:
-                print(f"Could not find REBASE enzyme ID for {name}: omitting")
+                # be more specific, this is a warning it just omits the REBASE URL
+                print(f"WARNING : Could not find REBASE enzyme ID for {name}: omitting url")
                 enzyme_id = None
             cls = newenzyme(name, enzyme_id)
             #
@@ -516,7 +519,7 @@ class DictionaryBuilder:
 
         update = os.getcwd()
         with open(os.path.join(update, "Restriction_Dictionary.py"), "w") as results:
-            print("Writing the dictionary containing the new Restriction classes...")
+            print("Writing the dictionary containing the new Restriction classes ... ", end='')
             results.write(start)
             results.write("rest_dict = {}\n")
             results.write("\n")
@@ -528,8 +531,8 @@ class DictionaryBuilder:
                         % (double_quote_repr(key), double_quote_repr(value))
                     )
                 results.write("}\n\n")
-            print("OK.\n")
-            print("Writing the dictionary containing the suppliers data...")
+            print("OK.")
+            print("Writing the dictionary containing the suppliers data ... ", end='')
             results.write("\n")
             results.write("# Turn black code style off\n# fmt: off\n")
             results.write("\n")
@@ -540,8 +543,8 @@ class DictionaryBuilder:
                 for value in suppliersdict[name]:
                     results.write("    %s,\n" % double_quote_repr(value))
                 results.write(")\n\n")
-            print("OK.\n")
-            print("Writing the dictionary containing the Restriction types...")
+            print("OK.")
+            print("Writing the dictionary containing the Restriction types ... ", end='')
             results.write("\n")
             results.write("typedict = {}\n")
             results.write("\n")
@@ -551,7 +554,7 @@ class DictionaryBuilder:
                     results.write("    %s,\n" % double_quote_repr(value))
                 results.write(")\n\n")
             results.write("# Turn black code style on\n# fmt: on\n")
-            print("OK.\n")
+            print("OK.")
 
     def install_dict(self):
         """Install the newly created dictionary in the site-packages folder.
@@ -621,8 +624,8 @@ class DictionaryBuilder:
         shutil.copyfile(old, os.path.join(update, "Restriction_Dictionary.old"))
         places = update, os.path.split(Bio.Restriction.Restriction.__file__)[0]
         print(
-            "\t\tCompilation of the new dictionary : OK."
-            "\n\t\tInstallation : No.\n"
+            " Compilation of the new dictionary : OK."
+            "\n Installation : No.\n"
             "\n You will find the newly created 'Restriction_Dictionary.py' file"
             "\n in the folder : \n"
             "\n\t%s\n"
@@ -654,9 +657,9 @@ class DictionaryBuilder:
             #
             #   nothing to be done
             #
-            print("\n Using the bairoch file : %s" % bairoch_now)
+            print("\nUsing the bairoch file : %s" % bairoch_now)
             enzyme_id_dict = load_enzyme_ids(bairoch_now)
-            print("\n Using the emboss files : %s" % ", ".join(emboss_now))
+            print("Using the emboss files : %s" % ", ".join(emboss_now))
             return tuple(open(os.path.join(base, n)) for n in emboss_now) + (
                 enzyme_id_dict,
             )
@@ -671,8 +674,8 @@ class DictionaryBuilder:
             r = input(" update [n] >>> ")
             if r in ["y", "yes", "Y", "Yes"]:
                 get_files()
-                print("\n Update complete. Creating the dictionaries.\n")
-                print("\n Using the files : %s" % ", ".join(emboss_now))
+                print("\nUpdate complete. Creating the dictionaries.")
+                print("Using the files : %s" % ", ".join(emboss_now))
                 return tuple(open(os.path.join(base, n)) for n in emboss_now)
             else:
                 #
@@ -779,10 +782,10 @@ class DictionaryBuilder:
             #
             print(
                 "\nWARNING : %s cut twice with different overhang length each time."
-                "\n\tUnable to deal with this behaviour. "
-                "\n\tThis enzyme will not be included in the database. Sorry." % name
+                "\n\t  Unable to deal with this behaviour. "
+                "\n\t  This enzyme will not be included in the database. Sorry." % name
             )
-            print("\tChecking...")
+            print("\t  Checking...")
             raise OverhangError
         if 0 <= fst5 <= size and 0 <= fst3 <= size:
             #
@@ -986,17 +989,24 @@ class DictionaryBuilder:
                         line.append(bl[2])
                         i2 += 1
                     else:
-                        raise TypeError
+                        # this error happens when line is an older format or without suppliers, append the two missing fields ..
+                        line.append("")
+                        line.append("")
+                        #raise TypeError
                 oldblock = block
                 i2 += 1
                 try:
+                    # check for ? in the enzyme line and omit entry as not defined
+                    if "?" in line:
+                        print("ERROR   : Not defined cleavage for Enzyme: ",line[0]," omitting entry" )
+                        continue
                     line = self.parseline(line)
                 except OverhangError:  # overhang error
                     n = name  # do not include the enzyme
                     if not bl[2]:
-                        print(f"Anyway, {n} is not commercially available.\n")
+                        print(f"\t  Anyway, {n} is not commercially available.\n")
                     else:
-                        print(f"Unfortunately, {n} is commercially available.\n")
+                        print(f"\t  Unfortunately, {n} is commercially available.\n")
 
                     continue
                 # Hyphens and dots can't be used as a Python name, nor as a


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Address issue: #4437

This Pull Request will be updating the parser on the Restriction Enzyme Dictionary creation script (/Scripts/Rebase/ranacompiler.py) to support all EMBOSS files generated by REBASE or self created using the EMBOSS  "rebaseextract" command. Minor changes on the output text were also done to make the messages more understandable.

REBASE will add the missing restriction Type I enzymes to embossa_[ers].XXX starting from the next release, as we requested. I would recommend generating the BioPython Restriction Enzyme Dictionary from "embossa" instead, as it will add some 3000 enzymes (+ the Type I) to the current dict. This is particularly important to be able to check any recombinant DNA construct against relevant restriction enzymes natural to the host, or used on the DNA construction process. 

I can add the changes to the relevant code and the newly generated dictionary later on another Pull Request.