### PR TITLE
Remove copy from the Array class in BIo.Align.substitution_matrices

### DIFF
--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -265,11 +265,6 @@ class Array(np.ndarray):
         """Return the alphabet property."""
         return self._alphabet
 
-    def copy(self):
-        """Create and return a copy of the array."""
-        other = Array(alphabet=self._alphabet, data=self)
-        return other
-
     def get(self, key, value=None):
         """Return the value of the key if found; return value otherwise."""
         try:
@@ -278,7 +273,7 @@ class Array(np.ndarray):
             return value
 
     def items(self):
-        """Return an iterator  of (key, value) pairs in the array."""
+        """Return an iterator of (key, value) pairs in the array."""
         dims = len(self.shape)
         if dims == 1:
             for index, key in enumerate(self._alphabet):


### PR DESCRIPTION
We can rely on the base class implementation to get the same result.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
