### PR TITLE
Faster Fasta

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -222,13 +222,66 @@ class FastaIterator(SequenceIterator):
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
         super().__init__(source, mode="t", fmt="Fasta")
-        self._data = SimpleFastaParser(self.stream)
+        try:
+            line = next(self.stream)
+        except StopIteration:
+            line = None
+        else:
+            if not line.startswith(">"):
+                warnings.warn(
+                    "Previously, the FASTA parser silently ignored comments at the "
+                    "beginning of the FASTA file (before the first sequence).\n"
+                    "\n"
+                    "Nowadays, the FASTA file format is usually understood not to "
+                    "have any such comments, and most software packages do not allow "
+                    "them. Therefore, the use of comments at the beginning of a FASTA "
+                    "file is now deprecated in Biopython.\n"
+                    "\n"
+                    "In a future Biopython release, this deprecation warning will be "
+                    "replaced by a ValueError. To avoid this, there are three "
+                    "options:\n"
+                    "\n"
+                    "(1) Modify your FASTA file to remove such comments at the "
+                    "beginning of the file.\n"
+                    "\n"
+                    "(2) Use SeqIO.parse with the 'fasta-pearson' format instead of "
+                    "'fasta'. This format is consistent with the FASTA format defined "
+                    "by William Pearson's FASTA aligner software. Thie format allows "
+                    "for comments before the first sequence; lines starting with the "
+                    "';' character anywhere in the file are also regarded as comment "
+                    "lines and are ignored.\n"
+                    "\n"
+                    "(3) Use the 'fasta-blast' format. This format regards any lines "
+                    "starting with '!', '#', or ';' as comment lines. The "
+                    "'fasta-blast' format may be safer than the 'fasta-pearson' "
+                    "format, as it explicitly indicates which lines are comments. ",
+                    BiopythonDeprecationWarning,
+                )
+                for line in self.stream:
+                    if line.startswith(">"):
+                        break
+                else:
+                    line = None
+        self._line = line
 
     def __next__(self):
-        try:
-            title, sequence = next(self._data)
-        except StopIteration:
-            raise StopIteration from None
+        line = self._line
+        if line is None:
+            raise StopIteration
+        title = line[1:].rstrip()
+        # Main logic
+        # Note, remove trailing whitespace, and any internal spaces
+        # (and any embedded \r which are possible in mangled files
+        # when not opened in universal read lines mode)
+        lines = []
+        for line in self.stream:
+            if line[0] == ">":
+                break
+            lines.append(line)
+        else:
+            line = None
+        self._line = line
+        sequence = "".join(lines).encode().translate(None, b" \t\r\n")
         try:
             first_word = title.split(None, 1)[0]
         except IndexError:

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -49,44 +49,14 @@ def SimpleFastaParser(handle):
     ('delta', 'CGCGC')
 
     """
-    try:
-        line = next(handle)
-    except StopIteration:
+    # Skip any text before the first record (e.g. blank lines, comments)
+    for line in handle:
+        if line[0] == ">":
+            title = line[1:].rstrip()
+            break
+    else:
+        # no break encountered - probably an empty file
         return
-    if not line.startswith(">"):
-        warnings.warn(
-            "Previously, the FASTA parser silently ignored comments at the "
-            "beginning of the FASTA file (before the first sequence).\n"
-            "\n"
-            "Nowadays, the FASTA file format is usually understood not to "
-            "have any such comments, and most software packages do not allow "
-            "them. Therefore, the use of comments at the beginning of a FASTA "
-            "file is now deprecated in Biopython.\n"
-            "\n"
-            "In a future Biopython release, this deprecation warning will be "
-            "replaced by a ValueError. To avoid this, there are three "
-            "options:\n"
-            "\n"
-            "(1) Modify your FASTA file to remove such comments at the "
-            "beginning of the file.\n"
-            "\n"
-            "(2) Use SeqIO.parse with the 'fasta-pearson' format instead of "
-            "'fasta'. This format is consistent with the FASTA format defined "
-            "by William Pearson's FASTA aligner software. Thie format allows "
-            "for comments before the first sequence; lines starting with the "
-            "';' character anywhere in the file are also regarded as comment "
-            "lines and are ignored.\n"
-            "\n"
-            "(3) Use the 'fasta-blast' format. This format regards any lines "
-            "starting with '!', '#', or ';' as comment lines. The "
-            "'fasta-blast' format may be safer than the 'fasta-pearson' "
-            "format, as it explicitly indicates which lines are comments. ",
-            BiopythonDeprecationWarning,
-        )
-        for line in handle:
-            if line.startswith(">"):
-                break
-    title = line[1:].rstrip()
 
     # Main logic
     # Note, remove trailing whitespace, and any internal spaces

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -62,12 +62,11 @@ Biopython modules, methods, functions
 
 Bio.SeqIO.FastaIO
 -----------------
-The ``SimpleFastaParser`` (which is used by Bio.SeqIO.parse if
-``format='fasta'`` or ``format='fasta-2line'``) interprets lines before the
-first line starting with '>' as comments and skips them. To be consistent with
-the most common interpretation of the FASTA file format, the use of such
-comment lines at the beginning of the FASTA file was deprecated in Biopython
-Release 1.85.
+Parsing a FASTA file using Bio.SeqIO.parse with ``format='fasta'`` interprets
+lines before the first line starting with '>' as comments and skips them. To be
+consistent with the most common interpretation of the FASTA file format, the
+use of such comment lines at the beginning of the FASTA file was deprecated in
+Biopython Release 1.85.
 As an alternative, you can use ``format='fasta-pearson'`` to specify the FASTA
 file format as defined by William Pearson's FASTA aligner program, allowing for
 comment lines at the top of the FASTA file (lines anywhere in the file starting


### PR DESCRIPTION
This speeds up `SeqIO.parse(..., fmt='fasta')` by 10% when parsing the human genome hg38, and by 20% when parsing a file of 1000000 sequences of 100 nucleotides (with the sequence on one line).

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

