### PR TITLE
Try using GA setup-python's built in caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: tj-actions/changed-files@v45
       id: changed-files
 
-    # Cache CI packages
+    # Cache pre-commit's own packages
     - uses: actions/cache@v4
       id: cache-precommit
       with:
@@ -41,6 +41,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.9
+        cache: 'pip'
+        cache-dependency-path: |
+          setup.py
+          .pre-commit-config.yaml
 
     - name: Installing pre-commit
       run: |
@@ -55,9 +59,6 @@ jobs:
       run: |
         pre-commit run --files ${{ steps.changed-files.outputs.all_changed_files }}
 
-  # Cache pip & python dependencies for Linux runner
-  # since it is used in most actions.
-  # Adapted from: https://medium.com/ai2-blog/python-caching-in-github-actions-e9452698e98d
   linux_prep:
     needs: [style]
     runs-on: ubuntu-latest
@@ -72,19 +73,16 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-
-    - uses: actions/cache@v4
-      id: cache-pip
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{runner.os}}-${{ env.pythonLocation }}-${{ matrix.python-version }}-v2-${{ hashFiles('setup.py') }}-${{ hashFiles('**/ci-dependencies.txt') }}
+        cache: 'pip'
+        cache-dependency-path: |
+          setup.py
+          ci-dependencies.txt
 
     - name: Install Python packaging tools
       run: |
         python -m pip install --upgrade pip setuptools wheel
 
     - name: Install Python dependencies
-      if: steps.cache-pip.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade --upgrade-strategy eager -r ci-dependencies.txt
 
@@ -102,6 +100,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.9
+        cache: 'pip'
+        cache-dependency-path: |
+          setup.py
 
     - name: Install Python packaging tools
       run: |
@@ -126,6 +127,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
 
     - name: Install Python packaging tools
       run: |
@@ -134,20 +136,6 @@ jobs:
     - name: Build wheel
       run: |
         python setup.py bdist_wheel
-
-    # - name: Archive wheels
-    #   uses: actions/upload-artifact@v2
-    #   with:
-    #     name: biopython_wheels
-    #     path: |
-    #       dist/*whl
-    #
-    # - name: Fetch archived wheels from previous jobs
-    #   uses: actions/download-artifact@v2
-    #   with:
-    #     name: biopython_wheels
-    #     path: dist
-
 
   # Run tests in parallel across Linux, MacOS, and Windows
   # hosts (thus the three steps and not the single matrix entry).
@@ -180,16 +168,12 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-
-    # Retrieve cache to speed things up
-    - uses: actions/cache@v4
-      id: cache-pip
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{runner.os}}-${{ env.pythonLocation }}-${{ matrix.python-version }}-v2-${{ hashFiles('setup.py') }}-${{ hashFiles('**/ci-dependencies.txt') }}
+        cache: 'pip'
+        cache-dependency-path: |
+          setup.py
+          ci-dependencies.txt
 
     - name: Install dependencies
-      if: steps.cache-pip.outputs.cache-hit != 'true'
       run: |
           python -m pip install --upgrade --upgrade-strategy eager -r ci-dependencies.txt
 
@@ -221,6 +205,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          setup.py
 
     - name: Install Python packaging tools
       run: |
@@ -259,6 +246,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          setup.py
 
     - name: Install Python packaging tools
       run: |
@@ -295,6 +285,9 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          setup.py
 
     - name: Install Python packaging tools
       run: |
@@ -336,19 +329,16 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.9
-
-    - uses: actions/cache@v4
-      id: cache-pip
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{runner.os}}-${{ env.pythonLocation }}-${{ matrix.python-version }}-v2-${{ hashFiles('setup.py') }}-${{ hashFiles('**/ci-dependencies.txt') }}
+        cache: 'pip'
+        cache-dependency-path: |
+          setup.py
+          .circleci/requirements-sphinx.txt
 
     - name: Install Python packaging tools
       run: |
         python -m pip install --upgrade pip setuptools wheel
 
     - name: Install dependencies
-      if: steps.cache-pip.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade --upgrade-strategy eager -r .circleci/requirements-sphinx.txt
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

I tried https://github.com/rhysd/actionlint on our GitHub Actions (GA) setup today:

```
$ actionlint --version
1.7.3
installed by building from source
built with go1.23.1 compiler for darwin/amd64
$ actionlint 
.github/workflows/ci.yml:344:59: property "python-version" is not defined in object type {} [expression]
    |
344 |         key: ${{runner.os}}-${{ env.pythonLocation }}-${{ matrix.python-version }}-v2-${{ hashFiles('setup.py') }}-${{ hashFiles('**/ci-dependencies.txt') }}
    |                                                           ^~~~~~~~~~~~~~~~~~~~~
```

That line is within a section not using a matrix, so I think the linter is correct. It wasn't obvious to me how to access the appropriate ``.python-version`` here.

That prompted me to look at a different solution to caching our pip-installed dependencies - this is built into the setup-python action.