### PR TITLE
Add type annotations to methods in Bio.PDB.Atom

### DIFF
--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -11,19 +11,15 @@ import copy
 import sys
 import warnings
 from typing import Optional
-from typing import TYPE_CHECKING
 from typing import TypeVar
 
 import numpy as np
 
-import Bio.PDB.Atom
 from Bio.Data import IUPACData
 from Bio.PDB.Entity import DisorderedEntityWrapper
 from Bio.PDB.PDBExceptions import PDBConstructionWarning
 from Bio.PDB.vectors import Vector
-
-if TYPE_CHECKING:
-    from Bio.PDB.Residue import Residue
+from Bio.PDB.Residue import Residue
 
 _AtomT = TypeVar("_AtomT", bound="Atom")
 
@@ -242,7 +238,7 @@ class Atom:
 
         return element
 
-    def _assign_atom_mass(self):
+    def _assign_atom_mass(self) -> float:
         """Return atom weight (PRIVATE)."""
         try:
             return IUPACData.atom_weights[self.element.capitalize()]
@@ -308,23 +304,23 @@ class Atom:
         """Set serial number."""
         self.serial_number = n
 
-    def set_bfactor(self, bfactor):
+    def set_bfactor(self, bfactor: Optional[float]):
         """Set isotroptic B factor."""
         self.bfactor = bfactor
 
-    def set_coord(self, coord):
+    def set_coord(self, coord: np.ndarray):
         """Set coordinates."""
         self.coord = coord
 
-    def set_altloc(self, altloc):
+    def set_altloc(self, altloc: str):
         """Set alternative location specifier."""
         self.altloc = altloc
 
-    def set_occupancy(self, occupancy):
+    def set_occupancy(self, occupancy: Optional[float]):
         """Set occupancy."""
         self.occupancy = occupancy
 
-    def set_sigatm(self, sigatm_array):
+    def set_sigatm(self, sigatm_array: Optional[np.ndarray]):
         """Set standard deviation of atomic parameters.
 
         The standard deviation of atomic parameters consists
@@ -336,7 +332,7 @@ class Atom:
         """
         self.sigatm_array = sigatm_array
 
-    def set_siguij(self, siguij_array):
+    def set_siguij(self, siguij_array: Optional[np.ndarray]):
         """Set standard deviations of anisotropic temperature factors.
 
         :param siguij_array: standard deviations of anisotropic temperature factors.
@@ -344,7 +340,7 @@ class Atom:
         """
         self.siguij_array = siguij_array
 
-    def set_anisou(self, anisou_array):
+    def set_anisou(self, anisou_array: Optional[np.ndarray]):
         """Set anisotropic B factor.
 
         :param anisou_array: anisotropic B factor.
@@ -352,11 +348,11 @@ class Atom:
         """
         self.anisou_array = anisou_array
 
-    def set_charge(self, pqr_charge):
+    def set_charge(self, pqr_charge: Optional[float]):
         """Set charge."""
         self.pqr_charge = pqr_charge
 
-    def set_radius(self, radius):
+    def set_radius(self, radius: Optional[float]):
         """Set radius."""
         self.radius = radius
 
