### PR TITLE
Drop Python 3.8 support and deprecate 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.10", "3.11"]
+        python-version: ["3.9", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-2019]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     runs-on: ${{ matrix.os }}
 
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.10", "3.11"]
+        python-version: ["3.9", "3.11", "3.12"]
 
     steps:
 
@@ -215,7 +215,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -253,7 +253,7 @@ jobs:
       matrix:
         # TODO - Try Python 3.11 again, was Python 3.11.0 was
         # failing when trying to delete SQlite databases.
-        python-version: ["3.8", "3.10", "3.12"]
+        python-version: ["3.9", "3.10", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -9,10 +9,12 @@ Python
 Python 3.9
 ----------
 First supported in release 1.79, although it was mostly working in 1.78.
+Support deprecated as of Release 1.84.
 
 Python 3.8
 ----------
-First supported in release 1.75. Support deprecated as of Release 1.83.
+First supported in release 1.75. Support deprecated as of Release 1.83,
+and no longer supported as of Release 1.84.
 
 Python 3.7
 ----------

--- a/setup.py
+++ b/setup.py
@@ -48,13 +48,15 @@ if "bdist_wheel" in sys.argv:
 
 
 # Make sure we have the right Python version.
-MIN_PY_VER = (3, 8)
+MIN_PY_VER = (3, 9)
 if sys.version_info[:2] < MIN_PY_VER:
     sys.stderr.write(
         ("ERROR: Biopython requires Python %i.%i or later. " % MIN_PY_VER)
         + ("Python %d.%d detected.\n" % sys.version_info[:2])
     )
     sys.exit(1)
+elif sys.version_info[:2] == (3, 9):
+    sys.stderr.write("WARNING: Biopython support for Python 3.9 is now deprecated.\n")
 
 
 class test_biopython(Command):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

See also numpy 2.0 discussion where dropping Python 3.9 is being considered.