### PR TITLE
SeqIO don't do at runtime what can be done at compile time

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -654,11 +654,39 @@ class FastaTwoLineWriter(FastaWriter):
 
 def as_fasta(record):
     """Turn a SeqRecord into a FASTA formatted string."""
+    warnings.warn(
+        """\
+FastaIO.as_fasta is deprecated.
+
+Instead of
+
+FastaIO.as_fasta(record)
+
+please use
+
+format(record, "fasta")
+""",
+        DeprecationWarning,
+    )
     return FastaWriter.to_string(record)
 
 
 def as_fasta_2line(record):
     """Turn a SeqRecord into a two-line FASTA formatted string."""
+    warnings.warn(
+        """\
+FastaIO.as_fasta_2line is deprecated.
+
+Instead of
+
+FastaIO.as_fasta_2line(record)
+
+please use
+
+format(record, "fasta-2line")
+""",
+        DeprecationWarning,
+    )
     return FastaTwoLineWriter.to_string(record)
 
 

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -592,18 +592,15 @@ class FastaWriter(SequenceWriter):
 
 
 class FastaTwoLineWriter(FastaWriter):
-    """Class to write 2-line per record Fasta format files (OBSOLETE).
+    """Class to write 2-line per record Fasta format files.
 
     This means we write the sequence information  without line
     wrapping, and will always write a blank line for an empty
     sequence.
-
-    Please use the ``as_fasta_2line`` function instead, or the top level
-    ``Bio.SeqIO.write()`` function instead using ``format="fasta"``.
     """
 
     def __init__(self, handle, record2title=None):
-        """Create a 2-line per record Fasta writer (OBSOLETE).
+        """Create a 2-line per record Fasta writer.
 
         Arguments:
          - handle - Handle to an output file, e.g. as returned
@@ -633,6 +630,27 @@ class FastaTwoLineWriter(FastaWriter):
         """
         super().__init__(handle, wrap=None, record2title=record2title)
 
+    @classmethod
+    def to_string(record):
+        """Return a string in FASTA format with the sequence as one line."""
+        id = _clean(record.id)
+        description = _clean(record.description)
+        if description and description.split(None, 1)[0] == id:
+            # The description includes the id at the start
+            title = description
+        elif description:
+            title = f"{id} {description}"
+        else:
+            title = id
+        assert "\n" not in title
+        assert "\r" not in title
+
+        data = _get_seq_string(record)  # Catches sequence being None
+        assert "\n" not in data
+        assert "\r" not in data
+
+        return f">{title}\n{data}\n"
+
 
 def as_fasta(record):
     """Turn a SeqRecord into a FASTA formatted string."""
@@ -640,28 +658,8 @@ def as_fasta(record):
 
 
 def as_fasta_2line(record):
-    """Turn a SeqRecord into a two-line FASTA formatted string.
-
-    This is used internally by the SeqRecord's .format("fasta-2line")
-    method and by the SeqIO.write(..., ..., "fasta-2line") function.
-    """
-    id = _clean(record.id)
-    description = _clean(record.description)
-    if description and description.split(None, 1)[0] == id:
-        # The description includes the id at the start
-        title = description
-    elif description:
-        title = f"{id} {description}"
-    else:
-        title = id
-    assert "\n" not in title
-    assert "\r" not in title
-
-    data = _get_seq_string(record)  # Catches sequence being None
-    assert "\n" not in data
-    assert "\r" not in data
-
-    return f">{title}\n{data}\n"
+    """Turn a SeqRecord into a two-line FASTA formatted string."""
+    return FastaTwoLineWriter.to_string(record)
 
 
 if __name__ == "__main__":

--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -631,7 +631,7 @@ class FastaTwoLineWriter(FastaWriter):
         super().__init__(handle, wrap=None, record2title=record2title)
 
     @classmethod
-    def to_string(record):
+    def to_string(cls, record):
         """Return a string in FASTA format with the sequence as one line."""
         id = _clean(record.id)
         description = _clean(record.description)

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -12,6 +12,7 @@ use this module.  It provides base classes to try and simplify things.
 
 from abc import ABC
 from abc import abstractmethod
+from io import StringIO
 from os import PathLike
 from typing import AnyStr
 from typing import Generic
@@ -206,6 +207,15 @@ class SequenceWriter(ABC, Generic[AnyStr]):
     def clean(self, text: str) -> str:
         """Use this to avoid getting newlines in the output."""
         return text.replace("\n", " ").replace("\r", " ")
+
+    @classmethod
+    def to_string(cls, record):
+        """Format the record and return the string."""
+        handle = StringIO()
+        writer = cls(handle)
+        records = [record]
+        writer.write_file(records)
+        return handle.getvalue()
 
     def write_record(self, record):
         """Write a single record to the output file.

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -1814,7 +1814,7 @@ def as_qual(record: SeqRecord) -> str:
 
 
 class FastqSolexaWriter(SequenceWriter):
-    r"""Write old style Solexa/Illumina FASTQ format files (with Solexa qualities) (OBSOLETE).
+    r"""Write old style Solexa/Illumina FASTQ format files (with Solexa qualities).
 
     This outputs FASTQ files like those from the early Solexa/Illumina
     pipeline, using Solexa scores and an ASCII offset of 64. These are
@@ -1865,6 +1865,31 @@ class FastqSolexaWriter(SequenceWriter):
 
     modes = "t"
 
+    @classmethod
+    def to_string(cls, record: SeqRecord) -> str:
+        """Turn a SeqRecord into a Solexa FASTQ formatted string.
+
+        This is used internally by the SeqRecord's .format("fastq-solexa")
+        method and by the SeqIO.write(..., ..., "fastq-solexa") function.
+        """
+        seq_str = _get_seq_string(record)
+        qualities_str = _get_solexa_quality_str(record)
+        if len(qualities_str) != len(seq_str):
+            raise ValueError(
+                "Record %s has sequence length %i but %i quality scores"
+                % (record.id, len(seq_str), len(qualities_str))
+            )
+        id_ = _clean(record.id) if record.id else ""
+        description = _clean(record.description)
+        if description and description.split(None, 1)[0] == id_:
+            # The description includes the id at the start
+            title = description
+        elif description:
+            title = f"{id_} {description}"
+        else:
+            title = id_
+        return f"@{title}\n{seq_str}\n+\n{qualities_str}\n"
+
     def write_record(self, record: SeqRecord) -> None:
         """Write a single FASTQ record to the file."""
         # TODO - Is an empty sequence allowed in FASTQ format?
@@ -1894,28 +1919,8 @@ class FastqSolexaWriter(SequenceWriter):
 
 
 def as_fastq_solexa(record: SeqRecord) -> str:
-    """Turn a SeqRecord into a Solexa FASTQ formatted string.
-
-    This is used internally by the SeqRecord's .format("fastq-solexa")
-    method and by the SeqIO.write(..., ..., "fastq-solexa") function.
-    """
-    seq_str = _get_seq_string(record)
-    qualities_str = _get_solexa_quality_str(record)
-    if len(qualities_str) != len(seq_str):
-        raise ValueError(
-            "Record %s has sequence length %i but %i quality scores"
-            % (record.id, len(seq_str), len(qualities_str))
-        )
-    id_ = _clean(record.id) if record.id else ""
-    description = _clean(record.description)
-    if description and description.split(None, 1)[0] == id_:
-        # The description includes the id at the start
-        title = description
-    elif description:
-        title = f"{id_} {description}"
-    else:
-        title = id_
-    return f"@{title}\n{seq_str}\n+\n{qualities_str}\n"
+    """Turn a SeqRecord into a Solexa FASTQ formatted string."""
+    return FastqSolexaWriter.to_string(record)
 
 
 class FastqIlluminaWriter(SequenceWriter):

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -1933,6 +1933,7 @@ class FastqIlluminaWriter(SequenceWriter):
         This is used internally by the SeqRecord's .format("fastq-illumina")
         method and by the SeqIO.write(..., ..., "fastq-illumina") function.
         """
+        # TODO - Is an empty sequence allowed in FASTQ format?
         seq_str = _get_seq_string(record)
         qualities_str = _get_illumina_quality_str(record)
         if len(qualities_str) != len(seq_str):
@@ -1952,30 +1953,7 @@ class FastqIlluminaWriter(SequenceWriter):
 
     def write_record(self, record: SeqRecord) -> None:
         """Write a single FASTQ record to the file."""
-        # TODO - Is an empty sequence allowed in FASTQ format?
-        seq = record.seq
-        if seq is None:
-            raise ValueError(f"No sequence for record {record.id}")
-        qualities_str = _get_illumina_quality_str(record)
-        if len(qualities_str) != len(seq):
-            raise ValueError(
-                "Record %s has sequence length %i but %i quality scores"
-                % (record.id, len(seq), len(qualities_str))
-            )
-
-        # FASTQ files can include a description, just like FASTA files
-        # (at least, this is what the NCBI Short Read Archive does)
-        id_ = self.clean(record.id) if record.id else ""
-        description = self.clean(record.description)
-        if description and description.split(None, 1)[0] == id_:
-            # The description includes the id at the start
-            title = description
-        elif description:
-            title = f"{id_} {description}"
-        else:
-            title = id_
-
-        self.handle.write(f"@{title}\n{seq}\n+\n{qualities_str}\n")
+        self.handle.write(self.to_string(record))
 
 
 def as_fastq_illumina(record: SeqRecord) -> str:

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -1805,11 +1805,7 @@ class QualPhredWriter(SequenceWriter):
 
 
 def as_qual(record: SeqRecord) -> str:
-    """Turn a SeqRecord into a QUAL formatted string.
-
-    This is used internally by the SeqRecord's .format("qual")
-    method and by the SeqIO.write(..., ..., "qual") function.
-    """
+    """Turn a SeqRecord into a QUAL formatted string."""
     return QualPhredWriter.to_string(record)
 
 
