### PR TITLE
Replace deprecated @abstractproperty decorators

### DIFF
--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -12,12 +12,10 @@ use this module.  It provides base classes to try and simplify things.
 
 from abc import ABC
 from abc import abstractmethod
-from abc import abstractproperty
 from os import PathLike
 from typing import AnyStr
 from typing import Generic
 from typing import IO
-from collections.abc import Iterator
 from typing import Optional
 from typing import Union
 
@@ -42,7 +40,8 @@ class SequenceIterator(ABC, Generic[AnyStr]):
     file stream modes.
     """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def modes(self):
         """File modes (binary or text) that the parser can handle.
 

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -361,7 +361,7 @@ are approximately equal.
 
 import warnings
 from math import log
-from abc import abstractproperty
+from abc import abstractmethod
 from typing import Callable
 from typing import IO
 from collections.abc import Iterator
@@ -998,12 +998,14 @@ class FastqIteratorAbstractBaseClass(SequenceIterator[str]):
 
     modes = "t"
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def q_mapping(self):
         """Dictionary that maps letters in the quality string to quality values."""
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def q_key(self):
         """Key name (string) of the quality values in record.letter_annotations."""
         pass


### PR DESCRIPTION
- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

The `@abstractproperty` decorator is deprecated (since python 3.3 apparently). This replaces them with the suggested combination of `@property` and `@abstractmethod`
(see: https://docs.python.org/3/library/abc.html#abc.abstractproperty)
