### PR TITLE
bugfix in alignment counts

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3580,7 +3580,9 @@ class Alignment:
                     # Don't count seq1 vs seq2 and seq2 vs seq1
                     break
                 for a, b in zip(seq1, seq2):
-                    if a == "-" or b == "-":
+                    if a == "-" and b == "-":
+                        pass
+                    elif a == "-" or b == "-":
                         gaps += 1
                     elif a == b:
                         identities += 1

--- a/Doc/Tutorial/chapter_align.rst
+++ b/Doc/Tutorial/chapter_align.rst
@@ -606,7 +606,7 @@ customized.
                      0 AGGTTT-- 6
    <BLANKLINE>
    >>> alignment.counts()
-   AlignmentCounts(gaps=8, identities=14, mismatches=2)
+   AlignmentCounts(gaps=6, identities=14, mismatches=2)
 
 Letter frequencies
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
A gap aligned to a gap is not really a gap. See #4221 .

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
