### PR TITLE
Relax BGZF block test (failed with zlib-ng)

### DIFF
--- a/Tests/test_bgzf.py
+++ b/Tests/test_bgzf.py
@@ -1,4 +1,4 @@
-# Copyright 2010-2016 by Peter Cock.
+# Copyright 2010-2016, 2024 by Peter Cock.
 # All rights reserved.
 # This code is part of the Biopython distribution and governed by its
 # license.  Please see the LICENSE file that should have been included
@@ -48,11 +48,28 @@ class BgzfTests(unittest.TestCase):
         self.assertEqual(data, new_data)
 
     def check_blocks(self, old_file, new_file):
+        """Verify newly created BGZF file has similar blocks to original.
+
+        We originally assumed it would have the same blocks, since zlib
+        behaviour has been near static for years. However, there is scope
+        for changes in default compression level or the zlib implementation
+        (e.g. zlib-ng) which breaks that assumption.
+
+        Therefore, from (start, raw_len, data_start, data_len) for each
+        block we only confirm that the data values match (and allow for
+        the compressed representation to vary).
+        """
         with open(old_file, "rb") as h:
-            old = list(bgzf.BgzfBlocks(h))
+            old = [
+                (data_start, data_len)
+                for (start, raw_len, data_start, data_len) in bgzf.BgzfBlocks(h)
+            ]
 
         with open(new_file, "rb") as h:
-            new = list(bgzf.BgzfBlocks(h))
+            new = [
+                (data_start, data_len)
+                for (start, raw_len, data_start, data_len) in bgzf.BgzfBlocks(h)
+            ]
 
         self.assertEqual(len(old), len(new))
         self.assertEqual(old, new)


### PR DESCRIPTION
Closes #4553 by relaxing the implicit test assumption that recompressing with zlib would always give the same compressed data (not try with zlib vs zlib-ng, nor would this hold if the default compression level were to change in future).

Fix based on idea from Ben Beasley, @musicinmybrain would you like to be named explicitly as a contributor?

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
