### PR TITLE
Use .. code-block:: python in this docstring

### DIFF
--- a/Bio/Restriction/__init__.py
+++ b/Bio/Restriction/__init__.py
@@ -16,11 +16,11 @@ Examples
 
     >>> from Bio.Seq import Seq
     >>> from Bio.Restriction import *
-    >>> pBs_mcs = 'GGTACCGGGCCCCCCCTCGAGGTCGACGGTATCGATAAGCTTGATATCGAATTCCTG'
-    >>> pBs_mcs += 'CAGCCCGGGGGATCCACTAGTTCTAGAGCGGCCGCCACCGCGGTGGAGCTC'
+    >>> pBs_mcs = "GGTACCGGGCCCCCCCTCGAGGTCGACGGTATCGATAAGCTTGATATCGAATTCCTG"
+    >>> pBs_mcs += "CAGCCCGGGGGATCCACTAGTTCTAGAGCGGCCGCCACCGCGGTGGAGCTC"
     >>> seq = Seq(pBs_mcs)  # Multiple-cloning site of pBluescript SK(-)
     >>> a = Analysis(AllEnzymes, seq)
-    >>> a.print_that()              # no argument -> print all the results
+    >>> a.print_that()  # no argument -> print all the results
     AbaSI      :  10, 12, 13, 16, 17, 18, 19, 20, 22, 23, 24, 25, 25, 26, 27...
     BmeDI      :  7, 8, 8, 9, 9, 13, 14, 15, 16, 17, 18, 19, 19, 21, 21...
     YkrI       :  10, 12, 13, 16, 16, 17, 19, 20, 21, 22, 23, 24, 25, 25, 26...

--- a/Bio/Restriction/__init__.py
+++ b/Bio/Restriction/__init__.py
@@ -11,6 +11,9 @@
 
 Examples
 --------
+
+.. code-block:: python
+
     >>> from Bio.Seq import Seq
     >>> from Bio.Restriction import *
     >>> pBs_mcs = 'GGTACCGGGCCCCCCCTCGAGGTCGACGGTATCGATAAGCTTGATATCGAATTCCTG'

--- a/Bio/Restriction/__init__.py
+++ b/Bio/Restriction/__init__.py
@@ -12,7 +12,7 @@
 Examples
 --------
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from Bio.Seq import Seq
     >>> from Bio.Restriction import *


### PR DESCRIPTION
Extracted from #3045 by @carlosp420, this fixes the doctest output rendering (was stopping at the first blank line)

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

