### PR TITLE
Do not mention BAM when encountering an invalid bgzipped file

### DIFF
--- a/Bio/bgzf.py
+++ b/Bio/bgzf.py
@@ -442,8 +442,7 @@ def _load_bgzf_block(handle, text_mode=False):
         raise StopIteration
     if magic != _bgzf_magic:
         raise ValueError(
-            r"A BGZF (e.g. a BAM file) block should start with "
-            r"%r, not %r; handle.tell() now says %r"
+            r"A BGZF block should start with %r, not %r; handle.tell() now says %r"
             % (_bgzf_magic, magic, handle.tell())
         )
     gzip_mod_time, gzip_extra_flags, gzip_os, extra_len = struct.unpack(


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

If a program reads both a BAM file and a bgzipped compressed FASTA or VCF file, the error message can confuse the user because it’s easy to overlook the "e.g.", and the user might think that the BAM file is the problematic one while it is the other.

We’ve had multiple reports of this for WhatsHap, which reads bgzipped references through pyfaidx. See these issues:

- https://github.com/whatshap/whatshap/issues/495
- https://github.com/whatshap/whatshap/issues/462
- https://github.com/whatshap/whatshap/issues/534

In WhatsHap, I will probably solve this by catching the exception and then printing an error message that also shows the name of the problematic file. However, this is a bit annoying because it’s merely a generic `ValueError` that bubbles up from pyfaidx and I will have to inspect its message in order to be able to distinguish it from other `ValueError`s. So I thought it would be nice to perhaps change this upstream as well.