### PR TITLE
Bio.SeqIO.NibIO use subclassing

### DIFF
--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -238,32 +238,18 @@ class SequenceWriter:
         # for sequential file formats.                   #
         ##################################################
 
-    def write_records(self, records, maxcount=None):
+    def write_records(self, records):
         """Write records to the output file, and return the number of records.
 
         records - A list or iterator returning SeqRecord objects
-        maxcount - The maximum number of records allowed by the
-        file format, or None if there is no maximum.
         """
         count = 0
-        if maxcount is None:
-            for record in records:
-                self.write_record(record)
-                count += 1
-        else:
-            for record in records:
-                if count == maxcount:
-                    if maxcount == 1:
-                        raise ValueError("More than one sequence found")
-                    else:
-                        raise ValueError(
-                            "Number of sequences is larger than %d" % maxcount
-                        )
-                self.write_record(record)
-                count += 1
+        for record in records:
+            self.write_record(record)
+            count += 1
         return count
 
-    def write_file(self, records, mincount=0, maxcount=None):
+    def write_file(self, records):
         """Write a complete file with the records, and return the number of records.
 
         records - A list or iterator returning SeqRecord objects
@@ -274,21 +260,9 @@ class SequenceWriter:
         ##################################################
         try:
             self.write_header()
-            count = self.write_records(records, maxcount)
+            count = self.write_records(records)
             self.write_footer()
         finally:
             if self.handle is not self.target:
                 self.handle.close()
-        if count < mincount:
-            if mincount == 1:  # Common case
-                raise ValueError("Must have one sequence")
-            elif mincount == maxcount:
-                raise ValueError(
-                    "Number of sequences is %d (expected %d)" % (count, mincount)
-                )
-            else:
-                raise ValueError(
-                    "Number of sequences is %d (expected at least %d)"
-                    % (count, mincount)
-                )
         return count

--- a/Bio/SeqIO/NibIO.py
+++ b/Bio/SeqIO/NibIO.py
@@ -162,9 +162,19 @@ class NibWriter(SequenceWriter):
         indices = nucleotides.translate(table)
         handle.write(binascii.unhexlify(indices))
 
-    def write_file(self, records):
-        """Write the complete file with the records, and return the number of records."""
-        count = super().write_file(records, mincount=1, maxcount=1)
+    def write_records(self, records):
+        """Write records to the output file, and return the number of records.
+
+        records - A list or iterator returning SeqRecord objects
+        """
+        count = 0
+        for record in records:
+            if count == 1:
+                raise ValueError("More than one sequence found")
+            self.write_record(record)
+            count += 1
+        if count != 1:
+            raise ValueError("Must have one sequence")
         return count
 
 


### PR DESCRIPTION
The writer base class in Bio.SeqIO can check at runtime if the number of records written is within the allowable minimum and maximum. But this is used only for nib files, and in this case the minimum = maximum =1 is already known at compile time. So we can just override the base class function, and remove the runtime checks.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

