### PR TITLE
Use C code to parse alignments in which dashes represent gaps

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1096,7 +1096,7 @@ class Alignment:
                           0 -ACGCATACTTG 11
         <BLANKLINE>
         """
-        parser = _parser.Coordinates(b"\0")
+        parser = _parser.PrintedAlignmentParser(b"\0")
         sequences = []
         for line in lines:
             nbytes, sequence = parser.feed(line)

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1102,7 +1102,8 @@ class Alignment:
             nbytes, sequence = parser.feed(line)
             sequences.append(sequence)
         shape = parser.shape
-        coordinates = np.empty(shape, dtype=np.int_)
+        # coordinates = np.empty(shape, dtype=np.int_)
+        coordinates = np.empty(shape, int)
         parser.fill(coordinates)
         return sequences, coordinates
 

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1102,7 +1102,6 @@ class Alignment:
             nbytes, sequence = parser.feed(line)
             sequences.append(sequence)
         shape = parser.shape
-        # coordinates = np.empty(shape, dtype=np.int_)
         coordinates = np.empty(shape, int)
         parser.fill(coordinates)
         return sequences, coordinates

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -51,8 +51,6 @@ from Bio.SeqRecord import SeqRecord, _RestrictedDict
 # importing from within the Biopython source tree, see PR #2007:
 # https://github.com/biopython/biopython/pull/2007
 
-print("numpy int_ is", np.int_)
-
 
 AlignmentCounts = collections.namedtuple(
     "AlignmentCounts", ["gaps", "identities", "mismatches"]
@@ -1040,9 +1038,9 @@ class Alignment:
         ['TAGGCATACGTG', 'AACGTACGT', 'ACGCATACTTG']
         >>> coordinates = Alignment.infer_coordinates(lines)
         >>> coordinates
-        array([[ 0,  1,  4,  6, 11, 12],
-               [ 0,  1,  4,  4,  9,  9],
-               [ 0,  0,  3,  5, 10, 11]])
+        [[ 0  1  4  6 11 12]
+         [ 0  1  4  4  9  9]
+         [ 0  0  3  5 10 11]]
         >>> alignment = Alignment(sequences, coordinates)
         """
         warnings.warn(
@@ -1082,12 +1080,12 @@ class Alignment:
         ...          b"-ACGCATACTTG",
         ...         ]
         >>> sequences, coordinates = Alignment.parse_printed_alignment(lines)
-        >>> sequences
+        >>> print(sequences)
         [b'TAGGCATACGTG', b'AACGTACGT', b'ACGCATACTTG']
-        >>> coordinates
-        array([[ 0,  1,  4,  6, 11, 12],
-               [ 0,  1,  4,  4,  9,  9],
-               [ 0,  0,  3,  5, 10, 11]])
+        >>> print(coordinates)
+        [[ 0  1  4  6 11 12]
+         [ 0  1  4  4  9  9]
+         [ 0  0  3  5 10 11]]
         >>> sequences = [Seq(sequence) for sequence in sequences]
         >>> sequences
         [Seq('TAGGCATACGTG'), Seq('AACGTACGT'), Seq('ACGCATACTTG')]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1037,10 +1037,10 @@ class Alignment:
         >>> sequences
         ['TAGGCATACGTG', 'AACGTACGT', 'ACGCATACTTG']
         >>> coordinates = Alignment.infer_coordinates(lines)
-        >>> print(coordinates)
-        [[ 0  1  4  6 11 12]
-         [ 0  1  4  4  9  9]
-         [ 0  0  3  5 10 11]]
+        >>> coordinates
+        array([[ 0,  1,  4,  6, 11, 12],
+               [ 0,  1,  4,  4,  9,  9],
+               [ 0,  0,  3,  5, 10, 11]])
         >>> alignment = Alignment(sequences, coordinates)
         """
         warnings.warn(

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1070,20 +1070,25 @@ class Alignment:
         sequences and coordinates can be used to create an Alignment object.
 
         This is an example for the alignment of three sequences TAGGCATACGTG,
-        AACGTACGT, and ACGCATACTTG, with gaps in the second and third sequence:
+        AACGTACGT, and ACGCATACTTG, with gaps in the second and third sequence.
+        Note that the input sequences are bytes objects.
 
         >>> from Bio.Align import Alignment
-        >>> lines = ["TAGGCATACGTG",
-        ...          "AACG--TACGT-",
-        ...          "-ACGCATACTTG",
+        >>> from Bio.Seq import Seq
+        >>> lines = [b"TAGGCATACGTG",
+        ...          b"AACG--TACGT-",
+        ...          b"-ACGCATACTTG",
         ...         ]
         >>> sequences, coordinates = Alignment.parse_printed_alignment(lines)
         >>> sequences
-        ['TAGGCATACGTG', 'AACGTACGT', 'ACGCATACTTG']
+        [b'TAGGCATACGTG', b'AACGTACGT', b'ACGCATACTTG']
         >>> coordinates
         array([[ 0,  1,  4,  6, 11, 12],
                [ 0,  1,  4,  4,  9,  9],
                [ 0,  0,  3,  5, 10, 11]])
+        >>> sequences = [Seq(sequence) for sequence in sequences]
+        >>> sequences
+        [Seq('TAGGCATACGTG'), Seq('AACGTACGT'), Seq('ACGCATACTTG')]
         >>> alignment = Alignment(sequences, coordinates)
         >>> print(alignment)
                           0 TAGGCATACGTG 12
@@ -1091,10 +1096,10 @@ class Alignment:
                           0 -ACGCATACTTG 11
         <BLANKLINE>
         """
-        sequences, coordinates = _parser.parse_printed_alignment(lines)
-        shape = coordinates.shape
-        coordinates = np.frombuffer(coordinates, int)
-        coordinates.shape = shape
+        sequences, coordinate_parser = _parser.parse_printed_alignment(lines)
+        shape = coordinate_parser.shape
+        coordinates = np.empty(shape, int)
+        coordinate_parser.fill(coordinates)
         return sequences, coordinates
 
     def __init__(self, sequences, coordinates=None):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1102,7 +1102,7 @@ class Alignment:
             nbytes, sequence = parser.feed(line)
             sequences.append(sequence)
         shape = parser.shape
-        coordinates = np.empty(shape)
+        coordinates = np.empty(shape, dtype=np.int_)
         parser.fill(coordinates)
         return sequences, coordinates
 

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1037,7 +1037,7 @@ class Alignment:
         >>> sequences
         ['TAGGCATACGTG', 'AACGTACGT', 'ACGCATACTTG']
         >>> coordinates = Alignment.infer_coordinates(lines)
-        >>> coordinates
+        >>> print(coordinates)
         [[ 0  1  4  6 11 12]
          [ 0  1  4  4  9  9]
          [ 0  0  3  5 10 11]]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1102,7 +1102,7 @@ class Alignment:
             nbytes, sequence = parser.feed(line)
             sequences.append(sequence)
         shape = parser.shape
