### PR TITLE
Bio.SeqIO remove unused variable

### DIFF
--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -1592,7 +1592,6 @@ class FastqPhredWriter(SequenceWriter):
 
     def write_record(self, record: SeqRecord) -> None:
         """Write a single FASTQ record to the file."""
-        self._record_written = True
         # TODO - Is an empty sequence allowed in FASTQ format?
         seq = record.seq
         if seq is None:
@@ -1706,8 +1705,6 @@ class QualPhredWriter(SequenceWriter):
 
     def write_record(self, record: SeqRecord) -> None:
         """Write a single QUAL record to the file."""
-        self._record_written = True
-
         handle = self.handle
         wrap = self.wrap
 
@@ -1852,8 +1849,6 @@ class FastqSolexaWriter(SequenceWriter):
 
     def write_record(self, record: SeqRecord) -> None:
         """Write a single FASTQ record to the file."""
-        self._record_written = True
-
         # TODO - Is an empty sequence allowed in FASTQ format?
         seq = record.seq
         if seq is None:
@@ -1936,8 +1931,6 @@ class FastqIlluminaWriter(SequenceWriter):
 
     def write_record(self, record: SeqRecord) -> None:
         """Write a single FASTQ record to the file."""
-        self._record_written = True
-
         # TODO - Is an empty sequence allowed in FASTQ format?
         seq = record.seq
         if seq is None:

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -116,7 +116,6 @@ class TabWriter(SequenceWriter):
         """Write a single tab line to the file."""
         assert self._header_written
         assert not self._footer_written
-        self._record_written = True
         self.handle.write(as_tab(record))
 
 


### PR DESCRIPTION
_record_written is not used anywhere.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