@@ -1872,6 +1868,7 @@ class FastqSolexaWriter(SequenceWriter):
         This is used internally by the SeqRecord's .format("fastq-solexa")
         method and by the SeqIO.write(..., ..., "fastq-solexa") function.
         """
+        # TODO - Is an empty sequence allowed in FASTQ format?
         seq_str = _get_seq_string(record)
         qualities_str = _get_solexa_quality_str(record)
         if len(qualities_str) != len(seq_str):
@@ -1892,30 +1889,7 @@ class FastqSolexaWriter(SequenceWriter):
 
     def write_record(self, record: SeqRecord) -> None:
         """Write a single FASTQ record to the file."""
-        # TODO - Is an empty sequence allowed in FASTQ format?
-        seq = record.seq
-        if seq is None:
-            raise ValueError(f"No sequence for record {record.id}")
-        qualities_str = _get_solexa_quality_str(record)
-        if len(qualities_str) != len(seq):
-            raise ValueError(
-                "Record %s has sequence length %i but %i quality scores"
-                % (record.id, len(seq), len(qualities_str))
-            )
-
-        # FASTQ files can include a description, just like FASTA files
-        # (at least, this is what the NCBI Short Read Archive does)
-        id_ = self.clean(record.id) if record.id else ""
-        description = self.clean(record.description)
-        if description and description.split(None, 1)[0] == id_:
-            # The description includes the id at the start
-            title = description
-        elif description:
-            title = f"{id_} {description}"
-        else:
-            title = id_
-
-        self.handle.write(f"@{title}\n{seq}\n+\n{qualities_str}\n")
+        self.handle.write(self.to_string(record))
 
 
 def as_fastq_solexa(record: SeqRecord) -> str:

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -376,6 +376,7 @@ from dataclasses import dataclass
 
 from Bio import BiopythonParserWarning
 from Bio import BiopythonWarning
+from Bio import BiopythonDeprecationWarning
 from Bio import StreamModeError
 from Bio.File import as_handle
 from Bio.Seq import Seq
@@ -1579,7 +1580,7 @@ assert SANGER_SCORE_OFFSET == ord("!")
 
 
 class FastqPhredWriter(SequenceWriter):
-    """Class to write standard FASTQ format files (using PHRED quality scores) (OBSOLETE).
+    """Class to write standard FASTQ format files (using PHRED quality scores).
 
     Although you can use this class directly, you are strongly encouraged
     to use the top level ``Bio.SeqIO.write()`` function instead via the format
@@ -1654,11 +1655,25 @@ class FastqPhredWriter(SequenceWriter):
 
 def as_fastq(record: SeqRecord) -> str:
     """Turn a SeqRecord into a Sanger FASTQ formatted string, and return it."""
+    warnings.warn(
+        """\
+QualityIO.as_fastq is deprecated.
+
+Instead of
+
+QualityIO.as_fastq(record)
+
+please use
+
+format(record, "fastq")
+""",
+        DeprecationWarning,
+    )
     return FastqPhredWriter.to_string(record)
 
 
 class QualPhredWriter(SequenceWriter):
-    """Class to write QUAL format files (using PHRED quality scores) (OBSOLETE).
+    """Class to write QUAL format files (using PHRED quality scores).
 
     Although you can use this class directly, you are strongly encouraged
     to use the top level ``Bio.SeqIO.write()`` function instead.
@@ -1806,6 +1821,20 @@ class QualPhredWriter(SequenceWriter):
 
 def as_qual(record: SeqRecord) -> str:
     """Turn a SeqRecord into a QUAL formatted string."""
+    warnings.warn(
+        """\
+QualityIO.as_qual is deprecated.
+
+Instead of
+
+QualityIO.as_qual(record)
+
+please use
+
+format(record, "qual")
+""",
+        DeprecationWarning,
+    )
     return QualPhredWriter.to_string(record)
 
 
@@ -1894,11 +1923,25 @@ class FastqSolexaWriter(SequenceWriter):
 
 def as_fastq_solexa(record: SeqRecord) -> str:
     """Turn a SeqRecord into a Solexa FASTQ formatted string."""
+    warnings.warn(
+        """\
+QualityIO.as_fastq_solexa is deprecated.
+
+Instead of
+
+QualityIO.as_fastq_solexa(record)
+
+please use
+
+format(record, "fastq-solexa")
+""",
+        DeprecationWarning,
+    )
     return FastqSolexaWriter.to_string(record)
 
 
 class FastqIlluminaWriter(SequenceWriter):
-    r"""Write Illumina 1.3+ FASTQ format files (with PHRED quality scores) (OBSOLETE).
+    r"""Write Illumina 1.3+ FASTQ format files (with PHRED quality scores).
 
     This outputs FASTQ files like those from the Solexa/Illumina 1.3+ pipeline,
     using PHRED scores and an ASCII offset of 64. Note these files are NOT
@@ -1958,6 +2001,20 @@ class FastqIlluminaWriter(SequenceWriter):
 
 def as_fastq_illumina(record: SeqRecord) -> str:
     """Turn a SeqRecord into an Illumina FASTQ formatted string."""
+    warnings.warn(
+        """\
+QualityIO.as_fastq_illumina is deprecated.
+
+Instead of
+
+QualityIO.as_fastq_illumina(record)
+
+please use
+
+format(record, "fastq-illumina")
+""",
+        DeprecationWarning,
+    )
     return FastqIlluminaWriter.to_string(record)
 
 

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -34,11 +34,14 @@ example above.
 
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
+from Bio import BiopythonDeprecationWarning
 
 from .Interfaces import _clean
 from .Interfaces import _get_seq_string
 from .Interfaces import SequenceIterator
 from .Interfaces import SequenceWriter
+
+import warnings
 
 
 class TabIterator(SequenceIterator):
@@ -106,8 +109,7 @@ class TabWriter(SequenceWriter):
     Any description, name or other annotation is not recorded.
 
     This class is not intended to be used directly. Instead, please use
-    the function ``as_tab``, or the top level ``Bio.SeqIO.write()`` function
-    with ``format="tab"``.
+    the top level ``Bio.SeqIO.write()`` function with ``format="tab"``.
     """
 
     modes = "t"
@@ -132,6 +134,20 @@ class TabWriter(SequenceWriter):
 
 def as_tab(record):
     """Return record as tab separated (id(tab)seq) string."""
+    warnings.warn(
+        """\
+TabIO.as_tab is deprecated.
+
+Instead of
+
+TabIO.as_tab(record)
+
+please use
+
+format(record, "tab")
+""",
+        DeprecationWarning,
+    )
     return TabWriter.to_string(record)
 
 

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -112,24 +112,27 @@ class TabWriter(SequenceWriter):
 
     modes = "t"
 
+    @classmethod
+    def to_string(cls, record):
+        """Return record as tab separated (id(tab)seq) string."""
+        title = _clean(record.id)
+        seq = _get_seq_string(record)  # Catches sequence being None
+        assert "\t" not in title
+        assert "\n" not in title
+        assert "\r" not in title
+        assert "\t" not in seq
+        assert "\n" not in seq
+        assert "\r" not in seq
+        return f"{title}\t{seq}\n"
+
     def write_record(self, record):
         """Write a single tab line to the file."""
-        assert self._header_written
-        assert not self._footer_written
-        self.handle.write(as_tab(record))
+        self.handle.write(self.to_string(record))
 
 
 def as_tab(record):
     """Return record as tab separated (id(tab)seq) string."""
-    title = _clean(record.id)
-    seq = _get_seq_string(record)  # Catches sequence being None
-    assert "\t" not in title
-    assert "\n" not in title
-    assert "\r" not in title
-    assert "\t" not in seq
-    assert "\n" not in seq
-    assert "\r" not in seq
-    return f"{title}\t{seq}\n"
+    return TabWriter.to_string(record)
 
 
 if __name__ == "__main__":

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -376,6 +376,7 @@ making up each alignment as SeqRecords.
 #
 # --Peter
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from collections.abc import Iterable
 from typing import Union
@@ -496,10 +497,15 @@ class AlignmentSequenceIterator(SequenceIterator):
 
     modes = "t"
 
+    @property
+    @abstractmethod
+    def fmt(self):
+        """Alignment file format name."""
+
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
-        super().__init__(source, fmt=self.fmt)  # type: ignore
-        alignment_iterator = AlignIO._FormatToIterator[self.fmt]  # type: ignore
+        super().__init__(source, fmt=self.fmt)
+        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
         alignments = alignment_iterator(self.stream, None)
         self.iterator = (record for alignment in alignments for record in alignment)
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -380,6 +380,7 @@ from collections.abc import Callable
 from collections.abc import Iterable
 from typing import Union
 
+from Bio import AlignIO
 from Bio.File import as_handle
 from Bio.SeqIO import AbiIO
 from Bio.SeqIO import AceIO
@@ -490,8 +491,8 @@ _FormatToWriter = {
 }
 
 
-class ClustalWriter(SequenceWriter):
-    """Clustal file writer."""
+class AlignmentSequenceWriter(SequenceWriter):
+    """Writes sequences as an alignment."""
 
     modes = "t"
 
