### PR TITLE
Add rid and rtoe attributes to qblast

### DIFF
--- a/Bio/Blast/__init__.py
+++ b/Bio/Blast/__init__.py
@@ -1078,6 +1078,10 @@ def qblast(
     and passes the values to the server as is.  More help is available at:
     https://ncbi.github.io/blast-cloud/dev/api.html
 
+    The http.client.HTTPResponse object returned by this function has the
+    additional attributes rid and rtoe with the Request ID and Request Time Of
+    Execution for this BLAST search.
+
     """
     programs = ["blastn", "blastp", "blastx", "tblastn", "tblastx"]
     if program not in programs:
@@ -1241,6 +1245,8 @@ def qblast(
         assert data.startswith(b"<p><!--\nQBlastInfoBegin")
     elif format_type in ("XML2", "JSON2"):
         assert data.startswith(b"PK\x03\x04")  # zipped file
+    stream.rid = rid
+    stream.rtoe = rtoe
     return stream
 
 


### PR DESCRIPTION
Add the rid (Request ID) and rtoe (Request Time Of Execution) attributes to the return value of `Bio.Blast.qblast`.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #4721 .


