### PR TITLE
Avoid numpy2 scalar repr change in example

### DIFF
--- a/Doc/Tutorial/chapter_motifs.rst
+++ b/Doc/Tutorial/chapter_motifs.rst
@@ -381,8 +381,8 @@ by summing over the columns:
 
 .. code:: pycon
 
-   >>> sum(m.relative_entropy)  # doctest:+ELLIPSIS
-   6.003321...
+   >>> print(f"Relative entropy is {sum(m.relative_entropy):0.5f}")
+   Relative entropy is 6.00332
 
 Creating a sequence logo
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Rather than dealing with ELLIPSIS settings and
6.003321... vs np.float64(6.0033218093539675)
explicitly print with set number of decimal places.

Addresses in part #4676

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