@@ -501,10 +502,9 @@ class ClustalWriter(SequenceWriter):
         records - A list or iterator returning SeqRecord objects
         """
         from Bio.Align import MultipleSeqAlignment
-        from Bio import AlignIO
 
         alignment = MultipleSeqAlignment(records)
-        alignment_count = AlignIO.write([alignment], self.handle, "clustal")
+        alignment_count = self.writer_class(self.handle).write_file([alignment])
         if alignment_count != 1:
             raise RuntimeError(
                 "Internal error - the underlying writer "
@@ -514,182 +514,10 @@ class ClustalWriter(SequenceWriter):
         return count
 
 
-class MafWriter(SequenceWriter):
-    """Multiple Alignment Format file writer."""
-
-    modes = "t"
-
-    def write_records(self, records):
-        """Write records to the output file, and return the number of records.
-
-        records - A list or iterator returning SeqRecord objects
-        """
-        from Bio.Align import MultipleSeqAlignment
-        from Bio import AlignIO
-
-        alignment = MultipleSeqAlignment(records)
-        alignment_count = AlignIO.write([alignment], self.handle, "maf")
-        if alignment_count != 1:
-            raise RuntimeError(
-                "Internal error - the underlying writer "
-                "should have returned 1, not %r" % alignment_count
-            )
-        count = len(alignment)
-        return count
-
-
-class MauveWriter(SequenceWriter):
-    """Mauve file writer."""
-
-    modes = "t"
-
-    def write_records(self, records):
-        """Write records to the output file, and return the number of records.
-
-        records - A list or iterator returning SeqRecord objects
-        """
-        from Bio.Align import MultipleSeqAlignment
-        from Bio import AlignIO
-
-        alignment = MultipleSeqAlignment(records)
-        alignment_count = AlignIO.write([alignment], self.handle, "mauve")
-        if alignment_count != 1:
-            raise RuntimeError(
-                "Internal error - the underlying writer "
-                "should have returned 1, not %r" % alignment_count
-            )
-        count = len(alignment)
-        return count
-
-
-class NexusWriter(SequenceWriter):
-    """Nexus file writer."""
-
-    modes = "t"
-
-    def write_records(self, records):
-        """Write records to the output file, and return the number of records.
-
-        records - A list or iterator returning SeqRecord objects
-        """
-        from Bio.Align import MultipleSeqAlignment
-        from Bio import AlignIO
-
-        alignment = MultipleSeqAlignment(records)
-        alignment_count = AlignIO.write([alignment], self.handle, "nexus")
-        if alignment_count != 1:
-            raise RuntimeError(
-                "Internal error - the underlying writer "
-                "should have returned 1, not %r" % alignment_count
-            )
-        count = len(alignment)
-        return count
-
-
-class PhylipWriter(SequenceWriter):
-    """Phylip file writer."""
-
-    modes = "t"
-
-    def write_records(self, records):
-        """Write records to the output file, and return the number of records.
-
-        records - A list or iterator returning SeqRecord objects
-        """
-        from Bio.Align import MultipleSeqAlignment
-        from Bio import AlignIO
-
-        alignment = MultipleSeqAlignment(records)
-        alignment_count = AlignIO.write([alignment], self.handle, "phylip")
-        if alignment_count != 1:
-            raise RuntimeError(
-                "Internal error - the underlying writer "
-                "should have returned 1, not %r" % alignment_count
-            )
-        count = len(alignment)
-        return count
-
-
-class SequentialPhylipWriter(SequenceWriter):
-    """Sequential phylip file writer."""
-
-    modes = "t"
-
-    def write_records(self, records):
-        """Write records to the output file, and return the number of records.
-
-        records - A list or iterator returning SeqRecord objects
-        """
-        from Bio.Align import MultipleSeqAlignment
-        from Bio import AlignIO
-
-        alignment = MultipleSeqAlignment(records)
-        alignment_count = AlignIO.write([alignment], self.handle, "phylip-sequential")
-        if alignment_count != 1:
-            raise RuntimeError(
-                "Internal error - the underlying writer "
-                "should have returned 1, not %r" % alignment_count
-            )
-        count = len(alignment)
-        return count
-
-
-class RelaxedPhylipWriter(SequenceWriter):
-    """Relaxes Phylip file writer."""
-
-    modes = "t"
-
-    def write_records(self, records):
-        """Write records to the output file, and return the number of records.
-
-        records - A list or iterator returning SeqRecord objects
-        """
-        from Bio.Align import MultipleSeqAlignment
-        from Bio import AlignIO
-
-        alignment = MultipleSeqAlignment(records)
-        alignment_count = AlignIO.write([alignment], self.handle, "phylip-relaxed")
-        if alignment_count != 1:
-            raise RuntimeError(
-                "Internal error - the underlying writer "
-                "should have returned 1, not %r" % alignment_count
-            )
-        count = len(alignment)
-        return count
-
-
-class StockholmWriter(SequenceWriter):
-    """Stockholm file writer."""
-
-    modes = "t"
-
-    def write_records(self, records):
-        """Write records to the output file, and return the number of records.
-
-        records - A list or iterator returning SeqRecord objects
-        """
-        from Bio.Align import MultipleSeqAlignment
-        from Bio import AlignIO
-
-        alignment = MultipleSeqAlignment(records)
-        alignment_count = AlignIO.write([alignment], self.handle, "stockholm")
-        if alignment_count != 1:
-            raise RuntimeError(
-                "Internal error - the underlying writer "
-                "should have returned 1, not %r" % alignment_count
-            )
-        count = len(alignment)
-        return count
-
-
-_FormatToWriter["clustal"] = ClustalWriter
-_FormatToWriter["maf"] = MafWriter
-_FormatToWriter["mauve"] = MauveWriter
-_FormatToWriter["nexus"] = NexusWriter
-_FormatToWriter["phylip"] = PhylipWriter
-_FormatToWriter["phylip-sequential"] = SequentialPhylipWriter
-_FormatToWriter["phylip-relaxed"] = RelaxedPhylipWriter
-_FormatToWriter["stockholm"] = StockholmWriter
+for fmt, writer_class in AlignIO._FormatToWriter.items():
+    name = fmt.replace("-", " ").title().replace(" ", "") + "Writer"
+    cls = type(name, (AlignmentSequenceWriter,), {"writer_class": writer_class})
+    _FormatToWriter[fmt] = cls  # type: ignore
 
 
 def write(

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -539,16 +539,10 @@ class AlignmentSequenceIterator(SequenceIterator):
         return next(self.iterator)
 
 
-class ClustalAlignmentSequenceIterator(AlignmentSequenceIterator):
-    """Hello."""
-
-    fmt = "clustal"
-
-    _alignment_iterator_class = AlignIO._FormatToIterator[fmt]
-
-
-cls = ClustalAlignmentSequenceIterator  # type: ignore
-_FormatToIterator["clustal"] = cls  # type: ignore
+fmt = "clustal"
+name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
+cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
+_FormatToIterator[fmt] = cls  # type: ignore
 
 
 class EmbossAlignmentSequenceIterator(OldAlignmentSequenceIterator):

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -667,7 +667,6 @@ def parse(handle, format, alphabet=None):
     # NOTE - The above docstring has some raw \n characters needed
     # for the StringIO example, hence the whole docstring is in raw
     # string mode (see the leading r before the opening quote).
-    from Bio import AlignIO
 
     # Try and give helpful error messages:
     if not isinstance(format, str):
@@ -682,9 +681,7 @@ def parse(handle, format, alphabet=None):
     iterator_generator = _FormatToIterator.get(format)
     if iterator_generator:
         return iterator_generator(handle)
-    if format in AlignIO._FormatToIterator:
-        # Use Bio.AlignIO to read in the alignments
-        return (r for alignment in AlignIO.parse(handle, format) for r in alignment)
+
     raise ValueError(f"Unknown format '{format}'")
 
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -458,8 +458,6 @@ _FormatToIterator = {
 }
 
 _FormatToString: dict[str, Callable[[SeqRecord], str]] = {
-    "fastq": QualityIO.as_fastq,
-    "fastq-sanger": QualityIO.as_fastq,
     "fastq-solexa": QualityIO.as_fastq_solexa,
     "fastq-illumina": QualityIO.as_fastq_illumina,
     "qual": QualityIO.as_qual,

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -496,18 +496,18 @@ class AlignmentSequenceIterator(SequenceIterator):
 
     modes = "t"
 
+    def __init__(self, source: _IOSource, fmt=None) -> None:  # type: ignore
+        """Hello."""
+        super().__init__(source, fmt=self.fmt)  # type: ignore
+        alignment_iterator = AlignIO._FormatToIterator[self.fmt]  # type: ignore
+        alignments = alignment_iterator(self.stream, None)
+        self.iterator = (record for alignment in alignments for record in alignment)
+
 
 class ClustalAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
     fmt = "clustal"
-
-    def __init__(self, source: _IOSource) -> None:
-        """Hello."""
-        super().__init__(source, fmt=self.fmt)
-        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
-        alignments = alignment_iterator(self.stream, None)
-        self.iterator = (record for alignment in alignments for record in alignment)
 
     def __next__(self):
         return next(self.iterator)

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -382,7 +382,6 @@ from collections.abc import Iterable
 from typing import Union
 
 from Bio import AlignIO
-from Bio.File import as_handle
 from Bio.SeqIO import AbiIO
 from Bio.SeqIO import AceIO
 from Bio.SeqIO import FastaIO
@@ -457,12 +456,6 @@ _FormatToIterator = {
     "xdna": XdnaIO.XdnaIterator,
 }
 
-_FormatToString: dict[str, Callable[[SeqRecord], str]] = {
-    "fastq-solexa": QualityIO.as_fastq_solexa,
-    "fastq-illumina": QualityIO.as_fastq_illumina,
-}
-
-# This could exclude file formats covered by _FormatToString?
 # Right now used in the unit tests as proxy for all supported outputs...
 _FormatToWriter = {
     "fasta": FastaIO.FastaWriter,
@@ -609,16 +602,6 @@ def write(
     if isinstance(sequences, SeqRecord):
         # This raised an exception in older versions of Biopython
         sequences = [sequences]
-
-    # Map the file format to a writer function/class
-    format_function = _FormatToString.get(format)
-    if format_function is not None:
-        count = 0
-        with as_handle(handle, "w") as fp:
-            for record in sequences:
-                fp.write(format_function(record))
-                count += 1
-        return count
 
     writer_class = _FormatToWriter.get(format)
     if writer_class is not None:

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -532,7 +532,7 @@ for fmt, alignment_iterator_class in AlignIO._FormatToIterator.items():
             "_alignment_iterator_class": alignment_iterator_class,
         },
     )
-    _FormatToIterator[fmt] = cls  # type: ignore
+    _FormatToIterator[fmt] = cls
 
 
 class AlignmentSequenceWriter(SequenceWriter):

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -560,7 +560,7 @@ class AlignmentSequenceWriter(SequenceWriter):
 
 for fmt, writer_class in AlignIO._FormatToWriter.items():
     name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceWriter"
-    cls = type(name, (AlignmentSequenceWriter,), {"writer_class": writer_class})  # type: ignore
+    cls = type(name, (AlignmentSequenceWriter,), {"writer_class": writer_class})
     _FormatToWriter[fmt] = cls  # type: ignore
 
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -491,10 +491,16 @@ _FormatToWriter = {
 }
 
 
-class ClustalAlignmentSequenceIterator(SequenceIterator):
+class AlignmentSequenceIterator(SequenceIterator):
     """Hello."""
 
     modes = "t"
+
+
+class ClustalAlignmentSequenceIterator(AlignmentSequenceIterator):
+    """Hello."""
+
+    fmt = "clustal"
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
@@ -510,10 +516,10 @@ class ClustalAlignmentSequenceIterator(SequenceIterator):
 _FormatToIterator["clustal"] = ClustalAlignmentSequenceIterator
 
 
-class EmbossAlignmentSequenceIterator(SequenceIterator):
+class EmbossAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
-    modes = "t"
+    fmt = "emboss"
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
@@ -529,10 +535,10 @@ class EmbossAlignmentSequenceIterator(SequenceIterator):
 _FormatToIterator["emboss"] = EmbossAlignmentSequenceIterator
 
 
-class FastaM10AlignmentSequenceIterator(SequenceIterator):
+class FastaM10AlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
-    modes = "t"
+    fmt = "fasta-m10"
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
@@ -548,10 +554,10 @@ class FastaM10AlignmentSequenceIterator(SequenceIterator):
 _FormatToIterator["fasta-m10"] = FastaM10AlignmentSequenceIterator
 
 
-class MafAlignmentSequenceIterator(SequenceIterator):
+class MafAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
-    modes = "t"
+    fmt = "maf"
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
@@ -567,10 +573,10 @@ class MafAlignmentSequenceIterator(SequenceIterator):
 _FormatToIterator["maf"] = MafAlignmentSequenceIterator
 
 
-class MauveAlignmentSequenceIterator(SequenceIterator):
+class MauveAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
-    modes = "t"
+    fmt = "mauve"
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
@@ -586,10 +592,10 @@ class MauveAlignmentSequenceIterator(SequenceIterator):
 _FormatToIterator["mauve"] = MauveAlignmentSequenceIterator
 
 
-class MsfAlignmentSequenceIterator(SequenceIterator):
+class MsfAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
-    modes = "t"
+    fmt = "msf"
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
@@ -605,10 +611,10 @@ class MsfAlignmentSequenceIterator(SequenceIterator):
 _FormatToIterator["msf"] = MsfAlignmentSequenceIterator
 
 
-class NexusAlignmentSequenceIterator(SequenceIterator):
+class NexusAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
-    modes = "t"
+    fmt = "nexus"
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
@@ -624,10 +630,10 @@ class NexusAlignmentSequenceIterator(SequenceIterator):
 _FormatToIterator["nexus"] = NexusAlignmentSequenceIterator
 
 
-class PhylipAlignmentSequenceIterator(SequenceIterator):
+class PhylipAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
-    modes = "t"
+    fmt = "phylip"
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
@@ -643,10 +649,10 @@ class PhylipAlignmentSequenceIterator(SequenceIterator):
 _FormatToIterator["phylip"] = PhylipAlignmentSequenceIterator
 
 
-class PhylipSequentialAlignmentSequenceIterator(SequenceIterator):
+class PhylipSequentialAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
-    modes = "t"
+    fmt = "phylip-sequential"
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
@@ -662,10 +668,10 @@ class PhylipSequentialAlignmentSequenceIterator(SequenceIterator):
 _FormatToIterator["phylip-sequential"] = PhylipSequentialAlignmentSequenceIterator
 
 
-class PhylipRelaxedAlignmentSequenceIterator(SequenceIterator):
+class PhylipRelaxedAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
-    modes = "t"
+    fmt = "phylip-relaxed"
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
@@ -681,10 +687,10 @@ class PhylipRelaxedAlignmentSequenceIterator(SequenceIterator):
 _FormatToIterator["phylip-relaxed"] = PhylipRelaxedAlignmentSequenceIterator
 
 
-class StockholmAlignmentSequenceIterator(SequenceIterator):
+class StockholmAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
-    modes = "t"
+    fmt = "stockholm"
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -504,8 +504,8 @@ class ClustalAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
-        super().__init__(source, fmt="clustal")
-        alignment_iterator = AlignIO._FormatToIterator["clustal"]
+        super().__init__(source, fmt=self.fmt)
+        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
         alignments = alignment_iterator(self.stream, None)
         self.iterator = (record for alignment in alignments for record in alignment)
 
@@ -523,8 +523,8 @@ class EmbossAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
-        super().__init__(source, fmt="emboss")
-        alignment_iterator = AlignIO._FormatToIterator["emboss"]
+        super().__init__(source, fmt=self.fmt)
+        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
         alignments = alignment_iterator(self.stream, None)
         self.iterator = (record for alignment in alignments for record in alignment)
 
@@ -542,8 +542,8 @@ class FastaM10AlignmentSequenceIterator(AlignmentSequenceIterator):
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
-        super().__init__(source, fmt="fasta-m10")
-        alignment_iterator = AlignIO._FormatToIterator["fasta-m10"]
+        super().__init__(source, fmt=self.fmt)
+        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
         alignments = alignment_iterator(self.stream, None)
         self.iterator = (record for alignment in alignments for record in alignment)
 
@@ -561,8 +561,8 @@ class MafAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
-        super().__init__(source, fmt="maf")
-        alignment_iterator = AlignIO._FormatToIterator["maf"]
+        super().__init__(source, fmt=self.fmt)
+        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
         alignments = alignment_iterator(self.stream, None)
         self.iterator = (record for alignment in alignments for record in alignment)
 
@@ -580,8 +580,8 @@ class MauveAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
-        super().__init__(source, fmt="mauve")
-        alignment_iterator = AlignIO._FormatToIterator["mauve"]
+        super().__init__(source, fmt=self.fmt)
+        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
         alignments = alignment_iterator(self.stream, None)
         self.iterator = (record for alignment in alignments for record in alignment)
 
@@ -599,8 +599,8 @@ class MsfAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
-        super().__init__(source, fmt="msf")
-        alignment_iterator = AlignIO._FormatToIterator["msf"]
+        super().__init__(source, fmt=self.fmt)
+        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
         alignments = alignment_iterator(self.stream, None)
         self.iterator = (record for alignment in alignments for record in alignment)
 
@@ -618,8 +618,8 @@ class NexusAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
-        super().__init__(source, fmt="nexus")
-        alignment_iterator = AlignIO._FormatToIterator["nexus"]
+        super().__init__(source, fmt=self.fmt)
+        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
         alignments = alignment_iterator(self.stream, None)
         self.iterator = (record for alignment in alignments for record in alignment)
 
@@ -637,8 +637,8 @@ class PhylipAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
-        super().__init__(source, fmt="phylip")
-        alignment_iterator = AlignIO._FormatToIterator["phylip"]
+        super().__init__(source, fmt=self.fmt)
+        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
         alignments = alignment_iterator(self.stream, None)
         self.iterator = (record for alignment in alignments for record in alignment)
 
@@ -656,8 +656,8 @@ class PhylipSequentialAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
-        super().__init__(source, fmt="phylip-sequential")
-        alignment_iterator = AlignIO._FormatToIterator["phylip-sequential"]
+        super().__init__(source, fmt=self.fmt)
+        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
         alignments = alignment_iterator(self.stream, None)
         self.iterator = (record for alignment in alignments for record in alignment)
 
@@ -675,8 +675,8 @@ class PhylipRelaxedAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
-        super().__init__(source, fmt="phylip-relaxed")
-        alignment_iterator = AlignIO._FormatToIterator["phylip-relaxed"]
+        super().__init__(source, fmt=self.fmt)
+        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
         alignments = alignment_iterator(self.stream, None)
         self.iterator = (record for alignment in alignments for record in alignment)
 
@@ -694,8 +694,8 @@ class StockholmAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
-        super().__init__(source, fmt="stockholm")
-        alignment_iterator = AlignIO._FormatToIterator["stockholm"]
+        super().__init__(source, fmt=self.fmt)
+        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
         alignments = alignment_iterator(self.stream, None)
         self.iterator = (record for alignment in alignments for record in alignment)
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -496,7 +496,7 @@ class AlignmentSequenceIterator(SequenceIterator):
 
     modes = "t"
 
-    def __init__(self, source: _IOSource, fmt=None) -> None:  # type: ignore
+    def __init__(self, source: _IOSource) -> None:
         """Hello."""
         super().__init__(source, fmt=self.fmt)  # type: ignore
         alignment_iterator = AlignIO._FormatToIterator[self.fmt]  # type: ignore
@@ -521,13 +521,6 @@ class EmbossAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     fmt = "emboss"
 
-    def __init__(self, source: _IOSource) -> None:
-        """Hello."""
-        super().__init__(source, fmt=self.fmt)
-        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
-        alignments = alignment_iterator(self.stream, None)
-        self.iterator = (record for alignment in alignments for record in alignment)
-
     def __next__(self):
         return next(self.iterator)
 
@@ -539,13 +532,6 @@ class FastaM10AlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
     fmt = "fasta-m10"
-
-    def __init__(self, source: _IOSource) -> None:
-        """Hello."""
-        super().__init__(source, fmt=self.fmt)
-        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
-        alignments = alignment_iterator(self.stream, None)
-        self.iterator = (record for alignment in alignments for record in alignment)
 
     def __next__(self):
         return next(self.iterator)
@@ -559,13 +545,6 @@ class MafAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     fmt = "maf"
 
-    def __init__(self, source: _IOSource) -> None:
-        """Hello."""
-        super().__init__(source, fmt=self.fmt)
-        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
-        alignments = alignment_iterator(self.stream, None)
-        self.iterator = (record for alignment in alignments for record in alignment)
-
     def __next__(self):
         return next(self.iterator)
 
@@ -577,13 +556,6 @@ class MauveAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
     fmt = "mauve"
-
-    def __init__(self, source: _IOSource) -> None:
-        """Hello."""
-        super().__init__(source, fmt=self.fmt)
-        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
-        alignments = alignment_iterator(self.stream, None)
-        self.iterator = (record for alignment in alignments for record in alignment)
 
     def __next__(self):
         return next(self.iterator)
@@ -597,13 +569,6 @@ class MsfAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     fmt = "msf"
 
-    def __init__(self, source: _IOSource) -> None:
-        """Hello."""
-        super().__init__(source, fmt=self.fmt)
-        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
-        alignments = alignment_iterator(self.stream, None)
-        self.iterator = (record for alignment in alignments for record in alignment)
-
     def __next__(self):
         return next(self.iterator)
 
@@ -615,13 +580,6 @@ class NexusAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
     fmt = "nexus"
-
-    def __init__(self, source: _IOSource) -> None:
-        """Hello."""
-        super().__init__(source, fmt=self.fmt)
-        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
-        alignments = alignment_iterator(self.stream, None)
-        self.iterator = (record for alignment in alignments for record in alignment)
 
     def __next__(self):
         return next(self.iterator)
@@ -635,13 +593,6 @@ class PhylipAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     fmt = "phylip"
 
-    def __init__(self, source: _IOSource) -> None:
-        """Hello."""
-        super().__init__(source, fmt=self.fmt)
-        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
-        alignments = alignment_iterator(self.stream, None)
-        self.iterator = (record for alignment in alignments for record in alignment)
-
     def __next__(self):
         return next(self.iterator)
 
@@ -653,13 +604,6 @@ class PhylipSequentialAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
     fmt = "phylip-sequential"
-
-    def __init__(self, source: _IOSource) -> None:
-        """Hello."""
-        super().__init__(source, fmt=self.fmt)
-        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
-        alignments = alignment_iterator(self.stream, None)
-        self.iterator = (record for alignment in alignments for record in alignment)
 
     def __next__(self):
         return next(self.iterator)
@@ -673,13 +617,6 @@ class PhylipRelaxedAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     fmt = "phylip-relaxed"
 
-    def __init__(self, source: _IOSource) -> None:
-        """Hello."""
-        super().__init__(source, fmt=self.fmt)
-        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
-        alignments = alignment_iterator(self.stream, None)
-        self.iterator = (record for alignment in alignments for record in alignment)
-
     def __next__(self):
         return next(self.iterator)
 
@@ -691,13 +628,6 @@ class StockholmAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
     fmt = "stockholm"
-
-    def __init__(self, source: _IOSource) -> None:
-        """Hello."""
-        super().__init__(source, fmt=self.fmt)
-        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
-        alignments = alignment_iterator(self.stream, None)
-        self.iterator = (record for alignment in alignments for record in alignment)
 
     def __next__(self):
         return next(self.iterator)

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -493,7 +493,7 @@ _FormatToWriter = {
 
 
 class AlignmentSequenceIterator(SequenceIterator):
-    """Hello."""
+    """Pareses an alignment file and yields sequence records."""
 
     modes = "t"
 
@@ -508,7 +508,7 @@ class AlignmentSequenceIterator(SequenceIterator):
         """Alignment iterator class."""
 
     def __init__(self, source: _IOSource) -> None:
-        """Hello."""
+        """Initialize the iterator."""
         super().__init__(source, fmt=self.fmt)
         # We need type(self) here, because _alignment_iterator_class is
         # actually a function instead of a class for some formats in

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -725,10 +725,7 @@ def read(handle, format, alphabet=None):
     Use the Bio.SeqIO.parse(handle, format) function if you want
     to read multiple records from the handle.
     """
