### PR TITLE
Deprecate ProteinAnalysis.get_amino_acids_percent() and create ProteinAnalysis.amino_acids_percent

### DIFF
--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -17,9 +17,9 @@ Examples
 >>> print(X.count_amino_acids()['E'])
 12
 >>> print("%0.2f" % X.get_amino_acids_percent()['A'])
-0.04
+3.95
 >>> print("%0.2f" % X.get_amino_acids_percent()['L'])
-0.12
+11.84
 >>> print("%0.2f" % X.molecular_weight())
 17103.16
 >>> print("%0.2f" % X.aromaticity())

--- a/Bio/SeqUtils/ProtParam.py
+++ b/Bio/SeqUtils/ProtParam.py
@@ -113,7 +113,9 @@ class ProteinAnalysis:
         if self.amino_acids_percent is None:
             aa_counts = self.count_amino_acids()
 
-            percentages = {aa: count / self.length for aa, count in aa_counts.items()}
+            percentages = {
+                aa: (count * 100 / self.length) for aa, count in aa_counts.items()
+            }
 
             self.amino_acids_percent = percentages
 
@@ -134,7 +136,7 @@ class ProteinAnalysis:
         aromatic_aas = "YWF"
         aa_percentages = self.get_amino_acids_percent()
 
-        aromaticity = sum(aa_percentages[aa] for aa in aromatic_aas)
+        aromaticity = sum(aa_percentages[aa] / 100 for aa in aromatic_aas)
 
         return aromaticity
 
@@ -331,9 +333,9 @@ class ProteinAnalysis:
         """
         aa_percentages = self.get_amino_acids_percent()
 
-        helix = sum(aa_percentages[r] for r in "EMALK")
-        turn = sum(aa_percentages[r] for r in "NPGSD")
-        sheet = sum(aa_percentages[r] for r in "VIYFWLT")
+        helix = sum(aa_percentages[r] / 100 for r in "EMALK")
+        turn = sum(aa_percentages[r] / 100 for r in "NPGSD")
+        sheet = sum(aa_percentages[r] / 100 for r in "VIYFWLT")
 
         return helix, turn, sheet
 

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -521,6 +521,9 @@ was updated to be consistent with the calculated values by Sharp & Li.
 Function 'GC' in Bio.SeqUtils was deprecated in Release 1.80, and removed in
 Release 1.82. Instead use function 'gc_fraction'.
 
+Function get_amino_acids_percent in Bio.SeqUtils.ProteinAnalysis was deprecated
+in Release 1.85. Use the amino_acids_percent property instead.
+
 Bio.PopGen.Async
 ----------------
 ``Bio.PopGen.Async`` was deprecated in Release 1.68, removed in Release 1.70.

--- a/Tests/test_ProtParam.py
+++ b/Tests/test_ProtParam.py
@@ -9,6 +9,7 @@
 
 import unittest
 
+from Bio import BiopythonDeprecationWarning
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqUtils import molecular_weight
@@ -39,13 +40,24 @@ class ProtParamTest(unittest.TestCase):
                 self.assertEqual(count_dict[i], self.text.count(i))
 
     def test_get_amino_acids_percent(self):
+        """Calculate amino acid percentages (DEPRECATED)."""
+        with self.assertWarns(BiopythonDeprecationWarning):
+            for analysis in self.analyses:
+                percent_dict = analysis.get_amino_acids_percent()
+                seq_len = len(self.text)
+                for i in percent_dict:
+                    self.assertAlmostEqual(
+                        percent_dict[i], self.text.count(i) / seq_len
+                    )
+
+    def test_amino_acids_percent(self):
         """Calculate amino acid percentages."""
         for analysis in self.analyses:
-            percent_dict = analysis.get_amino_acids_percent()
             seq_len = len(self.text)
-            for i in percent_dict:
+            for i in analysis.amino_acids_percent:
                 self.assertAlmostEqual(
-                    percent_dict[i], (self.text.count(i) * 100 / seq_len)
+                    analysis.amino_acids_percent[i],
+                    (self.text.count(i) * 100 / seq_len),
                 )
 
     def test_get_molecular_weight(self):

--- a/Tests/test_ProtParam.py
+++ b/Tests/test_ProtParam.py
@@ -44,7 +44,9 @@ class ProtParamTest(unittest.TestCase):
             percent_dict = analysis.get_amino_acids_percent()
             seq_len = len(self.text)
             for i in percent_dict:
-                self.assertAlmostEqual(percent_dict[i], self.text.count(i) / seq_len)
+                self.assertAlmostEqual(
+                    percent_dict[i], (self.text.count(i) * 100 / seq_len)
+                )
 
     def test_get_molecular_weight(self):
         """Calculate protein molecular weight."""


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4781

Deprecates `Bio.SeqUtils.ProteinAnalysis.get_amino_acids_percent()` and creates the `Bio.SeqUtils.ProteinAnalysis.amino_acids_percent` property to replace it. The new property returns percentages in the range of 0-100 instead of 0-1. See discussion on the above issue.