### PR TITLE
wildcard argument in counts calculation

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3723,7 +3723,7 @@ class Alignment:
                     start1, start2 = end1, end2
         return m
 
-    def counts(self, substitution_matrix=None, ignore_sequences=False):
+    def counts(self, substitution_matrix=None, wildcard=None, ignore_sequences=False):
         """Count the number of identities, mismatches, and gaps of an alignment.
 
         Arguments:
@@ -3733,6 +3733,10 @@ class Alignment:
                                  (typically from the ``Bio.Align.substitution_matrices``
                                  submodule) to also calculate the number of positive
                                  matches in an amino acid alignment.
+         - wildcard            - The wildcard character. This character is
+                                 ignored in the calculation of the number of
+                                 matches, mismatches, and positives.
+                                 Default value: None.
          - ignore_sequences    - If True, do not calculate the number of identities,
                                  positives, and mismatches, but only calculate the
                                  number of aligned sequences and number of gaps
@@ -3790,6 +3794,8 @@ class Alignment:
          - internal_gaps       - the number of gaps in the interior of the alignment;
          - gaps                - the total number of gaps in the alignment;
         """
+        if wildcard is not None:
+            wildcard = ord(wildcard)
         left_insertions = left_deletions = 0
         right_insertions = right_deletions = 0
         internal_insertions = internal_deletions = 0
@@ -3872,7 +3878,9 @@ class Alignment:
                         for c1, c2 in zip(
                             sequence1[start1:end1], sequence2[start2:end2]
                         ):
-                            if c1 == c2:
+                            if c1 == wildcard or c2 == wildcard:
+                                pass
+                            elif c1 == c2:
                                 identities += 1
                             else:
                                 mismatches += 1
@@ -3881,7 +3889,9 @@ class Alignment:
                         for c1, c2 in zip(
                             sequence1[start1:end1], sequence2[start2:end2]
                         ):
-                            if c1 == c2:
+                            if c1 == wildcard or c2 == wildcard:
+                                pass
+                            elif c1 == c2:
                                 identities += 1
                             else:
                                 mismatches += 1

--- a/Doc/Tutorial/chapter_align.rst
+++ b/Doc/Tutorial/chapter_align.rst
@@ -615,6 +615,10 @@ as properties.
    >>> counts.right_deletions
    2
 
+Use the ``wildcard`` argument to specify a letter that should be ignored when
+counting identities, positives, and mismatches (e.g. ``wildcard="?"`` or
+``wildcard="N"`` are common choices).
+
 For an alignment of more than two sequences, the number of identities,
 mismatches, and gaps are calculated and summed for all pairs of sequences in
 the alignment.

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -572,6 +572,14 @@ query             0 GA?T 4
         self.assertTrue(
             np.array_equal(alignment.aligned, np.array([[[0, 4]], [[0, 4]]]))
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 1)
+        counts = alignment.counts(wildcard="?")
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -588,6 +596,14 @@ query             4 GA?T 0
         self.assertTrue(
             np.array_equal(alignment.aligned, np.array([[[0, 4]], [[4, 0]]]))
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 1)
+        counts = alignment.counts(wildcard="?")
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 0)
         seq2 = "GAXT"
         aligner.wildcard = "X"
         score = aligner.score(seq1, seq2)
@@ -610,6 +626,14 @@ query             0 GAXT 4
         self.assertTrue(
             np.array_equal(alignment.aligned, np.array([[[0, 4]], [[0, 4]]]))
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 1)
+        counts = alignment.counts(wildcard="X")
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -626,6 +650,14 @@ query             4 GAXT 0
         self.assertTrue(
             np.array_equal(alignment.aligned, np.array([[[0, 4]], [[4, 0]]]))
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 1)
+        counts = alignment.counts(wildcard="X")
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 0)
         aligner.wildcard = None
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 2.0)
@@ -693,6 +725,14 @@ query             0 GA-A?T 5
                 np.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]]),
             )
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
+        counts = alignment.counts(wildcard="?")
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -712,6 +752,14 @@ query             5 GA-A?T 0
                 np.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]]),
             )
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
+        counts = alignment.counts(wildcard="?")
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
         seq1 = "GAXAT"
         seq2 = "GAAXT"
         aligner.wildcard = "X"