-    from Bio import AlignIO
-
-    if format in AlignIO._FormatToIterator:
-        records = parse(handle, format, alphabet)
+    with parse(handle, format, alphabet) as records:
         try:
             record = next(records)
         except StopIteration:
@@ -738,17 +735,6 @@ def read(handle, format, alphabet=None):
             raise ValueError("More than one record found in handle")
         except StopIteration:
             pass
-    else:
-        with parse(handle, format, alphabet) as records:
-            try:
-                record = next(records)
-            except StopIteration:
-                raise ValueError("No records found in handle") from None
-            try:
-                next(records)
-                raise ValueError("More than one record found in handle")
-            except StopIteration:
-                pass
     return record
 
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -496,13 +496,21 @@ class AlignmentSequenceIterator(SequenceIterator):
 
     def __init__(self, source: _IOSource) -> None:
         super().__init__(source, fmt="clustal")
-        self.iterator = (record for alignment in AlignIO.parse(self.stream, "clustal") for record in alignment)
+        alignment_iterator = AlignIO._FormatToIterator["clustal"]
+        alignments = alignment_iterator(self.stream, None)
+        self.iterator = (record for alignment in alignments for record in alignment)
 
     def __next__(self):
         return next(self.iterator)
 
 
 _FormatToIterator["clustal"] = AlignmentSequenceIterator