-        coordinates = np.empty(shape, np.int64)
+        coordinates = np.empty(shape)
         parser.fill(coordinates)
         return sequences, coordinates
 

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1096,10 +1096,14 @@ class Alignment:
                           0 -ACGCATACTTG 11
         <BLANKLINE>
         """
-        sequences, coordinate_parser = _parser.parse_printed_alignment(lines)
-        shape = coordinate_parser.shape
+        parser = _parser.Coordinates(b"\0")
+        sequences = []
+        for line in lines:
+            nbytes, sequence = parser.feed(line)
+            sequences.append(sequence)
+        shape = parser.shape
         coordinates = np.empty(shape, int)
-        coordinate_parser.fill(coordinates)
+        parser.fill(coordinates)
         return sequences, coordinates
 
     def __init__(self, sequences, coordinates=None):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -51,6 +51,8 @@ from Bio.SeqRecord import SeqRecord, _RestrictedDict
 # importing from within the Biopython source tree, see PR #2007:
 # https://github.com/biopython/biopython/pull/2007
 
+print("numpy int_ is", np.int_)
+
 
 AlignmentCounts = collections.namedtuple(
     "AlignmentCounts", ["gaps", "identities", "mismatches"]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -36,7 +36,7 @@ except ImportError:
     ) from None
 
 from Bio import BiopythonDeprecationWarning
-from Bio.Align import _parser  # type: ignore
+from Bio.Align import _aligncore  # type: ignore
 from Bio.Align import _pairwisealigner  # type: ignore
 from Bio.Align import _codonaligner  # type: ignore
 from Bio.Align import substitution_matrices
@@ -1096,7 +1096,7 @@ class Alignment:
                           0 -ACGCATACTTG 11
         <BLANKLINE>
         """
-        parser = _parser.PrintedAlignmentParser(b"\0")
+        parser = _aligncore.PrintedAlignmentParser(b"\0")
         sequences = []
         for line in lines:
             nbytes, sequence = parser.feed(line)

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1104,7 +1104,7 @@ class Alignment:
             nbytes, sequence = parser.feed(line)
             sequences.append(sequence)
         shape = parser.shape
-        coordinates = np.empty(shape, int)
+        coordinates = np.empty(shape, np.int64)
         parser.fill(coordinates)
         return sequences, coordinates
 

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1080,12 +1080,12 @@ class Alignment:
         ...          b"-ACGCATACTTG",
         ...         ]
         >>> sequences, coordinates = Alignment.parse_printed_alignment(lines)
-        >>> print(sequences)
+        >>> sequences
         [b'TAGGCATACGTG', b'AACGTACGT', b'ACGCATACTTG']
-        >>> print(coordinates)
-        [[ 0  1  4  6 11 12]
-         [ 0  1  4  4  9  9]
-         [ 0  0  3  5 10 11]]
+        >>> coordinates
+        array([[ 0,  1,  4,  6, 11, 12],
+               [ 0,  1,  4,  4,  9,  9],
+               [ 0,  0,  3,  5, 10, 11]])
         >>> sequences = [Seq(sequence) for sequence in sequences]
         >>> sequences
         [Seq('TAGGCATACGTG'), Seq('AACGTACGT'), Seq('ACGCATACTTG')]

--- a/Bio/Align/_aligncore.c
+++ b/Bio/Align/_aligncore.c
@@ -480,7 +480,7 @@ PyDoc_STRVAR(
 
 static PyTypeObject ParserType = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    .tp_name = "_parser.PrintedAlignmentParser",
+    .tp_name = "_aligncore.PrintedAlignmentParser",
     .tp_doc = Parser__doc__,
     .tp_basicsize = sizeof(Parser),
     .tp_itemsize = 0,
@@ -494,13 +494,13 @@ static PyTypeObject ParserType = {
 /* Module initialization function */
 static PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
-    .m_name = "_parser",
+    .m_name = "_aligncore",
     .m_doc = "fast C implementation of a parser for printed alignments; for internal use.",
     .m_size = -1,
 };
 
 PyMODINIT_FUNC
-PyInit__parser(void)
+PyInit__aligncore(void)
 {
     PyObject *module;
 

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -492,6 +492,7 @@ PyMODINIT_FUNC
 PyInit__parser(void)
 {
     PyObject *module;
+printf("C long is %ld bytes\n", sizeof(long));
 
     if (PyType_Ready(&ParserType) < 0)
         return NULL;

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -217,7 +217,7 @@ Parser_feed(Parser* self, PyObject* args, PyObject *kwds)
     }
     *d = '\0';
 
-    result = Py_BuildValue("lN", m, sequence);
+    result = Py_BuildValue("nN", m, sequence);
     if (result == NULL) Py_DECREF(sequence);
     return result;
 }
@@ -369,7 +369,7 @@ Parser_get_shape(Parser* self, void* closure)
     }
 
     self->k = k;