@@ -738,6 +786,14 @@ query             0 GA-AXT 5
                 np.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]]),
             )
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
+        counts = alignment.counts(wildcard="?")
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -757,6 +813,14 @@ query             5 GA-AXT 0
                 np.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]]),
             )
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
+        counts = alignment.counts(wildcard="?")
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
 
     def test_fogsaa_simple2(self):
         seq1 = "GA?AT"
@@ -787,6 +851,14 @@ query             0 GA-A?T 5
                 np.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]]),
             )
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
+        counts = alignment.counts(wildcard="?")
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -806,6 +878,14 @@ query             5 GA-A?T 0
                 np.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]]),
             )
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
+        counts = alignment.counts(wildcard="?")
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
         seq1 = "GAXAT"
         seq2 = "GAAXT"
         aligner.wildcard = "X"
@@ -832,6 +912,14 @@ query             0 GA-AXT 5
                 np.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]]),
             )
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
+        counts = alignment.counts(wildcard="X")
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -851,6 +939,14 @@ query             5 GA-AXT 0
                 np.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]]),
             )
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
+        counts = alignment.counts(wildcard="X")
+        self.assertEqual(counts.aligned, 4)
+        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.mismatches, 0)
 
 
 class TestPairwiseOpenPenalty(unittest.TestCase):
@@ -5306,6 +5402,14 @@ query             0 ACGATCGAGCNGCTACG 17
 """,
         )
         self.assertEqual(alignment.shape, (2, 17))
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 2)
+        counts = alignment.counts(wildcard="N")
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 1)
         self.assertEqual(
             alignment.format("psl"),
             """\
@@ -5336,6 +5440,14 @@ query            22 ACGATCGAGCNGCTACG  5
 """,
         )
         self.assertEqual(alignment.shape, (2, 17))
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 2)
+        counts = alignment.counts(wildcard="N")
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 1)
         self.assertEqual(
             alignment.format("psl"),
             """\
@@ -5367,6 +5479,14 @@ query             0 ACGATCGAGCNGCTACG 17
 """,
         )
         self.assertEqual(alignment.shape, (2, 17))
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 2)
+        counts = alignment.counts(wildcard="N")
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 1)
         self.assertEqual(
             alignment.format("psl"),
             """\
@@ -5398,6 +5518,14 @@ target            6 ACGCTCGAGCAGCTACG 23
 query            22 ACGATCGAGCNGCTACG  5
 """,
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 2)
+        counts = alignment.counts(wildcard="N")
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 1)
         self.assertEqual(alignment.shape, (2, 17))
         self.assertEqual(
             alignment.format("psl"),
@@ -5432,6 +5560,14 @@ target            0 TTTTTNACGCTCGAGCAGCTACG----- 23
 query             0 ------ACGATCGAGCNGCTACGCCCNC 22
 """,
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 2)
+        counts = alignment.counts(wildcard="N")
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 1)
         self.assertEqual(alignment.shape, (2, 28))
         self.assertEqual(
             alignment.format("psl"),
@@ -5462,6 +5598,14 @@ target            0 TTTTTNACGCTCGAGCAGCTACG----- 23
 query            22 ------ACGATCGAGCNGCTACGCCCNC  0
 """,
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 2)
+        counts = alignment.counts(wildcard="N")
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 1)
         self.assertEqual(alignment.shape, (2, 28))
         self.assertEqual(
             alignment.format("psl"),
@@ -5493,6 +5637,14 @@ target            0 TTTTTNACGCTCGAGCAGCTACG----- 23
 query             0 ------ACGATCGAGCNGCTACGCCCNC 22
 """,
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 2)
+        counts = alignment.counts(wildcard="N")
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 1)
         self.assertEqual(alignment.shape, (2, 28))
         self.assertEqual(
             alignment.format("psl"),
@@ -5525,6 +5677,14 @@ target            0 TTTTTNACGCTCGAGCAGCTACG----- 23
 query            22 ------ACGATCGAGCNGCTACGCCCNC  0
 """,
         )
+        counts = alignment.counts()
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 2)
+        counts = alignment.counts(wildcard="N")
+        self.assertEqual(counts.aligned, 17)
+        self.assertEqual(counts.identities, 15)
+        self.assertEqual(counts.mismatches, 1)
         self.assertEqual(alignment.shape, (2, 28))
         self.assertEqual(
             alignment.format("psl"),


### PR DESCRIPTION
When calculating identities, positives, and mismatches, allow a wildcard character.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