+
+
+# for fmt, writer_class in AlignIO._FormatToWriter.items():
+    # name = fmt.replace("-", " ").title().replace(" ", "") + "Writer"
+    # cls = type(name, (AlignmentSequenceWriter,), {"writer_class": writer_class})
+    # _FormatToWriter[fmt] = cls  # type: ignore
 
 
 class AlignmentSequenceWriter(SequenceWriter):

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -566,74 +566,45 @@ cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator
 _FormatToIterator[fmt] = cls  # type: ignore
 
 
-class MauveAlignmentSequenceIterator(OldAlignmentSequenceIterator):
-    """Hello."""
-
-    fmt = "mauve"
-
-
-cls = MauveAlignmentSequenceIterator  # type: ignore
-_FormatToIterator["mauve"] = cls  # type: ignore
+fmt = "mauve"
+name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
+cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
+_FormatToIterator[fmt] = cls  # type: ignore
 
 
-class MsfAlignmentSequenceIterator(OldAlignmentSequenceIterator):
-    """Hello."""
-
-    fmt = "msf"
-
-
-cls = MsfAlignmentSequenceIterator  # type: ignore
-_FormatToIterator["msf"] = cls  # type: ignore
+fmt = "msf"
+name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
+cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
+_FormatToIterator[fmt] = cls  # type: ignore
 
 
-class NexusAlignmentSequenceIterator(OldAlignmentSequenceIterator):
-    """Hello."""
-
-    fmt = "nexus"
-
-
-cls = NexusAlignmentSequenceIterator  # type: ignore
-_FormatToIterator["nexus"] = cls  # type: ignore
+fmt = "nexus"
+name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
+cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
+_FormatToIterator[fmt] = cls  # type: ignore
 
 
-class PhylipAlignmentSequenceIterator(OldAlignmentSequenceIterator):
-    """Hello."""
-
-    fmt = "phylip"
-
-
-cls = PhylipAlignmentSequenceIterator  # type: ignore
-_FormatToIterator["phylip"] = cls  # type: ignore
+fmt = "phylip"
+name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
+cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
+_FormatToIterator[fmt] = cls  # type: ignore
 
 
-class PhylipSequentialAlignmentSequenceIterator(OldAlignmentSequenceIterator):
-    """Hello."""
-
-    fmt = "phylip-sequential"
-
-
-cls = PhylipSequentialAlignmentSequenceIterator  # type: ignore
-_FormatToIterator["phylip-sequential"] = cls  # type: ignore
+fmt = "phylip-sequential"
+name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
+cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
+_FormatToIterator[fmt] = cls  # type: ignore
 
 
-class PhylipRelaxedAlignmentSequenceIterator(OldAlignmentSequenceIterator):
-    """Hello."""
+fmt = "phylip-relaxed"
+name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
+cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
+_FormatToIterator[fmt] = cls  # type: ignore
 
-    fmt = "phylip-relaxed"
-
-
-cls = PhylipRelaxedAlignmentSequenceIterator  # type: ignore
-_FormatToIterator["phylip-relaxed"] = cls  # type: ignore
-
-
-class StockholmAlignmentSequenceIterator(OldAlignmentSequenceIterator):
-    """Hello."""
-
-    fmt = "stockholm"
-
-
-cls = StockholmAlignmentSequenceIterator  # type: ignore
-_FormatToIterator["stockholm"] = cls  # type: ignore
+fmt = "stockholm"
+name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
+cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
+_FormatToIterator[fmt] = cls  # type: ignore
 
 
 class AlignmentSequenceWriter(SequenceWriter):

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -490,11 +490,14 @@ _FormatToWriter = {
     "xdna": XdnaIO.XdnaWriter,
 }
 
-class AlignmentSequenceIterator(SequenceIterator):
+
+class ClustalAlignmentSequenceIterator(SequenceIterator):
+    """Hello."""
 
     modes = "t"
 
     def __init__(self, source: _IOSource) -> None:
+        """Hello."""
         super().__init__(source, fmt="clustal")
         alignment_iterator = AlignIO._FormatToIterator["clustal"]
         alignments = alignment_iterator(self.stream, None)
@@ -504,13 +507,197 @@ class AlignmentSequenceIterator(SequenceIterator):
         return next(self.iterator)
 
 
-_FormatToIterator["clustal"] = AlignmentSequenceIterator
+_FormatToIterator["clustal"] = ClustalAlignmentSequenceIterator
 
 
-# for fmt, writer_class in AlignIO._FormatToWriter.items():
-    # name = fmt.replace("-", " ").title().replace(" ", "") + "Writer"
-    # cls = type(name, (AlignmentSequenceWriter,), {"writer_class": writer_class})
-    # _FormatToWriter[fmt] = cls  # type: ignore
+class EmbossAlignmentSequenceIterator(SequenceIterator):
+    """Hello."""
+
+    modes = "t"
+
+    def __init__(self, source: _IOSource) -> None:
+        """Hello."""
+        super().__init__(source, fmt="emboss")
+        alignment_iterator = AlignIO._FormatToIterator["emboss"]
+        alignments = alignment_iterator(self.stream, None)
+        self.iterator = (record for alignment in alignments for record in alignment)
+
+    def __next__(self):
+        return next(self.iterator)
+
+
+_FormatToIterator["emboss"] = EmbossAlignmentSequenceIterator
+
+
+class FastaM10AlignmentSequenceIterator(SequenceIterator):
+    """Hello."""
+
+    modes = "t"
+
+    def __init__(self, source: _IOSource) -> None:
+        """Hello."""
+        super().__init__(source, fmt="fasta-m10")
+        alignment_iterator = AlignIO._FormatToIterator["fasta-m10"]
+        alignments = alignment_iterator(self.stream, None)
+        self.iterator = (record for alignment in alignments for record in alignment)
+
+    def __next__(self):
+        return next(self.iterator)
+
+
+_FormatToIterator["fasta-m10"] = FastaM10AlignmentSequenceIterator
+
+
+class MafAlignmentSequenceIterator(SequenceIterator):
+    """Hello."""
+
+    modes = "t"
+
+    def __init__(self, source: _IOSource) -> None:
+        """Hello."""
+        super().__init__(source, fmt="maf")
+        alignment_iterator = AlignIO._FormatToIterator["maf"]
+        alignments = alignment_iterator(self.stream, None)
+        self.iterator = (record for alignment in alignments for record in alignment)
+
+    def __next__(self):
+        return next(self.iterator)
+
+
+_FormatToIterator["maf"] = MafAlignmentSequenceIterator
+
+
+class MauveAlignmentSequenceIterator(SequenceIterator):
+    """Hello."""
+
+    modes = "t"
+
+    def __init__(self, source: _IOSource) -> None:
+        """Hello."""
+        super().__init__(source, fmt="mauve")
+        alignment_iterator = AlignIO._FormatToIterator["mauve"]
+        alignments = alignment_iterator(self.stream, None)
+        self.iterator = (record for alignment in alignments for record in alignment)
+
+    def __next__(self):
+        return next(self.iterator)
+
+
+_FormatToIterator["mauve"] = MauveAlignmentSequenceIterator
+
+
+class MsfAlignmentSequenceIterator(SequenceIterator):
+    """Hello."""
+
+    modes = "t"
+
+    def __init__(self, source: _IOSource) -> None:
+        """Hello."""
+        super().__init__(source, fmt="msf")
+        alignment_iterator = AlignIO._FormatToIterator["msf"]
+        alignments = alignment_iterator(self.stream, None)
+        self.iterator = (record for alignment in alignments for record in alignment)
+
+    def __next__(self):
+        return next(self.iterator)
+
+
+_FormatToIterator["msf"] = MsfAlignmentSequenceIterator
+
+
+class NexusAlignmentSequenceIterator(SequenceIterator):
+    """Hello."""
+
+    modes = "t"
+
+    def __init__(self, source: _IOSource) -> None:
+        """Hello."""
+        super().__init__(source, fmt="nexus")
+        alignment_iterator = AlignIO._FormatToIterator["nexus"]
+        alignments = alignment_iterator(self.stream, None)
+        self.iterator = (record for alignment in alignments for record in alignment)
+
+    def __next__(self):
+        return next(self.iterator)
+
+
+_FormatToIterator["nexus"] = NexusAlignmentSequenceIterator
+
+
+class PhylipAlignmentSequenceIterator(SequenceIterator):
+    """Hello."""
+
+    modes = "t"
+
+    def __init__(self, source: _IOSource) -> None:
+        """Hello."""
+        super().__init__(source, fmt="phylip")
+        alignment_iterator = AlignIO._FormatToIterator["phylip"]
+        alignments = alignment_iterator(self.stream, None)
+        self.iterator = (record for alignment in alignments for record in alignment)
+
+    def __next__(self):
+        return next(self.iterator)
+
+
+_FormatToIterator["phylip"] = PhylipAlignmentSequenceIterator
+
+
+class PhylipSequentialAlignmentSequenceIterator(SequenceIterator):
+    """Hello."""
+
+    modes = "t"
+
+    def __init__(self, source: _IOSource) -> None:
+        """Hello."""
+        super().__init__(source, fmt="phylip-sequential")
+        alignment_iterator = AlignIO._FormatToIterator["phylip-sequential"]
+        alignments = alignment_iterator(self.stream, None)
+        self.iterator = (record for alignment in alignments for record in alignment)
+
+    def __next__(self):
+        return next(self.iterator)
+
+
+_FormatToIterator["phylip-sequential"] = PhylipSequentialAlignmentSequenceIterator
+
+
+class PhylipRelaxedAlignmentSequenceIterator(SequenceIterator):
+    """Hello."""
+
+    modes = "t"
+
+    def __init__(self, source: _IOSource) -> None:
+        """Hello."""
+        super().__init__(source, fmt="phylip-relaxed")
+        alignment_iterator = AlignIO._FormatToIterator["phylip-relaxed"]
+        alignments = alignment_iterator(self.stream, None)
+        self.iterator = (record for alignment in alignments for record in alignment)
+
+    def __next__(self):
+        return next(self.iterator)
+
+
+_FormatToIterator["phylip-relaxed"] = PhylipRelaxedAlignmentSequenceIterator
+
+
+class StockholmAlignmentSequenceIterator(SequenceIterator):
+    """Hello."""
+
+    modes = "t"
+
+    def __init__(self, source: _IOSource) -> None:
+        """Hello."""
+        super().__init__(source, fmt="stockholm")
+        alignment_iterator = AlignIO._FormatToIterator["stockholm"]
+        alignments = alignment_iterator(self.stream, None)
+        self.iterator = (record for alignment in alignments for record in alignment)
+
+    def __next__(self):
+        return next(self.iterator)
+
+
+_FormatToIterator["stockholm"] = StockholmAlignmentSequenceIterator
 
 
 class AlignmentSequenceWriter(SequenceWriter):
@@ -537,7 +724,7 @@ class AlignmentSequenceWriter(SequenceWriter):
 
 
 for fmt, writer_class in AlignIO._FormatToWriter.items():
