### PR TITLE
avoid using yield in Bio.SeqIO GckIO

### DIFF
--- a/Tests/test_SeqIO_Gck.py
+++ b/Tests/test_SeqIO_Gck.py
@@ -82,12 +82,12 @@ class TestGckWithArtificialData(unittest.TestCase):
 class TestGckWithImproperHeader(unittest.TestCase):
     def test_read(self):
         """Read a file with an incomplete header."""
-        handle = BytesIO(b"tiny")
+        stream = BytesIO(b"tiny")
         with self.assertRaisesRegex(
-            ValueError, "Improper header, cannot read 24 bytes from handle"
+            ValueError, "Improper header, cannot read 24 bytes from stream"
         ):
-            SeqIO.read(handle, "gck")
-        handle.close()
+            SeqIO.read(stream, "gck")
+        stream.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Avoid using `yield` in the Gck parser in Bio.SeqIO.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
