### PR TITLE
Edits to allow manual setting of Entrez's cache path.

### DIFF
--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -317,10 +317,13 @@ class DataHandlerMeta(type):
 
     def __init__(cls, *args, **kwargs):
         """Initialize the class."""
+        from Bio import Entrez
+
         try:
-            cls.directory = None  # use default directory for local cache
+            cls.directory = Entrez.local_cache  # use default directory for local cache
         except PermissionError:
-            cls._directory = None  # no local cache
+            cls._directory = Entrez.local_cache  # no local cache
+        del Entrez
 
     @property
     def directory(cls):

--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -142,6 +142,7 @@ max_tries = 3
 sleep_between_tries = 15
 tool = "biopython"
 api_key = None
+local_cache = None
 
 
 # XXX retmode?

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -239,6 +239,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Maximilian Greil <https://github.com/MaxGreil>
 - Maximilian Peters <maximili.peters at mail.huji.ac.il>
 - Melissa Gymrek <https://github.com/mgymrek>
+- Meridia Jane Bryant <https://github.com/meridiajane>
 - Michael Hoffman <https://github.com/michaelmhoffman>
 - Michael M. <https://github.com/michaelfm1211>
 - Michael R. Crusoe <https://orcid.org/0000-0002-2961-9670>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -94,6 +94,9 @@ Updated ``Bio.Restriction`` to the April 2024 release of REBASE.
 A bug in ``bgzf`` was resolved, restoring the ability to pass a file handle
 directly to ``BgzfWriter``.
 
+A bug in ``Entrez`` was resolved, allowing users to specify the path of their
+local cache.
+
 As in recent releases, more of our code is now explicitly available under
 either our original "Biopython License Agreement", or the very similar but
 more commonly used "3-Clause BSD License".  See the ``LICENSE.rst`` file for
@@ -107,6 +110,7 @@ possible, especially the following contributors:
 - Fabio Zanini (first contribution)
 - Joao Rodrigues
 - Judith Bernett (first contribution)
+- Meridia Jane Bryant (first contribution)
 - Michael M. (first contribution)
 - Michiel de Hoon
 - Peter Cock

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -94,8 +94,7 @@ Updated ``Bio.Restriction`` to the April 2024 release of REBASE.
 A bug in ``bgzf`` was resolved, restoring the ability to pass a file handle
 directly to ``BgzfWriter``.
 
-A bug in ``Entrez`` was resolved, allowing users to specify the path of their
-local cache.
+``Bio.Entrez.local_cache`` can be set to a directory for caching downloaded DTD/XSD files.
 
 As in recent releases, more of our code is now explicitly available under
 either our original "Biopython License Agreement", or the very similar but


### PR DESCRIPTION
Added 'local_cache' to Entrez's __init__ to allow manual setting of the cache generated by Parser (default to none). Editted the DataHandlerMeta class (__init__) to import Entrez.local_cache and use it for the cache directory. Added Meridia Jane to CONTRIB and NEWS

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #918