-    name = fmt.replace("-", " ").title().replace(" ", "") + "Writer"
+    name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceWriter"
     cls = type(name, (AlignmentSequenceWriter,), {"writer_class": writer_class})
     _FormatToWriter[fmt] = cls  # type: ignore
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -509,14 +509,14 @@ class AlignmentSequenceIterator(SequenceIterator):
         alignments = alignment_iterator(self.stream, None)
         self.iterator = (record for alignment in alignments for record in alignment)
 
+    def __next__(self):
+        return next(self.iterator)
+
 
 class ClustalAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
     fmt = "clustal"
-
-    def __next__(self):
-        return next(self.iterator)
 
 
 _FormatToIterator["clustal"] = ClustalAlignmentSequenceIterator
@@ -527,9 +527,6 @@ class EmbossAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     fmt = "emboss"
 
-    def __next__(self):
-        return next(self.iterator)
-
 
 _FormatToIterator["emboss"] = EmbossAlignmentSequenceIterator
 
@@ -538,9 +535,6 @@ class FastaM10AlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
     fmt = "fasta-m10"
-
-    def __next__(self):
-        return next(self.iterator)
 
 
 _FormatToIterator["fasta-m10"] = FastaM10AlignmentSequenceIterator
@@ -551,9 +545,6 @@ class MafAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     fmt = "maf"
 
-    def __next__(self):
-        return next(self.iterator)
-
 
 _FormatToIterator["maf"] = MafAlignmentSequenceIterator
 
@@ -562,9 +553,6 @@ class MauveAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
     fmt = "mauve"
-
-    def __next__(self):
-        return next(self.iterator)
 
 
 _FormatToIterator["mauve"] = MauveAlignmentSequenceIterator
@@ -575,9 +563,6 @@ class MsfAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     fmt = "msf"
 
-    def __next__(self):
-        return next(self.iterator)
-
 
 _FormatToIterator["msf"] = MsfAlignmentSequenceIterator
 
@@ -586,9 +571,6 @@ class NexusAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
     fmt = "nexus"
-
-    def __next__(self):
-        return next(self.iterator)
 
 
 _FormatToIterator["nexus"] = NexusAlignmentSequenceIterator
@@ -599,9 +581,6 @@ class PhylipAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     fmt = "phylip"
 
-    def __next__(self):
-        return next(self.iterator)
-
 
 _FormatToIterator["phylip"] = PhylipAlignmentSequenceIterator
 
@@ -610,9 +589,6 @@ class PhylipSequentialAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
     fmt = "phylip-sequential"
-
-    def __next__(self):
-        return next(self.iterator)
 
 
 _FormatToIterator["phylip-sequential"] = PhylipSequentialAlignmentSequenceIterator
@@ -623,9 +599,6 @@ class PhylipRelaxedAlignmentSequenceIterator(AlignmentSequenceIterator):
 
     fmt = "phylip-relaxed"
 
-    def __next__(self):
-        return next(self.iterator)
-
 
 _FormatToIterator["phylip-relaxed"] = PhylipRelaxedAlignmentSequenceIterator
 
@@ -634,9 +607,6 @@ class StockholmAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
     fmt = "stockholm"
-
-    def __next__(self):
-        return next(self.iterator)
 
 
 _FormatToIterator["stockholm"] = StockholmAlignmentSequenceIterator

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -403,7 +403,7 @@ from Bio.SeqIO import UniprotIO
 from Bio.SeqIO import XdnaIO
 from Bio.SeqRecord import SeqRecord
 
-from .Interfaces import _TextIOSource
+from .Interfaces import _TextIOSource, SequenceWriter
 
 # Convention for format names is "mainname-subtype" in lower case.
 # Please use the same names as BioPerl or EMBOSS where possible.
@@ -490,6 +490,208 @@ _FormatToWriter = {
 }
 
 
