### PR TITLE
Improve warning message to help with debugging on very large structures.

### DIFF
--- a/Bio/PDB/StructureBuilder.py
+++ b/Bio/PDB/StructureBuilder.py
@@ -169,8 +169,8 @@ class StructureBuilder:
                         # if this exception is ignored, a residue will be missing
                         self.residue = None
                         raise PDBConstructionException(
-                            "Blank altlocs in duplicate residue %s ('%s', %i, '%s')"
-                            % (resname, field, resseq, icode)
+                            "Blank altlocs in duplicate residue %s ('%s', %i, '%s') of chain '%s'"
+                            % (resname, field, resseq, icode, self.chain.id)
                         )
                     self.chain.detach_child(res_id)
                     new_residue = Residue(res_id, resname, self.segid)

--- a/Tests/test_PDB_PDBParser.py
+++ b/Tests/test_PDB_PDBParser.py
@@ -61,7 +61,7 @@ class FlawedPDB_tests(unittest.TestCase):
                     "Atom N defined twice in residue <Residue ARG het=  resseq=2 icode= > at line 22.",
                     "disordered atom found with blank altloc before line 34.",
                     "Residue (' ', 4, ' ') redefined at line 44.",
-                    "Blank altlocs in duplicate residue SER (' ', 4, ' ') at line 44.",
+                    "Blank altlocs in duplicate residue SER (' ', 4, ' ') of chain 'A' at line 44.",
                     "Residue (' ', 10, ' ') redefined at line 76.",
                     "Residue (' ', 14, ' ') redefined at line 107.",
                     "Residue (' ', 16, ' ') redefined at line 136.",


### PR DESCRIPTION
Small patch to add the chain identifier to the error message, to help debugging on very large structures.

This:
```
PDBConstructionException: Blank altlocs in duplicate residue ILE (' ', 105, ' ')
```

Becomes:
```
PDBConstructionException: Blank altlocs in duplicate residue ILE (' ', 105, ' ') of chain 'BI'
```

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.