@@ -369,7 +365,7 @@ class Atom:
         """
         self.disordered_flag = 1
 
-    def is_disordered(self):
+    def is_disordered(self) -> int:
         """Return the disordered flag (1 if disordered, 0 otherwise)."""
         return self.disordered_flag
 
@@ -387,19 +383,19 @@ class Atom:
         """Remove reference to parent."""
         self.parent = None
 
-    def get_sigatm(self):
+    def get_sigatm(self) -> Optional[np.ndarray]:
         """Return standard deviation of atomic parameters."""
         return self.sigatm_array
 
-    def get_siguij(self):
+    def get_siguij(self) -> Optional[np.ndarray]:
         """Return standard deviations of anisotropic temperature factors."""
         return self.siguij_array
 
-    def get_anisou(self):
+    def get_anisou(self) -> Optional[np.ndarray]:
         """Return anisotropic B factor."""
         return self.anisou_array
 
-    def get_parent(self):
+    def get_parent(self) -> Optional[Residue]:
         """Return parent residue."""
         return self.parent
 
@@ -407,11 +403,11 @@ class Atom:
         """Return the serial number."""
         return self.serial_number
 
-    def get_name(self):
+    def get_name(self) -> str:
         """Return atom name."""
         return self.name
 
-    def get_id(self):
+    def get_id(self) -> str:
         """Return the id of the atom (which is its atom name)."""
         return self.id
 
@@ -427,39 +423,39 @@ class Atom:
         except AttributeError:
             return (None, None, None, None, self.name, self.altloc)
 
-    def get_coord(self):
+    def get_coord(self) -> np.ndarray:
         """Return atomic coordinates."""
         return self.coord
 
-    def get_bfactor(self):
+    def get_bfactor(self) -> Optional[float]:
         """Return B factor."""
         return self.bfactor
 
-    def get_occupancy(self):
+    def get_occupancy(self) -> Optional[float]:
         """Return occupancy."""
         return self.occupancy
 
-    def get_fullname(self):
+    def get_fullname(self) -> str:
         """Return the atom name, including leading and trailing spaces."""
         return self.fullname
 
-    def get_altloc(self):
+    def get_altloc(self) -> str:
         """Return alternative location specifier."""
         return self.altloc
 
-    def get_level(self):
+    def get_level(self) -> str:
         """Return level."""
         return self.level
 
-    def get_charge(self):
+    def get_charge(self) -> Optional[float]:
         """Return charge."""
         return self.pqr_charge
 
-    def get_radius(self):
+    def get_radius(self) -> Optional[float]:
         """Return radius."""
         return self.radius
 
-    def transform(self, rot, tran):
+    def transform(self, rot: np.ndarray, tran: np.ndarray):
         """Apply rotation and translation to the atomic coordinates.
 
         :param rot: A right multiplying rotation matrix
@@ -481,7 +477,7 @@ class Atom:
         """
         self.coord = np.dot(self.coord, rot) + tran
 
-    def get_vector(self):
+    def get_vector(self) -> Vector:
         """Return coordinates as Vector.
 
         :return: coordinates as 3D vector
@@ -514,7 +510,7 @@ class DisorderedAtom(DisorderedEntityWrapper):
     method.
     """
 
-    def __init__(self, id):
+    def __init__(self, id: str):
         """Create DisorderedAtom.
 
         Arguments:
@@ -554,7 +550,7 @@ class DisorderedAtom(DisorderedEntityWrapper):
         coords = np.asarray([a.coord for a in children], dtype=np.float32)
         return np.average(coords, axis=0, weights=None)
 
-    def disordered_get_list(self):
+    def disordered_get_list(self) -> list[Atom]:
         """Return list of atom instances.
 
         Sorts children by altloc (empty, then alphabetical).
@@ -575,7 +571,7 @@ class DisorderedAtom(DisorderedEntityWrapper):
             self.last_occupancy = occupancy
             self.disordered_select(altloc)
 
-    def disordered_remove(self, altloc):
+    def disordered_remove(self, altloc: str):
         """Remove a child atom altloc from the DisorderedAtom.
 
         Arguments:
@@ -597,7 +593,7 @@ class DisorderedAtom(DisorderedEntityWrapper):
             self.selected_child = None
             self.last_occupancy = -sys.maxsize
 
-    def transform(self, rot, tran):
+    def transform(self, rot: np.ndarray, tran: np.ndarray):
         """Apply rotation and translation to all children.
 
         See the documentation of Atom.transform for details.


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Related: https://github.com/biopython/biopython/issues/4836

The linked issue asks about runtime type checks in the Bio.PDB.Atom methods. @flaar94 suggested type checks might slow down code, but we should at least have type annotations so IDEs and mypy can catch mistakes.