### PR TITLE
remove deprecated attribute from Bio.Nexus

### DIFF
--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -19,7 +19,6 @@ import sys
 import warnings
 from functools import reduce
 
-from Bio import BiopythonDeprecationWarning
 from Bio import BiopythonWarning
 from Bio import File
 from Bio.Data import IUPACData
@@ -663,28 +662,6 @@ class Nexus:
             self.read(input)
         else:
             self.read(DEFAULTNEXUS)
-
-    def get_original_taxon_order(self):
-        """Included for backwards compatibility (DEPRECATED)."""
-        warnings.warn(
-            "The get_original_taxon_order method has been deprecated "
-            "and will likely be removed from Biopython in the near "
-            "future. Please use the taxlabels attribute instead.",
-            BiopythonDeprecationWarning,
-        )
-        return self.taxlabels
-
-    def set_original_taxon_order(self, value):
-        """Included for backwards compatibility (DEPRECATED)."""
-        warnings.warn(
-            "The set_original_taxon_order method has been deprecated "
-            "and will likely be removed from Biopython in the near "
-            "future. Please use the taxlabels attribute instead.",
-            BiopythonDeprecationWarning,
-        )
-        self.taxlabels = value
-
-    original_taxon_order = property(get_original_taxon_order, set_original_taxon_order)
 
     def read(self, input):
         """Read and parse NEXUS input (a filename, file-handle, or string)."""

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -623,6 +623,12 @@ Bio.Wise
 The ``Bio.Wise`` module was deprecated in Release 1.80, and removed in Release
 1.82.
 
+Bio.Nexus
+---------
+The ``original_taxon_order`` attribute of the ``Nexus`` class in
+``Bio.Nexus.Nexus`` was deprecated in Release 1.80, and removed in
+Release 1.85.  Please use the ``taxlabels`` attribute instead.
+
 Scripts/Restriction/ranacompiler.py
 -----------------------------------
 The ``is_palindrom`` function was removed in Release 1.79.


### PR DESCRIPTION
This PR removes the `original_taxon_order` attribute of the `Nexus` class in
`Bio.Nexus.Nexus`; the `taxlabels` attribute can be used instead.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