+class ClustalWriter(SequenceWriter):
+    """Clustal file writer."""
+
+    modes = "t"
+
+    def write_records(self, records):
+        """Write records to the output file, and return the number of records.
+
+        records - A list or iterator returning SeqRecord objects
+        """
+        from Bio.Align import MultipleSeqAlignment
+        from Bio import AlignIO
+
+        alignment = MultipleSeqAlignment(records)
+        alignment_count = AlignIO.write([alignment], self.handle, "clustal")
+        if alignment_count != 1:
+            raise RuntimeError(
+                "Internal error - the underlying writer "
+                "should have returned 1, not %r" % alignment_count
+            )
+        count = len(alignment)
+        return count
+
+
+class MafWriter(SequenceWriter):
+    """Multiple Alignment Format file writer."""
+
+    modes = "t"
+
+    def write_records(self, records):
+        """Write records to the output file, and return the number of records.
+
+        records - A list or iterator returning SeqRecord objects
+        """
+        from Bio.Align import MultipleSeqAlignment
+        from Bio import AlignIO
+
+        alignment = MultipleSeqAlignment(records)
+        alignment_count = AlignIO.write([alignment], self.handle, "maf")
+        if alignment_count != 1:
+            raise RuntimeError(
+                "Internal error - the underlying writer "
+                "should have returned 1, not %r" % alignment_count
+            )
+        count = len(alignment)
+        return count
+
+
+class MauveWriter(SequenceWriter):
+    """Mauve file writer."""
+
+    modes = "t"
+
+    def write_records(self, records):
+        """Write records to the output file, and return the number of records.
+
+        records - A list or iterator returning SeqRecord objects
+        """
+        from Bio.Align import MultipleSeqAlignment
+        from Bio import AlignIO
+
+        alignment = MultipleSeqAlignment(records)
+        alignment_count = AlignIO.write([alignment], self.handle, "mauve")
+        if alignment_count != 1:
+            raise RuntimeError(
+                "Internal error - the underlying writer "
+                "should have returned 1, not %r" % alignment_count
+            )
+        count = len(alignment)
+        return count
+
+
+class NexusWriter(SequenceWriter):
+    """Nexus file writer."""
+
+    modes = "t"
+
+    def write_records(self, records):
+        """Write records to the output file, and return the number of records.
+
+        records - A list or iterator returning SeqRecord objects
+        """
+        from Bio.Align import MultipleSeqAlignment
+        from Bio import AlignIO
+
+        alignment = MultipleSeqAlignment(records)
+        alignment_count = AlignIO.write([alignment], self.handle, "nexus")
+        if alignment_count != 1:
+            raise RuntimeError(
+                "Internal error - the underlying writer "
+                "should have returned 1, not %r" % alignment_count
+            )
+        count = len(alignment)
+        return count
+
+
+class PhylipWriter(SequenceWriter):
+    """Phylip file writer."""
+
+    modes = "t"
+
+    def write_records(self, records):
+        """Write records to the output file, and return the number of records.
+
+        records - A list or iterator returning SeqRecord objects
+        """
+        from Bio.Align import MultipleSeqAlignment
+        from Bio import AlignIO
+
+        alignment = MultipleSeqAlignment(records)
+        alignment_count = AlignIO.write([alignment], self.handle, "phylip")
+        if alignment_count != 1:
+            raise RuntimeError(
+                "Internal error - the underlying writer "
+                "should have returned 1, not %r" % alignment_count
+            )
+        count = len(alignment)
+        return count
+
+
+class SequentialPhylipWriter(SequenceWriter):
+    """Sequential phylip file writer."""
+
+    modes = "t"
+
+    def write_records(self, records):
+        """Write records to the output file, and return the number of records.
+
+        records - A list or iterator returning SeqRecord objects
+        """
+        from Bio.Align import MultipleSeqAlignment
+        from Bio import AlignIO
+
+        alignment = MultipleSeqAlignment(records)
+        alignment_count = AlignIO.write([alignment], self.handle, "phylip-sequential")
+        if alignment_count != 1:
+            raise RuntimeError(
+                "Internal error - the underlying writer "
+                "should have returned 1, not %r" % alignment_count
+            )
+        count = len(alignment)
+        return count
+
+
+class RelaxedPhylipWriter(SequenceWriter):
+    """Relaxes Phylip file writer."""
+
+    modes = "t"
+
+    def write_records(self, records):
+        """Write records to the output file, and return the number of records.
+
+        records - A list or iterator returning SeqRecord objects
+        """
+        from Bio.Align import MultipleSeqAlignment
+        from Bio import AlignIO
+
+        alignment = MultipleSeqAlignment(records)
+        alignment_count = AlignIO.write([alignment], self.handle, "phylip-relaxed")
+        if alignment_count != 1:
+            raise RuntimeError(
+                "Internal error - the underlying writer "
+                "should have returned 1, not %r" % alignment_count
+            )
+        count = len(alignment)
+        return count
+
+
+class StockholmWriter(SequenceWriter):
+    """Stockholm file writer."""
+
+    modes = "t"
+
+    def write_records(self, records):
+        """Write records to the output file, and return the number of records.
+
+        records - A list or iterator returning SeqRecord objects
+        """
+        from Bio.Align import MultipleSeqAlignment
+        from Bio import AlignIO
+
+        alignment = MultipleSeqAlignment(records)
+        alignment_count = AlignIO.write([alignment], self.handle, "stockholm")
+        if alignment_count != 1:
+            raise RuntimeError(
+                "Internal error - the underlying writer "
+                "should have returned 1, not %r" % alignment_count
+            )
+        count = len(alignment)
+        return count
+
+
+_FormatToWriter["clustal"] = ClustalWriter
+_FormatToWriter["maf"] = MafWriter
+_FormatToWriter["mauve"] = MauveWriter
+_FormatToWriter["nexus"] = NexusWriter
+_FormatToWriter["phylip"] = PhylipWriter
+_FormatToWriter["phylip-sequential"] = SequentialPhylipWriter
+_FormatToWriter["phylip-relaxed"] = RelaxedPhylipWriter
+_FormatToWriter["stockholm"] = StockholmWriter
+
+
 def write(
     sequences: Iterable[SeqRecord] | SeqRecord,
     handle: _TextIOSource,
@@ -546,22 +748,6 @@ def write(
                 "Internal error - the underlying %s writer "
                 "should have returned the record count, not %r" % (format, count)
             )
-        return count
-
-    if format in AlignIO._FormatToWriter:
-        # Try and turn all the records into a single alignment,
-        # and write that using Bio.AlignIO
-        # Using a lazy import as most users won't need this loaded:
-        from Bio.Align import MultipleSeqAlignment
-
-        alignment = MultipleSeqAlignment(sequences)
-        alignment_count = AlignIO.write([alignment], handle, format)
-        if alignment_count != 1:
-            raise RuntimeError(
-                "Internal error - the underlying writer "
-                "should have returned 1, not %r" % alignment_count
-            )
-        count = len(alignment)
         return count
 
     if format in _FormatToIterator or format in AlignIO._FormatToIterator:

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -560,14 +560,10 @@ cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator
 _FormatToIterator[fmt] = cls  # type: ignore
 
 
-class MafAlignmentSequenceIterator(OldAlignmentSequenceIterator):
-    """Hello."""
-
-    fmt = "maf"
-
-
-cls = MafAlignmentSequenceIterator  # type: ignore
-_FormatToIterator["maf"] = cls  # type: ignore
+fmt = "maf"
+name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
+cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
+_FormatToIterator[fmt] = cls  # type: ignore
 
 
 class MauveAlignmentSequenceIterator(OldAlignmentSequenceIterator):

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -492,7 +492,7 @@ _FormatToWriter = {
 }
 
 
-class AlignmentSequenceIterator(SequenceIterator):
+class OldAlignmentSequenceIterator(SequenceIterator):
     """Hello."""
 
     modes = "t"
@@ -513,17 +513,45 @@ class AlignmentSequenceIterator(SequenceIterator):
         return next(self.iterator)
 
 
+class AlignmentSequenceIterator(SequenceIterator):
+    """Hello."""
+
+    modes = "t"
+
+    @property
+    @abstractmethod
+    def fmt(self):
+        """Alignment file format name."""
+
+    @property
+    @abstractmethod
+    def _alignment_iterator_class(self):
+        """Alignment iterator_class."""
+
+    def __init__(self, source: _IOSource) -> None:
+        """Hello."""
+        super().__init__(source, fmt=self.fmt)
+        alignment_iterator_class = self._alignment_iterator_class
+        alignments = alignment_iterator_class(self.stream, None)
+        self.iterator = (record for alignment in alignments for record in alignment)
+
+    def __next__(self):
+        return next(self.iterator)
+
+
 class ClustalAlignmentSequenceIterator(AlignmentSequenceIterator):
     """Hello."""
 
     fmt = "clustal"
+
+    _alignment_iterator_class = AlignIO._FormatToIterator[fmt]
 
 
 cls = ClustalAlignmentSequenceIterator  # type: ignore
 _FormatToIterator["clustal"] = cls  # type: ignore
 
 
-class EmbossAlignmentSequenceIterator(AlignmentSequenceIterator):
+class EmbossAlignmentSequenceIterator(OldAlignmentSequenceIterator):
     """Hello."""
 
     fmt = "emboss"
@@ -533,7 +561,7 @@ cls = EmbossAlignmentSequenceIterator  # type: ignore
 _FormatToIterator["emboss"] = cls  # type: ignore
 
 
-class FastaM10AlignmentSequenceIterator(AlignmentSequenceIterator):
+class FastaM10AlignmentSequenceIterator(OldAlignmentSequenceIterator):
     """Hello."""
 
     fmt = "fasta-m10"
@@ -543,7 +571,7 @@ cls = FastaM10AlignmentSequenceIterator  # type: ignore
 _FormatToIterator["fasta-m10"] = cls  # type: ignore
 
 
-class MafAlignmentSequenceIterator(AlignmentSequenceIterator):
+class MafAlignmentSequenceIterator(OldAlignmentSequenceIterator):
     """Hello."""
 
     fmt = "maf"
@@ -553,7 +581,7 @@ cls = MafAlignmentSequenceIterator  # type: ignore
 _FormatToIterator["maf"] = cls  # type: ignore
 
 
-class MauveAlignmentSequenceIterator(AlignmentSequenceIterator):
+class MauveAlignmentSequenceIterator(OldAlignmentSequenceIterator):
     """Hello."""
 
     fmt = "mauve"
@@ -563,7 +591,7 @@ cls = MauveAlignmentSequenceIterator  # type: ignore
 _FormatToIterator["mauve"] = cls  # type: ignore
 
 
-class MsfAlignmentSequenceIterator(AlignmentSequenceIterator):
+class MsfAlignmentSequenceIterator(OldAlignmentSequenceIterator):
     """Hello."""
 
     fmt = "msf"
@@ -573,7 +601,7 @@ cls = MsfAlignmentSequenceIterator  # type: ignore
 _FormatToIterator["msf"] = cls  # type: ignore
 
 
-class NexusAlignmentSequenceIterator(AlignmentSequenceIterator):
+class NexusAlignmentSequenceIterator(OldAlignmentSequenceIterator):
     """Hello."""
 
     fmt = "nexus"
@@ -583,7 +611,7 @@ cls = NexusAlignmentSequenceIterator  # type: ignore
 _FormatToIterator["nexus"] = cls  # type: ignore
 
 
-class PhylipAlignmentSequenceIterator(AlignmentSequenceIterator):
+class PhylipAlignmentSequenceIterator(OldAlignmentSequenceIterator):
     """Hello."""
 
     fmt = "phylip"
@@ -593,7 +621,7 @@ cls = PhylipAlignmentSequenceIterator  # type: ignore
 _FormatToIterator["phylip"] = cls  # type: ignore
 
 
-class PhylipSequentialAlignmentSequenceIterator(AlignmentSequenceIterator):
+class PhylipSequentialAlignmentSequenceIterator(OldAlignmentSequenceIterator):
     """Hello."""
 
     fmt = "phylip-sequential"
@@ -603,7 +631,7 @@ cls = PhylipSequentialAlignmentSequenceIterator  # type: ignore
 _FormatToIterator["phylip-sequential"] = cls  # type: ignore
 
 
-class PhylipRelaxedAlignmentSequenceIterator(AlignmentSequenceIterator):
+class PhylipRelaxedAlignmentSequenceIterator(OldAlignmentSequenceIterator):
     """Hello."""
 
     fmt = "phylip-relaxed"
@@ -613,7 +641,7 @@ cls = PhylipRelaxedAlignmentSequenceIterator  # type: ignore
 _FormatToIterator["phylip-relaxed"] = cls  # type: ignore
 
 
-class StockholmAlignmentSequenceIterator(AlignmentSequenceIterator):
+class StockholmAlignmentSequenceIterator(OldAlignmentSequenceIterator):
     """Hello."""
 
     fmt = "stockholm"

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -531,8 +531,12 @@ class AlignmentSequenceIterator(SequenceIterator):
     def __init__(self, source: _IOSource) -> None:
         """Hello."""
         super().__init__(source, fmt=self.fmt)
-        alignment_iterator_class = self._alignment_iterator_class
-        alignments = alignment_iterator_class(self.stream, None)
+        # We need type(self) here, because _alignment_iterator_class is
+        # actually a function instead of a class for some formats in
+        # Bio.AlignIO, and Python will turn the function into a bound method
+        # with self as the first argument.
+        alignment_iterator_class = type(self)._alignment_iterator_class
+        alignments = alignment_iterator_class(self.stream, None)  # type: ignore
         self.iterator = (record for alignment in alignments for record in alignment)
 
     def __next__(self):
@@ -544,25 +548,16 @@ name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterat
 cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
 _FormatToIterator[fmt] = cls  # type: ignore
 
-
-class EmbossAlignmentSequenceIterator(OldAlignmentSequenceIterator):
-    """Hello."""
-
-    fmt = "emboss"
-
-
-cls = EmbossAlignmentSequenceIterator  # type: ignore
-_FormatToIterator["emboss"] = cls  # type: ignore
+fmt = "emboss"
+name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
+cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
+_FormatToIterator[fmt] = cls  # type: ignore
 
 
-class FastaM10AlignmentSequenceIterator(OldAlignmentSequenceIterator):
-    """Hello."""
-
-    fmt = "fasta-m10"
-
-
-cls = FastaM10AlignmentSequenceIterator  # type: ignore
-_FormatToIterator["fasta-m10"] = cls  # type: ignore
+fmt = "fasta-m10"
+name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
+cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
+_FormatToIterator[fmt] = cls  # type: ignore
 
 
 class MafAlignmentSequenceIterator(OldAlignmentSequenceIterator):

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -458,7 +458,6 @@ _FormatToIterator = {
 }
 
 _FormatToString: dict[str, Callable[[SeqRecord], str]] = {
-    "tab": TabIO.as_tab,
     "fastq": QualityIO.as_fastq,
     "fastq-sanger": QualityIO.as_fastq,
     "fastq-solexa": QualityIO.as_fastq_solexa,

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -492,27 +492,6 @@ _FormatToWriter = {
 }
 
 
-class OldAlignmentSequenceIterator(SequenceIterator):
-    """Hello."""
-
-    modes = "t"
-
-    @property
-    @abstractmethod
-    def fmt(self):
-        """Alignment file format name."""
-
-    def __init__(self, source: _IOSource) -> None:
-        """Hello."""
-        super().__init__(source, fmt=self.fmt)
-        alignment_iterator = AlignIO._FormatToIterator[self.fmt]
-        alignments = alignment_iterator(self.stream, None)
-        self.iterator = (record for alignment in alignments for record in alignment)
-
-    def __next__(self):
-        return next(self.iterator)
-
-
 class AlignmentSequenceIterator(SequenceIterator):
     """Hello."""
 
@@ -543,68 +522,17 @@ class AlignmentSequenceIterator(SequenceIterator):
         return next(self.iterator)
 
 
-fmt = "clustal"
-name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
-cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
-_FormatToIterator[fmt] = cls  # type: ignore
-
-fmt = "emboss"
-name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
-cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
-_FormatToIterator[fmt] = cls  # type: ignore
-
-
-fmt = "fasta-m10"
-name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
-cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
-_FormatToIterator[fmt] = cls  # type: ignore
-
-
-fmt = "maf"
-name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
-cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
-_FormatToIterator[fmt] = cls  # type: ignore
-
-
-fmt = "mauve"
-name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
-cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
-_FormatToIterator[fmt] = cls  # type: ignore
-
-
-fmt = "msf"
-name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
-cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
-_FormatToIterator[fmt] = cls  # type: ignore
-
-
-fmt = "nexus"
-name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
-cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
-_FormatToIterator[fmt] = cls  # type: ignore
-
-
-fmt = "phylip"
-name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
-cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
-_FormatToIterator[fmt] = cls  # type: ignore
-
-
-fmt = "phylip-sequential"
-name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
-cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
-_FormatToIterator[fmt] = cls  # type: ignore
-
-
-fmt = "phylip-relaxed"
-name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
-cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
-_FormatToIterator[fmt] = cls  # type: ignore
-
-fmt = "stockholm"
-name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
-cls = type(name, (AlignmentSequenceIterator,), {"fmt": fmt, "_alignment_iterator_class": AlignIO._FormatToIterator[fmt]})  # type: ignore
-_FormatToIterator[fmt] = cls  # type: ignore
+for fmt, alignment_iterator_class in AlignIO._FormatToIterator.items():
+    name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceIterator"
+    cls = type(
+        name,
+        (AlignmentSequenceIterator,),
+        {
+            "fmt": fmt,
+            "_alignment_iterator_class": alignment_iterator_class,
+        },
+    )  # type: ignore
+    _FormatToIterator[fmt] = cls  # type: ignore
 
 
 class AlignmentSequenceWriter(SequenceWriter):

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -460,7 +460,6 @@ _FormatToIterator = {
 _FormatToString: dict[str, Callable[[SeqRecord], str]] = {
     "fastq-solexa": QualityIO.as_fastq_solexa,
     "fastq-illumina": QualityIO.as_fastq_illumina,
-    "qual": QualityIO.as_qual,
 }
 
 # This could exclude file formats covered by _FormatToString?

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -531,7 +531,7 @@ for fmt, alignment_iterator_class in AlignIO._FormatToIterator.items():
             "fmt": fmt,
             "_alignment_iterator_class": alignment_iterator_class,
         },
-    )  # type: ignore
+    )
     _FormatToIterator[fmt] = cls  # type: ignore
 
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -458,7 +458,6 @@ _FormatToIterator = {
 }
 
 _FormatToString: dict[str, Callable[[SeqRecord], str]] = {
-    "fasta-2line": FastaIO.as_fasta_2line,
     "tab": TabIO.as_tab,
     "fastq": QualityIO.as_fastq,
     "fastq-sanger": QualityIO.as_fastq,

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -519,7 +519,8 @@ class ClustalAlignmentSequenceIterator(AlignmentSequenceIterator):
     fmt = "clustal"
 
 
-_FormatToIterator["clustal"] = ClustalAlignmentSequenceIterator
+cls = ClustalAlignmentSequenceIterator  # type: ignore
+_FormatToIterator["clustal"] = cls  # type: ignore
 
 
 class EmbossAlignmentSequenceIterator(AlignmentSequenceIterator):
@@ -528,7 +529,8 @@ class EmbossAlignmentSequenceIterator(AlignmentSequenceIterator):
     fmt = "emboss"
 
 
-_FormatToIterator["emboss"] = EmbossAlignmentSequenceIterator
+cls = EmbossAlignmentSequenceIterator  # type: ignore
+_FormatToIterator["emboss"] = cls  # type: ignore
 
 
 class FastaM10AlignmentSequenceIterator(AlignmentSequenceIterator):
@@ -537,7 +539,8 @@ class FastaM10AlignmentSequenceIterator(AlignmentSequenceIterator):
     fmt = "fasta-m10"
 
 
-_FormatToIterator["fasta-m10"] = FastaM10AlignmentSequenceIterator
+cls = FastaM10AlignmentSequenceIterator  # type: ignore
+_FormatToIterator["fasta-m10"] = cls  # type: ignore
 
 
 class MafAlignmentSequenceIterator(AlignmentSequenceIterator):
@@ -546,7 +549,8 @@ class MafAlignmentSequenceIterator(AlignmentSequenceIterator):
     fmt = "maf"
 
 
-_FormatToIterator["maf"] = MafAlignmentSequenceIterator
+cls = MafAlignmentSequenceIterator  # type: ignore
+_FormatToIterator["maf"] = cls  # type: ignore
 
 
 class MauveAlignmentSequenceIterator(AlignmentSequenceIterator):
@@ -555,7 +559,8 @@ class MauveAlignmentSequenceIterator(AlignmentSequenceIterator):
     fmt = "mauve"
 
 
-_FormatToIterator["mauve"] = MauveAlignmentSequenceIterator
+cls = MauveAlignmentSequenceIterator  # type: ignore
+_FormatToIterator["mauve"] = cls  # type: ignore
 
 
 class MsfAlignmentSequenceIterator(AlignmentSequenceIterator):
@@ -564,7 +569,8 @@ class MsfAlignmentSequenceIterator(AlignmentSequenceIterator):
     fmt = "msf"
 
 
-_FormatToIterator["msf"] = MsfAlignmentSequenceIterator
+cls = MsfAlignmentSequenceIterator  # type: ignore
+_FormatToIterator["msf"] = cls  # type: ignore
 
 
 class NexusAlignmentSequenceIterator(AlignmentSequenceIterator):
@@ -573,7 +579,8 @@ class NexusAlignmentSequenceIterator(AlignmentSequenceIterator):
     fmt = "nexus"
 
 
-_FormatToIterator["nexus"] = NexusAlignmentSequenceIterator
+cls = NexusAlignmentSequenceIterator  # type: ignore
+_FormatToIterator["nexus"] = cls  # type: ignore
 
 
 class PhylipAlignmentSequenceIterator(AlignmentSequenceIterator):
@@ -582,7 +589,8 @@ class PhylipAlignmentSequenceIterator(AlignmentSequenceIterator):
     fmt = "phylip"
 
 
-_FormatToIterator["phylip"] = PhylipAlignmentSequenceIterator
+cls = PhylipAlignmentSequenceIterator  # type: ignore
+_FormatToIterator["phylip"] = cls  # type: ignore
 
 
 class PhylipSequentialAlignmentSequenceIterator(AlignmentSequenceIterator):
@@ -591,7 +599,8 @@ class PhylipSequentialAlignmentSequenceIterator(AlignmentSequenceIterator):
     fmt = "phylip-sequential"
 
 
-_FormatToIterator["phylip-sequential"] = PhylipSequentialAlignmentSequenceIterator
+cls = PhylipSequentialAlignmentSequenceIterator  # type: ignore
+_FormatToIterator["phylip-sequential"] = cls  # type: ignore
 
 
 class PhylipRelaxedAlignmentSequenceIterator(AlignmentSequenceIterator):
@@ -600,7 +609,8 @@ class PhylipRelaxedAlignmentSequenceIterator(AlignmentSequenceIterator):
     fmt = "phylip-relaxed"
 
 
-_FormatToIterator["phylip-relaxed"] = PhylipRelaxedAlignmentSequenceIterator
+cls = PhylipRelaxedAlignmentSequenceIterator  # type: ignore
+_FormatToIterator["phylip-relaxed"] = cls  # type: ignore
 
 
 class StockholmAlignmentSequenceIterator(AlignmentSequenceIterator):
@@ -609,7 +619,8 @@ class StockholmAlignmentSequenceIterator(AlignmentSequenceIterator):
     fmt = "stockholm"
 
 
-_FormatToIterator["stockholm"] = StockholmAlignmentSequenceIterator
+cls = StockholmAlignmentSequenceIterator  # type: ignore
+_FormatToIterator["stockholm"] = cls  # type: ignore
 
 
 class AlignmentSequenceWriter(SequenceWriter):
@@ -637,7 +648,7 @@ class AlignmentSequenceWriter(SequenceWriter):
 
 for fmt, writer_class in AlignIO._FormatToWriter.items():
     name = fmt.replace("-", " ").title().replace(" ", "") + "AlignmentSequenceWriter"
-    cls = type(name, (AlignmentSequenceWriter,), {"writer_class": writer_class})
+    cls = type(name, (AlignmentSequenceWriter,), {"writer_class": writer_class})  # type: ignore
     _FormatToWriter[fmt] = cls  # type: ignore
 
 

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -458,7 +458,6 @@ _FormatToIterator = {
 }
 
 _FormatToString: dict[str, Callable[[SeqRecord], str]] = {
-    "fasta": FastaIO.as_fasta,
     "fasta-2line": FastaIO.as_fasta_2line,
     "tab": TabIO.as_tab,
     "fastq": QualityIO.as_fastq,

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -564,6 +564,9 @@ for fmt, writer_class in AlignIO._FormatToWriter.items():
     _FormatToWriter[fmt] = cls  # type: ignore
 
 
+del AlignIO
+
+
 def write(
     sequences: Iterable[SeqRecord] | SeqRecord,
     handle: _TextIOSource,
@@ -622,7 +625,7 @@ def write(
             )
         return count
 
-    if format in _FormatToIterator or format in AlignIO._FormatToIterator:
+    if format in _FormatToIterator:
         raise ValueError(f"Reading format '{format}' is supported, but not writing")
 
     raise ValueError(f"Unknown format '{format}'")

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -404,7 +404,7 @@ from Bio.SeqIO import UniprotIO
 from Bio.SeqIO import XdnaIO
 from Bio.SeqRecord import SeqRecord
 
-from .Interfaces import _TextIOSource, SequenceWriter
+from .Interfaces import _IOSource, _TextIOSource, SequenceIterator, SequenceWriter
 
 # Convention for format names is "mainname-subtype" in lower case.
 # Please use the same names as BioPerl or EMBOSS where possible.
@@ -489,6 +489,20 @@ _FormatToWriter = {
     "tab": TabIO.TabWriter,
     "xdna": XdnaIO.XdnaWriter,
 }
+
+class AlignmentSequenceIterator(SequenceIterator):
+
+    modes = "t"
+
+    def __init__(self, source: _IOSource) -> None:
+        super().__init__(source, fmt="clustal")
+        self.iterator = (record for alignment in AlignIO.parse(self.stream, "clustal") for record in alignment)
+
+    def __next__(self):
+        return next(self.iterator)
+
+
+_FormatToIterator["clustal"] = AlignmentSequenceIterator
 
 
 class AlignmentSequenceWriter(SequenceWriter):

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -13,7 +13,6 @@
 # In particular, the SeqRecord and BioSQL.BioSeq.DBSeqRecord classes
 # need to be in sync (this is the BioSQL "Database SeqRecord").
 import numbers
-from io import StringIO
 from typing import Any
 from typing import cast
 from collections.abc import Iterator
@@ -848,20 +847,14 @@ class SeqRecord:
             return str(self)
         from Bio import SeqIO
 
-        # Easy case, can call string-building function directly
-        if format_spec in SeqIO._FormatToString:
-            return SeqIO._FormatToString[format_spec](self)
-
-        # Harder case, make a temp handle instead
-        handle = StringIO()
+        cls = SeqIO._FormatToWriter[format_spec]
         try:
-            SeqIO.write(self, handle, format_spec)
+            return cls.to_string(self)  # type: ignore
         except StreamModeError:
             raise ValueError(
                 "Binary format %s cannot be used with SeqRecord format method"
                 % format_spec
             ) from None
-        return handle.getvalue()
 
     def __len__(self) -> int:
         """Return the length of the sequence.

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -76,6 +76,22 @@ Another option is to use ``format='fasta-blast'``; this follows the FASTA file
 format accepted by BLAST, treating any lines starting with '#', ';', or '!' as
 comment lines and ignoring them.
 
+The functions ``as_fasta`` and ``as_fasta_2line`` in ``Bio.SeqIO.FastaIO`` were
+deprecated in release 1.86. Please use ``format(record, "fasta")`` or
+``format(record, "fasta-2line")`` instead.
+
+Bio.SeqIO.qualityIO
+-------------------
+The functions ``as_fastq``, ``as_fastq_solexa``, ``as_fastq_illumina``, and
+``as_qual`` in ``Bio.SeqIO.QualityIO`` were deprecated in release 1.86.
+Please use ``format(record, "fastq")``, ``format(record, "fastq-solexa")``, 
+``format(record, "fastq-illumina")``, or ``format(record, "qual")`` instead.
+
+Bio.SeqIO.TabIO
+-------------------
+The function ``as_tab`` in ``Bio.SeqIO.TabIO`` was deprecated in release 1.86.
+Please use ``format(record, "qual")`` instead.
+
 Bio.SeqIO.UniprotIO
 -------------------
 Parsing a UniProt XML file opened in text mode (if the file was opened using

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -90,7 +90,7 @@ Please use ``format(record, "fastq")``, ``format(record, "fastq-solexa")``,
 Bio.SeqIO.TabIO
 -------------------
 The function ``as_tab`` in ``Bio.SeqIO.TabIO`` was deprecated in release 1.86.
-Please use ``format(record, "qual")`` instead.
+Please use ``format(record, "tab")`` instead.
 
 Bio.SeqIO.UniprotIO
 -------------------


### PR DESCRIPTION
Reorganize SeqIO to avoid doing at runtime what can be done at compile time.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
