### PR TITLE
Replace \bpversion in API links with RST module links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
     hooks:
     -   id: rstcheck
         args: [
-            '--ignore-roles=ref,numref',
+            '--ignore-roles=ref,numref,py:mod',
             --ignore-directives=toctree,
             --ignore-substitutions=version,
             --report-level=warning,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,7 @@ repos:
         args: [
             '--ignore-roles=ref,numref',
             --ignore-directives=toctree,
+            --ignore-substitutions=version,
             --report-level=warning,
             --ignore-messages=Unknown\ target\ name
         ]

--- a/Doc/Tutorial/chapter_contributing.rst
+++ b/Doc/Tutorial/chapter_contributing.rst
@@ -34,7 +34,7 @@ Contributing Documentation
 We’re happy to take feedback or contributions - either via a bug-report
 or on the Mailing List. While reading this tutorial, perhaps you noticed
 some topics you were interested in which were missing, or not clearly
-explained. There is also Biopython’s built in documentation (the
+explained. There is also Biopython’s built-in documentation (the
 docstrings, these are also
 `online <http://biopython.org/DIST/docs/api>`__), where again, you may
 be able to help fill in any blanks.

--- a/Doc/Tutorial/chapter_cookbook.rst
+++ b/Doc/Tutorial/chapter_cookbook.rst
@@ -105,7 +105,7 @@ For this discussion, we’ll use the GenBank file for the pPCP1 plasmid
 from *Yersinia pestis biovar Microtus*. The file is included with the
 Biopython unit tests under the GenBank folder, or you can get it from
 our website,
-```NC_005816.gb`` <https://raw.githubusercontent.com/biopython/biopython/master/Tests/GenBank/NC_005816.gb>`__.
+`NC_005816.gb <https://raw.githubusercontent.com/biopython/biopython/master/Tests/GenBank/NC_005816.gb>`__.
 This file contains one and only one record, so we can read it in as a
 ``SeqRecord`` using the ``Bio.SeqIO.read()`` function:
 
@@ -949,7 +949,7 @@ To show how you might approach this with Biopython, we’ll need a
 sequence to search, and as an example we’ll again use the bacterial
 plasmid – although this time we’ll start with a plain FASTA file with no
 pre-marked genes:
-```NC_005816.fna`` <https://raw.githubusercontent.com/biopython/biopython/master/Tests/GenBank/NC_005816.fna>`__.
+`NC_005816.fna <https://raw.githubusercontent.com/biopython/biopython/master/Tests/GenBank/NC_005816.fna>`__.
 This is a bacterial sequence, so we’ll want to use NCBI codon table 11
 (see Section :ref:`sec:translation` about
 translation).

--- a/Doc/Tutorial/chapter_cookbook.rst
+++ b/Doc/Tutorial/chapter_cookbook.rst
@@ -117,7 +117,7 @@ This file contains one and only one record, so we can read it in as a
    >>> original_rec = SeqIO.read("NC_005816.gb", "genbank")
 
 So, how can we generate a shuffled versions of the original sequence? I
-would use the built in Python ``random`` module for this, in particular
+would use the built-in Python ``random`` module for this, in particular
 the function ``random.shuffle`` – but this works on a Python list. Our
 sequence is a ``Seq`` object, so in order to shuffle it we need to turn
 it into a list:
@@ -761,8 +761,7 @@ variants are very different from the original FASTQ standard as used by
 Sanger, the NCBI, and elsewhere (format name ``fastq`` or
 ``fastq-sanger``).
 
-For more details, see the built in help (also
-`online <http://www.biopython.org/docs/\bpversion/api/Bio.SeqIO.QualityIO.html>`__):
+For more details, see the built-in help (also at :py:mod:`Bio.SeqIO.QualityIO`):
 
 .. code:: pycon
 
@@ -924,7 +923,7 @@ line (but currently FASTQ output is not supported), e.g.
 The way Biopython uses mixed case sequence strings to represent the
 trimming points deliberately mimics what the Roche tools do.
 
-For more information on the Biopython SFF support, consult the built in
+For more information on the Biopython SFF support, consult the built-in
 help:
 
 .. code:: pycon

--- a/Doc/Tutorial/chapter_graphics.rst
+++ b/Doc/Tutorial/chapter_graphics.rst
@@ -80,7 +80,7 @@ from a GenBank file (see Chapter :ref:`chapter:seqio`).
 This example uses the pPCP1 plasmid from *Yersinia pestis biovar
 Microtus*, the file is included with the Biopython unit tests under the
 GenBank folder, or online
-```NC_005816.gb`` <https://raw.githubusercontent.com/biopython/biopython/master/Tests/GenBank/NC_005816.gb>`__
+`NC_005816.gb <https://raw.githubusercontent.com/biopython/biopython/master/Tests/GenBank/NC_005816.gb>`__
 from our website.
 
 .. code:: python

--- a/Doc/Tutorial/chapter_introduction.rst
+++ b/Doc/Tutorial/chapter_introduction.rst
@@ -218,7 +218,7 @@ Frequently Asked Questions (FAQ)
 
 #. | *What file formats do* ``Bio.SeqIO`` *and* ``Bio.AlignIO`` *read
      and write?*
-   | Check the built in docstrings (``from Bio import SeqIO``, then
+   | Check the built-in docstrings (``from Bio import SeqIO``, then
      ``help(SeqIO)``), or see http://biopython.org/wiki/SeqIO and
      http://biopython.org/wiki/AlignIO on the wiki for the latest
      listing.

--- a/Doc/Tutorial/chapter_msa.rst
+++ b/Doc/Tutorial/chapter_msa.rst
@@ -224,9 +224,8 @@ With any supported file format, you can load an alignment in exactly the
 same way just by changing the format string. For example, use “phylip”
 for PHYLIP files, “nexus” for NEXUS files or “emboss” for the alignments
 output by the EMBOSS tools. There is a full listing on the wiki page
-(http://biopython.org/wiki/AlignIO) and in the built-in documentation
-(also
-`online <http://biopython.org/docs/\bpversion/api/Bio.AlignIO.html>`__):
+(http://biopython.org/wiki/AlignIO) and in the built-in documentation,
+:py:mod:`Bio.AlignIO`:
 
 .. code:: pycon
 

--- a/Doc/Tutorial/chapter_pairwise2.rst
+++ b/Doc/Tutorial/chapter_pairwise2.rst
@@ -37,8 +37,7 @@ tricky part are the last two letters of the function name (here:
 matches (and mismatches) and gaps. The first letter decodes the match
 score, e.g. ``x`` means that a match counts 1 while mismatches have no
 costs. With ``m`` general values for either matches or mismatches can be
-defined (for more options see `Biopython’s
-API <http://biopython.org/docs/1.77/api/Bio.pairwise2.html>`__). The
+defined (for full details see :py:mod:`Bio.pairwise2`). The
 second letter decodes the cost for gaps; ``x`` means no gap costs at
 all, with ``s`` different penalties for opening and extending a gap can
 be assigned. So, ``globalxx`` means that only matches between both
@@ -207,5 +206,4 @@ penalties and end gaps penalties can be different for both sequences,
 sequences can be supplied as lists (useful if you have residues that are
 encoded by more than one character), etc. These features are hard (if at
 all) to realize with other alignment tools. For more details see the
-modules documentation in `Biopython’s
-API <http://biopython.org/docs/\bpversion/api/Bio.pairwise2.html>`__.
+module's API documentation :py:mod:`Bio.pairwise2`.

--- a/Doc/Tutorial/chapter_phenotype.rst
+++ b/Doc/Tutorial/chapter_phenotype.rst
@@ -42,7 +42,7 @@ or `DuctApe <https://combogenomics.github.io/DuctApe/>`__. The parser
 will return one or a generator of PlateRecord objects, depending on
 whether the read or parse method is being used. You can test the parse
 function by using the
-```Plates.csv`` <https://github.com/biopython/biopython/blob/master/Doc/examples/Plates.csv>`__
+`Plates.csv <https://github.com/biopython/biopython/blob/master/Doc/examples/Plates.csv>`__
 file provided with the Biopython source code.
 
 .. doctest examples lib:numpy

--- a/Doc/Tutorial/chapter_phylo.rst
+++ b/Doc/Tutorial/chapter_phylo.rst
@@ -22,7 +22,7 @@ save it.
 
 Create a simple Newick file named ``simple.dnd`` using your favorite
 text editor, or use
-```simple.dnd`` <https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/simple.dnd>`__
+`simple.dnd <https://raw.githubusercontent.com/biopython/biopython/master/Doc/examples/simple.dnd>`__
 provided with the Biopython source code:
 
 .. code:: text

--- a/Doc/Tutorial/chapter_quick_start.rst
+++ b/Doc/Tutorial/chapter_quick_start.rst
@@ -40,11 +40,9 @@ one right way to do something. However, this can also be a real benefit
 because it gives you lots of flexibility and control over the libraries.
 The tutorial helps to show you the common or easy ways to do things so
 that you can just make things work. To learn more about the alternative
-possibilities, look in the Cookbook
-(Chapter :ref:`chapter:cookbook`, this has some cools
-tricks and tips), and built in “docstrings” (via the Python help
-command, or the `API
-documentation <http://biopython.org/docs/\bpversion/api/>`__) or
+possibilities, look in the Cookbook (Chapter :ref:`chapter:cookbook`,
+this has some cools tricks and tips), and built-in “docstrings” (via
+the Python help command or :py:mod:`Bio` and :py:mod:`BioSQL`), or
 ultimately the code itself.
 
 .. _`sec:sequences`:

--- a/Doc/Tutorial/chapter_searchio.rst
+++ b/Doc/Tutorial/chapter_searchio.rst
@@ -254,10 +254,8 @@ attributes that you can access using the same method.
    10.0
 
 For a complete list of accessible attributes, you can check each
-format-specific documentation. Here are the ones `for
-BLAST <http://biopython.org/docs/\bpversion/api/Bio.SearchIO.BlastIO.html>`__
-and for
-`BLAT <http://biopython.org/docs/\bpversion/api/Bio.SearchIO.BlatIO.html>`__.
+format-specific documentation. e.g. :py:mod:`Bio.SearchIO.BlastIO`
+and :py:mod:`Bio.SearchIO.BlatIO`.
 
 Having looked at using ``print`` on ``QueryResult`` objects, let’s drill
 down deeper. What exactly is a ``QueryResult``? In terms of Python
@@ -426,9 +424,9 @@ that could make it even easier to work with ``QueryResult`` objects: the
 ``filter`` and ``map`` methods.
 
 If you’re familiar with Python’s list comprehensions, generator
-expressions or the built in ``filter`` and ``map`` functions, you’ll
+expressions or the built-in ``filter`` and ``map`` functions, you’ll
 know how useful they are for working with list-like objects (if you’re
-not, check them out!). You can use these built in methods to manipulate
+not, check them out!). You can use these built-in methods to manipulate
 ``QueryResult`` objects, but you’ll end up with regular Python lists and
 lose the ability to do more interesting manipulations.
 
@@ -749,8 +747,7 @@ various details. Here are some examples:
    >>> blast_hsp.aln_span  # how long the alignment is
    61
 
-Check out the ``HSP``
-`documentation <http://biopython.org/docs/\bpversion/api/Bio.SearchIO.html#module-Bio.SearchIO#module-Bio.SearchIO>`__
+Check out the ``HSP`` documentation under :py:mod:`Bio.SearchIO`
 for a full list of these predefined properties.
 
 Furthermore, each sequence search tool usually computes its own
@@ -953,9 +950,8 @@ objects. However, you can use their ``*_all`` counterparts:
 return a list containing ``SeqRecord`` or ``MultipleSeqAlignment``
 objects from each of the HSP fragment. There are other attributes that
 behave similarly, i.e. they only work for HSPs with one fragment. Check
-out the ``HSP``
-`documentation <http://biopython.org/docs/\bpversion/api/Bio.SearchIO.html#module-Bio.SearchIO>`__
-for a full list.
+out the ``HSP`` documentation under :py:mod:`Bio.SearchIO` for a full
+list.
 
 Finally, to check whether you have multiple fragments or not, you can
 use the ``is_fragmented`` property like so:

--- a/Doc/Tutorial/chapter_seq_annot.rst
+++ b/Doc/Tutorial/chapter_seq_annot.rst
@@ -19,10 +19,8 @@ EMBL files, this information is quite important.
 While this chapter should cover most things to do with the ``SeqRecord``
 and ``SeqFeature`` objects in this chapter, you may also want to read
 the ``SeqRecord`` wiki page (http://biopython.org/wiki/SeqRecord), and
-the built in documentation (also online –
-`SeqRecord <http://biopython.org/docs/\bpversion/api/Bio.SeqRecord.html>`__
-and
-`SeqFeature <http://biopython.org/docs/\bpversion/api/Bio.SeqFeature.html>`__):
+the built-in documentation (:py:mod:`Bio.SeqRecord` and
+:py:mod:`Bio.SeqFeature`):
 
 .. code:: pycon
 

--- a/Doc/Tutorial/chapter_seq_objects.rst
+++ b/Doc/Tutorial/chapter_seq_objects.rst
@@ -400,7 +400,7 @@ sequences are normally read from the 5’ to 3’ direction, while in the
 figure the template strand is shown reversed.
 
 Now let’s transcribe the coding strand into the corresponding mRNA,
-using the ``Seq`` object’s built in ``transcribe`` method:
+using the ``Seq`` object’s built-in ``transcribe`` method:
 
 .. cont-doctest
 

--- a/Doc/Tutorial/chapter_seqio.rst
+++ b/Doc/Tutorial/chapter_seqio.rst
@@ -9,8 +9,8 @@ Chapter :ref:`chapter:quick_start` and also used
 in Chapter :ref:`chapter:seq_annot`. This aims to
 provide a simple interface for working with assorted sequence file
 formats in a uniform way. See also the ``Bio.SeqIO`` wiki page
-(http://biopython.org/wiki/SeqIO), and the built in documentation (also
-`online <http://biopython.org/docs/\bpversion/api/Bio.SeqIO.html>`__):
+(http://biopython.org/wiki/SeqIO), and the built-in documentation
+:py:mod:`Bio.Seq`:
 
 .. code:: pycon
 
@@ -94,9 +94,8 @@ Similarly, if you wanted to read in a file in another file format, then
 assuming ``Bio.SeqIO.parse()`` supports it you would just need to change
 the format string as appropriate, for example “swiss” for SwissProt
 files or “embl” for EMBL text files. There is a full listing on the wiki
-page (http://biopython.org/wiki/SeqIO) and in the built in documentation
-(also
-`online <http://biopython.org/docs/\bpversion/api/Bio.SeqIO.html>`__).
+page (http://biopython.org/wiki/SeqIO) and in the built-in documentation
+:py:mod:`Bio.SeqIO`:
 
 Another very common way to use a Python iterator is within a list
 comprehension (or a generator expression). For example, if all you
@@ -1440,7 +1439,7 @@ with just:
 
 The ``Bio.SeqIO.convert()`` function will take handles *or* filenames.
 Watch out though – if the output file already exists, it will overwrite
-it! To find out more, see the built in help:
+it! To find out more, see the built-in help:
 
 .. code:: pycon
 
@@ -1476,7 +1475,7 @@ output file.
 
 To start with, we’ll use ``Bio.SeqIO.parse()`` to load some nucleotide
 sequences from a file, then print out their reverse complements using
-the ``Seq`` object’s built in ``.reverse_complement()`` method (see
+the ``Seq`` object’s built-in ``.reverse_complement()`` method (see
 Section :ref:`sec:seq-reverse-complement`):
 
 .. code:: pycon
@@ -1489,7 +1488,7 @@ Section :ref:`sec:seq-reverse-complement`):
 
 Now, if we want to save these reverse complements to a file, we’ll need
 to make ``SeqRecord`` objects. We can use the ``SeqRecord`` object’s
-built in ``.reverse_complement()`` method (see
+built-in ``.reverse_complement()`` method (see
 Section :ref:`sec:SeqRecord-reverse-complement`)
 but we must decide how to name our new records.
 
@@ -1563,7 +1562,7 @@ Getting your SeqRecord objects as formatted strings
 Suppose that you don’t really want to write your records to a file or
 handle – instead you want a string containing the records in a
 particular file format. The ``Bio.SeqIO`` interface is based on handles,
-but Python has a useful built in module which provides a string based
+but Python has a useful built-in module which provides a string based
 handle.
 
 For an example of how you might use this, let’s load in a bunch of

--- a/Doc/Tutorial/chapter_testing.rst
+++ b/Doc/Tutorial/chapter_testing.rst
@@ -320,7 +320,7 @@ In general instead include the docstring tests by adding them to the
 Writing doctests
 ----------------
 
-Python modules, classes and functions support built in documentation
+Python modules, classes and functions support built-in documentation
 using docstrings. The `doctest
 framework <https://docs.python.org/3/library/doctest.html>`__ (included
 with Python) allows the developer to embed working examples in the

--- a/Doc/Tutorial/index.rst
+++ b/Doc/Tutorial/index.rst
@@ -5,6 +5,8 @@ Biopython Tutorial & Cookbook
 Named authors: Jeff Chang, Brad Chapman, Iddo Friedberg, Thomas Hamelryck,
 Michiel de Hoon, Peter Cock, Tiago Antao, Eric Talevich, Bartek Wilczyński.
 
+This is from Biopython |version|.
+
 .. toctree::
    :maxdepth: 1
    :caption: Table of contents:

--- a/Doc/index.rst
+++ b/Doc/index.rst
@@ -1,6 +1,8 @@
 Biopython Documentation
 =======================
 
+This is from Biopython |version|.
+
 .. toctree::
    :maxdepth: 2
    :caption: Table of contents


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4571.

Also standardises on "built-in" over "built in", and fixes a couple of links with inadvertent triple back-ticks in the RST.
