### PR TITLE
 Relax test_phenotype_fit.py test precision here

### DIFF
--- a/Tests/test_phenotype_fit.py
+++ b/Tests/test_phenotype_fit.py
@@ -65,7 +65,7 @@ class TestPhenoMicro(unittest.TestCase):
         self.assertEqual(w.model, "gompertz")
         self.assertAlmostEqual(w.lag, 6.0425868725090357, places=5)
         self.assertAlmostEqual(w.plateau, 188.51404344898586, places=4)
-        self.assertAlmostEqual(w.slope, 48.190618284831132, places=4)
+        self.assertAlmostEqual(w.slope, 48.190618284831132, places=3)
         self.assertAlmostEqual(w.v, 0.10000000000000001, places=5)
         self.assertAlmostEqual(w.y0, 45.879770069807989, places=4)
         self.assertEqual(w.max, 313.0)


### PR DESCRIPTION
Lately failing on CircleCI, possibly NumPy 2 related by the timing but not confirmed.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->


e.g.

```
======================================================================
FAIL: test_WellRecord (test_phenotype_fit.TestPhenoMicro)
Test basic functionalities of WellRecord objects.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/circleci/project/biopython-1.84.dev0/Tests/test_phenotype_fit.py", line 68, in test_WellRecord
    self.assertAlmostEqual(w.slope, 48.190618284831132, places=4)
AssertionError: np.float64(48.19069017500249) != 48.19061828483113 within 4 places (np.float64(7.189017135544873e-05) difference)

----------------------------------------------------------------------
```