### PR TITLE
Allow NA as a valid molecule type in GenBank files

### DIFF
--- a/Bio/GenBank/Scanner.py
+++ b/Bio/GenBank/Scanner.py
@@ -1413,6 +1413,7 @@ class GenBankScanner(InsdcScanner):
                 line[47:54].strip() == ""
                 or "DNA" in line[47:54].strip().upper()
                 or "RNA" in line[47:54].strip().upper()
+                or line[47:54].strip().upper() == "NA"
             ):
                 raise ValueError(
                     "LOCUS line does not contain valid "


### PR DESCRIPTION
I updated the code to not raise an exception if the molecule is listed as `NA`. It's not identical to the other checks because if I had opted to use

```python
or "NA" in line[47:54].strip().upper()
```

That would cover any string in those positions that have the letters "N" and "A" in them, including RNA, DNA, VNA 99NA, etc.

This issue has been open for a couple of months now so I thought it was ok to take it. @veghp can you confirm that this works? @peterjc, can you review this?

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4879 
