### PR TITLE
fix: free expat_parse resources when exception raised to prevent resource leaks

### DIFF
--- a/Bio/Blast/__init__.py
+++ b/Bio/Blast/__init__.py
@@ -729,12 +729,21 @@ class Records(UserList):
                     except AttributeError:
                         break
                     else:
-                        raise ValueError(
-                            f"premature end of XML file (after reading {parser.CurrentByteIndex} bytes)"
-                        )
+                        try:
+                            parser.Parse(b"", True)
+                        except expat.ExpatError as e:
+                            if parser.StartElementHandler is not None:
+                                raise ValueError(
+                                    f"premature end of XML file: line {e.lineno}, column {e.offset}"
+                                )
+                            raise e
                 try:
                     parser.Parse(data, False)
                 except expat.ExpatError as e:
+                    try:
+                        parser.Parse(b"", True)
+                    except expat.ExpatError:
+                        pass
                     if parser.StartElementHandler:
                         # We saw the initial <!xml declaration, so we can be
                         # sure that we are parsing XML data. Most likely, the
@@ -764,7 +773,7 @@ class Records(UserList):
         try:
             self._parser.Parse(b"", True)
             del self._parser
-        except AttributeError:
+        except (AttributeError, expat.ExpatError):
             pass
 
         try:
@@ -808,10 +817,18 @@ class Records(UserList):
             # Read in another block of data from the file.
             data = stream.read(BLOCK)
             if data == b"":
-                if parser.StartElementHandler is not None:
-                    raise ValueError(
-                        f"premature end of XML file (after reading {parser.CurrentByteIndex} bytes)"
-                    )
+                try:
+                    del self._parser
+                    try:
+                        parser.Parse(b"", True)
+                    except expat.ExpatError as e:
+                        if parser.StartElementHandler is not None:
+                            raise ValueError(
+                                f"premature end of XML file: line {e.lineno}, column {e.offset}"
+                            )
+                        raise e
+                except AttributeError:
+                    pass
                 raise StopIteration
             try:
                 parser.Parse(data, False)

--- a/Bio/Blast/__init__.py
+++ b/Bio/Blast/__init__.py
@@ -762,6 +762,17 @@ class Records(UserList):
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         try:
+            self._parser.Parse(b"", True)
+            del self._parser
+        except AttributeError:
+            pass
+
+        try:
+            del self._cache
+        except AttributeError:
+            pass
+
+        try:
             stream = self._stream
         except AttributeError:
             return
@@ -797,8 +808,6 @@ class Records(UserList):
             # Read in another block of data from the file.
             data = stream.read(BLOCK)
             if data == b"":
-                del self._cache
-                del self._parser
                 if parser.StartElementHandler is not None:
                     raise ValueError(
                         f"premature end of XML file (after reading {parser.CurrentByteIndex} bytes)"

--- a/Tests/test_Blast_parser.py
+++ b/Tests/test_Blast_parser.py
@@ -14716,7 +14716,7 @@ class TestBlastErrors(unittest.TestCase):
 
     def test_premature_end_header(self):
         """Try to parse an XML file terminating in the header."""
-        message = r"^premature end of XML file \(after reading [1-9]\d* bytes\)$"
+        message = r"^premature end of XML file: line [0-9]\d*, column [0-9]\d*$"
         filename = "broken1.xml"
         path = os.path.join("Blast", filename)
         with open(path, "rb") as stream:
@@ -14736,7 +14736,7 @@ class TestBlastErrors(unittest.TestCase):
 
     def test_premature_end_first_block(self):
         """Try to parse an XML file terminating within the first block."""
-        message = r"^premature end of XML file \(after reading [1-9]\d* bytes\)$"
+        message = r"^premature end of XML file: line [0-9]\d*, column [0-9]\d*$"
         filename = "broken2.xml"
         path = os.path.join("Blast", filename)
         with open(path, "rb") as stream:
@@ -14758,7 +14758,7 @@ class TestBlastErrors(unittest.TestCase):
 
     def test_premature_end_second_block(self):
         """Try to parse an XML file terminating in the second block."""
-        message = r"^premature end of XML file \(after reading [1-9]\d* bytes\)$"
+        message = r"^premature end of XML file: line [0-9]\d*, column [0-9]\d*$"
         filename = "broken3.xml"
         path = os.path.join("Blast", filename)
         with open(path, "rb") as stream:
@@ -14780,7 +14780,7 @@ class TestBlastErrors(unittest.TestCase):
 
     def test_premature_end_after_one_record(self):
         """Try to parse an XML file terminating after the first record."""
-        message = r"^premature end of XML file \(after reading [1-9]\d* bytes\)$"
+        message = r"^premature end of XML file: line [0-9]\d*, column [0-9]\d*$"
         filename = "broken4.xml"
         path = os.path.join("Blast", filename)
         with open(path, "rb") as stream:


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->


### Description:

This PR addresses a resource management issue with the `parse()` function when using the expat XML parser. According to the [official Python documentation](https://docs.python.org/3/library/pyexpat.html#xml.parsers.expat.xmlparser.Parse), the `isfinal` argument of `expat.Parse(data, isfinal)` must be set to `True` on the final call to ensure that all resources are freed and the parsing is completed correctly. Failing to set `isfinal=True` risks leaving resources unreleased, which may result in memory or resource leaks, especially in cases of exceptions or premature termination of the generator.

### Problem:

In the current implementation, `expat.Parse()` is not always called with `isfinal=True` in two scenarios:

1. Exception during parsing: If an exception is raised before reaching the end of the XML file, `expat.Parse()` does not receive its final call with `isfinal=True`, leaving resources open.

2. Premature exit from the generator loop: If the user of the `parse()` function exits the generator early (e.g., via a break or return statement), the final `Parse()` call with `isfinal=True` is also skipped, causing a potential resource leak.

### Solution:

1. Handling exceptions: I’ve added a `finally` block that ensures `expat.Parse()` is always called with `isfinal=True`, regardless of whether an exception occurs, ensuring that resources are properly freed at the end of parsing.

2. Premature loop termination: This PR addresses exceptions but doesn’t yet handle cases where the generator is stopped early by the caller (e.g., via break or return). I’m open to suggestions for resolving this in future updates.