### PR TITLE
Remove Conda Defaults channel for Appveyor Miniconda

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@ build_script:
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
         throw "There are newer queued builds for this pull request, failing early." }
   - ps: Start-FileDownload "https://repo.continuum.io/miniconda/Miniconda$env:PY_MAJOR_VER-latest-Windows-$env:PYTHON_ARCH.exe" C:\Miniconda.exe; echo "Finished downloading miniconda"
-  - cmd: C:\Miniconda.exe /S /D=C:\Py
+  - ps: start -Wait -FilePath C:\Miniconda.exe -ArgumentList "/S /D=C:\Py"
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --remove channels defaults
   - conda config --set always_yes yes

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,6 +34,7 @@ build_script:
   - ps: Start-FileDownload "https://repo.continuum.io/miniconda/Miniconda$env:PY_MAJOR_VER-latest-Windows-$env:PYTHON_ARCH.exe" C:\Miniconda.exe; echo "Finished downloading miniconda"
   - cmd: C:\Miniconda.exe /S /D=C:\Py
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
+  - conda config --remove channels defaults
   - conda config --set always_yes yes
   - conda update conda
   - python -m pip install --upgrade coverage setuptools "numpy!=2.1.0"


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.
(Note: pre-commit breaks when running on windows due to bash script)

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4788
Made Modifications to appveyor build script:
1) Removed the `defaults` channel from miniconda installation to avoid any potential future license/ToS issues
2) Changed bash command to equivalent powershell command for consistency

See: https://ci.appveyor.com/project/flaar94/biopython/builds/50465569/job/wocpsxfac045ah7m for build success

Regarding installation instructions:
I did some searchs and found conda mentioned in 3 places in biopython/biopython:
1) Appveyor
2) conda-forge symbol in the Readme
3) A mention in chapter_contributing.rst regarding contributing to distributing packages on conda

There is a mention in Biopython/docs, but it tells the users to use the conda-forge channel because
"The default Conda channel does have Biopython, but is often out of date." It might be worth adding a note about the ToS/license issues in addition, but I think there should be no immediate risk

