### PR TITLE
Make appveyor use conda-forge while updating

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ build_script:
   - ps: start -Wait -FilePath C:\Miniconda.exe -ArgumentList "/S /D=C:\Py"
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes
-  - conda update conda
+  - conda update conda --channel conda-forge --override-channels
   - python -m pip install --upgrade coverage setuptools "numpy!=2.1.0"
   - python -m pip install .
 


### PR DESCRIPTION
- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This should fix the issue that was causing us to use conda's `defaults` channels again. They seem to have changed the `channels` list to include all of the URLs in the defaults channels instead of having just `defaults` which is what broke the previous code. It appears that the only place that we are actually using conda's defaults channels is in `conda update conda`. The package installations should be using pip and pypi.  Therefore the easiest fix seems to be to add arguments to force `update` to use conda-forge instead of the paid `defaults` channels. 

Note: Adding `defaults` to `denylist_channels` as shown in anaconda's docs actually seems to just break conda.

Context commit:
https://github.com/biopython/biopython/commit/cf7844c6e81b8d64b0e093b9cccdd2dbc42e04e0#diff-e1ab4c3cec24f841948eb867754d4ad0b9b6d11eaa6b5bfbe0357aceb0a49effR36