-    return Py_BuildValue("ll", n, k);
+    return Py_BuildValue("nn", n, k);
 }
 
 static PyGetSetDef Parser_getset[] = {

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -196,6 +196,7 @@ Parser_feed(Parser* self, PyObject* args, PyObject *kwds)
     else if (buffer + m != s) {
         PyErr_Format(PyExc_ValueError,
                      "line has length %zd (expected %zd)", m, self->mmmm);
+        PyMem_Free(row);
         return NULL;
     }
 
@@ -288,7 +289,7 @@ Parser_fill(Parser* self, PyObject* args)
     gaps = PyMem_Malloc(n * sizeof(bool));
     if (!gaps) goto exit;
 
-    data = PyMem_Calloc(n, sizeof(Py_ssize_t*));
+    data = PyMem_Malloc(n * sizeof(Py_ssize_t*));
     if (!data) goto exit;
 
     for (i = 0; i < n; i++) {
@@ -353,7 +354,7 @@ Parser_get_shape(Parser* self, void* closure)
     Py_ssize_t k = 1;
 
     if (n > 0) {
-        data = PyMem_Calloc(n, sizeof(Py_uintptr_t*));
+        data = PyMem_Malloc(n * sizeof(Py_uintptr_t*));
         if (!data) return NULL;
         memcpy(data, self->data, n*sizeof(Py_uintptr_t*));
         for (i = 0; i < n; i++) {

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -13,9 +13,9 @@ static PyTypeObject ParserType;
 
 typedef struct {
     PyObject_HEAD
-    long** data;
-    /* Array of n long* pointers; each pointer points to an array of
-       long of variable length.  This array contains, for each sequence,
+    Py_uintptr_t** data;
+    /* Array of n Py_uintptr_t* pointers; each pointer points to an array of
+       Py_uintptr_t of variable length.  This array contains, for each sequence,
        the positions in the printed alignment at which a letter is followed by
        a gap, or vice-versa.  If the first character is a gap, then the first
        column in data is 0.
@@ -31,7 +31,7 @@ Parser_dealloc(Parser *self)
 {
     Py_ssize_t i;
     const Py_ssize_t n = self->nnnn;
-    long** data = self->data;
+    Py_uintptr_t** data = self->data;
     if (data) {
         for (i = 0; i < n; i++) {
             if (data[i] == NULL) break;
@@ -132,8 +132,8 @@ Parser_feed(Parser* self, PyObject* args, PyObject *kwds)
     Py_ssize_t p = 0;
     Py_ssize_t offset = 0;
     Py_ssize_t start, end, step;
-    long** data;
-    long* row;
+    Py_uintptr_t** data;
+    Py_uintptr_t* row;
     char c;
     bool gap = false;
 
@@ -142,11 +142,11 @@ Parser_feed(Parser* self, PyObject* args, PyObject *kwds)
     buffer = PyBytes_AS_STRING(line) + offset;
 
     s = buffer;
-    row = PyMem_Malloc(size*sizeof(long));
+    row = PyMem_Malloc(size*sizeof(Py_uintptr_t));
     if (!row) return NULL;
     if (*s == '-') row[i++] = 0;
 
-    data = PyMem_Realloc(self->data, (n+1)*size*sizeof(long*));
+    data = PyMem_Realloc(self->data, (n+1)*size*sizeof(Py_uintptr_t*));
     if (!data) {
         PyMem_Free(row);
         return NULL;
@@ -168,7 +168,7 @@ Parser_feed(Parser* self, PyObject* args, PyObject *kwds)
 
         if (i == size) {
             size *= 2;
-            row = PyMem_Realloc(row, size*sizeof(long));
+            row = PyMem_Realloc(row, size*sizeof(Py_uintptr_t));
             if (!row) {
                 PyMem_Free(data[n]);
                 return NULL;
@@ -177,7 +177,7 @@ Parser_feed(Parser* self, PyObject* args, PyObject *kwds)
         }
         row[i++] = s - buffer;
     }
-    row = PyMem_Realloc(row, i*sizeof(long));
+    row = PyMem_Realloc(row, i*sizeof(Py_uintptr_t));
     if (!row) {
         PyMem_Free(data[n]);
         return NULL;
@@ -250,7 +250,7 @@ Parser_fill(Parser* self, PyObject* args)
     long step;
     long end;
     Py_ssize_t* starts = NULL;
-    long** data = NULL;
+    Py_uintptr_t** data = NULL;
     bool* gaps = NULL;
     long* buffer;
 
@@ -337,15 +337,15 @@ Parser_get_shape(Parser* self, void* closure)
     Py_ssize_t i;
     Py_ssize_t index;
     Py_ssize_t min_index;
-    long** data = self->data;
+    Py_uintptr_t** data = self->data;
     const Py_ssize_t n = self->nnnn;
     const Py_ssize_t m = self->mmmm;
     Py_ssize_t k = 1;
 
     if (n > 0) {
-        data = PyMem_Calloc(n, sizeof(long*));
+        data = PyMem_Calloc(n, sizeof(Py_uintptr_t*));
         if (!data) return NULL;
-        memcpy(data, self->data, n*sizeof(long*));
+        memcpy(data, self->data, n*sizeof(Py_uintptr_t*));
         for (i = 0; i < n; i++) {
             index = *(data[i]);
             if (index == 0) {

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -492,7 +492,7 @@ PyMODINIT_FUNC
 PyInit__parser(void)
 {
     PyObject *module;
-printf("C long is %ld bytes; C long long is %ld bytes\n", sizeof(long), sizeof(long long));
+printf("C long is %ld bytes; C long long is %ld bytes; int64_t is %ld bytes\n", sizeof(long), sizeof(long long), sizeof(int64_t));
 
     if (PyType_Ready(&ParserType) < 0)
         return NULL;

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -20,9 +20,9 @@ typedef struct {
        a gap, or vice-versa.  If the first character is a gap, then the first
        column in data is 0.
      */
-    Py_ssize_t n;  /* number of sequences in the alignment */
-    Py_ssize_t m;  /* number of columns in the printed alignment */
-    Py_ssize_t k;  /* number of columns of the coordinates array */
+    Py_ssize_t nnnn;  /* number of sequences in the alignment */
+    Py_ssize_t mmmm;  /* number of columns in the printed alignment */
+    Py_ssize_t kkkk;  /* number of columns of the coordinates array */
     char eol;      /* optional end-of-line character (set to '\n' by default) */
 } Parser;
 
@@ -30,7 +30,7 @@ static void
 Parser_dealloc(Parser *self)
 {
     Py_ssize_t i;
-    const Py_ssize_t n = self->n;
+    const Py_ssize_t n = self->nnnn;
     long** data = self->data;
     if (data) {
         for (i = 0; i < n; i++) {
@@ -69,15 +69,15 @@ array_converter(PyObject* argument, void* pointer)
                      "buffer has incorrect rank %d (expected 2)",
                       view->ndim);
     }
-    else if (view->shape[0] != self->n) {
+    else if (view->shape[0] != self->nnnn) {
         PyErr_Format(PyExc_RuntimeError,
                      "buffer has incorrect number of rows %zd (expected %zd)",
-                      view->shape[0], self->n);
+                      view->shape[0], self->nnnn);
     }
-    else if (view->shape[1] != self->k) {
+    else if (view->shape[1] != self->kkkk) {
         PyErr_Format(PyExc_RuntimeError,
                      "buffer has incorrect number of columns %zd (expected %zd)",
-                      view->shape[1], self->k);
+                      view->shape[1], self->kkkk);
     }
     else if (view->itemsize != sizeof(long)) {
         PyErr_Format(PyExc_RuntimeError,
@@ -125,8 +125,8 @@ Parser_feed(Parser* self, PyObject* args, PyObject *kwds)
     const char* s;
     char* d;
     const char eol = self->eol;
-    Py_ssize_t n = self->n;
-    Py_ssize_t m = self->m;
+    Py_ssize_t n = self->nnnn;
+    Py_ssize_t m = self->mmmm;
     Py_ssize_t size = 2;
     Py_ssize_t i = 0;
     Py_ssize_t p = 0;
@@ -184,15 +184,15 @@ Parser_feed(Parser* self, PyObject* args, PyObject *kwds)
     }
     data[n] = row;
     m = s - buffer;
-    if (n == 0) self->m = m;
+    if (n == 0) self->mmmm = m;
     else if (buffer + m != s) {
         PyErr_Format(PyExc_ValueError,
-                     "line has length %zi (expected %zi)", m, self->m);
+                     "line has length %zd (expected %zd)", m, self->mmmm);
         return NULL;
     }
 
     n++;
-    self->n = n;
+    self->nnnn = n;
 
     sequence = PyBytes_FromStringAndSize(NULL, p);
     if (!sequence) return NULL;
@@ -254,7 +254,7 @@ Parser_fill(Parser* self, PyObject* args)
     bool* gaps = NULL;
     long* buffer;
 
-    n = self->n;
+    n = self->nnnn;
     if (n == 0) Py_RETURN_NONE;
 
     view.obj = (PyObject*) self;
@@ -272,7 +272,7 @@ Parser_fill(Parser* self, PyObject* args)
     }
     for (i = 0; i < n; i++) buffer[i*k] = 0;
 
-    m = self->m;
+    m = self->mmmm;
 
     starts = PyMem_Calloc(n, sizeof(Py_ssize_t));
     if (!starts) goto exit;
@@ -338,8 +338,8 @@ Parser_get_shape(Parser* self, void* closure)
     Py_ssize_t index;
     Py_ssize_t min_index;
     long** data = self->data;
-    const Py_ssize_t n = self->n;
-    const Py_ssize_t m = self->m;
+    const Py_ssize_t n = self->nnnn;
+    const Py_ssize_t m = self->mmmm;
     Py_ssize_t k = 1;
 
     if (n > 0) {
@@ -368,7 +368,7 @@ Parser_get_shape(Parser* self, void* closure)
         }
     }
 
-    self->k = k;
+    self->kkkk = k;
     return Py_BuildValue("nn", n, k);
 }
 
@@ -409,7 +409,7 @@ Parser_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self = (Parser *)type->tp_alloc(type, 0);
     if (!self) return NULL;
     self->eol = eol;
-    self->n = 0;
+    self->nnnn = 0;
     return (PyObject *)self;
 }
 

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -247,8 +247,8 @@ Parser_fill(Parser* self, PyObject* args)
     Py_buffer view;
     Py_ssize_t i, j, k, n, m, p;
     Py_ssize_t start;
-    long step;
-    long end;
+    Py_ssize_t step;
+    Py_ssize_t end;
     Py_ssize_t* starts = NULL;
     Py_uintptr_t** data = NULL;
     bool* gaps = NULL;

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -492,7 +492,7 @@ PyMODINIT_FUNC
 PyInit__parser(void)
 {
     PyObject *module;
-printf("C long is %ld bytes\n", sizeof(long));
+printf("C long is %ld bytes; C long long is %ld bytes\n", sizeof(long), sizeof(long long));
 
     if (PyType_Ready(&ParserType) < 0)
         return NULL;

--- a/Bio/Align/_parser.c
+++ b/Bio/Align/_parser.c
@@ -29,9 +29,9 @@ typedef struct {
 static void
 Parser_dealloc(Parser *self)
 {
+    Py_ssize_t i;
+    const Py_ssize_t n = self->n;
     long** data = self->data;
-    ssize_t i;
-    const ssize_t n = self->n;
     if (data) {
         for (i = 0; i < n; i++) {
             if (data[i] == NULL) break;

--- a/Bio/Align/bigbed.py
+++ b/Bio/Align/bigbed.py
@@ -858,12 +858,10 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                         data[:size]
                     )
                     if child_chromIx == chromIx:
-                        while True:
-                            if end <= child_chromStart or child_chromEnd <= start:
-                                if child_chromStart != child_chromEnd:
-                                    break
-                                if child_chromStart != end and child_chromEnd != start:
-                                    break
+                        if (child_chromStart < end and start < child_chromEnd) or (
+                            child_chromStart == child_chromEnd
+                            and (child_chromStart == end or start == child_chromEnd)
+                        ):
                             yield (
                                 child_chromIx,
                                 child_chromStart,
@@ -872,7 +870,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                                 size,
                                 len(data),
                             )
-                            break
                 else:
                     i = 0
                     n = len(data)

--- a/Bio/Align/bigbed.py
+++ b/Bio/Align/bigbed.py
@@ -228,32 +228,45 @@ class AlignmentWriter(interfaces.AlignmentWriter):
         declaration=None,
         targets=None,
         compress=True,
+        itemsPerSlot=512,
+        blockSize=256,
         extraIndex=(),
     ):
         """Create an AlignmentWriter object.
 
         Arguments:
-         - target      - output stream or file name.
-         - bedN        - number of columns in the BED file.
-                         This must be between 3 and 12; default value is 12.
-         - declaration - an AutoSQLTable object declaring the fields in the BED file.
-                         Required only if the BED file contains extra (custom) fields.
-                         Default value is None.
-         - targets     - A list of SeqRecord objects with the chromosomes in the
-                         order as they appear in the alignments. The sequence
-                         contents in each SeqRecord may be undefined, but the
-                         sequence length must be defined, as in this example:
+         - target       - output stream or file name.
+         - bedN         - number of columns in the BED file.
+                          This must be between 3 and 12; default value is 12.
+         - declaration  - an AutoSQLTable object declaring the fields in the
+                          BED file.
+                          Required only if the BED file contains extra (custom)
+                          fields.
+                          Default value is None.
+         - targets      - A list of SeqRecord objects with the chromosomes in
+                          the order as they appear in the alignments. The
+                          sequence contents in each SeqRecord may be undefined,
+                          but the sequence length must be defined, as in this
+                          example:
 
-                         SeqRecord(Seq(None, length=248956422), id="chr1")
+                          SeqRecord(Seq(None, length=248956422), id="chr1")
 
-                         If targets is None (the default value), the alignments
-                         must have an attribute .targets providing the list of
-                         SeqRecord objects.
-         - compress    - If True (default), compress data using zlib.
-                         If False, do not compress data.
-         - extraIndex  - List of strings with the names of extra columns to be
-                         indexed.
-                         Default value is an empty list.
+                          If targets is None (the default value), the alignments
+                          must have an attribute .targets providing the list of
+                          SeqRecord objects.
+         - compress     - If True (default), compress data using zlib.
+                          If False, do not compress data.
+                          Use compress=False for faster searching.
+         - blockSize    - Number of items to bundle in r-tree.
+                          See UCSC's bedToBigBed program for more information.
+                          Default value is 256.
+         - itemsPerSlot - Number of data points bundled at lowest level.
+                          See UCSC's bedToBigBed program for more information.
+                          Use itemsPerSlot=1 for faster searching.
+                          Default value is 512.
+         - extraIndex   - List of strings with the names of extra columns to be
+                          indexed.
+                          Default value is an empty list.
         """
         if bedN < 3 or bedN > 12:
             raise ValueError("bedN must be between 3 and 12")
@@ -263,8 +276,8 @@ class AlignmentWriter(interfaces.AlignmentWriter):
         self.targets = targets
         self.compress = compress
         self.extraIndexNames = extraIndex
-        self.itemsPerSlot = 512
-        self.blockSize = 256
+        self.itemsPerSlot = itemsPerSlot
+        self.blockSize = blockSize
 
     def write_file(self, stream, alignments):
         """Write the alignments to the file stream, and return the number of alignments.

--- a/Bio/Align/bigbed.py
+++ b/Bio/Align/bigbed.py
@@ -920,10 +920,10 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             row = next(self._data)
         except StopIteration:
             return
-        return self._create_alignment(row)
-
-    def _create_alignment(self, row):
         chromId, chromStart, chromEnd, rest = row
+        return self._create_alignment(chromId, chromStart, chromEnd, rest)
+
+    def _create_alignment(self, chromId, chromStart, chromEnd, rest):
         if rest:
             words = rest.decode().split("\t")
         else:
@@ -1052,7 +1052,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 end = start + 1
         data = self._search_index(stream, chromIx, start, end)
         for row in data:
-            alignment = self._create_alignment(row)
+            chromIx, chromStart, chromEnd, rest = row
+            alignment = self._create_alignment(chromIx, chromStart, chromEnd, rest)
             yield alignment
 
 

--- a/Bio/Align/bigbed.py
+++ b/Bio/Align/bigbed.py
@@ -864,14 +864,13 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                                 break
                             if child_chromStart != end and child_chromEnd != start:
                                 break
-                        rest = data[size:-1]
                         yield (
                             child_chromIx,
                             child_chromStart,
                             child_chromEnd,
-                            rest,
-                            0,
-                            len(rest),
+                            data,
+                            size,
+                            len(data) - size - 1,
                         )
                         break
                 else:
@@ -943,7 +942,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         self, chromId, chromStart, chromEnd, rest, dataStart, dataEnd
     ):
         if rest:
-            words = rest.decode().split("\t")
+            words = rest[dataStart:dataEnd].decode().split("\t")
         else:
             words = []
         target_record = self.targets[chromId]

--- a/Bio/Align/bigbed.py
+++ b/Bio/Align/bigbed.py
@@ -857,7 +857,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                         child_chromIx, child_chromStart, child_chromEnd = (
                             formatter.unpack(data[:size])
                         )
-                        rest = data[size:-1]
                         if child_chromIx != chromIx:
                             break
                         if end <= child_chromStart or child_chromEnd <= start:
@@ -865,6 +864,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                                 break
                             if child_chromStart != end and child_chromEnd != start:
                                 break
+                        rest = data[size:-1]
                         yield (child_chromIx, child_chromStart, child_chromEnd, rest)
                         break
                 else:

--- a/Bio/Align/bigbed.py
+++ b/Bio/Align/bigbed.py
@@ -854,10 +854,10 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 if self._compressed > 0:
                     data = zlib.decompress(data)
                 if self.itemsPerSlot == 1:
+                    child_chromIx, child_chromStart, child_chromEnd = formatter.unpack(
+                        data[:size]
+                    )
                     while True:
-                        child_chromIx, child_chromStart, child_chromEnd = (
-                            formatter.unpack(data[:size])
-                        )
                         if child_chromIx != chromIx:
                             break
                         if end <= child_chromStart or child_chromEnd <= start:

--- a/Bio/Align/bigbed.py
+++ b/Bio/Align/bigbed.py
@@ -857,23 +857,22 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                     child_chromIx, child_chromStart, child_chromEnd = formatter.unpack(
                         data[:size]
                     )
-                    while True:
-                        if child_chromIx != chromIx:
+                    if child_chromIx == chromIx:
+                        while True:
+                            if end <= child_chromStart or child_chromEnd <= start:
+                                if child_chromStart != child_chromEnd:
+                                    break
+                                if child_chromStart != end and child_chromEnd != start:
+                                    break
+                            yield (
+                                child_chromIx,
+                                child_chromStart,
+                                child_chromEnd,
+                                data,
+                                size,
+                                len(data),
+                            )
                             break
-                        if end <= child_chromStart or child_chromEnd <= start:
-                            if child_chromStart != child_chromEnd:
-                                break
-                            if child_chromStart != end and child_chromEnd != start:
-                                break
-                        yield (
-                            child_chromIx,
-                            child_chromStart,
-                            child_chromEnd,
-                            data,
-                            size,
-                            len(data),
-                        )
-                        break
                 else:
                     i = 0
                     n = len(data)

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -202,7 +202,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
     def _create_alignment(
         self, chromId, chromStart, chromEnd, data, dataStart, dataEnd
     ):
-        data = bytes(data)
+        data = bytes(data[dataStart:dataEnd])
         buffer = memoryview(data)
         records = []
         strands = []

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -216,11 +216,11 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
             i = j + 1
             prefix = buffer[i : i + 1]
             if prefix == b"#":
-                match = re.match(b"^[^;]*", buffer[i:])
-                j = i + match.span()[1]
+                m = re.match(b"^[^;]*", buffer[i:])
+                j = i + m.span()[1]
             elif prefix == b"a":
-                match = re.match(b"^[^;]*", buffer[i:])
-                j = i + match.span()[1]
+                m = re.match(b"^[^;]*", buffer[i:])
+                j = i + m.span()[1]
                 line = buffer[i:j].tobytes()
                 words = line[1:].split()
                 for word in words:
@@ -239,10 +239,8 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
                             "Unknown annotation variable '%s'" % key.decode()
                         )
             elif prefix == b"s":
-                match = re.match(
-                    b"^s\s*\S*\s*\d*\s*\d*\s*[+-]\s*\d*\s*", buffer[i:]  # noqa: W605
-                )
-                j = i + match.span()[1]
+                m = re.match(rb"^s\s*\S*\s*\d*\s*\d*\s*[+-]\s*\d*\s*", buffer[i:])
+                j = i + m.span()[1]
                 line = buffer[i:j].tobytes()
                 words = line.split(None, 5)
                 if len(words) != 6:
@@ -268,8 +266,8 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
                 i = j + 1
                 strands.append(strand)
             elif prefix == b"i":
-                match = re.match(b"^[^;]*", buffer[i:])
-                j = i + match.span()[1]
+                m = re.match(b"^[^;]*", buffer[i:])
+                j = i + m.span()[1]
                 line = buffer[i:j].tobytes()
                 words = line.split(None, 5)
                 assert len(words) == 6
@@ -285,8 +283,8 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
                 record.annotations["rightStatus"] = rightStatus
                 record.annotations["rightCount"] = rightCount
             elif prefix == b"e":
-                match = re.match(b"^[^;]*", buffer[i:])
-                j = i + match.span()[1]
+                m = re.match(b"^[^;]*", buffer[i:])
+                j = i + m.span()[1]
                 line = buffer[i:j].tobytes()
                 words = line.split(None, 6)
                 assert len(words) == 7
@@ -311,8 +309,8 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
                     annotations["empty"] = annotation
                 annotation.append(empty)
             elif prefix == b"q":
-                match = re.match(b"^[^;]*", buffer[i:])
-                j = i + match.span()[1]
+                m = re.match(b"^[^;]*", buffer[i:])
+                j = i + m.span()[1]
                 line = buffer[i:j].tobytes()
                 words = line.split(None, 2)
                 assert len(words) == 3

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -323,7 +323,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
             else:
                 raise ValueError(f"Error parsing alignment - unexpected line:\n{line}")
         shape = printed_alignment_parser.shape
-        coordinates = np.empty(shape, dtype=np.int_)
+        coordinates = np.empty(shape, int)
         printed_alignment_parser.fill(coordinates)
         for record, strand, row in zip(records, strands, coordinates):
             if strand == b"+":

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -243,7 +243,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
                     j = i + len(line)
                 else:
                     line = data[i:j]
-                words = line.split()
+                words = line.split(None, 6)
                 if len(words) != 7:
                     raise ValueError(
                         "Error parsing alignment - 's' line must have 7 fields"
@@ -271,7 +271,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
                     j = i + len(line)
                 else:
                     line = data[i:j]
-                words = line.split()
+                words = line.split(None, 5)
                 assert len(words) == 6
                 assert words[1].decode() == src  # from the previous "s" line
                 leftStatus = words[2].decode()
@@ -292,7 +292,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
                     j = i + len(line)
                 else:
                     line = data[i:j]
-                words = line.split()
+                words = line.split(None, 6)
                 assert len(words) == 7
                 src = words[1].decode()
                 start = int(words[2])
@@ -322,7 +322,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
                     j = i + len(line)
                 else:
                     line = data[i:j]
-                words = line.split()
+                words = line.split(None, 2)
                 assert len(words) == 3
                 assert words[1].decode() == src  # from the previous "s" line
                 value = words[2].replace(b"-", b"")

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -20,7 +20,7 @@ import zlib
 
 from Bio.Align import Alignment, Alignments
 from Bio.Align import bigbed, maf
-from Bio.Align import _parser  # type: ignore
+from Bio.Align import _aligncore  # type: ignore
 from Bio.Align.bigbed import AutoSQLTable, Field
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
@@ -223,7 +223,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
         strands = []
         annotations = {}
         score = None
-        printed_alignment_parser = _parser.PrintedAlignmentParser(b";")
+        printed_alignment_parser = _aligncore.PrintedAlignmentParser(b";")
         j = -1
         sequences = []
         while True:

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -328,11 +328,11 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
         coordinates = np.empty(shape, int)
         printed_alignment_parser.fill(coordinates)
         for record, strand, row in zip(records, strands, coordinates):
-            if strand == b"-":
-                row[:] = row[-1] - row[0] - row
+            if strand == b"+":
+                row += record.seq.defined_ranges[0][0]
+            else:  # strand == b"-"
                 record.seq = record.seq.reverse_complement()
-            start = record.seq.defined_ranges[0][0]
-            row += start
+                row[:] = record.seq.defined_ranges[0][1] - row
         alignment = Alignment(records, coordinates)
         if annotations is not None:
             alignment.annotations = annotations

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -199,8 +199,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
             self._index = 0
         self.targets[0].id = "%s.%s" % (self.reference, self.targets[0].id)
 
-    def _create_alignment(self, chunk):
-        chromId, chromStart, chromEnd, data = chunk
+    def _create_alignment(self, chromId, chromStart, chromEnd, data):
         data = bytes(data)
         buffer = memoryview(data)
         records = []

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -199,7 +199,9 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
             self._index = 0
         self.targets[0].id = "%s.%s" % (self.reference, self.targets[0].id)
 
-    def _create_alignment(self, chromId, chromStart, chromEnd, data):
+    def _create_alignment(
+        self, chromId, chromStart, chromEnd, data, dataStart, dataEnd
+    ):
         data = bytes(data)
         buffer = memoryview(data)
         records = []

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -67,23 +67,35 @@ class AlignmentWriter(bigbed.AlignmentWriter):
         target,
         targets=None,
         compress=True,
+        blockSize=256,
+        itemsPerSlot=512,
     ):
         """Create an AlignmentWriter object.
 
         Arguments:
-         - target      - output stream or file name.
-         - targets     - A list of SeqRecord objects with the chromosomes in the
-                         order as they appear in the alignments. The sequence
-                         contents in each SeqRecord may be undefined, but the
-                         sequence length must be defined, as in this example:
+         - target       - output stream or file name.
+         - targets      - A list of SeqRecord objects with the chromosomes in
+                          the order as they appear in the alignments. The
+                          sequence contents in each SeqRecord may be undefined,
+                          but the sequence length must be defined, as in this
+                          example:
 
-                         SeqRecord(Seq(None, length=248956422), id="chr1")
+                          SeqRecord(Seq(None, length=248956422), id="chr1")
 
-                         If targets is None (the default value), the alignments
-                         must have an attribute .targets providing the list of
-                         SeqRecord objects.
-         - compress    - If True (default), compress data using zlib.
-                         If False, do not compress data.
+                          If targets is None (the default value), the alignments
+                          must have an attribute .targets providing the list of
+                          SeqRecord objects.
+         - compress     - If True (default), compress data using zlib.
+                          If False, do not compress data.
+                          Use compress=False for faster searching.
+         - blockSize    - Number of items to bundle in r-tree.
+                          See UCSC's bedToBigBed program for more information.
+                          Default value is 256.
+         - itemsPerSlot - Number of data points bundled at lowest level.
+                          See UCSC's bedToBigBed program for more information.
+                          Use itemsPerSlot=1 for faster searching.
+                          Default value is 512.
+
         """
         super().__init__(
             target,
@@ -91,6 +103,8 @@ class AlignmentWriter(bigbed.AlignmentWriter):
             declaration=declaration,
             targets=targets,
             compress=compress,
+            blockSize=blockSize,
+            itemsPerSlot=itemsPerSlot,
         )
 
     def write_file(self, stream, alignments):

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -240,12 +240,12 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                 src = words[1].decode()
                 start = int(words[2])
                 size = int(words[3])
-                strand = words[4].decode()
+                strand = words[4]
                 srcSize = int(words[5])
-                text = words[6].decode()
-                for gap_char in ".=_":
-                    text = text.replace(gap_char, "-")
-                aligned_sequences.append(text.encode())
+                text = words[6]
+                for gap_char in (b".", b"=", b"_"):
+                    text = text.replace(gap_char, b"-")
+                aligned_sequences.append(text)
                 seq = Seq(None, length=srcSize)
                 record = SeqRecord(seq, id=src, name="", description="")
                 records.append(record)
@@ -253,13 +253,12 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                 sizes.append(size)
                 strands.append(strand)
             elif line.startswith(b"i "):
-                line = line.decode()
                 words = line.strip().split()
                 assert len(words) == 6
-                assert words[1] == src  # from the previous "s" line
-                leftStatus = words[2]
+                assert words[1].decode() == src  # from the previous "s" line
+                leftStatus = words[2].decode()
                 leftCount = int(words[3])
-                rightStatus = words[4]
+                rightStatus = words[4].decode()
                 rightCount = int(words[5])
                 assert leftStatus in AlignmentIterator.status_characters
                 assert rightStatus in AlignmentIterator.status_characters
@@ -268,20 +267,19 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                 record.annotations["rightStatus"] = rightStatus
                 record.annotations["rightCount"] = rightCount
             elif line.startswith(b"e"):
-                line = line.decode()
                 words = line[1:].split()
                 assert len(words) == 6
-                src = words[0]
+                src = words[0].decode()
                 start = int(words[1])
                 size = int(words[2])
                 strand = words[3]
                 srcSize = int(words[4])
-                status = words[5]
+                status = words[5].decode()
                 assert status in AlignmentIterator.empty_status_characters
                 sequence = Seq(None, length=srcSize)
                 record = SeqRecord(sequence, id=src, name="", description="")
                 end = start + size
-                if strand == "+":
+                if strand == b"+":
                     segment = (start, end)
                 else:
                     segment = (srcSize - start, srcSize - end)
@@ -292,12 +290,11 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                     annotations["empty"] = annotation
                 annotation.append(empty)
             elif line.startswith(b"q "):
-                line = line.decode()
                 words = line.strip().split()
                 assert len(words) == 3
-                assert words[1] == src  # from the previous "s" line
-                value = words[2].replace("-", "")
-                record.annotations["quality"] = value
+                assert words[1].decode() == src  # from the previous "s" line
+                value = words[2].replace(b"-", b"")
+                record.annotations["quality"] = value.decode()
             elif not line.strip():
                 # reached the end of the alignment, but keep reading to be sure
                 continue
@@ -313,7 +310,7 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                 )
             record.seq = Seq({start: sequence}, length=srcSize)
         for record, strand, row in zip(records, strands, coordinates):
-            if strand == "-":
+            if strand == b"-":
                 row[:] = row[-1] - row[0] - row
                 record.seq = record.seq.reverse_complement()
             start = record.seq.defined_ranges[0][0]

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -15,7 +15,7 @@ See https://genome.ucsc.edu/goldenPath/help/bigMaf.html
 
 import struct
 import zlib
-from io import StringIO
+from io import BytesIO
 
 
 from Bio.Align import Alignment, Alignments
@@ -200,11 +200,11 @@ class AlignmentIterator(bigbed.AlignmentIterator):
 
     def _create_alignment(self, chunk):
         chromId, chromStart, chromEnd, rest = chunk
-        data = rest.replace(b";", b"\n").decode()
-        stream = StringIO()
+        data = rest.replace(b";", b"\n")
+        stream = BytesIO()
         stream.write(data)
         stream.seek(0)
-        aline = next(stream)
+        aline = next(stream).decode()
         records = []
         starts = []
         sizes = []
@@ -225,6 +225,7 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                 raise ValueError("Unknown annotation variable '%s'" % key)
 
         for line in stream:
+            line = line.decode()
             if line.startswith("#"):
                 continue
             elif line.startswith("a"):

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -205,6 +205,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
         records = []
         strands = []
         annotations = {}
+        score = None
         printed_alignment_parser = _parser.Coordinates(b";")
         j = -1
         sequences = []

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -211,9 +211,10 @@ class AlignmentIterator(bigbed.AlignmentIterator):
         aligned_sequences = []
         annotations = {}
         for line in stream:
-            if line.startswith(b"#"):
+            prefix = line[:1]
+            if prefix == b"#":
                 continue
-            elif line.startswith(b"a"):
+            elif prefix == b"a":
                 words = line[1:].split()
                 for word in words:
                     key, value = word.split(b"=")
@@ -231,7 +232,7 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                             "Unknown annotation variable '%s'" % key.decode()
                         )
                 continue
-            elif line.startswith(b"s "):
+            elif prefix == b"s":
                 words = line.strip().split()
                 if len(words) != 7:
                     raise ValueError(
@@ -252,7 +253,7 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                 starts.append(start)
                 sizes.append(size)
                 strands.append(strand)
-            elif line.startswith(b"i "):
+            elif prefix == b"i":
                 words = line.strip().split()
                 assert len(words) == 6
                 assert words[1].decode() == src  # from the previous "s" line
@@ -266,15 +267,15 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                 record.annotations["leftCount"] = leftCount
                 record.annotations["rightStatus"] = rightStatus
                 record.annotations["rightCount"] = rightCount
-            elif line.startswith(b"e"):
-                words = line[1:].split()
-                assert len(words) == 6
-                src = words[0].decode()
-                start = int(words[1])
-                size = int(words[2])
-                strand = words[3]
-                srcSize = int(words[4])
-                status = words[5].decode()
+            elif prefix == b"e":
+                words = line.split()
+                assert len(words) == 7
+                src = words[1].decode()
+                start = int(words[2])
+                size = int(words[3])
+                strand = words[4]
+                srcSize = int(words[5])
+                status = words[6].decode()
                 assert status in AlignmentIterator.empty_status_characters
                 sequence = Seq(None, length=srcSize)
                 record = SeqRecord(sequence, id=src, name="", description="")
@@ -289,7 +290,7 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                     annotation = []
                     annotations["empty"] = annotation
                 annotation.append(empty)
-            elif line.startswith(b"q "):
+            elif prefix == b"q":
                 words = line.strip().split()
                 assert len(words) == 3
                 assert words[1].decode() == src  # from the previous "s" line

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -202,8 +202,10 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
     def _create_alignment(
         self, chromId, chromStart, chromEnd, data, dataStart, dataEnd
     ):
-        data = bytes(data[dataStart:dataEnd])
+        assert data[dataEnd - 1] == 0
         buffer = memoryview(data)
+        buffer = buffer[dataStart:dataEnd]
+        data = bytes(data[dataStart:dataEnd])
         records = []
         strands = []
         annotations = {}
@@ -318,7 +320,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
                 assert words[1].decode() == src  # from the previous "s" line
                 value = words[2].replace(b"-", b"")
                 record.annotations["quality"] = value.decode()
-            elif prefix == b"":
+            elif prefix == b"\00":
                 # reached the end of the alignment
                 break
             else:

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -204,25 +204,25 @@ class AlignmentIterator(bigbed.AlignmentIterator):
         stream = BytesIO()
         stream.write(data)
         stream.seek(0)
-        aline = next(stream).decode()
         records = []
         starts = []
         sizes = []
         strands = []
         aligned_sequences = []
         annotations = {}
+        aline = next(stream)
         words = aline[1:].split()
         for word in words:
-            key, value = word.split("=")
-            if key == "score":
+            key, value = word.split(b"=")
+            if key == b"score":
                 score = float(value)
-            elif key == "pass":
+            elif key == b"pass":
                 value = int(value)
                 if value <= 0:
                     raise ValueError("pass value must be positive (found %d)" % value)
                 annotations["pass"] = value
             else:
-                raise ValueError("Unknown annotation variable '%s'" % key)
+                raise ValueError("Unknown annotation variable '%s'" % key.decode())
 
         for line in stream:
             line = line.decode()

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -18,7 +18,7 @@ import zlib
 
 
 from Bio.Align import Alignment, Alignments
-from Bio.Align import interfaces, bigbed
+from Bio.Align import bigbed, maf
 from Bio.Align.bigbed import AutoSQLTable, Field
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
@@ -118,7 +118,7 @@ class AlignmentWriter(bigbed.AlignmentWriter):
         ).write(fixed_alignments)
 
 
-class AlignmentIterator(bigbed.AlignmentIterator):
+class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
     """Alignment iterator for bigMaf files.
 
     The file may contain multiple alignments, which are loaded and returned
@@ -136,9 +136,6 @@ class AlignmentIterator(bigbed.AlignmentIterator):
 
     fmt = "bigMaf"
     mode = "b"
-
-    status_characters = ("C", "I", "N", "n", "M", "T")
-    empty_status_characters = ("C", "I", "M", "n")
 
     def __init__(self, source):
         """Create an AlignmentIterator object.
@@ -198,19 +195,18 @@ class AlignmentIterator(bigbed.AlignmentIterator):
         self.targets[0].id = "%s.%s" % (self.reference, self.targets[0].id)
 
     def _create_alignment(self, chunk):
-        chromId, chromStart, chromEnd, rest = chunk
-        data = rest.replace(b";", b"\n")
+        chromId, chromStart, chromEnd, data = chunk
         records = []
         starts = []
         sizes = []
         strands = []
         aligned_sequences = []
         annotations = {}
-        j = 0
+        j = -1
         while True:
-            i = j
+            i = j + 1
             try:
-                j = data.find(b"\n", i) + 1
+                j = data.find(b";", i)
             except ValueError:
                 line = data[i:]
                 j = i + len(line)

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -201,6 +201,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
 
     def _create_alignment(self, chunk):
         chromId, chromStart, chromEnd, data = chunk
+        data = bytes(data)
         buffer = memoryview(data)
         records = []
         strands = []
@@ -252,7 +253,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
                 strand = words[4]
                 srcSize = int(words[5])
                 i = j
-                n, sequence = printed_alignment_parser.feed(buffer[i:])
+                n, sequence = printed_alignment_parser.feed(data, i)
                 if len(sequence) != size:
                     raise ValueError(
                         "sequence size is incorrect (found %d, expected %d)"

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -323,7 +323,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
             else:
                 raise ValueError(f"Error parsing alignment - unexpected line:\n{line}")
         shape = printed_alignment_parser.shape
-        coordinates = np.empty(shape)
+        coordinates = np.empty(shape, dtype=np.int_)
         printed_alignment_parser.fill(coordinates)
         for record, strand, row in zip(records, strands, coordinates):
             if strand == b"+":

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -205,7 +205,6 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
         assert data[dataEnd - 1] == 0
         buffer = memoryview(data)
         buffer = buffer[dataStart:dataEnd]
-        data = bytes(data[dataStart:dataEnd])
         records = []
         strands = []
         annotations = {}
@@ -256,7 +255,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
                 strand = words[4]
                 srcSize = int(words[5])
                 i = j
-                n, sequence = printed_alignment_parser.feed(data, i)
+                n, sequence = printed_alignment_parser.feed(data, dataStart + i)
                 if len(sequence) != size:
                     raise ValueError(
                         "sequence size is incorrect (found %d, expected %d)"

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -323,7 +323,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
             else:
                 raise ValueError(f"Error parsing alignment - unexpected line:\n{line}")
         shape = printed_alignment_parser.shape
-        coordinates = np.empty(shape, np.int64)
+        coordinates = np.empty(shape)
         printed_alignment_parser.fill(coordinates)
         for record, strand, row in zip(records, strands, coordinates):
             if strand == b"+":

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -323,7 +323,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
             else:
                 raise ValueError(f"Error parsing alignment - unexpected line:\n{line}")
         shape = printed_alignment_parser.shape
-        coordinates = np.empty(shape, int)
+        coordinates = np.empty(shape, np.int64)
         printed_alignment_parser.fill(coordinates)
         for record, strand, row in zip(records, strands, coordinates):
             if strand == b"+":

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -200,7 +200,7 @@ class AlignmentIterator(bigbed.AlignmentIterator):
 
     def _create_alignment(self, chunk):
         chromId, chromStart, chromEnd, rest = chunk
-        data = rest.decode().replace(";", "\n")
+        data = rest.replace(b";", b"\n").decode()
         stream = StringIO()
         stream.write(data)
         stream.seek(0)

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -209,7 +209,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
         strands = []
         annotations = {}
         score = None
-        printed_alignment_parser = _parser.Coordinates(b";")
+        printed_alignment_parser = _parser.PrintedAlignmentParser(b";")
         j = -1
         sequences = []
         while True:

--- a/Bio/Align/bigpsl.py
+++ b/Bio/Align/bigpsl.py
@@ -472,8 +472,7 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                     "Expected field name '%s'; found '%s'" % (name, fields[i].name)
                 )
 
-    def _create_alignment(self, chunk):
-        chromId, tStart, tEnd, rest = chunk
+    def _create_alignment(self, chromId, tStart, tEnd, rest):
         words = rest.decode().split("\t")
         if len(words) != 22:
             raise ValueError(

--- a/Bio/Align/bigpsl.py
+++ b/Bio/Align/bigpsl.py
@@ -473,7 +473,8 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                 )
 
     def _create_alignment(self, chromId, tStart, tEnd, rest, dataStart, dataEnd):
-        words = rest[dataStart:dataEnd].decode().split("\t")
+        assert rest[dataEnd - 1] == 0
+        words = rest[dataStart : dataEnd - 1].decode().split("\t")
         if len(words) != 22:
             raise ValueError(
                 "Unexpected number of fields (%d, expected 22)" % len(words)

--- a/Bio/Align/bigpsl.py
+++ b/Bio/Align/bigpsl.py
@@ -472,7 +472,7 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                     "Expected field name '%s'; found '%s'" % (name, fields[i].name)
                 )
 
-    def _create_alignment(self, chromId, tStart, tEnd, rest):
+    def _create_alignment(self, chromId, tStart, tEnd, rest, dataStart, dataEnd):
         words = rest.decode().split("\t")
         if len(words) != 22:
             raise ValueError(

--- a/Bio/Align/bigpsl.py
+++ b/Bio/Align/bigpsl.py
@@ -473,7 +473,7 @@ class AlignmentIterator(bigbed.AlignmentIterator):
                 )
 
     def _create_alignment(self, chromId, tStart, tEnd, rest, dataStart, dataEnd):
-        words = rest.decode().split("\t")
+        words = rest[dataStart:dataEnd].decode().split("\t")
         if len(words) != 22:
             raise ValueError(
                 "Unexpected number of fields (%d, expected 22)" % len(words)

--- a/Bio/Align/maf.py
+++ b/Bio/Align/maf.py
@@ -342,6 +342,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         starts = []
         sizes = []
         strands = []
+        score = None
         aligned_sequences = []
         annotations = {}
         words = aline[1:].split()

--- a/Bio/Align/maf.py
+++ b/Bio/Align/maf.py
@@ -338,10 +338,6 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         aline = self._aline
         if aline is None:
             return
-        alignment = self._create_alignment(aline, stream)
-        return alignment
-
-    def _create_alignment(self, aline, stream):
         records = []
         starts = []
         sizes = []

--- a/Doc/Tutorial/chapter_align.rst
+++ b/Doc/Tutorial/chapter_align.rst
@@ -102,6 +102,8 @@ sequences included in this alignment:
 
 and an attribute ``coordinates`` with the alignment coordinates:
 
+.. cont-doctest
+
 .. code:: pycon
 
    >>> alignment.coordinates

--- a/Doc/Tutorial/chapter_align.rst
+++ b/Doc/Tutorial/chapter_align.rst
@@ -150,7 +150,13 @@ aligned sequences as follows:
    CGGTTTTT
    AG-TTT--
    AGGTTT--
+   >>> lines = [line.encode() for line in lines]  # convert to bytes
+   >>> lines
+   [b'CGGTTTTT', b'AG-TTT--', b'AGGTTT--']
    >>> sequences, coordinates = Alignment.parse_printed_alignment(lines)
+   >>> sequences
+   [b'CGGTTTTT', b'AGTTT', b'AGGTTT']
+   >>> sequences = [sequence.decode() for sequence in sequences]
    >>> sequences
    ['CGGTTTTT', 'AGTTT', 'AGGTTT']
    >>> coordinates

--- a/Doc/Tutorial/chapter_align.rst
+++ b/Doc/Tutorial/chapter_align.rst
@@ -5191,8 +5191,8 @@ bigMaf
 
 A bigMaf file is a bigBed file with a BED3+1 format consisting of the 3
 required BED fields plus a custom field that stores a MAF alignment
-block as a string, crearing an indexed binary version of a MAF file (see
-section :ref:`subsec:align_bigmaf`). The associated AutoSql file
+block as a string, creating an indexed binary version of a MAF file (see
+section :ref:`subsec:align_maf`). The associated AutoSql file
 `bigMaf.as <https://genome.ucsc.edu/goldenPath/help/examples/bigMaf.as>`__
 is provided by UCSC. To create a bigMaf file, you can either use the
 ``mafToBigMaf`` and ``bedToBigBed`` programs from UCSC. or you can use

--- a/Doc/Tutorial/chapter_align.rst
+++ b/Doc/Tutorial/chapter_align.rst
@@ -4574,6 +4574,12 @@ dictionary. Please refer to the test script ``test_Align_bigbed.py`` in
 the ``Tests`` subdirectory in the Biopython distribution for more
 examples of writing alignment files in the bigBed format.
 
+Optional arguments are ``compress`` (default value is ``True``), ``blockSize``
+(default value is 256), and ``itemsPerSlot`` (default value is 512). See the
+documentation of UCSC's ``bedToBigBed`` program for a description of these
+arguments.  Searching a ``bigBed`` file can be faster by using
+``compress=False`` and ``itemsPerSlot=1`` when creating the bigBed file.
+
 .. _`subsec:align_psl`:
 
 Pattern Space Layout (PSL)
@@ -4934,6 +4940,12 @@ you can use a (binary) stream for output. Additional options are
 See section :ref:`subsec:align_psl` for an explanation on how the
 number of matches, mismatches, repeat region matches, and matches to
 unknown nucleotides are obtained.
+
+Further optional arguments are ``blockSize`` (default value is 256), and
+``itemsPerSlot`` (default value is 512). See the documentation of UCSC's
+``bedToBigBed`` program for a description of these arguments.  Searching a
+``bigPsl`` file can be faster by using ``compress=False`` and
+``itemsPerSlot=1`` when creating the bigPsl file.
 
 .. _`subsec:align_maf`:
 
@@ -5350,6 +5362,9 @@ be of the form ``reference.chromosome``, where ``reference`` refers to
 the reference species. ``Bio.Align.write`` has the additional keyword
 argument ``compress`` (``True`` by default) specifying whether the data
 should be compressed using zlib.
+Further optional arguments are ``blockSize`` (default value is 256), and
+``itemsPerSlot`` (default value is 512). See the documentation of UCSC's
+``bedToBigBed`` program for a description of these arguments.
 
 As a bigMaf file is a special case of a bigBed file, you can use the
 ``search`` method on the ``alignments`` object to find alignments to
@@ -5379,6 +5394,9 @@ start and end positions may be ``None`` to start searching from position
 0 or to continue searching until the end of the chromosome,
 respectively. Note that we can search on genomic position for the
 reference species only.
+
+Searching a ``bigMaf`` file can be faster by using ``compress=False`` and
+``itemsPerSlot=1`` when creating the bigMaf file.
 
 .. _`subsec:align_chain`:
 

--- a/Doc/Tutorial/chapter_align.rst
+++ b/Doc/Tutorial/chapter_align.rst
@@ -102,8 +102,6 @@ sequences included in this alignment:
 
 and an attribute ``coordinates`` with the alignment coordinates:
 
-.. cont-doctest
-
 .. code:: pycon
 
    >>> alignment.coordinates

--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ PACKAGES = [
 EXTENSIONS = [
     Extension("Bio.Align._codonaligner", ["Bio/Align/_codonaligner.c"]),
     Extension("Bio.Align._pairwisealigner", ["Bio/Align/_pairwisealigner.c"]),
-    Extension("Bio.Align._parser", ["Bio/Align/_parser.c"]),
+    Extension("Bio.Align._aligncore", ["Bio/Align/_aligncore.c"]),
     Extension("Bio.cpairwise2", ["Bio/cpairwise2module.c"]),
     Extension("Bio.Nexus.cnexus", ["Bio/Nexus/cnexus.c"]),
     Extension("Bio.motifs._pwm", ["Bio/motifs/_pwm.c"]),


### PR DESCRIPTION
Several alignment formats store the alignment using dashes to represent gaps. Currently these are parsed into Alignment objects using Python code. For long alignments, in particular genome-scale alignments stored in the Maf or bigMaf format, this takes a long time (see issue #4656). This PR replaces the Python-based parsing code with C code, which is much faster. With this code, searching a Maf file indexed using `Bio.AlignIO` or searching a bigMaf file takes approximately an equal amount of time.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

