### PR TITLE
Bio.SeqIO QualityIO subclass

### DIFF
--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -1016,16 +1016,18 @@ class FastqIteratorAbstractBaseClass(SequenceIterator[str]):
         attribute under the key `q_key`.
         """
         super().__init__(source, mode="t", fmt="Fastq")
-        try:
-            line = next(self.stream)
-        except StopIteration:  # empty file?
-            self.line = None
-        else:
-            self.line = line
+        self.line = None
 
     def __next__(self) -> SeqRecord:
         """Parse the file and generate SeqRecord objects."""
         line = self.line
+        if line is None:
+            try:
+                line = next(self.stream)
+            except StopIteration:  # empty file?
+                self.line = None
+            else:
+                self.line = line
         if line is None:
             raise StopIteration
         if line[0] != "@":

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -847,15 +847,16 @@ def _parse_blocks(stream, line):
                 raise ValueError("End of file without quality information.")
             else:
                 raise ValueError("Unexpected end of file")
+        seq_len = len(seq_string)
         # The title here is optional, but if present must match!
         second_title = line[1:].rstrip()
         if second_title and second_title != title_line:
             raise ValueError("Sequence and quality captions differ.")
+        seq_string = seq_string.encode()
         # This is going to slow things down a little, but assuming
         # this isn't allowed we should try and catch it here:
-        if " " in seq_string or "\t" in seq_string:
+        if seq_string and min(seq_string) < ord("!"):  # first printable character
             raise ValueError("Whitespace is not allowed in the sequence.")
-        seq_len = len(seq_string)
 
         # There will now be at least one line of quality data, followed by
         # another sequence, or EOF
@@ -994,7 +995,66 @@ def FastqGeneralIterator(source: _TextIOSource) -> Iterator[tuple[str, str, str]
         except StopIteration:
             return  # Premature end of file, or just empty?
 
-        yield from _parse_blocks(handle, line)
+        while True:
+            if line[0] != "@":
+                raise ValueError(
+                    "Records in Fastq files should start with '@' character"
+                )
+            title_line = line[1:].rstrip()
+            seq_string = ""
+            # There will now be one or more sequence lines; keep going until we
+            # find the "+" marking the quality line:
+            for line in handle:
+                if line[0] == "+":
+                    break
+                seq_string += line.rstrip()
+            else:
+                if seq_string:
+                    raise ValueError("End of file without quality information.")
+                else:
+                    raise ValueError("Unexpected end of file")
+            # The title here is optional, but if present must match!
+            second_title = line[1:].rstrip()
+            if second_title and second_title != title_line:
+                raise ValueError("Sequence and quality captions differ.")
+            # This is going to slow things down a little, but assuming
+            # this isn't allowed we should try and catch it here:
+            if " " in seq_string or "\t" in seq_string:
+                raise ValueError("Whitespace is not allowed in the sequence.")
+            seq_len = len(seq_string)
+
+            # There will now be at least one line of quality data, followed by
+            # another sequence, or EOF
+            line = None
+            quality_string = ""
+            for line in handle:
+                if line[0] == "@":
+                    # This COULD be the start of a new sequence. However, it MAY just
+                    # be a line of quality data which starts with a "@" character.  We
+                    # should be able to check this by looking at the sequence length
+                    # and the amount of quality data found so far.
+                    if len(quality_string) >= seq_len:
+                        # We expect it to be equal if this is the start of a new record.
+                        # If the quality data is longer, we'll raise an error below.
+                        break
+                    # Continue - its just some (more) quality data.
+                quality_string += line.rstrip()
+            else:
+                if line is None:
+                    raise ValueError("Unexpected end of file")
+                line = None
+
+            if seq_len != len(quality_string):
+                raise ValueError(
+                    "Lengths of sequence and quality values differs for %s (%i and %i)."
+                    % (title_line, seq_len, len(quality_string))
+                )
+
+            # Return the record and then continue...
+            yield (title_line, seq_string, quality_string)
+
+            if line is None:
+                break
 
 
 class FastqIteratorAbstractBaseClass(SequenceIterator[str]):

--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -1000,7 +1000,8 @@ class NonFastqTests(unittest.TestCase):
 
     def test_sff_as_fastq(self):
         for f in ("fastq", "fastq-sanger", "fastq-solexa", "fastq-illumina"):
-            self.assertRaises(ValueError, SeqIO.parse, "Roche/greek.sff", f)
+            generator = SeqIO.parse("Roche/greek.sff", f)
+            self.assertRaises(ValueError, next, generator)
 
 
 class TestsConverter(SeqIOConverterTestBaseClass, QualityIOTestBaseClass):


### PR DESCRIPTION
In Bio.SeqIO QualityIO, the classes `FastqPhredIterator`, `FastqSolexaIterator`, and `FastqIlluminaIterator` are essentially the same, so we may as well use a base class for them instead of having the same code three times.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
