### PR TITLE
Drop CodeCov from CI (wasn't working)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,7 +46,3 @@ test_script:
   - coverage run run_tests.py --offline
   - coverage xml
   - cd ..
-
-after_test:
-  - conda install -c conda-forge codecov
-  - codecov --file Tests/coverage.xml -X pycov -X gcov

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,0 @@
-# See https://github.com/codecov/support/wiki/Codecov-Yaml
-# and https://codecov.io/gh/biopython/biopython which is
-# updated via our TravisCI and AppVeyor testing.
-
-coverage:
-  ignore:
-   - "Tests/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,12 +201,10 @@ jobs:
       run: |
         python -m pip install .
 
-    - name: Run test suite and get coverage
+    - name: Run test suite
       run: |
         cd Tests
-        rm -rf coverage.xml
-        coverage run run_tests.py --offline
-        coverage xml
+        python run_tests.py --offline
       shell: bash
 
   test_macos:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -97,11 +97,9 @@ optional dependencies included), plus also style checks using ``pre-commit``
 **The continuous integration checks must pass before your pull request will be
 merged.**
 
-The continuous integration tests collect test coverage information via
-CodeCov: https://codecov.io/github/biopython/biopython/
-
-Ideally the CodeCov checks will also pass, but we currently do not insist on
-this when reviewing pull requests.
+We have previously used CodeCov to track test coverage information, and would
+like to restore this - but historically did not insist their test coverage
+checks passed when reviewing  pull requests.
 
 Contributing to the Biopython Tutorial
 --------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,6 @@
 .. image:: https://img.shields.io/github/actions/workflow/status/biopython/biopython/ci.yml?logo=github-actions
    :alt: GitHub workflow status
    :target: https://github.com/biopython/biopython/actions
-.. image:: https://img.shields.io/codecov/c/github/biopython/biopython/master.svg?logo=codecov
-   :alt: Test coverage on CodeCov
-   :target: https://codecov.io/github/biopython/biopython/
 .. image:: http://depsy.org/api/package/pypi/biopython/badge.svg
    :alt: Research software impact on Depsy
    :target: http://depsy.org/package/python/biopython


### PR DESCRIPTION
Currently this sometimes causes a CI failure, and isn't doing anything useful due to changes on the CodeCov side. Closes #3752 - but I would like to see this functionality restored in the medium term.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

