### PR TITLE
Implement z-scoring and gap optimization in CE Align

### DIFF
--- a/Bio/PDB/ccealignmodule.c
+++ b/Bio/PDB/ccealignmodule.c
@@ -211,6 +211,149 @@ calcS(
     return S;
 }
 
+static const double tableZtoP[] = {
+    1.0, 9.20e-01, 8.41e-01, 7.64e-01, 6.89e-01, 6.17e-01, 5.49e-01, 4.84e-01, 4.24e-01, 3.68e-01,
+    3.17e-01, 2.71e-01, 2.30e-01, 1.94e-01, 1.62e-01, 1.34e-01, 1.10e-01, 8.91e-02, 7.19e-02, 5.74e-02,
+    4.55e-02, 3.57e-02, 2.78e-02, 2.14e-02, 1.64e-02, 1.24e-02, 9.32e-03, 6.93e-03, 5.11e-03, 3.73e-03,
+    2.70e-03, 1.94e-03, 1.37e-03, 9.67e-04, 6.74e-04, 4.65e-04, 3.18e-04, 2.16e-04, 1.45e-04, 9.62e-05,
+    6.33e-05, 4.13e-05, 2.67e-05, 1.71e-05, 1.08e-05, 6.80e-06, 4.22e-06, 2.60e-06, 1.59e-06, 9.58e-07,
+    5.73e-07, 3.40e-07, 1.99e-07, 1.16e-07, 6.66e-08, 3.80e-08, 2.14e-08, 1.20e-08, 6.63e-09, 3.64e-09,
+    1.97e-09, 1.06e-09, 5.65e-10, 2.98e-10, 1.55e-10, 8.03e-11, 4.11e-11, 2.08e-11, 1.05e-11, 5.20e-12,
+    2.56e-12, 1.25e-12, 6.02e-13, 2.88e-13, 1.36e-13, 6.38e-14, 2.96e-14, 1.36e-14, 6.19e-15, 2.79e-15,
+    1.24e-15, 5.50e-16, 2.40e-16, 1.04e-16, 4.46e-17, 1.90e-17, 7.97e-18, 3.32e-18, 1.37e-18, 5.58e-19,
+    2.26e-19, 9.03e-20, 3.58e-20, 1.40e-20, 5.46e-21, 2.10e-21, 7.99e-22, 3.02e-22, 1.13e-22, 4.16e-23,
+    1.52e-23, 5.52e-24, 1.98e-24, 7.05e-25, 2.48e-25, 8.64e-26, 2.98e-26, 1.02e-26, 3.44e-27, 1.15e-27,
+    3.82e-28, 1.25e-28, 4.08e-29, 1.31e-29, 4.18e-30, 1.32e-30, 4.12e-31, 1.27e-31, 3.90e-32, 1.18e-32,
+    3.55e-33, 1.06e-33, 3.11e-34, 9.06e-35, 2.61e-35, 7.47e-36, 2.11e-36, 5.91e-37, 1.64e-37, 4.50e-38,
+    1.22e-38, 3.29e-39, 8.77e-40, 2.31e-40, 6.05e-41, 1.56e-41, 4.00e-42, 1.02e-42, 2.55e-43, 6.33e-44,
+    1.56e-44, 3.80e-45, 9.16e-46, 2.19e-46, 5.17e-47, 1.21e-47, 2.81e-48, 6.45e-49, 1.46e-49, 3.30e-50};
+
+static const double tablePtoZ[] = {
+    0.00, 0.73, 1.24, 1.64, 1.99, 2.30, 2.58, 2.83, 3.07, 3.29,
+    3.50, 3.70, 3.89, 4.07, 4.25, 4.42, 4.58, 4.74, 4.89, 5.04,
+    5.19, 5.33, 5.46, 5.60, 5.73, 5.86, 5.99, 6.11, 6.23, 6.35,
+    6.47, 6.58, 6.70, 6.81, 6.92, 7.02, 7.13, 7.24, 7.34, 7.44,
+    7.54, 7.64, 7.74, 7.84, 7.93, 8.03, 8.12, 8.21, 8.30, 8.40,
+    8.49, 8.57, 8.66, 8.75, 8.84, 8.92, 9.01, 9.09, 9.17, 9.25,
+    9.34, 9.42, 9.50, 9.58, 9.66, 9.73, 9.81, 9.89, 9.97, 10.04,
+    10.12, 10.19, 10.27, 10.34, 10.41, 10.49, 10.56, 10.63, 10.70, 10.77,
+    10.84, 10.91, 10.98, 11.05, 11.12, 11.19, 11.26, 11.32, 11.39, 11.46,
+    11.52, 11.59, 11.66, 11.72, 11.79, 11.85, 11.91, 11.98, 12.04, 12.10,
+    12.17, 12.23, 12.29, 12.35, 12.42, 12.48, 12.54, 12.60, 12.66, 12.72,
+    12.78, 12.84, 12.90, 12.96, 13.02, 13.07, 13.13, 13.19, 13.25, 13.31,
+    13.36, 13.42, 13.48, 13.53, 13.59, 13.65, 13.70, 13.76, 13.81, 13.87,
+    13.92, 13.98, 14.03, 14.09, 14.14, 14.19, 14.25, 14.30, 14.35, 14.41,
+    14.46, 14.51, 14.57, 14.62, 14.67, 14.72, 14.77, 14.83, 14.88, 14.93};
+
+static double zToP(const double z)
+{
+    int index = (int)(z / 0.1);
+
+    if (index < 0) {
+        index = 0;
+    }
+    if (index > 149) {
+        index = 149;
+    }
+
+    return tableZtoP[index];
+}
+
+static double pToZ(const double p)
+{
+    int index = (int)(-log10(p) * 3.0);
+
+    if (index < 0) {
+        index = 0;
+    }
+    if (index > 149) {
+        index = 149;
+    }
+
+    return tablePtoZ[index];
+}
+
+static const double similarityAvgs[] =
+    {2.54, 2.51, 2.72, 3.01, 3.31, 3.61, 3.90, 4.19, 4.47, 4.74,
+        4.99, 5.22, 5.46, 5.70, 5.94, 6.13, 6.36, 6.52, 6.68, 6.91};
+static const double similaritySDs[] =
+    {1.33, 0.88, 0.73, 0.71, 0.74, 0.80, 0.86, 0.92, 0.98, 1.04,
+        1.08, 1.10, 1.15, 1.19, 1.23, 1.25, 1.32, 1.34, 1.36, 1.45};
+
+static double zScoreSimilarity(
+    const int fragmentSize,
+    const int pathLength,
+    const double similarity)
+{
+    if (fragmentSize != 8 || pathLength < 1) {
+        return 0.0;
+    }
+
+    double similarityAvg, similaritySD;
+
+    if (pathLength < 21) {
+        similarityAvg = similarityAvgs[pathLength - 1];
+        similaritySD = similaritySDs[pathLength - 1];
+    }
+    else {
+        similarityAvg = 0.209874 * pathLength + 2.944714;
+        similaritySD = 0.039487 * pathLength + 0.675735;
+    }
+    if (similarity > similarityAvg) {
+        return 0.0;
+    }
+
+    return (similarityAvg - similarity) / similaritySD;
+}
+
+static const double gapCountAvgs[] =
+    {0.00, 11.50, 23.32, 35.95, 49.02, 62.44, 76.28, 90.26,
+        104.86, 119.97, 134.86, 150.54, 164.86, 179.57, 194.39,
+        209.38, 224.74, 238.96, 253.72, 270.79};
+static const double gapCountSDs[] =
+    {0.00, 9.88, 14.34, 17.99, 21.10, 23.89, 26.55, 29.00, 31.11,
+        33.10, 35.02, 36.03, 37.19, 38.82, 41.04, 43.35, 45.45,
+        48.41, 50.87, 52.27};
+
+static double zScoreGapCount(
+    const int fragmentSize,
+    const int pathLength,
+    const int gapCount)
+{
+    if (fragmentSize != 8 || pathLength < 2) {
+        return 0.0;
+    }
+
+    double gapCountAvg, gapCountSD;
+
+    if (pathLength < 21) {
+        gapCountAvg = gapCountAvgs[pathLength - 1];
+        gapCountSD = gapCountSDs[pathLength - 1];
+    }
+    else {
+        gapCountAvg = 14.949173 * pathLength - 14.581193;
+        gapCountSD = 2.045067 * pathLength + 13.191095;
+    }
+    if (gapCount > gapCountAvg) {
+        return 0.0;
+    }
+
+    return (gapCountAvg - gapCount) / gapCountSD;
+}
+
+static double calcZScore(
+    const int fragmentSize,
+    const int pathLength,
+    const double pathSimilarity,
+    const int gapCount)
+{
+    const double z1 = zScoreSimilarity(
+        fragmentSize, pathLength, pathSimilarity);
+    const double z2 = zScoreGapCount(fragmentSize, pathLength, gapCount);
+
+    return pToZ(zToP(z1) * zToP(z2));
+}
+
 static pcePoint
 getCoords(PyObject *L, int length)
 {
@@ -425,6 +568,21 @@ findPath(
         } // ROF -- end for iB
     }     // ROF -- end for iA
 
