### PR TITLE
Update esummary_clinvar.dtd for fda_recognized_database

### DIFF
--- a/Bio/Entrez/DTDs/esummary_clinvar.dtd
+++ b/Bio/Entrez/DTDs/esummary_clinvar.dtd
@@ -200,6 +200,7 @@
 <!ELEMENT	description		%T_string;>
 <!ELEMENT	last_evaluated		%T_date;>
 <!ELEMENT	review_status		%T_string;>
+<!ELEMENT	fda_recognized_database		%T_string;>
 <!ELEMENT	trait_set		%T_TraitSetType;>
 
 <!-- Definition of Structure type: T_ClassificationType -->
@@ -210,6 +211,7 @@
 			description?,
 			last_evaluated?,
 			review_status?,
+			fda_recognized_database?,
 			trait_set?
 			)
 			">
@@ -263,7 +265,9 @@
 <!ELEMENT	genes		%T_GenesType;>
 <!ELEMENT	molecular_consequence_list		%T_MolecularConsequenceListType;>
 <!ELEMENT	protein_change		%T_string;>
-<!ELEMENT	fda_recognized_database		%T_string;>
+<!-- Already defined ...
+	fda_recognized_database	 as 	%T_string;
+ ... Already defined -->
 <!ELEMENT	error		%T_string;>
 
 <!-- Definition of Structure type: T_DocSum -->
@@ -312,3 +316,4 @@
 ~~-->
 
 <!ELEMENT eSummaryResult (DocumentSummarySet?)>
+

--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -19,7 +19,7 @@ http://www.ncbi.nlm.nih.gov/books/NBK25501/
 
 This module provides a number of functions like ``efetch`` (short for
 Entrez Fetch) which will return the data as a handle object. This is
-a standad interface used in Python for reading data from a file, or
+a standard interface used in Python for reading data from a file, or
 in this case a remote network connection, and provides methods like
 ``.read()`` or offers iteration over the contents line by line. See
 also "What the heck is a handle?" in the Biopython Tutorial and


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4851

The Entrez parser's locally stored DTDs are outdated and don't define the `<fda_recognized_database>` tag, causing ESummary queries to the ClinVar database to fail. This PR updates the DTD.