### PR TITLE
Warn on writing INSDC-noncompliant feature and qualifier keys

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -380,7 +380,7 @@ class _InsdcWriter(SequenceWriter):
     )
 
     def _write_feature_qualifier(self, key, value=None, quote=None):
-        if not all(ch in _allowed_table_component_name_chars for ch in key):
+        if not _allowed_table_component_name_chars.issuperset(key):
             warnings.warn(
                 f"Feature qualifier key '{key}' contains characters not"
                 " allowed by standard.",
@@ -458,7 +458,7 @@ class _InsdcWriter(SequenceWriter):
         assert feature.type, feature
 
         f_type = feature.type.replace(" ", "_")
-        if not all(ch in _allowed_table_component_name_chars for ch in f_type):
+        if not _allowed_table_component_name_chars.issuperset(f_type):
             warnings.warn(
                 f"Feature key '{f_type}' contains characters not allowed by"
                 " standard.",

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -47,6 +47,9 @@ from .Interfaces import _get_seq_string
 from .Interfaces import SequenceIterator
 from .Interfaces import SequenceWriter
 
+# Set containing all characters allowed in feature qualifier keys. See
+# https://www.insdc.org/submitting-standards/feature-table/#3.1
+_allowed_table_component_name_chars = set(ascii_letters + digits + "_-'*")
 
 # NOTE
 # ====
@@ -377,15 +380,15 @@ class _InsdcWriter(SequenceWriter):
     )
 
     def _write_feature_qualifier(self, key, value=None, quote=None):
-        allowed_chars = ascii_letters + digits + "_-'*"
-        if not all(ch in allowed_chars for ch in key):
+        if not all(ch in _allowed_table_component_name_chars for ch in key):
             warnings.warn(
-                "Feature qualifier key contains characters not allowed by standard.",
+                f"Feature qualifier key '{key}' contains characters not"
+                " allowed by standard.",
                 BiopythonWarning,
             )
         if len(key) > 20:
             warnings.warn(
-                "Feature qualifier key is longer than maximum length"
+                f"Feature qualifier key '{key}' is longer than maximum length"
                 " specified by standard (20 characters).",
                 BiopythonWarning,
             )
@@ -455,16 +458,16 @@ class _InsdcWriter(SequenceWriter):
         assert feature.type, feature
 
         f_type = feature.type.replace(" ", "_")
-        allowed_chars = ascii_letters + digits + "_-'*"
-        if not all(ch in allowed_chars for ch in f_type):
+        if not all(ch in _allowed_table_component_name_chars for ch in f_type):
             warnings.warn(
-                "Feature key contains characters not allowed by standard.",
+                f"Feature key '{f_type}' contains characters not allowed by"
+                " standard.",
                 BiopythonWarning,
             )
         if len(f_type) > 15:
             warnings.warn(
-                "Feature key is longer than maximum length specified"
-                " by standard (15 characters).",
+                f"Feature key '{f_type}' is longer than maximum length"
+                " specified by standard (15 characters).",
                 BiopythonWarning,
             )
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

From the [DDBJ/ENA/GenBank Feature Table Definition](https://www.insdc.org/submitting-standards/feature-table/#3.1):
> 3.1 Naming conventions
> Feature table components, including feature keys, qualifiers, accession 
> numbers, database name abbreviations, and location operators, are all named 
> following the same conventions. Component names may be no more than 20 
> characters long  (Feature keys 15, Feature qualifiers 20) and must 
> contain at least one letter. The following characters are permitted to 
> occur in feature table component names: 
> 
> * Uppercase letters (A-Z) 
> * Lowercase letters (a-z) Numbers (0-9) 
> * Underscore (_) 
> * Hyphen (-) 
> * Single quotation mark or apostrophe (') 
> * Asterisk (*) 

Currently, Biopython allows you to read or write INSDC files with feature and qualifier keys that don't follow these rules without warning. This PR warns `BiopythonWarning` if you try to write a noncompliant feature or qualifier key.