### PR TITLE
Tweak to doctest examples for numpy2

### DIFF
--- a/Doc/Tutorial/chapter_msa.rst
+++ b/Doc/Tutorial/chapter_msa.rst
@@ -1570,8 +1570,8 @@ of each residue:
    K 0.2569
    R 0.1697
    <BLANKLINE>
-   >>> np.sum(residue_frequencies)
-   1.0
+   >>> sum(residue_frequencies) == 1.0
+   True
 
 The expected frequency of residue pairs is then
 

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -1415,8 +1415,8 @@ of each residue:
    K 0.2569
    R 0.1697
    <BLANKLINE>
-   >>> background.sum()
-   1.0
+   >>> sum(background) == 1.0
+   True
 
 The expected frequency of residue pairs is then
 


### PR DESCRIPTION
Avoid printing 1.0 vs np.float64(1.0) by comparing to one, and use Python sum function over the numpy method/function to avoid getting np.True_ over True.

Not ideal as this is slightly unnatural style, but it makes the test work on numpy 1 or 2.

Addresses in part issue #4676

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
