### PR TITLE
avoid yield in SeqIO AbiIO iterator

### DIFF
--- a/Bio/SeqIO/AbiIO.py
+++ b/Bio/SeqIO/AbiIO.py
@@ -16,6 +16,7 @@ http://www6.appliedbiosystems.com/support/software_community/ABIF_File_Format.pd
 """
 
 import datetime
+import io
 import struct
 import sys
 from os.path import basename
@@ -348,24 +349,23 @@ class AbiIterator(SequenceIterator):
 
     def __init__(self, source, trim=False):
         """Return an iterator for the Abi file format."""
-        self.trim = trim
         super().__init__(source, mode="b", fmt="ABI")
-
-    def parse(self, handle):
-        """Start parsing the file, and return a SeqRecord generator."""
         # check if input file is a valid Abi file
-        marker = handle.read(4)
+        marker = self.stream.read(4)
         if not marker:
             # handle empty file gracefully
             raise ValueError("Empty file.")
-
         if marker != b"ABIF":
-            raise OSError(f"File should start ABIF, not {marker!r}")
-        records = self.iterate(handle)
-        return records
+            raise ValueError(f"File should start with ABIF, not {marker!r}")
+        self.trim = trim
 
-    def iterate(self, handle):
+    def parse(self, handle):
+        """To be removed."""
+        return
+
+    def __next__(self):
         """Parse the file and generate SeqRecord objects."""
+        stream = self.stream
         # dirty hack for handling time information
         times = {"RUND1": "", "RUND2": "", "RUNT1": "", "RUNT2": ""}
 
@@ -373,7 +373,13 @@ class AbiIterator(SequenceIterator):
         annot = dict(zip(_EXTRACT.values(), [None] * len(_EXTRACT)))
 
         # parse header and extract data from directories
-        header = struct.unpack(_HEADFMT, handle.read(struct.calcsize(_HEADFMT)))
+        size = struct.calcsize(_HEADFMT)
+        data = stream.read(size)
+        if len(data) == 0:
+            raise StopIteration
+        elif len(data) < size:
+            raise ValueError("premature end of file")
+        header = struct.unpack(_HEADFMT, data)
 
         # Set default sample ID value, which we expect to be present in most
         # cases in the SMPL1 tag, but may be missing.
@@ -381,7 +387,7 @@ class AbiIterator(SequenceIterator):
 
         raw = {}
         seq = qual = None
-        for tag_name, tag_number, tag_data in _abi_parse_header(header, handle):
+        for tag_name, tag_number, tag_data in _abi_parse_header(header, stream):
             key = tag_name + str(tag_number)
 
             raw[key] = tag_data
@@ -412,9 +418,9 @@ class AbiIterator(SequenceIterator):
         # fsa check
         is_fsa_file = all(tn not in raw for tn in ("PBAS1", "PBAS2"))
 
-        if is_fsa_file:
+        if is_fsa_file is True:
             try:
-                file_name = basename(handle.name).replace(".fsa", "")
+                file_name = basename(stream.name).replace(".fsa", "")
             except AttributeError:
                 file_name = ""
 
@@ -431,7 +437,7 @@ class AbiIterator(SequenceIterator):
         else:
             # use the file name as SeqRecord.name if available
             try:
-                file_name = basename(handle.name).replace(".ab1", "")
+                file_name = basename(stream.name).replace(".ab1", "")
             except AttributeError:
                 file_name = ""
             record = SeqRecord(
@@ -444,25 +450,27 @@ class AbiIterator(SequenceIterator):
         if qual:
             # Expect this to be missing for FSA files.
             record.letter_annotations["phred_quality"] = qual
-        elif not is_fsa_file and not qual and self.trim:
+        elif is_fsa_file is False and not qual and self.trim is True:
             raise ValueError(
                 "The 'abi-trim' format can not be used for files without"
                 " quality values."
             )
 
-        if self.trim and not is_fsa_file:
+        if self.trim is True and not is_fsa_file:
             record = _abi_trim(record)
 
         record.annotations["molecule_type"] = "DNA"
-        yield record
+        # Move to the end of file to indicate that we finished reading
+        stream.seek(0, io.SEEK_END)
+        return record
 
 
-def _AbiTrimIterator(handle):
+def _AbiTrimIterator(stream):
     """Return an iterator for the Abi file format that yields trimmed SeqRecord objects (PRIVATE)."""
-    return AbiIterator(handle, trim=True)
+    return AbiIterator(stream, trim=True)
 
 
-def _abi_parse_header(header, handle):
+def _abi_parse_header(header, stream):
     """Return directory contents (PRIVATE)."""
     # header structure (after ABIF marker):
     # file version, tag name, tag number,
@@ -471,17 +479,15 @@ def _abi_parse_header(header, handle):
     head_elem_size = header[4]
     head_elem_num = header[5]
     head_offset = header[7]
-    index = 0
 
-    while index < head_elem_num:
+    for index in range(head_elem_num):
         start = head_offset + index * head_elem_size
         # add directory offset to tuple
         # to handle directories with data size <= 4 bytes
-        handle.seek(start)
-        dir_entry = struct.unpack(_DIRFMT, handle.read(struct.calcsize(_DIRFMT))) + (
+        stream.seek(start)
+        dir_entry = struct.unpack(_DIRFMT, stream.read(struct.calcsize(_DIRFMT))) + (
             start,
         )
-        index += 1
         # only parse desired dirs
         key = dir_entry[0].decode()
         key += str(dir_entry[1])
@@ -497,8 +503,8 @@ def _abi_parse_header(header, handle):
         # so offset needs to be changed
         if data_size <= 4:
             data_offset = tag_offset + 20
-        handle.seek(data_offset)
-        data = handle.read(data_size)
+        stream.seek(data_offset)
+        data = stream.read(data_size)
         yield tag_name, tag_number, _parse_tag_data(elem_code, elem_num, data)
 
 

--- a/Bio/SeqIO/AbiIO.py
+++ b/Bio/SeqIO/AbiIO.py
@@ -418,7 +418,7 @@ class AbiIterator(SequenceIterator):
         # fsa check
         is_fsa_file = all(tn not in raw for tn in ("PBAS1", "PBAS2"))
 
-        if is_fsa_file is True:
+        if is_fsa_file:
             try:
                 file_name = basename(stream.name).replace(".fsa", "")
             except AttributeError:
@@ -450,13 +450,13 @@ class AbiIterator(SequenceIterator):
         if qual:
             # Expect this to be missing for FSA files.
             record.letter_annotations["phred_quality"] = qual
-        elif is_fsa_file is False and not qual and self.trim is True:
+        elif not is_fsa_file and not qual and self.trim:
             raise ValueError(
                 "The 'abi-trim' format can not be used for files without"
                 " quality values."
             )
 
-        if self.trim is True and not is_fsa_file:
+        if self.trim and not is_fsa_file:
             record = _abi_trim(record)
 
         record.annotations["molecule_type"] = "DNA"

--- a/Tests/test_SeqIO_AbiIO.py
+++ b/Tests/test_SeqIO_AbiIO.py
@@ -534,7 +534,7 @@ class TestAbiFake(unittest.TestCase):
         """Test if error is raised if filetype is not ABIF."""
         for trace in test_data_fake:
             self.assertRaises(
-                IOError, SeqIO.read, test_data_fake[trace]["handle"], "abi"
+                ValueError, SeqIO.read, test_data_fake[trace]["handle"], "abi"
             )
 
 


### PR DESCRIPTION
In the AbiIO iterator, avoid going through `yield`, plus some minor changes.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
