### PR TITLE
Updated line join and end cap settings for Bio.Phylo matplotlib phylogenetic trees

### DIFF
--- a/Bio/Phylo/_utils.py
+++ b/Bio/Phylo/_utils.py
@@ -475,6 +475,8 @@ def draw(
         y_top=0,
         color="black",
         lw=".1",
+        capstyle="round",
+        joinstyle="round",
     ):
         """Create a line with or without a line collection object.
 
@@ -482,19 +484,34 @@ def draw(
         customized by altering this function.
         """
         if not use_linecollection and orientation == "horizontal":
-            axes.hlines(y_here, x_start, x_here, color=color, lw=lw)
+            line = axes.hlines(y_here, x_start, x_here, color=color, lw=lw)
+            line.set_solid_capstyle(capstyle)
+            line.set_solid_joinstyle(joinstyle)
+
         elif use_linecollection and orientation == "horizontal":
             horizontal_linecollections.append(
                 mpcollections.LineCollection(
-                    [[(x_start, y_here), (x_here, y_here)]], color=color, lw=lw
+                    [[(x_start, y_here), (x_here, y_here)]],
+                    color=color,
+                    lw=lw,
+                    linestyle="solid",
+                    capstyle=capstyle,
+                    joinstyle=joinstyle,
                 )
             )
         elif not use_linecollection and orientation == "vertical":
-            axes.vlines(x_here, y_bot, y_top, color=color)
+            line = axes.vlines(x_here, y_bot, y_top, color=color, lw=lw)
+            line.set_solid_capstyle(capstyle)
+            line.set_solid_joinstyle(joinstyle)
         elif use_linecollection and orientation == "vertical":
             vertical_linecollections.append(
                 mpcollections.LineCollection(
-                    [[(x_here, y_bot), (x_here, y_top)]], color=color, lw=lw
+                    [[(x_here, y_bot), (x_here, y_top)]],
+                    color=color,
+                    lw=lw,
+                    linestyle="solid",
+                    capstyle=capstyle,
+                    joinstyle=joinstyle,
                 )
             )
 


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #4709 

This PR updates matplotlib drawing of phylogenetic trees to properly set options for joining lines and adding end caps. Both the cap and line join style were set to round, but this could be changed based on preference.