+    double zScoreBuffer[MAX_PATHS];
+
+    for (int i = 0; i < bufferSize; i++) {
+        const int pathLength = lenBuffer[i];
+        const double pathSimilarity = similarityBuffer[i];
+        int gapCount = 0;
+
+        for (int j = 1; j < pathLength; j++) {
+            gapCount += pathBuffer[i][j].pA - pathBuffer[i][j - 1].pA - 1;
+            gapCount += pathBuffer[i][j].pB - pathBuffer[i][j - 1].pB - 1;
+        }
+
+        zScoreBuffer[i] = calcZScore(fragmentSize, pathLength, pathSimilarity, gapCount);
+    }
+
     // To make it simpler to use this code and more portable, we are decoupling
     // the path finding (the actual CEAlign innovation) from the RMSD
     // calculation.
@@ -461,9 +619,11 @@ findPath(
             }
         }
 
+        const double zScore = zScoreBuffer[o];
         PyObject *pairList = Py_BuildValue("[NN]", pathAList, pathBList);
         Py_INCREF(pairList);
-        PyList_SET_ITEM(result, o, pairList);
+        PyObject *pathAndScore = Py_BuildValue("[Nd]", pairList, zScore);
+        PyList_SET_ITEM(result, o, pathAndScore);
     }
 
     return result;

