### PR TITLE
Avoid loading of doctest: use Bio._utils instead

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -3277,6 +3277,7 @@ def complement_rna(sequence, inplace=False):
 
 
 if __name__ == "__main__":
+    from doctest import IGNORE_EXCEPTION_DETAIL
     from Bio._utils import run_doctest
 
-    run_doctest()
+    run_doctest(optionflags=IGNORE_EXCEPTION_DETAIL)

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -3276,14 +3276,7 @@ def complement_rna(sequence, inplace=False):
     return sequence.decode("ASCII")
 
 
-def _test():
-    """Run the Bio.Seq module's doctests (PRIVATE)."""
-    print("Running doctests...")
-    import doctest
-
-    doctest.testmod(optionflags=doctest.IGNORE_EXCEPTION_DETAIL)
-    print("Done")
-
-
 if __name__ == "__main__":
-    _test()
+    from Bio._utils import run_doctest
+
+    run_doctest()

--- a/Bio/_utils.py
+++ b/Bio/_utils.py
@@ -11,6 +11,7 @@ import os
 from typing import Any
 from typing import Callable
 from typing import cast
+from typing import Dict
 from typing import Optional
 from typing import Protocol
 from typing import TypeVar
@@ -73,15 +74,15 @@ def run_doctest(target_dir: Optional[str] = None, *args: Any, **kwargs: Any) -> 
     import doctest
 
     # default doctest options
-    default_kwargs = {"optionflags": doctest.ELLIPSIS}
-    kwargs.update(default_kwargs)
+    doctest_attributes: Dict[str, Any] = {"optionflags": doctest.ELLIPSIS}
+    doctest_attributes.update(kwargs)
 
     cur_dir = os.path.abspath(os.curdir)
 
     print("Running doctests...")
     try:
         os.chdir(find_test_dir(target_dir))
-        doctest.testmod(*args, **kwargs)
+        doctest.testmod(*args, **doctest_attributes)
     finally:
         # and revert back to initial directory
         os.chdir(cur_dir)

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -150,6 +150,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Hussein Faara <https://github.com/hfaara18>
 - Hye-Shik Chang <perky at domain fallin.lv>
 - Iddo Friedberg <https://github.com/idoerg>
+- Igor S. Gerasimov <https://github.com/foxtran>
 - Ilya Flyamer <https://github.com/Phlya>
 - Isaac Ellmen <https://github.com/Ellmen>
 - Ivan Antonov <https://github.com/vanya-antonov>


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #4890

In addition, fixes issues in Bio._utils since default_kwargs should be updated, not kwargs. 
