### PR TITLE
Standardize on 'import numpy as np' throughout the codebase

### DIFF
--- a/Tests/test_PDB_DSSP.py
+++ b/Tests/test_PDB_DSSP.py
@@ -21,7 +21,7 @@ import unittest
 import warnings
 
 try:
-    import numpy  # noqa: F401
+    import numpy as np  # noqa: F401
 except ImportError:
     from Bio import MissingPythonDependencyError
 

--- a/Tests/test_PDB_parse_pdb_header.py
+++ b/Tests/test_PDB_parse_pdb_header.py
@@ -11,7 +11,7 @@
 import unittest
 
 try:
-    import numpy  # noqa F401
+    import numpy as np  # noqa F401
 except ImportError:
     from Bio import MissingPythonDependencyError
 


### PR DESCRIPTION
This correction ensures the use of "import numpy as np" instead of "import numpy"
fixes : #4238