--- a/Bio/PDB/cealign.py
+++ b/Bio/PDB/cealign.py
@@ -52,6 +52,10 @@ class CEAligner:
         self.max_gap = max_gap
 
         self.rms = None
+        self._rigid_motion = None
+        self.refcoord = None
+        self._coord = None
+        self._superimposer = QCPSuperimposer()
 
     def get_guide_coord_from_structure(self, structure):
         """Return the coordinates of guide atoms in the structure.
@@ -86,7 +90,7 @@ class CEAligner:
             )
             raise PDBException(msg)
 
-    def align(self, structure, transform=True):
+    def align(self, structure, transform=True, *, final_optimization=True):
         """Align the input structure onto the reference structure.
 
         Parameters
@@ -96,10 +100,15 @@ class CEAligner:
             the RMSD between the two structures to the input structure. If
             False, the structure is not modified but the optimal RMSD will
             still be calculated.
+        final_optimization: bool, optional
+            If True (default), apply additional optimization to statistically
+            significant alignments.
         """
         self.rms = None  # clear before aligning
+        self._rigid_motion = None
 
         coord = self.get_guide_coord_from_structure(structure)
+        self._coord = coord
 
         if len(coord) < self.window_size * 2:
             n_atoms = len(coord)
@@ -112,71 +121,74 @@ class CEAligner:
         # Run CEAlign
         # CEAlign returns the best N paths, sorted descending by length,
         # where each path is a pair of lists with aligned atom indices.
-        paths = run_cealign(self.refcoord, coord, self.window_size, self.max_gap)
-        longest_paths = [
-            path for path in paths if len(path[0][0]) == len(paths[0][0][0])
+        alignments = run_cealign(self.refcoord, coord, self.window_size, self.max_gap)
+        longest_alignments = [
+            alignment
+            for alignment in alignments
+            if alignment.length == alignments[0].length
         ]
 
         # Iterate over paths and find the one that gives the lowest
         # corresponding RMSD. Use QCP to align the molecules.
-        aln = QCPSuperimposer()
-        best_rmsd = float("inf")
-        best_rigid_motion = None
-        best_path = None
-        best_z_score = None
-        for path, z_score in longest_paths:
-            idxA, idxB = path
+        self.rms = float("inf")
+        superimposer = self._superimposer
+        best_alignment = None
+        for alignment in longest_alignments:
+            idxA, idxB = alignment.path
 
             coordsA = np.array([self.refcoord[i] for i in idxA])
             coordsB = np.array([coord[i] for i in idxB])
 
-            aln.set(coordsA, coordsB)
-            aln.run()
-            if aln.rms < best_rmsd:
-                best_rmsd = aln.rms
-                best_rigid_motion = (aln.rot, aln.tran)
-                best_path = path
-                best_z_score = z_score
+            superimposer.set(coordsA, coordsB)
+            superimposer.run()
+            if superimposer.rms < self.rms:
+                best_alignment = alignment
+                self.rms = superimposer.rms
+                self._rigid_motion = (superimposer.rot, superimposer.tran)
 
-        if best_rigid_motion is None:
+        if best_alignment is None:
             raise RuntimeError("Failed to find a suitable alignment.")
 
         # Gap optimization
-        if best_z_score and best_z_score >= 3.5:
-            for ab_index in [0, 1]:
-                for index in range(1, len(best_path[ab_index]) - 1):
-                    best_shift = 0
-                    left = best_path[ab_index][index - 1]
-                    center = best_path[ab_index][index]
-                    right = best_path[ab_index][index + 1]
-
-                    for shift in range(
-                        max(-self.window_size // 2, left - center + 1),
-                        min(self.window_size // 2 + 1, right - center),
-                    ):
-                        best_path[ab_index][index] += shift
-                        idxA, idxB = best_path
-
-                        coordsA = np.array([self.refcoord[i] for i in idxA])
-                        coordsB = np.array([coord[i] for i in idxB])
-
-                        aln.set(coordsA, coordsB)
-                        aln.run()
-                        best_path[ab_index][index] -= shift
-
-                        if aln.rms < best_rmsd:
-                            best_shift = shift
-                            best_rmsd = aln.rms
-                            best_rigid_motion = (aln.rot, aln.tran)
-
-                    best_path[ab_index][index] += best_shift
+        if final_optimization and best_alignment.z_score >= 3.5:
+            self._optimize(best_alignment)
 
         if transform:
             # Transform all atoms
-            rotmtx, trvec = best_rigid_motion
+            rotmtx, trvec = self._rigid_motion
             for chain in structure.get_chains():
                 for resid in chain.get_unpacked_list():
                     for atom in resid.get_unpacked_list():
                         atom.transform(rotmtx, trvec)
 
-        self.rms = best_rmsd
+    def _optimize(self, alignment):
+        best_path = alignment.path
+        superimposer = self._superimposer
+
+        for ab_index in [0, 1]:
+            for index in range(1, len(best_path[ab_index]) - 1):
+                best_shift = 0
+                left = best_path[ab_index][index - 1]
+                center = best_path[ab_index][index]
+                right = best_path[ab_index][index + 1]
+
+                for shift in range(
+                    max(-self.window_size // 2, left - center + 1),
+                    min(self.window_size // 2 + 1, right - center),
+                ):
+                    best_path[ab_index][index] += shift
+                    idxA, idxB = best_path
+
+                    coordsA = np.array([self.refcoord[i] for i in idxA])
+                    coordsB = np.array([self._coord[i] for i in idxB])
+
+                    superimposer.set(coordsA, coordsB)
+                    superimposer.run()
+                    best_path[ab_index][index] -= shift
+
+                    if superimposer.rms < self.rms:
+                        best_shift = shift
+                        self.rms = superimposer.rms
+                        self._rigid_motion = (superimposer.rot, superimposer.tran)
+
+                best_path[ab_index][index] += best_shift

--- a/Bio/PDB/cealign.py
+++ b/Bio/PDB/cealign.py
@@ -144,21 +144,16 @@ class CEAligner:
         # Gap optimization
         if best_z_score and best_z_score >= 3.5:
             for ab_index in [0, 1]:
-                gaps = [
-                    (index, gap)
-                    for index, gap in enumerate(
-                        right - left - 1
-                        for left, right in zip(
-                            best_path[ab_index], best_path[ab_index][1:]
-                        )
-                    )
-                    if gap
-                ]
-
-                for index, gap in gaps:
+                for index in range(1, len(best_path[ab_index]) - 1):
                     best_shift = 0
+                    left = best_path[ab_index][index - 1]
+                    center = best_path[ab_index][index]
+                    right = best_path[ab_index][index + 1]
 
-                    for shift in range(min(self.window_size // 2 + 1, gap + 1)):
+                    for shift in range(
+                        max(-self.window_size // 2, left - center + 1),
+                        min(self.window_size // 2 + 1, right - center),
+                    ):
                         best_path[ab_index][index] += shift
                         idxA, idxB = best_path
 

--- a/Bio/PDB/cealign.py
+++ b/Bio/PDB/cealign.py
@@ -113,14 +113,18 @@ class CEAligner:
         # CEAlign returns the best N paths, sorted descending by length,
         # where each path is a pair of lists with aligned atom indices.
         paths = run_cealign(self.refcoord, coord, self.window_size, self.max_gap)
-        longest_paths = [path for path in paths if len(path[0]) == len(paths[0][0])]
+        longest_paths = [
+            path for path in paths if len(path[0][0]) == len(paths[0][0][0])
+        ]
 
         # Iterate over paths and find the one that gives the lowest
         # corresponding RMSD. Use QCP to align the molecules.
         aln = QCPSuperimposer()
-        best_rmsd, best_rigid_motion = 1e6, None
+        best_rmsd = float("inf")
+        best_rigid_motion = None
         best_path = None
-        for path in longest_paths:
+        best_z_score = None
+        for path, z_score in longest_paths:
             idxA, idxB = path
 
             coordsA = np.array([self.refcoord[i] for i in idxA])
@@ -132,41 +136,45 @@ class CEAligner:
                 best_rmsd = aln.rms
                 best_rigid_motion = (aln.rot, aln.tran)
                 best_path = path
-
-        # Gap optimization
-        for ab_index in [0, 1]:
-            gaps = [
-                (index, gap)
-                for index, gap in enumerate(
-                    right - left - 1
-                    for left, right in zip(best_path[ab_index], best_path[ab_index][1:])
-                )
-                if gap
-            ]
-
-            for index, gap in gaps:
-                best_shift = 0
-
-                for shift in range(min(self.window_size // 2 + 1, gap + 1)):
-                    best_path[ab_index][index] += shift
-                    idxA, idxB = best_path
-
-                    coordsA = np.array([self.refcoord[i] for i in idxA])
-                    coordsB = np.array([coord[i] for i in idxB])
-
-                    aln.set(coordsA, coordsB)
-                    aln.run()
-                    best_path[ab_index][index] -= shift
-
-                    if aln.rms < best_rmsd:
-                        best_shift = shift
-                        best_rmsd = aln.rms
-                        best_rigid_motion = (aln.rot, aln.tran)
-
-                best_path[ab_index][index] += best_shift
+                best_z_score = z_score
 
         if best_rigid_motion is None:
             raise RuntimeError("Failed to find a suitable alignment.")
+
+        # Gap optimization
+        if best_z_score and best_z_score >= 3.5:
+            for ab_index in [0, 1]:
+                gaps = [
+                    (index, gap)
+                    for index, gap in enumerate(
+                        right - left - 1
+                        for left, right in zip(
+                            best_path[ab_index], best_path[ab_index][1:]
+                        )
+                    )
+                    if gap
+                ]
+
+                for index, gap in gaps:
+                    best_shift = 0
+
+                    for shift in range(min(self.window_size // 2 + 1, gap + 1)):
+                        best_path[ab_index][index] += shift
+                        idxA, idxB = best_path
+
+                        coordsA = np.array([self.refcoord[i] for i in idxA])
+                        coordsB = np.array([coord[i] for i in idxB])
+
+                        aln.set(coordsA, coordsB)
+                        aln.run()
+                        best_path[ab_index][index] -= shift
+
+                        if aln.rms < best_rmsd:
+                            best_shift = shift
+                            best_rmsd = aln.rms
+                            best_rigid_motion = (aln.rot, aln.tran)
+
+                    best_path[ab_index][index] += best_shift
 
         if transform:
             # Transform all atoms

--- a/Tests/test_PDB_CEAligner.py
+++ b/Tests/test_PDB_CEAligner.py
@@ -41,9 +41,9 @@ class CEAlignerTests(unittest.TestCase):
 
         aligner = CEAligner()
         aligner.set_reference(s1)
-        aligner.align(s2)
+        aligner.align(s2, final_optimization=False)
 
-        self.assertAlmostEqual(aligner.rms, 3.66, places=2)
+        self.assertAlmostEqual(aligner.rms, 3.74, places=2)
 
         # Assert the transformation was done right by comparing
         # the moved coordinates to a 'ground truth' reference.
@@ -69,11 +69,26 @@ class CEAlignerTests(unittest.TestCase):
 
         aligner = CEAligner()
         aligner.set_reference(s1)
-        aligner.align(s2, transform=False)
+        aligner.align(s2, transform=False, final_optimization=False)
         s2_coords_final = [list(a.coord) for a in s2.get_atoms()]
 
-        self.assertAlmostEqual(aligner.rms, 3.66, places=2)
+        self.assertAlmostEqual(aligner.rms, 3.74, places=2)
         self.assertEqual(s2_original_coords, s2_coords_final)
+
+    def test_ce_aligner_final_optimization(self):
+        """Test aligning 7CFN on 6WQA with the final optimization."""
+        ref = "PDB/6WQA.cif"
+        mob = "PDB/7CFN.cif"
+
+        parser = MMCIFParser(QUIET=1)
+        s1 = parser.get_structure("6wqa", ref)
+        s2 = parser.get_structure("7cfn", mob)
+
+        aligner = CEAligner()
+        aligner.set_reference(s1)
+        aligner.align(s2)
+
+        self.assertAlmostEqual(aligner.rms, 3.66, places=2)
 
     def test_cealigner_nucleic(self):
         """Test aligning 1LCD on 1LCD."""

--- a/Tests/test_PDB_CEAligner.py
+++ b/Tests/test_PDB_CEAligner.py
@@ -43,7 +43,7 @@ class CEAlignerTests(unittest.TestCase):
         aligner.set_reference(s1)
         aligner.align(s2)
 
-        self.assertAlmostEqual(aligner.rms, 3.74, places=2)
+        self.assertAlmostEqual(aligner.rms, 3.66, places=2)
 
         # Assert the transformation was done right by comparing
         # the moved coordinates to a 'ground truth' reference.
@@ -72,7 +72,7 @@ class CEAlignerTests(unittest.TestCase):
         aligner.align(s2, transform=False)
         s2_coords_final = [list(a.coord) for a in s2.get_atoms()]
 
-        self.assertAlmostEqual(aligner.rms, 3.74, places=2)
+        self.assertAlmostEqual(aligner.rms, 3.66, places=2)
         self.assertEqual(s2_original_coords, s2_coords_final)
 
     def test_cealigner_nucleic(self):


### PR DESCRIPTION
### Acknowledgements

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

### Description

In this pull request, I implement z-score calculation and gap optimization in the PDB module's implementation of CE Align. The **z-score** is a measure of statistical significance or how likely a particular alignment would be encountered by chance. **Gap optimization** is a procedure that iteratively adjusts gaps in an alignment to improve the alignment's RMSD. In the CE Align algorithm, gap optimization is performed when the z-score is above a certain threshold (normally 3.5).

These changes improve the alignment by searching through alternative alignments when the alignment is statistically significant.

### Testing

I adjusted the unit tests for the improved RMSD, and I performed some manual testing.

I used the [MALIDUP](http://prodata.swmed.edu/malidup/) and [MALISAM](http://prodata.swmed.edu/malisam/) databases to manually test these changes.

Here is my testing script:
```python
import os
import time
from itertools import islice
import re
from Bio.PDB import PDBParser, CEAligner
from collections import deque
import pandas as pd


pattern = re.compile("^[a-z0-9]{4}_\\w\\d.pdb$")
parser = PDBParser()
aligner = CEAligner()
results = deque()

for dirpath, _, filenames in islice(os.walk("data/dup"), 1, None):
    dirname = os.path.split(dirpath)[-1]
    pdb_code = dirname[1:5]
    pdb_filenames = list(filename for filename in filenames if pattern.match(filename))

    assert len(pdb_filenames) == 2

    structure_1 = parser.get_structure(pdb_code, os.path.join(dirpath, pdb_filenames[0]))
    structure_2 = parser.get_structure(pdb_code, os.path.join(dirpath, pdb_filenames[1]))

    start_time = time.time()
    aligner.set_reference(structure_1)
    aligner.align(structure_2, transform=False)
    results.append({
        "PDB Code": pdb_code,
        "RMSD": aligner.rms,
        "Length": aligner.length,
        "Time": time.time() - start_time,
        "Did optimize?": aligner.did_optimize,
        "Z Score": aligner.z_score,
    })

results = pd.DataFrame(results)
print(results[["RMSD", "Length", "Time", "Did optimize?", "Z Score"]].describe())
print(results["Did optimize?"].describe())

pattern = re.compile("^[a-z0-9]{4}_\\w{2}.pdb$")
results = deque()

for dirpath, _, filenames in islice(os.walk("data/analogs"), 1, None):
    dirname = os.path.split(dirpath)[-1]
    pdb_filenames = list(filename for filename in filenames if pattern.match(filename))

    assert len(pdb_filenames) == 2

    structure_1 = parser.get_structure(pdb_filenames[0][:4], os.path.join(dirpath, pdb_filenames[0]))
    structure_2 = parser.get_structure(pdb_filenames[1][:4], os.path.join(dirpath, pdb_filenames[1]))

    start_time = time.time()
    aligner.set_reference(structure_1)
    aligner.align(structure_2, transform=False)
    results.append({
        "Directory": dirname,
        "RMSD": aligner.rms,
        "Length": aligner.length,
        "Time": time.time() - start_time,
        "Did optimize?": aligner.did_optimize,
        "Z Score": aligner.z_score,
    })

results = pd.DataFrame(results)
print(results[["RMSD", "Length", "Time", "Did optimize?", "Z Score"]].describe())
print(results["Did optimize?"].describe())
```

### Results with New Code

#### MALIDUP

```
             RMSD      Length        Time     Z Score
count  241.000000  241.000000  241.000000  241.000000
mean     3.287257   83.352697    0.024016    6.248091
std      1.269601   41.113411    0.025839    0.665213
min      0.628612   24.000000    0.001868    4.580000
25%      2.361698   56.000000    0.007987    5.860000
50%      3.189827   72.000000    0.016907    6.230000
75%      4.294839  104.000000    0.027342    6.700000
max      7.228586  256.000000    0.178572    7.930000
count      241
unique       1
top       True
freq       241
Name: Did optimize?, dtype: object
```

#### MALISAM

```
             RMSD      Length        Time    Z Score
count  130.000000  130.000000  130.000000  130.00000
mean     3.764365   61.292308    0.011495    6.69200
std      0.718092   12.932410    0.004768    0.40069
min      2.093043   24.000000    0.003485    5.60000
25%      3.212446   56.000000    0.008451    6.47000
50%      3.726223   56.000000    0.010203    6.70000
75%      4.314141   72.000000    0.013439    6.89250
max      5.365077  112.000000    0.033091    7.64000
count      130
unique       1
top       True
freq       130
Name: Did optimize?, dtype: object
```

### Results with Original Code

#### MALIDUP

```
             RMSD      Length        Time
count  241.000000  241.000000  241.000000
mean     3.449998   83.352697    0.008540
std      1.290120   41.113411    0.011653
min      0.628612   24.000000    0.000344
25%      2.570221   56.000000    0.001848
50%      3.416172   72.000000    0.004262
75%      4.406737  104.000000    0.010367
max      7.300840  256.000000    0.081144
```

#### MALISAM

```
             RMSD      Length        Time
count  130.000000  130.000000  130.000000
mean     3.946192   61.292308    0.004038
std      0.699545   12.932410    0.002931
min      2.480055   24.000000    0.000751
25%      3.409361   56.000000    0.002134
50%      3.872238   56.000000    0.003014
75%      4.476527   72.000000    0.005288
max      5.590935  112.000000    0.015195
```

### Discussion

The calculated z-score is above the threshold (3.5) and gap optimization is performed for all of the alignments in testing. This is unsurprising because the test alignments come from curated databases of homologous domains (MALIDUP) or structurally analogous motifs (MALISAM).

The z-score calculation and the gap optimization increase the total alignment time. However, I did not notice the difference in execution time without timing the test program. In homology searches, gap optimization should not be performed on every alignment because a z-score threshold of 3.5 corresponds to around 1 in 1000 alignments.

As expected, the alignment length is not affected by gap optimization. I included the alignment length as a simple sanity check.

Finally, CE Align with gap optimization does show better RMSDs.

The z-score calculation code is adapted from the [original CE Align code](https://github.com/kad-ecoli/CE). The gap optimization code is written by myself based on the description in the paper. I found it challenging to understand the gap optimization implementation in the original CE Align code.

I implement the z-score calculation in the C extension module because an alignment path's similarity metric is used to calculate the alignment path's z-score. The similarity metric is readily available in the extension module, and the original code was already available in C.

I implement gap optimization in Python because gap optimization is dependent on RMSD calculation, which is readily available in Python and not available in C.

### References

- [CE Align paper](https://pubmed.ncbi.nlm.nih.gov/9796821/)
- [Original CE Align code](https://github.com/kad-ecoli/CE)