### PR TITLE
Configure build-time dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
 
     - name: Install from source
       run: |
-        python -m pip install .
+        python -m pip install --use-pep517 .
 
     - name: Run test suite
       run: |
@@ -236,7 +236,7 @@ jobs:
 
     - name: Install from source
       run: |
-        python -m pip install .
+        python -m pip install --use-pep517 .
 
     - name: Run test suite
       run: |
@@ -274,7 +274,7 @@ jobs:
 
     - name: Install from source
       run: |
-        python -m pip install .
+        python -m pip install --use-pep517 .
 
     - name: Run test suite
       run: |
@@ -310,7 +310,7 @@ jobs:
 
     - name: Install from source
       run: |
-        python -m pip install .
+        python -m pip install --use-pep517 .
 
     - name: Run test suite
       run: |
@@ -358,7 +358,7 @@ jobs:
 
     - name: Install from source
       run: |
-        python -m pip install .
+        python -m pip install --use-pep517 .
 
     - name: Make documentation
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,10 @@ repos:
     -   id: mypy
         # equivalent to "files" in .mypy.ini
         files: '^(Bio|BioSQL)/'
+-   repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.18
+    hooks:
+    -   id: validate-pyproject
 -   repo: https://github.com/asottile/blacken-docs
     rev: 1.16.0
     hooks:

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -95,6 +95,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Christian Balbin <christian at domain balbin.com>
 - Christian Brueffer <christian at domain brueffer.de>
 - Christian Zmasek <https://github.com/cmzmasek>
+- Christopher Covington <https://github.com/covracer>
 - Chunlei Wu <https://github.com/newgene>
 - Claude Paroz <claude at two (as digit) xlibre dot net>
 - Connor McCoy <cmccoy at the dot org domain fhcrc>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -117,6 +117,7 @@ Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
 - Anil Tuncel (first contribution)
+- Christopher Covington (first contribution)
 - David Cain
 - Fabio Zanini (first contribution)
 - Joao Rodrigues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel"]


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes https://github.com/astral-sh/uv/issues/4069#issuecomment-2186762048

https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use describes this style of configuring build-time dependencies (requirements). As of 2024-06-24, `uv pip install .` (uv 0.1.41) and `pip install --use-pep517 .` (pip 24.1) will fail without this file.

Flags which can work around the issue for prior biopython versions are `--legacy-setup-py` (uv only) and `--no-build-isolation` (pip and uv).

Test installation with the `--use-pep517` flag and add a pre-commit hook to validate `pyproject.toml`.