### PR TITLE
Misc test fixes including numpy 2 doctests for motifs

### DIFF
--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -358,12 +358,12 @@ def egquery(**keywds):
 
     >>> from Bio import Entrez
     >>> Entrez.email = "Your.Name.Here@example.org"
-    >>> handle = Entrez.egquery(term="biopython")
-    >>> record = Entrez.read(handle)
-    >>> handle.close()
-    >>> for row in record["eGQueryResult"]:
-    ...     if "pmc" in row["DbName"]:
-    ...         print(int(row["Count"]) > 60)
+    >>> handle = Entrez.egquery(term="biopython")  # doctest: +SKIP
+    >>> record = Entrez.read(handle)  # doctest: +SKIP
+    >>> handle.close()  # doctest: +SKIP
+    >>> for row in record["eGQueryResult"]:  # doctest: +SKIP
+    ...     if "pmc" in row["DbName"]:  # doctest: +SKIP
+    ...         print(int(row["Count"]) > 60)  # doctest: +SKIP
     True
 
     :returns: Handle to the results, by default in XML format.

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -32,7 +32,8 @@ class GenericPositionMatrix(dict):
                 self.length = len(values[letter])
             elif self.length != len(values[letter]):
                 raise Exception("data has inconsistent lengths")
-            self[letter] = list(values[letter])
+            # Cast any numpy floats into Python floats:
+            self[letter] = [float(_) for _ in values[letter]]
         self.alphabet = alphabet
 
     def __str__(self):

--- a/Tests/test_PDB_PDBMLParser.py
+++ b/Tests/test_PDB_PDBMLParser.py
@@ -6,9 +6,11 @@ returned by the mmCIF parser for any PDB structure.
 """
 
 import unittest
+import warnings
 
 from Bio.PDB import MMCIFParser
 from Bio.PDB import PDBMLParser
+from Bio.PDB.PDBExceptions import PDBConstructionWarning
 
 
 class TestPDBMLParser(unittest.TestCase):
@@ -16,21 +18,25 @@ class TestPDBMLParser(unittest.TestCase):
         mmcif_parser = MMCIFParser()
         pdbml_parser = PDBMLParser()
 
-        for entry in ["1GBT", "6WG6", "3JQH"]:
-            mmcif_structure = mmcif_parser.get_structure(entry, f"PDB/{entry}.cif")
-            pdbml_structure = pdbml_parser.get_structure(f"PDB/{entry}.xml")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PDBConstructionWarning)
+            for entry in ["1GBT", "6WG6", "3JQH"]:
+                mmcif_structure = mmcif_parser.get_structure(entry, f"PDB/{entry}.cif")
+                pdbml_structure = pdbml_parser.get_structure(f"PDB/{entry}.xml")
             self.assertEqual(mmcif_structure, pdbml_structure)
 
     def test_get_structure_filehandle(self):
         mmcif_parser = MMCIFParser()
         pdbml_parser = PDBMLParser()
 
-        for entry in ["1GBT"]:
-            with open(f"PDB/{entry}.cif") as mmcif_file, open(
-                f"PDB/{entry}.xml"
-            ) as pdbml_file:
-                mmcif_structure = mmcif_parser.get_structure(entry, mmcif_file)
-                pdbml_structure = pdbml_parser.get_structure(pdbml_file)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PDBConstructionWarning)
+            for entry in ["1GBT"]:
+                with open(f"PDB/{entry}.cif") as mmcif_file, open(
+                    f"PDB/{entry}.xml"
+                ) as pdbml_file:
+                    mmcif_structure = mmcif_parser.get_structure(entry, mmcif_file)
+                    pdbml_structure = pdbml_parser.get_structure(pdbml_file)
                 self.assertEqual(mmcif_structure, pdbml_structure)
 
 

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -367,14 +367,14 @@ class TestExtract(unittest.TestCase):
                 "join{[0:2](-), [3:4](-)}",
             )
 
-        # Origin-spanning location containing the entire sequence
-        self.assertEqual(
-            str(SimpleLocation.fromstring("3..2", 4, True)), "join{[2:4], [0:2]}"
-        )
-        self.assertEqual(
-            str(SimpleLocation.fromstring("complement(3..2)", 4, True)),
-            "join{[0:2](-), [2:4](-)}",
-        )
+            # Origin-spanning location containing the entire sequence
+            self.assertEqual(
+                str(SimpleLocation.fromstring("3..2", 4, True)), "join{[2:4], [0:2]}"
+            )
+            self.assertEqual(
+                str(SimpleLocation.fromstring("complement(3..2)", 4, True)),
+                "join{[0:2](-), [2:4](-)}",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This follows up #4725 by skipping the NCBI EGQuery doctest, silences a couple of overlooked warnings from the test suite, and takes the pragmatic solution to the motif doctest issues under numpy 2.0 and this should close #4676.

With this I think we're OK to start the Biopython 1.84 release - and at very least encouraging some testing with numpy 1+2 using the Biopython from git.