### PR TITLE
Introducing Biopython Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,9 @@
 .. image:: http://depsy.org/api/package/pypi/biopython/badge.svg
    :alt: Research software impact on Depsy
    :target: http://depsy.org/package/python/biopython
+.. image:: https://img.shields.io/badge/Gurubase-Ask%20Biopython%20Guru-006BFF
+   :alt: Biopython Guru
+   :target: https://gurubase.io/g/biopython
 
 .. image:: https://github.com/biopython/biopython/raw/master/Doc/images/biopython_logo_m.png
    :alt: The Biopython Project


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Biopython Guru](https://gurubase.io/g/biopython) to Gurubase. Biopython Guru uses the data from this repo and data from the [docs](https://biopython.org/docs/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Biopython Guru", which highlights that Biopython now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Biopython Guru in Gurubase, just let me know that's totally fine.