### PR TITLE
Remove error message if wheel is not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,15 +37,6 @@ except ImportError:
         "Try running: python -m ensurepip"
     )
 
-if "bdist_wheel" in sys.argv:
-    try:
-        import wheel  # noqa: F401
-    except ImportError:
-        sys.exit(
-            "We need both setuptools AND wheel packages installed "
-            "for bdist_wheel to work. Try running: pip install wheel"
-        )
-
 
 # Make sure we have the right Python version.
 MIN_PY_VER = (3, 9)

--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,28 @@ try:
     from setuptools import setup
     from setuptools import Command
     from setuptools import Extension
+    from setuptools import __version__ as setuptools_version
 except ImportError:
     sys.exit(
         "We need the Python library setuptools to be installed. "
         "Try running: python -m ensurepip"
     )
+
+
+setuptools_version_tuple = tuple(int(x) for x in setuptools_version.split("."))
+if setuptools_version_tuple < (70, 1) and "bdist_wheel" in sys.argv:
+    # Check for presence of wheel in setuptools < 70.1
+    # Before setuptools 70.1, wheel is needed to make a bdist_wheel.
+    # Since 70.1 was released including
+    # https://github.com/pypa/setuptools/pull/4369,
+    # it is not needed.
+    try:
+        import wheel  # noqa: F401
+    except ImportError:
+        sys.exit(
+            "We need both setuptools AND wheel packages installed "
+            "for bdist_wheel to work. Try running: pip install wheel"
+        )
 
 
 # Make sure we have the right Python version.


### PR DESCRIPTION
Since https://github.com/pypa/setuptools/pull/4369 was merged, wheel is vendored into setuptools and no
longer needs to be installed for `bdist_wheel` to work.

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

