### PR TITLE
Bio.SeqIO QualityIO q_mapping

### DIFF
--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -1088,8 +1088,9 @@ class FastqIteratorAbstractBaseClass(SequenceIterator[str]):
         id = descr.split()[0]
         name = id
         record = SeqRecord(Seq(seq_string), id=id, name=name, description=descr)
+        q_mapping = self.q_mapping
         try:
-            qualities = [self.q_mapping[letter2] for letter2 in quality_string]
+            qualities = [q_mapping[letter2] for letter2 in quality_string]
         except KeyError:
             raise ValueError("Invalid character in quality string") from None
         # For speed, will now use a dirty trick to speed up assigning the


### PR DESCRIPTION
Get the class attribute `q_mapping` once, instead of each time for each letter in the quality string. See #4838

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

