### PR TITLE
Improve CE Align

### DIFF
--- a/Bio/PDB/ccealignmodule.c
+++ b/Bio/PDB/ccealignmodule.c
@@ -267,16 +267,6 @@ findPath(
         pathBuffer[i] = 0;
     }
 
-    // The implementation uses this array during
-    // the construction of the current path.
-    // This array keeps track of similarities for
-    // all gap indices for all path lengths.
-    double *allSimilarityBuffer = (double *)malloc(sizeof(double) * smaller);
-
-    for (int i = 0; i < smaller; i++) {
-        allSimilarityBuffer[i] = -1e6;
-    }
-
     //======================================================================
     // Start the search through the similarity matrix.
     //
@@ -295,7 +285,7 @@ findPath(
             // Initialize current path
             path curPath = (path)malloc(sizeof(afp) * smaller);
             int curPathLength = 1;
-            double curPathSimilarity = 0.0;
+            double curPathSimilarity = S[iA][iB];
 
             curPath[0].first = iA;
             curPath[0].second = iB;
@@ -379,19 +369,14 @@ findPath(
                     const int m = fragmentSize;
                     const int w = (m - 1) * (m - 2) / 2; // w is the number of terms in the similarity summation
 
-                    const double oldTermCount = n * w + m * n * (n - 1) / 2;
-                    const double oldSimilarity = curPathLength > 1
-                              ? allSimilarityBuffer[curPathLength - 2]
-                              : S[iA][iB];
+                    const double curTermCount = n * w + m * n * (n - 1) / 2;
                     const double addTermCount = w + m * n;
                     const double addSimilarity = (gapBestSimilarity * m * n + S[gA][gB] * w) / addTermCount;
-                    const double newTermCount = oldTermCount + addTermCount;
-                    const double newSimilarity = (oldSimilarity * oldTermCount + addSimilarity * addTermCount) / newTermCount;
+                    const double newTermCount = curTermCount + addTermCount;
+                    const double newSimilarity = (curPathSimilarity * curTermCount + addSimilarity * addTermCount) / newTermCount;
 
-                    curPathSimilarity = newSimilarity;
-
-                    if (curPathSimilarity > D1) {
-                        allSimilarityBuffer[curPathLength - 1] = curPathSimilarity;
+                    if (newSimilarity > D1) {
+                        curPathSimilarity = newSimilarity;
                         curPathLength++;
                     }
                     else {
@@ -482,7 +467,6 @@ findPath(
     }
 
     // Free memory
-    free(allSimilarityBuffer);
     free(pathBuffer);
 
     return result;

--- a/Bio/PDB/ccealignmodule.c
+++ b/Bio/PDB/ccealignmodule.c
@@ -267,23 +267,15 @@ findPath(
         pathBuffer[i] = 0;
     }
 
-    // The implementation uses this 2D array during
+    // The implementation uses this array during
     // the construction of the current path.
-    // This 2D array keeps track of similarities for
+    // This array keeps track of similarities for
     // all gap indices for all path lengths.
-    double **allSimilarityBuffer = (double **)malloc(sizeof(double *) * smaller);
+    double *allSimilarityBuffer = (double *)malloc(sizeof(double) * smaller);
 
     for (int i = 0; i < smaller; i++) {
-        allSimilarityBuffer[i] =
-            (double *)malloc((gapMax * 2 + 1) * sizeof(double));
-
-        // Initialize the ASB
-        for (int j = 0; j < gapMax * 2 + 1; j++) {
-            allSimilarityBuffer[i][j] = -1e6;
-        }
+        allSimilarityBuffer[i] = -1e6;
     }
-
-    int *tIndex = (int *)malloc(sizeof(int) * smaller);
 
     //======================================================================
     // Start the search through the similarity matrix.
@@ -299,9 +291,6 @@ findPath(
                 continue;
             if (iB > lenB - fragmentSize * (bestPathLength - 1))
                 break;
-
-            // Reset tIndex
-            tIndex[0] = 0;
 
             // Initialize current path
             path curPath = (path)malloc(sizeof(afp) * smaller);
@@ -346,10 +335,6 @@ findPath(
                     // 2nd: If this candidate AFP is bad, ignore it.
                     if (S[jA][jB] <= D0)
                         continue;
-                    // 3rd: if too close to end, ignore it.
-                    if (S[jA][jB] == -1.0)
-                        // TODO: Remove
-                        continue;
 
                     double curSimilarity = 0.0;
 
@@ -367,7 +352,6 @@ findPath(
                         curPath[curPathLength].second = jB;
                         gapBestSimilarity = curSimilarity;
                         gapBestIndex = g;
-                        allSimilarityBuffer[curPathLength - 1][g] = curSimilarity;
                     }
                 } /// ROF -- END GAP SEARCHING
 
@@ -397,8 +381,7 @@ findPath(
 
                     const double oldTermCount = n * w + m * n * (n - 1) / 2;
                     const double oldSimilarity = curPathLength > 1
-                              ? (allSimilarityBuffer[curPathLength - 2]
-                                               [tIndex[curPathLength - 1]])
+                              ? allSimilarityBuffer[curPathLength - 2]
                               : S[iA][iB];
                     const double addTermCount = w + m * n;
                     const double addSimilarity = (gapBestSimilarity * m * n + S[gA][gB] * w) / addTermCount;
@@ -408,9 +391,7 @@ findPath(
                     curPathSimilarity = newSimilarity;
 
                     if (curPathSimilarity > D1) {
-                        allSimilarityBuffer[curPathLength - 1][gapBestIndex] =
-                            curPathSimilarity;
-                        tIndex[curPathLength] = gapBestIndex;
+                        allSimilarityBuffer[curPathLength - 1] = curPathSimilarity;
                         curPathLength++;
                     }
                     else {
@@ -501,12 +482,7 @@ findPath(
     }
 
     // Free memory
-    for (int i = 0; i < smaller; i++) {
-        free(allSimilarityBuffer[i]);
-    }
-
     free(allSimilarityBuffer);
-    free(tIndex);
     free(pathBuffer);
 
     return result;

--- a/Bio/PDB/ccealignmodule.c
+++ b/Bio/PDB/ccealignmodule.c
@@ -96,8 +96,8 @@ typedef struct {
 
 // An AFP (aligned fragment pair), and list/pointer
 typedef struct {
-    int first;
-    int second;
+    int pA;
+    int pB;
 } afp, *path, **pathCache;
 
 // Calculate distance matrix
@@ -134,10 +134,10 @@ similarityI(
     const afp afpJ,
     const int fragmentSize)
 {
-    const int iA = afpI.first;
-    const int iB = afpI.second;
-    const int jA = afpJ.first;
-    const int jB = afpJ.second;
+    const int iA = afpI.pA;
+    const int iB = afpI.pB;
+    const int jA = afpJ.pA;
+    const int jB = afpJ.pB;
     const int m = fragmentSize;
     double similarity = fabs(dA[iA][jA] - dB[iB][jB]) +
         fabs(dA[iA + m-1][jA + m-1] - dB[iB + m-1][jB + m-1]);
@@ -160,10 +160,10 @@ similarityII(
     const afp afpI,
     const int fragmentSize)
 {
-    const int iA = afpI.first;
-    const int iB = afpI.second;
+    const int iA = afpI.pA;
+    const int iB = afpI.pB;
     double similarity = 0.0;
-    // Term count is the closed form of the number of terms in the summation
+    // Term count is the number of terms in the summation
     const int termCount = (fragmentSize - 1) * (fragmentSize - 2) / 2;
 
     for (int k = 0; k < fragmentSize - 2; k++) {
@@ -306,8 +306,8 @@ findPath(
                 // Check all possible gaps from here
                 //
                 for (int g = 0; g < (gapMax * 2) + 1; g++) {
-                    int jA = curPath[curPathLength - 1].first + fragmentSize;
-                    int jB = curPath[curPathLength - 1].second + fragmentSize;
+                    int jA = curPath[curPathLength - 1].pA + fragmentSize;
+                    int jB = curPath[curPathLength - 1].pB + fragmentSize;
 
                     if ((g + 1) % 2 == 0) {
                         jA += (g + 1) / 2;
@@ -353,13 +353,13 @@ findPath(
                 int jGap = (gapBestIndex + 1) / 2;
 
                 if ((gapBestIndex + 1) % 2 == 0) {
-                    gA = curPath[curPathLength - 1].first + fragmentSize + jGap;
-                    gB = curPath[curPathLength - 1].second + fragmentSize;
+                    gA = curPath[curPathLength - 1].pA + fragmentSize + jGap;
+                    gB = curPath[curPathLength - 1].pB + fragmentSize;
                 }
                 else {
-                    gA = curPath[curPathLength - 1].first + fragmentSize;
+                    gA = curPath[curPathLength - 1].pA + fragmentSize;
                     gB =
-                        curPath[curPathLength - 1].second + fragmentSize + jGap;
+                        curPath[curPathLength - 1].pB + fragmentSize + jGap;
                 }
 
                 // TODO: This implementation calculates the average inter-residue distance difference.
@@ -434,16 +434,17 @@ findPath(
         Py_INCREF(pathAList);
         Py_INCREF(pathBList);
 
+        // TODO: Can we use the length buffer here?
         for (int j = 0; j < smaller; j++) {
-            if (pathBuffer[o][j].first != -1) {
-                const int idxA = pathBuffer[o][j].first;
-                const int idxB = pathBuffer[o][j].second;
+            if (pathBuffer[o][j].pA != -1) {
+                const int pA = pathBuffer[o][j].pA;
+                const int pB = pathBuffer[o][j].pB;
 
                 for (int k = 0; k < fragmentSize; k++) {
-                    PyObject *v = Py_BuildValue("i", idxA + k);
+                    PyObject *v = Py_BuildValue("i", pA + k);
                     PyList_Append(pathAList, v);
                     Py_DECREF(v);
-                    v = Py_BuildValue("i", idxB + k);
+                    v = Py_BuildValue("i", pB + k);
                     PyList_Append(pathBList, v);
                     Py_DECREF(v);
                 }

--- a/Bio/PDB/ccealignmodule.c
+++ b/Bio/PDB/ccealignmodule.c
@@ -349,30 +349,17 @@ findPath(
                     break;
                 }
 
-                int gA, gB;
-                int jGap = (gapBestIndex + 1) / 2;
-
-                if ((gapBestIndex + 1) % 2 == 0) {
-                    gA = curPath[curPathLength - 1].pA + fragmentSize + jGap;
-                    gB = curPath[curPathLength - 1].pB + fragmentSize;
-                }
-                else {
-                    gA = curPath[curPathLength - 1].pA + fragmentSize;
-                    gB =
-                        curPath[curPathLength - 1].pB + fragmentSize + jGap;
-                }
-
-                // TODO: This implementation calculates the average inter-residue distance difference.
-                // Instead, the implementation should calculate the average similarity as described in the paper.
+                // The current path has n AFPs, and we are considering adding the (n+1)-th AFP.
+                // Imagine a matrix where entry ij is D_ij of the i-th and j-th AFPs in the path.
+                // The path similarity is the average of the upper triangle of this matrix.
+                const afp afpJ = curPath[curPathLength];
                 const double n = (double) curPathLength;
-                const int m = fragmentSize;
-                const int w = (m - 1) * (m - 2) / 2; // w is the number of terms in the similarity summation
-
-                const double curTermCount = n * w + m * n * (n - 1) / 2;
-                const double addTermCount = w + m * n;
-                const double addSimilarity = (gapBestSimilarity * m * n + S[gA][gB] * w) / addTermCount;
-                const double newTermCount = curTermCount + addTermCount;
-                const double newSimilarity = (curPathSimilarity * curTermCount + addSimilarity * addTermCount) / newTermCount;
+                const double curTermCount = n + n * (n - 1) / 2;
+                const double newTermCount = n + 1 + n * (n + 1) / 2;
+                // Notice that the new term count is the current term count plus n + 1.
+                const double newSimilarity = (curTermCount * curPathSimilarity +
+                        n * gapBestSimilarity +
+                        S[afpJ.pA][afpJ.pB]) / newTermCount;
 
                 if (newSimilarity > D1) {
                     curPathSimilarity = newSimilarity;

--- a/Bio/PDB/ccealignmodule.c
+++ b/Bio/PDB/ccealignmodule.c
@@ -101,13 +101,13 @@ typedef struct {
 } afp, *path, **pathCache;
 
 // Calculate Distance Matrix
-double **
-calcDM(pcePoint coords, int len) {
-
+static double **
+calcDM(pcePoint coords, int len)
+{
     double **dm = (double **)malloc(sizeof(double *) * len);
+
     for (int i = 0; i < len; i++)
         dm[i] = (double *)malloc(sizeof(double) * len);
-
     for (int row = 0; row < len; row++) {
         for (int col = row; col < len; col++) {
             double xd = coords[row].x - coords[col].x;
@@ -117,12 +117,14 @@ calcDM(pcePoint coords, int len) {
             dm[row][col] = dm[col][row] = sqrt(distsq);
         }
     }
+
     return dm;
 }
 
 // Calculate Score Matrix
-double **
-calcS(double **d1, double **d2, int lenA, int lenB, int wSize) {
+static double **
+calcS(double **d1, double **d2, int lenA, int lenB, int wSize)
+{
     int i;
     double winSize = (double)wSize;
 
@@ -170,8 +172,9 @@ calcS(double **d1, double **d2, int lenA, int lenB, int wSize) {
     return S;
 }
 
-pcePoint
-getCoords(PyObject *L, int length) {
+static pcePoint
+getCoords(PyObject *L, int length)
+{
     // make space for the current coords
     pcePoint coords = (pcePoint)malloc(sizeof(cePoint) * length);
 
@@ -206,10 +209,10 @@ getCoords(PyObject *L, int length) {
 }
 
 // Find the best N alignment paths
-PyObject *
+static PyObject *
 findPath(double **S, double **dA, double **dB, int lenA, int lenB,
-                   int winSize, int gapMax) {
-
+                   int winSize, int gapMax)
+{
     const double D0 = 3.0;
     const double D1 = 4.0;
     int i, j;
@@ -505,7 +508,6 @@ findPath(double **S, double **dA, double **dB, int lenA, int lenB,
     Py_INCREF(result);
 
     for (int o = 0; o < bufferSize; o++) {
-
         // Make a new list to store this path
         PyObject *pathAList = PyList_New(0);
         PyObject *pathBList = PyList_New(0);
@@ -544,7 +546,6 @@ findPath(double **S, double **dA, double **dB, int lenA, int lenB,
     free(tIndex);
     free(winCache);
     free(bestPath);
-
     free(pathBuffer);
 
     return result;
@@ -552,7 +553,8 @@ findPath(double **S, double **dA, double **dB, int lenA, int lenB,
 
 // Main Function
 PyObject *
-PyCealign(PyObject *Py_UNUSED(self), PyObject *args) {
+PyCealign(PyObject *Py_UNUSED(self), PyObject *args)
+{
 
     int i = 0;
     int windowSize = 8;
@@ -628,7 +630,8 @@ PyDoc_STRVAR(module_doc,
 This module implements a single function: run_cealign. \
 Refer to its docstring for more documentation on usage and implementation.");
 
-PyObject *PyInit_ccealign(void) {
+PyObject *PyInit_ccealign(void)
+{
     static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,
                                            "ccealign",
                                            module_doc,

--- a/Bio/PDB/ccealignmodule.c
+++ b/Bio/PDB/ccealignmodule.c
@@ -434,23 +434,17 @@ findPath(
         Py_INCREF(pathAList);
         Py_INCREF(pathBList);
 
-        // TODO: Can we use the length buffer here?
-        for (int j = 0; j < smaller; j++) {
-            if (pathBuffer[o][j].pA != -1) {
-                const int pA = pathBuffer[o][j].pA;
-                const int pB = pathBuffer[o][j].pB;
+        for (int j = 0; j < lenBuffer[o]; j++) {
+            const int pA = pathBuffer[o][j].pA;
+            const int pB = pathBuffer[o][j].pB;
 
-                for (int k = 0; k < fragmentSize; k++) {
-                    PyObject *v = Py_BuildValue("i", pA + k);
-                    PyList_Append(pathAList, v);
-                    Py_DECREF(v);
-                    v = Py_BuildValue("i", pB + k);
-                    PyList_Append(pathBList, v);
-                    Py_DECREF(v);
-                }
-            }
-            else {
-                break;
+            for (int k = 0; k < fragmentSize; k++) {
+                PyObject *v = Py_BuildValue("i", pA + k);
+                PyList_Append(pathAList, v);
+                Py_DECREF(v);
+                v = Py_BuildValue("i", pB + k);
+                PyList_Append(pathBList, v);
+                Py_DECREF(v);
             }
         }
 

--- a/Bio/PDB/ccealignmodule.c
+++ b/Bio/PDB/ccealignmodule.c
@@ -157,10 +157,12 @@ static double **
 calcS(double **dA, double **dB, int lenA, int lenB, int wSize)
 {
     // Initialize the 2D similarity matrix
-    double **S = (double **)malloc(sizeof(double *) * lenA);
+    const int rowCount = lenA - wSize + 1;
+    const int colCount = lenB - wSize + 1;
+    double **S = (double **)malloc(sizeof(double *) * rowCount);
 
-    for (int i = 0; i < lenA; i++) {
-        S[i] = (double *)malloc(sizeof(double) * lenB);
+    for (int i = 0; i < rowCount; i++) {
+        S[i] = (double *)malloc(sizeof(double) * colCount);
     }
 
     //
@@ -171,7 +173,7 @@ calcS(double **dA, double **dB, int lenA, int lenB, int wSize)
     //
     for (int iA = 0; iA < rowCount; iA++) {
         for (int iB = 0; iB < colCount; iB++) {
-            S[iA][iB] = similarityII(dA, dB, iA, iB, iA, iB, wSize);
+            S[iA][iB] = similarityII(d1, d2, iA, iB, iA, iB, wSize);
         }
     }
 
@@ -277,17 +279,13 @@ findPath(double **S, double **dA, double **dB, int lenA, int lenB,
     // Start the search through the CE matrix.
     //
     int iA, iB;
-    for (iA = 0; iA < lenA; iA++) {
+    for (iA = 0; iA <= lenA - winSize; iA++) {
         if (iA > lenA - winSize * (bestPathLength - 1))
             break;
 
-        for (iB = 0; iB < lenB; iB++) {
+        for (iB = 0; iB <= lenB - winSize; iB++) {
             if (S[iA][iB] >= D0)
                 continue;
-
-            if (S[iA][iB] == -1.0)
-                continue;
-
             if (iB > lenB - winSize * (bestPathLength - 1))
                 break;
 
@@ -332,12 +330,9 @@ findPath(double **S, double **dA, double **dB, int lenA, int lenB,
                     // long paths and make sure we don't run over the end of
                     // the S, matrix.
 
-                    // 1st: If jA and jB are at the end of the matrix
-                    if (jA > lenA - winSize || jB > lenB - winSize) {
-                        // FIXME, was: jA > lenA-winSize-1 || jB >
-                        // lenB-winSize-1
+                    // 1st: If jA and jB are at the end of the similarity matrix
+                    if (jA > lenA - winSize || jB > lenB - winSize)
                         continue;
-                    }
                     // 2nd: If this gapped octapeptide is bad, ignore it.
                     if (S[jA][jB] > D0)
                         continue;
@@ -603,8 +598,8 @@ PyCealign(PyObject *Py_UNUSED(self), PyObject *args)
         free(dmB[i]);
     free(dmB);
 
-    /* similarity matrix */
-    for (i = 0; i < lenA; i++)
+    // Similarity matrix
+    for (i = 0; i <= lenA - windowSize; i++)
         free(S[i]);
     free(S);
 

--- a/Bio/PDB/ccealignmodule.c
+++ b/Bio/PDB/ccealignmodule.c
@@ -336,7 +336,7 @@ findPath(
                         jB += (g + 1) / 2;
                     }
 
-                    // Following are three heuristics to ensure high quality
+                    // Following are two heuristics to ensure high quality
                     // long paths and make sure we don't run over the end of
                     // the S, matrix.
 
@@ -345,9 +345,6 @@ findPath(
                         continue;
                     // 2nd: If this candidate AFP is bad, ignore it.
                     if (S[jA][jB] >= D0)
-                        continue;
-                    // 3rd: if too close to end, ignore it.
-                    if (S[jA][jB] == -1.0)
                         continue;
 
                     double curSimilarity = 0.0;

--- a/Bio/PDB/ccealignmodule.c
+++ b/Bio/PDB/ccealignmodule.c
@@ -390,6 +390,7 @@ findPath(
             if (curPathLength > lenBuffer[bufferIndex] ||
                 (curPathLength == lenBuffer[bufferIndex] &&
                  curPathSimilarity > similarityBuffer[bufferIndex])) {
+                // TODO: We should use a heap, not a circular buffer
                 bufferIndex += 1;
                 bufferIndex %= MAX_PATHS;
                 bufferSize =

--- a/Bio/PDB/ccealignmodule.c
+++ b/Bio/PDB/ccealignmodule.c
@@ -325,8 +325,7 @@ findPath(
             //
             // Build the best path starting from iA, iB
             //
-            int done = 0;
-            while (!done) {
+            while (1) {
                 double gapBestScore = 1e6;
                 int gapBestIndex = -1;
 
@@ -421,16 +420,13 @@ findPath(
                         curPathLength++;
                     }
                     else {
-                        // heuristic -- path is getting sloppy, stop looking
-                        done = 1;
-                        gapBestIndex = -1;
+                        // Heuristic -- path is getting sloppy, stop looking
                         break;
                     }
                 }
                 else {
                     // if here, then there was no good candidate AFP,
                     // so quit and restart from iA, iB+1
-                    done = 1;
                     curPathLength--;
                     break;
                 }

--- a/Bio/PDB/ccealignmodule.c
+++ b/Bio/PDB/ccealignmodule.c
@@ -285,12 +285,10 @@ findPath(
             int curPathLength = 1;
             double curPathSimilarity = S[iA][iB];
 
-            curPath[0].first = iA;
-            curPath[0].second = iB;
+            curPath[0] = (afp) {iA, iB};
 
             for (int i = 1; i < smaller; i++) {
-                curPath[i].first = -1;
-                curPath[i].second = -1;
+                curPath[i] = (afp) {-1, -1};
             }
 
             //
@@ -336,8 +334,7 @@ findPath(
 
                     // store GAPPED best
                     if (curSimilarity > D1 && curSimilarity > gapBestSimilarity) {
-                        curPath[curPathLength].first = jA;
-                        curPath[curPathLength].second = jB;
+                        curPath[curPathLength] = (afp) {jA, jB};
                         gapBestSimilarity = curSimilarity;
                         gapBestIndex = g;
                     }
@@ -397,8 +394,7 @@ findPath(
                 path pathCopy = (path)malloc(sizeof(afp) * smaller);
 
                 for (int i = 0; i < smaller; i++) {
-                    pathCopy[i].first = curPath[i].first;
-                    pathCopy[i].second = curPath[i].second;
+                    pathCopy[i] = curPath[i];
                 }
                 if (pathBuffer[bufferIndex]) {
                     free(pathBuffer[bufferIndex]);

--- a/Bio/PDB/cealign.py
+++ b/Bio/PDB/cealign.py
@@ -113,7 +113,10 @@ class CEAligner:
         # CEAlign returns the best N paths, where each path is a pair of lists
         # with aligned atom indices. Paths are not guaranteed to be unique.
         paths = run_cealign(self.refcoord, coord, self.window_size, self.max_gap)
-        unique_paths = {(tuple(pA), tuple(pB)) for pA, pB in paths}
+        longest_length = len(paths[0][0])
+        unique_paths = [
+            (tuple(pA), tuple(pB)) for pA, pB in paths if len(pA) == longest_length
+        ]
 
         # Iterate over unique paths and find the one that gives the lowest
         # corresponding RMSD. Use QCP to align the molecules.

--- a/Bio/PDB/cealign.py
+++ b/Bio/PDB/cealign.py
@@ -111,18 +111,18 @@ class CEAligner:
 
         # Run CEAlign
         # CEAlign returns the best N paths, where each path is a pair of lists
-        # with aligned atom indices. Paths are not guaranteed to be unique.
+        # with aligned atom indices.
         paths = run_cealign(self.refcoord, coord, self.window_size, self.max_gap)
         longest_length = len(paths[0][0])
-        unique_paths = [
+        longest_paths = [
             (tuple(pA), tuple(pB)) for pA, pB in paths if len(pA) == longest_length
         ]
 
-        # Iterate over unique paths and find the one that gives the lowest
+        # Iterate over paths and find the one that gives the lowest
         # corresponding RMSD. Use QCP to align the molecules.
         best_rmsd, best_u = 1e6, None
-        for u_path in unique_paths:
-            idxA, idxB = u_path
+        for path in longest_paths:
+            idxA, idxB = path
 
             coordsA = np.array([self.refcoord[i] for i in idxA])
             coordsB = np.array([coord[i] for i in idxB])

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -54,6 +54,11 @@ A function called ``Bio.Phylo.to_igraph`` has been added to convert a
 ``Bio.Phylo.Tree`` into an ``igraph.Graph`` graph, in parallel to the existing
 function to convert the same object into a ``networkx`` graph.
 
+The PDB module's CE Align code for pairwise structure alignment was cleaned up,
+and the improved CE align code now considers more alignments and selects one of
+the longer alignments with the smallest RMSD. As a result, users may find
+alignments with slightly smaller RMSDs when using CE Align.
+
 The PDB module no longer uses the PDB FTP server by default.
 Instead, the PDB module uses the HTTPS server in most cases.
 For ``get_all_assemblies``, the PDB module now uses the


### PR DESCRIPTION
### Acknowledgements

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

### Description

In this pull request, I refactor, optimize, and simplify the implementation of CE Align in Biopython. I committed my changes in small increments in case one would like to see how my changes evolved.

Some notable changes are:
* the removal of extra space and unnecessary buffers,
* negation of "similarity" or "scores" so that a higher score indicates more similarity,
* changing how the total path similarity is calculated to match the CE align paper.

### Testing

The original unit tests still pass.

I tested my changes by aligning various human protein kinases with Aurora A kinase as the reference structure. I found a list of human kinases in [this paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6930252/#MOESM5).

Here are the kinase PDB codes:
```
['6NPZB', '3E8DB', '5OTFA', '2VD5A', '5UVCA', '4YHJB', '4TNDA', '2ACXA', '5LOHA', '2BIYA', '4OTGA', '4CRSA', '6C0UA', '4RA4A', '2I0EB', '3TXOA', '3A8XA', '5F9EB', '6C0TA', '5WNED', '5U7RB', '2Z7RA', '4NW6A', '1VZOA', '6G78A', '3WF9A', '3HDNA', '4FR4F', '6BXIB', '6R4DA', '4AF3A', '6GR9A', '2JC6C', '2JAMB', '4FG7A', '2VZ6B', '3BHHB', '6AYWB', '2V7OA', '2W4OA', '6CD6A', '6CMJB', '3TACA', '6FCKA', '4A9UA', '6FHBA', '2CKED', '5A6NA', '5JZNA', '3M42A', '3R1NA', '2HAKF', '3IECC', '3FE3B', '5ES1A', '4UMPB', '2HW6A', '2AC3A', '2X4FB', '3DLSA', '2Y7JC', '6NO9A', '2IWIA', '5TA8A', '4I6FA', '4B6LA', '3COKB', '6C9JA', '6B2EA', '4NIFD', '4JG8A', '3KN6B', '5YKSB', '2WTKC', '3LM5A', '5L2QC', '5CEMA', '4JNWB', '6GZDA', '6GZMB', '4HOKM', '2CMWA', '2C47D', '6GROA', '4NFNA', '6CNXA', '6NCGA', '2JIIB', '5ACBC', '5EFQC', '5G6VA', '6GU4A', '6GUFC', '3G33C', '3O0GA', '1XO2B', '6O9L8', '5XS2A', '4OR5F', '4AGUC', '4AAAA', '3ZDUA', '4BGQA', '6RAAA', '6FYLA', '6RCTB', '6FYVA', '6Q4QB', '6QY9A', '4YU2D', '5LXDB', '5Y86A', '6H0UB', '4H39A', '3GC8B', '1CM8B', '4MYGB', '1WBWA', '6QAWA', '6GESB', '5O7IA', '3O2MB', '3E7OA', '4IJPA', '1WAKA', '5MYVA', '4B9DB', '5M53A', '4WSQB', '4W9WA', '6F7BA', '4F9BA', '5EBZL', '2A1AB', '4X7LA', '4U6RA', '4Y8DB', '6G3AA', '4KIKB', '4MWIA', '6BHCA', '5VD3A', '5VE6A', '4OAUC', '2BUJA', '6O8BB', '5O0YA', '5AP1A', '5CI7A', '6QAVC', '6FDYU', '5VD7A', '5VDKA', '5WE8B', '5O21B', '4ANBA', '1S9IA', '3ALOA', '3VN9A', '6QHRA', '4IDVD', '5VIOD', '5IU2B', '6CQDB', '5J5TA', '4ZK5A', '3DAKD', '5KBQA', '6FD3A', '5ZJWA', '2F57B', '4KS8A', '2JFMA', '6HXFC', '4W8EA', '2XIKA', '4FZAB', '5DH3A', '3COMB', '2WTKB', '6BDNA', '5AX9C', '6GIPA', '4ASXB', '2QLUA', '3MY0O', '3MDYC', '3G2FA', '4MNEB', '6MIBA', '6BFNB', '2NRUD', '5KKRB', '5HVKA', '4TPTA', '5CENA', '5X5OA', '4UYAA', '5JGDA', '4UY9B', '3OMVB', '4ITIA', '5NG0B', '6B8YA', '5QINA', '6B5JC', '4TWPB', '2XYNC', '3LCTA', '5U6BD', '3SXSA', '1K2PA', '3LCDA', '3D7UC', '6FIOA', '6FERF', '5XGNA', '4P2KA', '3FXXA', '2R2PA', '2REIA', '3KULB', '5MJBB', '3ZFMA', '5L6PA', '3ZEWA', '3PP0B', '3KEXA', '3BCEC', '3CBLA', '3KXXB', '5UI0B', '4K33A', '6JPJA', '3HNGA', '4XUFB', '2DQ7X', '2HK5A', '3QQUC', '4XLVA', '3QGYB', '4L00B', '6C7YA', '6M9HA', '5TQ8A', '6GL9B', '3CJGA', '1PKGA', '3LCKA', '3A4OX', '3BRBA', '4IWDA', '3PLSA', '5KVTA', '4AT4A', '3V5QB', '5GRNA', '4H1MA', '2ETMA', '6CZ4A', '6FEKA', '4GT4A', '4UXLA', '1YI6B', '5CXHA', '2OSCA', '3EQPB', '3ZONA', '4GVJA', '1U59A']
```

#### Testing Script
```python
import os.path
import time
import pandas as pd
from Bio.PDB import PDBList, MMCIFParser, CEAligner


df = pd.read_excel('data/41598_2019_56499_MOESM5_ESM.xlsx')
pdb_codes = df['10_PDB_validation'].dropna()
pdb_list = PDBList()

pdb_list.download_pdb_files([pdb_code[:4] for pdb_code in pdb_codes], pdir='data/pdb')
pdb_codes = [pdb_code for pdb_code in pdb_codes if os.path.exists(f'data/pdb/{pdb_code[:4].lower()}.cif')]

parser = MMCIFParser()
# I downloaded 3E5A manually from RCSB.
aurora_a = parser.get_structure('3E5A', 'data/pdb/3e5a.cif')

aligner = CEAligner()
aligner.set_reference(aurora_a)
alignments = []

start_time = time.time()

for pdb_code in pdb_codes:
    structure = parser.get_structure(pdb_code[:4].upper(), f'data/pdb/{pdb_code[:4].lower()}.cif')
    aligner.align(structure)
    alignments.append({
        'PDB Code': pdb_code[:4],
        'RMSD': aligner.rms,
    })

print(f'Time: {time.time() - start_time}')

alignments = pd.DataFrame(alignments)
print(alignments['RMSD'].describe())

```

#### Original CE Align
```
Time: 64.08160495758057
count    270.000000
mean       3.205020
std        0.748432
min        1.043961
25%        2.639412
50%        3.146602
75%        3.759536
max        5.427452
Name: RMSD, dtype: float64
```

#### Improved CE Align
```
Time: 62.18356680870056
count    270.000000
mean       2.951104
std        0.618955
min        1.041904
25%        2.546669
50%        2.946635
75%        3.419845
max        4.352589
Name: RMSD, dtype: float64
```

The execution time is similar with better RMSD scores in the improved implementation of CE Align.

### Math

Note that equation (11), which is the average of all $D_{ij}$ where $i$ and $j$ are AFPs in the path, can be simplified if we assume that $D_{ij}$ is symmetric:

```math
\frac{1}{(n+1)^2} \sum_{i=0}^n \sum_{j=0}^n D_{ij} = \frac{1}{n + 1 + \frac{n(n+1)}{2}} \sum_{i=0}^n \sum_{j=i}^n D_{ij}.
```

To get the recursive form of equation (11) in the CE Align paper:
```math
\begin{align*}
    \sum_{i=0}^n \sum_{j=i}^n D_{ij} &= \sum_{i=0}^n \left( \sum_{j=i}^{n-1} D_{ij} + D_{in} \right) \\
    &= \sum_{i=0}^n \sum_{j=i}^{n-1} D_{ij} + \sum_{i=0}^n D_{in} \\
    &= \sum_{i=0}^{n-1} \sum_{j=i}^{n-1} D_{ij} + \sum_{i=0}^n D_{in}.
\end{align*}
```

To get the closed form of the number of terms in the summation, we calculate:
```math
\begin{align*}
    \sum_{i=0}^n \sum_{j=i}^n 1 &= \sum_{i=0}^n (n - i + 1) \\
    &= (n+1)^2 - \sum_{i=0}^n i \\
    &= n^2 + 2n + 1 - \frac{n(n+1)}{2} \\
    &= n^2 + 2n + 1 - \frac{n^2}{2} - \frac{n}{2} \\
    &= \frac{n^2}{2} + \frac{3n}{2} + 1 \\
    &= n + 1 + \frac{n(n+1)}{2}.
\end{align*}
```

### References
* [Protein structure alignment by incremental combinatorial extension (CE) of the optimal path](https://pubmed.ncbi.nlm.nih.gov/9796821/)
  * Main paper describing the CE Align algorithm.
* [A Structurally-Validated Multiple Sequence Alignment of 497 Human Protein Kinase Domains](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6930252/)
  * Source of PDB codes for human protein kinases.