### PR TITLE
Allow parsers in Bio.SeqIO to handle both text and binary modes

### DIFF
--- a/Bio/SeqIO/AbiIO.py
+++ b/Bio/SeqIO/AbiIO.py
@@ -347,9 +347,11 @@ def _get_string_tag(opt_bytes_value, default=None):
 class AbiIterator(SequenceIterator):
     """Parser for Abi files."""
 
+    modes = "b"
+
     def __init__(self, source, trim=False):
         """Return an iterator for the Abi file format."""
-        super().__init__(source, mode="b", fmt="ABI")
+        super().__init__(source, fmt="ABI")
         # check if input file is a valid Abi file
         marker = self.stream.read(4)
         if not marker:

--- a/Bio/SeqIO/AceIO.py
+++ b/Bio/SeqIO/AceIO.py
@@ -22,6 +22,8 @@ from .Interfaces import SequenceIterator
 class AceIterator(SequenceIterator):
     """Return SeqRecord objects from an ACE file."""
 
+    modes = "t"
+
     def __init__(
         self,
         source: _TextIOSource,
@@ -69,7 +71,7 @@ class AceIterator(SequenceIterator):
         90
 
         """
-        super().__init__(source, mode="t", fmt="ACE")
+        super().__init__(source, fmt="ACE")
         self.ace_contigs = Ace.parse(self.stream)
 
     def __next__(self):

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -143,6 +143,8 @@ def FastaTwoLineParser(handle):
 class FastaIterator(SequenceIterator):
     """Parser for plain Fasta files without comments."""
 
+    modes = "t"
+
     def __init__(
         self,
         source: _TextIOSource,
@@ -191,7 +193,7 @@ class FastaIterator(SequenceIterator):
         """
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
-        super().__init__(source, mode="t", fmt="Fasta")
+        super().__init__(source, fmt="Fasta")
         try:
             line = next(self.stream)
         except StopIteration:
@@ -266,6 +268,8 @@ class FastaIterator(SequenceIterator):
 class FastaTwoLineIterator(SequenceIterator):
     """Parser for Fasta files with exactly two lines per record."""
 
+    modes = "t"
+
     def __init__(self, source):
         """Iterate over two-line Fasta records (as SeqRecord objects).
 
@@ -278,7 +282,7 @@ class FastaTwoLineIterator(SequenceIterator):
         Only the default title to ID/name/description parsing offered
         by the relaxed FASTA parser is offered.
         """
-        super().__init__(source, mode="t", fmt="FASTA")
+        super().__init__(source, fmt="FASTA")
         self._data = FastaTwoLineParser(self.stream)
 
     def __next__(self):
@@ -299,6 +303,8 @@ class FastaTwoLineIterator(SequenceIterator):
 
 class FastaBlastIterator(SequenceIterator):
     """Parser for Fasta files, allowing for comments as in BLAST."""
+
+    modes = "t"
 
     def __init__(
         self,
@@ -348,7 +354,7 @@ class FastaBlastIterator(SequenceIterator):
         """
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
-        super().__init__(source, mode="t", fmt="FASTA")
+        super().__init__(source, fmt="FASTA")
         for line in self.stream:
             if line[0] not in "#!;":
                 if not line.startswith(">"):
@@ -396,6 +402,8 @@ class FastaBlastIterator(SequenceIterator):
 
 class FastaPearsonIterator(SequenceIterator):
     """Parser for Fasta files, allowing for comments as in the FASTA aligner."""
+
+    modes = "t"
 
     def __init__(
         self,
@@ -446,7 +454,7 @@ class FastaPearsonIterator(SequenceIterator):
         """
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
-        super().__init__(source, mode="t", fmt="Fasta")
+        super().__init__(source, fmt="Fasta")
         for line in self.stream:
             if line.startswith(">"):
                 self._line = line

--- a/Bio/SeqIO/GckIO.py
+++ b/Bio/SeqIO/GckIO.py
@@ -73,13 +73,15 @@ def _read_p4string(stream):
 class GckIterator(SequenceIterator):
     """Parser for GCK files."""
 
+    modes = "b"
+
     def __init__(self, source):
         """Break up a GCK file into SeqRecord objects.
 
         Note that a GCK file can only contain one sequence, so this
         iterator will always return a single record.
         """
-        super().__init__(source, mode="b", fmt="GCK")
+        super().__init__(source, fmt="GCK")
         # Skip file header
         # GCK files start with a 24-bytes header. Bytes 4 and 8 seem to
         # always be 12, maybe this could act as a magic cookie. Bytes

--- a/Bio/SeqIO/GfaIO.py
+++ b/Bio/SeqIO/GfaIO.py
@@ -119,6 +119,8 @@ class Gfa1Iterator(SequenceIterator):
     Documentation: https://gfa-spec.github.io/GFA-spec/GFA1.html
     """
 
+    modes = "t"
+
     def __init__(
         self,
         source: _TextIOSource,
@@ -128,7 +130,7 @@ class Gfa1Iterator(SequenceIterator):
         Arguments:
          - source - input stream opened in text mode, or a path to a file
         """
-        super().__init__(source, mode="t", fmt="GFA 1.0")
+        super().__init__(source, fmt="GFA 1.0")
 
     def __next__(self):
         for line in self.stream:
@@ -164,6 +166,8 @@ class Gfa2Iterator(SequenceIterator):
     Documentation for version 2: https://gfa-spec.github.io/GFA-spec/GFA2.html
     """
 
+    modes = "t"
+
     def __init__(
         self,
         source: _TextIOSource,
@@ -173,7 +177,7 @@ class Gfa2Iterator(SequenceIterator):
         Arguments:
          - source - input stream opened in text mode, or a path to a file
         """
-        super().__init__(source, mode="t", fmt="GFA 2.0")
+        super().__init__(source, fmt="GFA 2.0")
 
     def __next__(self):
         for line in self.stream:

--- a/Bio/SeqIO/IgIO.py
+++ b/Bio/SeqIO/IgIO.py
@@ -22,6 +22,8 @@ from .Interfaces import SequenceIterator
 class IgIterator(SequenceIterator):
     """Parser for IntelliGenetics files."""
 
+    modes = "t"
+
     def __init__(self, source):
         """Iterate over IntelliGenetics records (as SeqRecord objects).
 
@@ -60,7 +62,7 @@ class IgIterator(SequenceIterator):
         SYK_SYK length 330
 
         """
-        super().__init__(source, mode="t", fmt="IntelliGenetics")
+        super().__init__(source, fmt="IntelliGenetics")
         for line in self.stream:
             if not line.startswith(";;"):
                 break

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -62,6 +62,8 @@ _allowed_table_component_name_chars = set(ascii_letters + digits + "_-'*")
 class GenBankIterator(SequenceIterator):
     """Parser for GenBank files."""
 
+    modes = "t"
+
     def __init__(self, source):
         """Break up a Genbank file into SeqRecord objects.
 
@@ -99,7 +101,7 @@ class GenBankIterator(SequenceIterator):
         AF297471.1
 
         """
-        super().__init__(source, mode="t", fmt="GenBank")
+        super().__init__(source, fmt="GenBank")
         self.records = GenBankScanner(debug=0).parse_records(self.stream)
 
     def __next__(self):
@@ -114,6 +116,8 @@ class GenBankIterator(SequenceIterator):
 
 class EmblIterator(SequenceIterator):
     """Parser for EMBL files."""
+
+    modes = "t"
 
     def __init__(self, source):
         """Break up an EMBL file into SeqRecord objects.
@@ -158,7 +162,7 @@ class EmblIterator(SequenceIterator):
         CQ797900.1
 
         """
-        super().__init__(source, mode="t", fmt="EMBL")
+        super().__init__(source, fmt="EMBL")
         self.records = EmblScanner(debug=0).parse_records(self.stream)
 
     def __next__(self):
@@ -174,6 +178,8 @@ class EmblIterator(SequenceIterator):
 class ImgtIterator(SequenceIterator):
     """Parser for IMGT files."""
 
+    modes = "t"
+
     def __init__(self, source):
         """Break up an IMGT file into SeqRecord objects.
 
@@ -184,7 +190,7 @@ class ImgtIterator(SequenceIterator):
         Note that for genomes or chromosomes, there is typically only
         one record.
         """
-        super().__init__(source, mode="t", fmt="IMGT")
+        super().__init__(source, fmt="IMGT")
         self.records = _ImgtScanner(debug=0).parse_records(self.stream)
 
     def __next__(self):
@@ -200,6 +206,8 @@ class ImgtIterator(SequenceIterator):
 class GenBankCdsFeatureIterator(SequenceIterator):
     """Parser for GenBank files, creating a SeqRecord for each CDS feature."""
 
+    modes = "t"
+
     def __init__(self, source):
         """Break up a Genbank file into SeqRecord objects for each CDS feature.
 
@@ -209,7 +217,7 @@ class GenBankCdsFeatureIterator(SequenceIterator):
         many CDS features.  These are returned as with the stated amino acid
         translation sequence (if given).
         """
-        super().__init__(source, mode="t", fmt="GenBank")
+        super().__init__(source, fmt="GenBank")
         self.records = GenBankScanner(debug=0).parse_cds_features(self.stream)
 
     def __next__(self):
@@ -225,6 +233,8 @@ class GenBankCdsFeatureIterator(SequenceIterator):
 class EmblCdsFeatureIterator(SequenceIterator):
     """Parser for EMBL files, creating a SeqRecord for each CDS feature."""
 
+    modes = "t"
+
     def __init__(self, source):
         """Break up a EMBL file into SeqRecord objects for each CDS feature.
 
@@ -234,7 +244,7 @@ class EmblCdsFeatureIterator(SequenceIterator):
         many CDS features.  These are returned as with the stated amino acid
         translation sequence (if given).
         """
-        super().__init__(source, mode="t", fmt="EMBL")
+        super().__init__(source, fmt="EMBL")
         self.records = EmblScanner(debug=0).parse_cds_features(self.stream)
 
     def __next__(self):

--- a/Bio/SeqIO/NibIO.py
+++ b/Bio/SeqIO/NibIO.py
@@ -53,6 +53,8 @@ from .Interfaces import SequenceWriter
 class NibIterator(SequenceIterator):
     """Parser for nib files."""
 
+    modes = "b"
+
     def __init__(self, source):
         """Iterate over a nib file and yield a SeqRecord.
 
@@ -79,7 +81,7 @@ class NibIterator(SequenceIterator):
         nAGAAGagccgcNGgCActtGAnTAtCGTCgcCacCaGncGncTtGNtGG 50
 
         """
-        super().__init__(source, mode="b", fmt="Nib")
+        super().__init__(source, fmt="Nib")
         word = self.stream.read(4)
         if not word:
             raise ValueError("Empty file.")

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -114,6 +114,8 @@ def AtomIterator(pdb_id, structure):
 class PdbSeqresIterator(SequenceIterator):
     """Parser for PDB files."""
 
+    modes = "t"
+
     def __init__(self, source: _TextIOSource) -> None:
         """Iterate over chains in a PDB file as SeqRecord objects.
 
@@ -151,7 +153,7 @@ class PdbSeqresIterator(SequenceIterator):
         Note the chain is recorded in the annotations dictionary, and any PDB DBREF
         lines are recorded in the database cross-references list.
         """
-        super().__init__(source, mode="t", fmt="PDB")
+        super().__init__(source, fmt="PDB")
         self.cache = None
 
     def __next__(self):
@@ -276,6 +278,8 @@ class PdbSeqresIterator(SequenceIterator):
 class PdbAtomIterator(SequenceIterator):
     """Parser for structures in a PDB files."""
 
+    modes = "t"
+
     def __init__(self, source: _TextIOSource) -> None:
         """Iterate over structures in a PDB file as SeqRecord objects.
 
@@ -372,6 +376,8 @@ STRUCT_REF_SEQ_FIELDS = (
 
 class CifSeqresIterator(SequenceIterator):
     """Parser for chains in an mmCIF files."""
+
+    modes = "t"
 
     def __init__(self, source: _TextIOSource) -> None:
         """Iterate over chains in an mmCIF file as SeqRecord objects.
@@ -497,6 +503,8 @@ class CifSeqresIterator(SequenceIterator):
 
 class CifAtomIterator(SequenceIterator):
     """Parser for structures in an mmCIF files."""
+
+    modes = "t"
 
     def __init__(self, source: _TextIOSource) -> None:
         """Iterate over structures in an mmCIF file as SeqRecord objects.

--- a/Bio/SeqIO/PhdIO.py
+++ b/Bio/SeqIO/PhdIO.py
@@ -67,6 +67,8 @@ from .QualityIO import _get_phred_quality
 class PhdIterator(SequenceIterator):
     """Parser for PHD files."""
 
+    modes = "t"
+
     def __init__(self, source: _TextIOSource) -> None:
         """Return SeqRecord objects from a PHD file.
 
@@ -75,7 +77,7 @@ class PhdIterator(SequenceIterator):
 
         This uses the Bio.Sequencing.Phd module to do the hard work.
         """
-        super().__init__(source, mode="t", fmt="PHD")
+        super().__init__(source, fmt="PHD")
 
     def __next__(self):
         phd_record = Phd._read(self.stream)

--- a/Bio/SeqIO/PirIO.py
+++ b/Bio/SeqIO/PirIO.py
@@ -110,6 +110,8 @@ _pir_mol_type = {
 class PirIterator(SequenceIterator):
     """Parser for PIR files."""
 
+    modes = "t"
+
     def __init__(self, source):
         """Iterate over a PIR file and yield SeqRecord objects.
 
@@ -128,7 +130,7 @@ class PirIterator(SequenceIterator):
         HLA:HLA01083 length 188
 
         """
-        super().__init__(source, mode="t", fmt="Pir")
+        super().__init__(source, fmt="Pir")
         # Skip any text before the first record (e.g. blank lines, comments)
         for line in self.stream:
             if line[0] == ">":

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -996,6 +996,8 @@ def FastqGeneralIterator(source: _TextIOSource) -> Iterator[tuple[str, str, str]
 class FastqIteratorAbstractBaseClass(SequenceIterator[str]):
     """Abstract base class for FASTQ file parsers."""
 
+    modes = "t"
+
     @abstractproperty
     def q_mapping(self):
         """Dictionary that maps letters in the quality string to quality values."""
@@ -1015,7 +1017,7 @@ class FastqIteratorAbstractBaseClass(SequenceIterator[str]):
         The quality values are stored in the `letter_annotations` dictionary
         attribute under the key `q_key`.
         """
-        super().__init__(source, mode="t", fmt="Fastq")
+        super().__init__(source, fmt="Fastq")
         self.line = None
 
     def __next__(self) -> SeqRecord:
@@ -1420,6 +1422,8 @@ class FastqIlluminaIterator(FastqIteratorAbstractBaseClass):
 class QualPhredIterator(SequenceIterator):
     """Parser for QUAL files with PHRED quality scores but no sequence."""
 
+    modes = "t"
+
     def __init__(
         self,
         source: _TextIOSource,
@@ -1480,7 +1484,7 @@ class QualPhredIterator(SequenceIterator):
         """
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
-        super().__init__(source, mode="t", fmt="QUAL")
+        super().__init__(source, fmt="QUAL")
         # Skip any text before the first record (e.g. blank lines, comments)
         for line in self.stream:
             if line[0] == ">":

--- a/Bio/SeqIO/SeqXmlIO.py
+++ b/Bio/SeqIO/SeqXmlIO.py
@@ -441,6 +441,8 @@ class SeqXmlIterator(SequenceIterator):
     method calls.
     """
 
+    modes = "b"
+
     # Small block size can be a problem with libexpat 2.6.0 onwards:
     BLOCK = 1024
 
@@ -451,7 +453,7 @@ class SeqXmlIterator(SequenceIterator):
         # if the text handle was opened with a different encoding than the
         # one specified in the XML file. With a binary handle, the correct
         # encoding is picked up by the parser from the XML file.
-        super().__init__(stream_or_path, mode="b", fmt="SeqXML")
+        super().__init__(stream_or_path, fmt="SeqXML")
         stream = self.stream
         parser = sax.make_parser()
         content_handler = ContentHandler()

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -749,6 +749,8 @@ def _sff_read_raw_record(handle, number_of_flows_per_read):
 class SffIterator(SequenceIterator):
     """Parser for Standard Flowgram Format (SFF) files."""
 
+    modes = "b"
+
     # the read header format (fixed part):
     # read_header_length     H
     # name_length            H
@@ -829,7 +831,7 @@ class SffIterator(SequenceIterator):
         """
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
-        super().__init__(source, mode="b", fmt="SFF")
+        super().__init__(source, fmt="SFF")
         self.trim = trim
         stream = self.stream
         (

--- a/Bio/SeqIO/SnapGeneIO.py
+++ b/Bio/SeqIO/SnapGeneIO.py
@@ -291,6 +291,8 @@ def _get_child_value(node, name, default=None, error=None):
 class SnapGeneIterator(SequenceIterator):
     """Parser for SnapGene files."""
 
+    modes = "b"
+
     def __init__(self, source):
         """Parse a SnapGene file and return a SeqRecord object.
 
@@ -299,7 +301,7 @@ class SnapGeneIterator(SequenceIterator):
         Note that a SnapGene file can only contain one sequence, so this
         iterator will always return a single record.
         """
-        super().__init__(source, mode="b", fmt="SnapGene")
+        super().__init__(source, fmt="SnapGene")
         self.packets = _iterate(self.stream)
         try:
             packet_type, length, data = next(self.packets)

--- a/Bio/SeqIO/SwissIO.py
+++ b/Bio/SeqIO/SwissIO.py
@@ -27,6 +27,8 @@ from .Interfaces import SequenceIterator
 class SwissIterator(SequenceIterator):
     """Parser to break up a Swiss-Prot/UniProt file into SeqRecord objects."""
 
+    modes = "t"
+
     def __init__(self, source: _TextIOSource) -> None:
         """Iterate over a Swiss-Prot file and return SeqRecord objects.
 
@@ -47,7 +49,7 @@ class SwissIterator(SequenceIterator):
         Rather than calling it directly, you are expected to use this
         parser via Bio.SeqIO.parse(..., format="swiss") instead.
         """
-        super().__init__(source, mode="t", fmt="SwissProt")
+        super().__init__(source, fmt="SwissProt")
 
     def __next__(self):
         swiss_record = SwissProt._read(self.stream)

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -44,6 +44,8 @@ from .Interfaces import SequenceWriter
 class TabIterator(SequenceIterator):
     """Parser for tab-delimited files."""
 
+    modes = "t"
+
     def __init__(self, source):
         """Iterate over tab separated lines as SeqRecord objects.
 
@@ -75,7 +77,7 @@ class TabIterator(SequenceIterator):
         gi|45478721|ref|NP_995576.1| length 90
 
         """
-        super().__init__(source, mode="t", fmt="Tab-separated plain-text")
+        super().__init__(source, fmt="Tab-separated plain-text")
 
     def __next__(self):
         for line in self.stream:

--- a/Bio/SeqIO/TwoBitIO.py
+++ b/Bio/SeqIO/TwoBitIO.py
@@ -170,9 +170,11 @@ class _TwoBitSequenceData(SequenceDataAbstractBaseClass):
 class TwoBitIterator(SequenceIterator):
     """Parser for UCSC twoBit (.2bit) files."""
 
+    modes = "b"
+
     def __init__(self, source):
         """Read the file index."""
-        super().__init__(source, mode="b", fmt="twoBit")
+        super().__init__(source, fmt="twoBit")
         # wait to close the file until the TwoBitIterator goes out of scope:
         self.should_close_stream = False
         stream = self.stream

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -34,6 +34,8 @@ REFERENCE_JOURNAL = "%(name)s %(volume)s:%(first)s-%(last)s(%(pub_date)s)"
 class UniprotIterator(SequenceIterator):
     """Parser for UniProt XML files, returning SeqRecord objects."""
 
+    modes = "b"
+
     def __init__(
         self,
         source: _BytesIOSource,
@@ -55,7 +57,7 @@ class UniprotIterator(SequenceIterator):
         """
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
-        super().__init__(source, mode="b", fmt="UniProt XML")
+        super().__init__(source, fmt="UniProt XML")
         self.return_raw_comments = return_raw_comments
         self._data = ElementTree.iterparse(
             self.stream, events=("start", "start-ns", "end")

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -18,10 +18,13 @@ originally introduced by SwissProt ("swiss" format in Bio.SeqIO).
 
 from xml.etree import ElementTree
 from xml.parsers.expat import errors
+import warnings
 
 from Bio import SeqFeature
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+
+from Bio import BiopythonDeprecationWarning
 
 from .Interfaces import _BytesIOSource
 from .Interfaces import SequenceIterator
@@ -34,7 +37,7 @@ REFERENCE_JOURNAL = "%(name)s %(volume)s:%(first)s-%(last)s(%(pub_date)s)"
 class UniprotIterator(SequenceIterator):
     """Parser for UniProt XML files, returning SeqRecord objects."""
 
-    modes = "b"
+    modes = "bt"
 
     def __init__(
         self,
@@ -58,6 +61,16 @@ class UniprotIterator(SequenceIterator):
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
         super().__init__(source, fmt="UniProt XML")
+        if self.mode == "t":
+            warnings.warn(
+                "Opening a UniProt XML file in text mode is "
+                "deprecated, as it may lead to garbled characters. "
+                "We recommend opening the file in binary mode; "
+                "parsing UniProt XML files opened in text mode will "
+                "no longer be supported in a future release of "
+                "Biopython.",
+                BiopythonDeprecationWarning,
+            )
         self.return_raw_comments = return_raw_comments
         self._data = ElementTree.iterparse(
             self.stream, events=("start", "start-ns", "end")

--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -145,6 +145,8 @@ def _read_feature(handle, record):
 class XdnaIterator(SequenceIterator):
     """Parser for Xdna files."""
 
+    modes = "b"
+
     def __init__(self, source):
         """Parse a Xdna file and return a SeqRecord object.
 
@@ -154,7 +156,7 @@ class XdnaIterator(SequenceIterator):
         contain a single sequence.
 
         """
-        super().__init__(source, mode="b", fmt="Xdna")
+        super().__init__(source, fmt="Xdna")
         header = self.stream.read(112)
         if not header:
             raise ValueError("Empty file.")

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -75,6 +75,14 @@ Another option is to use ``format='fasta-blast'``; this follows the FASTA file
 format accepted by BLAST, treating any lines starting with '#', ';', or '!' as
 comment lines and ignoring them.
 
+Bio.SeqIO.UniprotIO
+-------------------
+Parsing a UniProt XML file opened in text mode (if the file was opened using
+``open("myuniprotfile.xml")``) was deprecated in Release 1.85, as this may lead
+to garbled characters.  Please open the file in binary mode (as in
+``open("myuniprotfile.xml", "rb")``), or let ``Bio.SeqIO.parse`` take care of
+opening and closing files by passing the file name instead of a file handle.
+
 Bio.Entrez
 ----------
 The ``egquery`` function wrapping the NCBI EGQuery (Entrez Global Query)

--- a/Tests/test_SeqIO_UniprotIO.py
+++ b/Tests/test_SeqIO_UniprotIO.py
@@ -13,18 +13,20 @@ from seq_tests_common import SeqRecordTestBaseClass
 from Bio import SeqIO
 from Bio.SeqRecord import SeqRecord
 
+from Bio import BiopythonDeprecationWarning
+
 
 class ParserTests(SeqRecordTestBaseClass):
     """Tests Uniprot XML parser."""
 
-    def test_uni001(self):
+    def check_uni001(self, mode):
         """Parsing Uniprot file uni001."""
         filename = "uni001"
         # test the record parser
 
         datafile = os.path.join("SwissProt", filename)
 
-        with open(datafile, "rb") as handle:
+        with open(datafile, mode) as handle:
             seq_record = SeqIO.read(handle, "uniprot-xml")
 
         self.assertIsInstance(seq_record, SeqRecord)
@@ -132,6 +134,12 @@ class ParserTests(SeqRecordTestBaseClass):
         )
         self.assertEqual(seq_record.annotations["sequence_version"], 1)
         self.assertEqual(seq_record.annotations["proteinExistence"], ["Predicted"])
+
+    def test_uni001(self):
+        """Parsing Uniprot file uni001 in text mode and in binary mode."""
+        self.check_uni001("rb")
+        with self.assertWarns(BiopythonDeprecationWarning):
+            self.check_uni001("rt")
 
     def test_uni003(self):
         """Parsing Uniprot file uni003."""


### PR DESCRIPTION
For now, this is used only in the UniProt XML parser. It may also be useful for the FASTA and other parsers, as parsing binary is much faster than parsing text.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

