### PR TITLE
 mmCIF writer should always write initial data_ token #4747 

### DIFF
--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -33,7 +33,7 @@ class MMCIF2Dict(dict):
             self[token[0:5]] = token[5:]
             if not token[0:5].startswith("data_"):
                 raise ValueError(
-                    f"The mmCIF file {filename} does not start with 'data_'"
+                    "The input mmCIF file must begin with a 'data_' directive."
                 )
             i = 0
             n = 0

--- a/Bio/PDB/MMCIF2Dict.py
+++ b/Bio/PDB/MMCIF2Dict.py
@@ -31,6 +31,10 @@ class MMCIF2Dict(dict):
             except StopIteration:
                 return  # for Python 3.7 and PEP 479
             self[token[0:5]] = token[5:]
+            if not token[0:5].startswith("data_"):
+                raise ValueError(
+                    f"The mmCIF file {filename} does not start with 'data_'"
+                )
             i = 0
             n = 0
             for token in tokens:

--- a/Bio/PDB/mmcifio.py
+++ b/Bio/PDB/mmcifio.py
@@ -148,6 +148,8 @@ class MMCIFIO(StructureIO):
         # Write out top data_ line
         if data_val:
             out_file.write("data_" + data_val + "\n#\n")
+        else:
+            out_file.write("data_" + "\n#\n")
 
         for key, key_list in key_lists.items():
             # Pick a sample mmCIF value, which can be a list or a single value

--- a/Tests/PDB/a_structure.cif
+++ b/Tests/PDB/a_structure.cif
@@ -1,3 +1,4 @@
+data_a_structure
 loop_
 _atom_type.symbol 
 N  

--- a/Tests/test_PDB_MMCIF2Dict.py
+++ b/Tests/test_PDB_MMCIF2Dict.py
@@ -323,6 +323,29 @@ class MMCIF2dictTests(unittest.TestCase):
         )
         self.assertNotEqual(mmcif_dict, mmcif_dict2)
 
+    def test_file_not_starting_with_data_raises_error(self):
+        test_data = """\
+            error_test
+            _test_key_value foo # Ignore this comment
+            loop_
+            _test_loop
+            a b c d # Ignore this comment
+            e f g
+
+        """
+        test_data2 = """\
+            data error_test_data_
+            _test_key_value foo # Ignore this comment
+            loop_
+            _test_loop
+            a b c d # Ignore this comment
+            e f g
+        """
+        file = io.StringIO(textwrap.dedent(test_data))
+        file2 = io.StringIO(textwrap.dedent(test_data2))
+        self.assertRaises(ValueError, MMCIF2Dict, file)
+        self.assertRaises(ValueError, MMCIF2Dict, file2)
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)

--- a/Tests/test_PDB_MMCIFIO.py
+++ b/Tests/test_PDB_MMCIFIO.py
@@ -213,6 +213,20 @@ class WriteTest(unittest.TestCase):
             finally:
                 os.remove(filename)
 
+    def test_mmcifio_no_data_val(self):
+        idless = self.pdb_parser.get_structure("", "PDB/1A8O.pdb")
+        self.io.set_structure(idless)
+        filenumber, filename = tempfile.mkstemp()
+        os.close(filenumber)
+        try:
+            self.io.save(filename)
+            struct2 = self.mmcif_parser.get_structure("1a8o", filename)
+            nresidues = len(list(struct2.get_residues()))
+            self.assertEqual(len(struct2), 1)
+            self.assertEqual(nresidues, 158)
+        finally:
+            os.remove(filename)
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
These changes should do the two things described in #4747 . Please tell me if there are any problems, and I will do my best to fix them. 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
