### PR TITLE
Address C compiler warnings

### DIFF
--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -5636,9 +5636,9 @@ exit: \
     const double epsilon = self->epsilon; \
     Trace** M; \
     TraceGapsWatermanSmithBeyer** gaps; \
-    double** M_row; \
-    double** Ix_row; \
-    double** Iy_row; \
+    double** M_row = NULL; \
+    double** Ix_row = NULL; \
+    double** Iy_row = NULL; \
     int ng; \
     int nm; \
     double score; \

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -5999,8 +5999,13 @@ exit: \
      * expanded nodes, lower_bound contains the global lower_bound, a and b \
      * contain the lower bounds for the current cell. ch contains the types of \
      * the potential children */ \
-    int type_total = 1, new_type, npA, npB; \
-    double new_score, new_lower, new_upper, next_lower, next_upper; \
+    int type_total = 1; \
+    /* The initial values for new_type, npA, npB, new_score, new_lower, \
+    new_upper, next_lower, and next_upper don't mean anything; they're never \
+    used and are only initialized to stop compiler warnings */ \
+    int new_type = 0, npA = 0, npB = 0; \
+    double new_score = 0, new_lower = 0, new_upper = 0, next_lower = 0, \
+        next_upper = 0; \
     const double gap_open_A = self->target_internal_open_gap_score; \
     const double gap_open_B = self->query_internal_open_gap_score; \
     const double gap_extend_A = self->target_internal_extend_gap_score; \

--- a/Bio/cpairwise2module.c
+++ b/Bio/cpairwise2module.c
@@ -340,52 +340,52 @@ static PyObject *cpairwise2__make_score_matrix_fast(PyObject *self,
         best_score = local_max_score;
 
     /* Save the score and traceback matrices into real python objects. */
-	if(!score_only) {
-		if(!(py_score_matrix = PyList_New(lenA+1)))
-			goto _cleanup_make_score_matrix_fast;
-		if(!(py_trace_matrix = PyList_New(lenA+1)))
-			goto _cleanup_make_score_matrix_fast;
+    if(!score_only) {
+            if(!(py_score_matrix = PyList_New(lenA+1)))
+                    goto _cleanup_make_score_matrix_fast;
+            if(!(py_trace_matrix = PyList_New(lenA+1)))
+                    goto _cleanup_make_score_matrix_fast;
 
-		for(row=0; row<=lenA; row++) {
-			PyObject *py_score_row, *py_trace_row;
-			if(!(py_score_row = PyList_New(lenB+1)))
-				goto _cleanup_make_score_matrix_fast;
-			PyList_SET_ITEM(py_score_matrix, row, py_score_row);
-			if(!(py_trace_row = PyList_New(lenB+1)))
-				goto _cleanup_make_score_matrix_fast;
-			PyList_SET_ITEM(py_trace_matrix, row, py_trace_row);
+            for(row=0; row<=lenA; row++) {
+                    PyObject *py_score_row, *py_trace_row;
+                    if(!(py_score_row = PyList_New(lenB+1)))
+                            goto _cleanup_make_score_matrix_fast;
+                    PyList_SET_ITEM(py_score_matrix, row, py_score_row);
+                    if(!(py_trace_row = PyList_New(lenB+1)))
+                            goto _cleanup_make_score_matrix_fast;
+                    PyList_SET_ITEM(py_trace_matrix, row, py_trace_row);
 
-			for(col=0; col<=lenB; col++) {
-				PyObject *py_score, *py_trace;
-				int offset = row*(lenB+1) + col;
+                    for(col=0; col<=lenB; col++) {
+                            PyObject *py_score, *py_trace;
+                            int offset = row*(lenB+1) + col;
 
-				/* Set py_score_matrix[row][col] to the score. */
-				if(!(py_score = PyFloat_FromDouble(score_matrix[offset])))
-					goto _cleanup_make_score_matrix_fast;
-				PyList_SET_ITEM(py_score_row, col, py_score);
+                            /* Set py_score_matrix[row][col] to the score. */
+                            if(!(py_score = PyFloat_FromDouble(score_matrix[offset])))
+                                    goto _cleanup_make_score_matrix_fast;
+                            PyList_SET_ITEM(py_score_row, col, py_score);
 
-				/* Set py_trace_matrix[row][col] to a list of indexes.  On
-				   the edges of the matrix (row or column is 0), the
-				   matrix should be [None]. */
-				if(!row || !col) {
-					if(!(py_trace = Py_BuildValue("B", 1)))
-						goto _cleanup_make_score_matrix_fast;
-					Py_INCREF(Py_None);
-					PyList_SET_ITEM(py_trace_row, col, Py_None);
-				}
-				else {
-					if(!(py_trace = Py_BuildValue("B", trace_matrix[offset])))
-						goto _cleanup_make_score_matrix_fast;
-					PyList_SET_ITEM(py_trace_row, col, py_trace);
+                            /* Set py_trace_matrix[row][col] to a list of indexes.  On
+                               the edges of the matrix (row or column is 0), the
+                               matrix should be [None]. */
+                            if(!row || !col) {
+                                    if(!(py_trace = Py_BuildValue("B", 1)))
+                                            goto _cleanup_make_score_matrix_fast;
+                                    Py_INCREF(Py_None);
+                                    PyList_SET_ITEM(py_trace_row, col, Py_None);
+                            }
+                            else {
+                                    if(!(py_trace = Py_BuildValue("B", trace_matrix[offset])))
+                                            goto _cleanup_make_score_matrix_fast;
+                                    PyList_SET_ITEM(py_trace_row, col, py_trace);
 
-				}
-			}
-		}
-	}
-	else {
-		py_score_matrix = PyList_New(1);
-		py_trace_matrix = PyList_New(1);
-	}
+                            }
+                    }
+            }
+    }
+    else {
+            py_score_matrix = PyList_New(1);
+            py_trace_matrix = PyList_New(1);
+    }
     py_retval = Py_BuildValue("(OOd)", py_score_matrix, py_trace_matrix, best_score);
 
  _cleanup_make_score_matrix_fast:


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

When building Biopython, the GCC raises some warnings, specifically about possibly misleading indentation and possibly uninitialized variables (mostly in the new FOGSAA code but also in some older code). The "uninitialized" variables the compiler complains about are never actually accessed before they are initialized, but GCC warns regardless.

This PR fixes those warnings by removing the "misleading" indentation and zero-initializing the "potentially uninitialized" variables. This PR doesn't change any behavior, only make the compiler complain less.