### PR TITLE
PairwiseAligner attribute names

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3963,6 +3963,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "query_left_open_gap_score": "open_left_deletion_score",
                  "query_left_extend_gap_score": "extend_left_deletion_score",
                  "query_right_open_gap_score": "open_right_deletion_score",
+                 "query_right_extend_gap_score": "extend_right_deletion_score",
                }
     def __setattr__(self, key, value):
         try:
@@ -4028,7 +4029,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             "open_left_deletion_score": self.open_left_deletion_score,
             "extend_left_deletion_score": self.extend_left_deletion_score,
             "open_right_deletion_score": self.open_right_deletion_score,
-            "query_right_extend_gap_score": self.query_right_extend_gap_score,
+            "extend_right_deletion_score": self.extend_right_deletion_score,
             "mode": self.mode,
         }
         if self.substitution_matrix is None:
@@ -4051,7 +4052,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         self.open_left_deletion_score = state["open_left_deletion_score"]
         self.extend_left_deletion_score = state["extend_left_deletion_score"]
         self.open_right_deletion_score = state["open_right_deletion_score"]
-        self.query_right_extend_gap_score = state["query_right_extend_gap_score"]
+        self.extend_right_deletion_score = state["extend_right_deletion_score"]
         self.mode = state["mode"]
         substitution_matrix = state.get("substitution_matrix")
         if substitution_matrix is None:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3956,6 +3956,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "target_internal_extend_gap_score": "extend_internal_insertion_score",
                  "target_left_open_gap_score": "open_left_insertion_score",
                  "target_left_extend_gap_score": "extend_left_insertion_score",
+                 "target_right_open_gap_score": "open_right_insertion_score",
                }
     def __setattr__(self, key, value):
         try:
@@ -4014,7 +4015,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             "extend_internal_insertion_score": self.extend_internal_insertion_score,
             "open_left_insertion_score": self.open_left_insertion_score,
             "extend_left_insertion_score": self.extend_left_insertion_score,
-            "target_right_open_gap_score": self.target_right_open_gap_score,
+            "open_right_insertion_score": self.open_right_insertion_score,
             "target_right_extend_gap_score": self.target_right_extend_gap_score,
             "query_internal_open_gap_score": self.query_internal_open_gap_score,
             "query_internal_extend_gap_score": self.query_internal_extend_gap_score,
@@ -4037,7 +4038,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         self.extend_internal_insertion_score = state["extend_internal_insertion_score"]
         self.open_left_insertion_score = state["open_left_insertion_score"]
         self.extend_left_insertion_score = state["extend_left_insertion_score"]
-        self.target_right_open_gap_score = state["target_right_open_gap_score"]
+        self.open_right_insertion_score = state["open_right_insertion_score"]
         self.target_right_extend_gap_score = state["target_right_extend_gap_score"]
         self.query_internal_open_gap_score = state["query_internal_open_gap_score"]
         self.query_internal_extend_gap_score = state["query_internal_extend_gap_score"]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3952,23 +3952,32 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         for name, value in kwargs.items():
             setattr(self, name, value)
 
+    new_keys = {"target_internal_open_gap_score": "open_internal_insertion_score",
+                "target_internal_extend_gap_score": "extend_internal_insertion_score",
+                "target_left_open_gap_score": "open_left_insertion_score",
+               }
     def __setattr__(self, key, value):
-        if key == "target_internal_extend_gap_score":
-            key = "extend_internal_insertion_score"
-        elif key == "target_internal_open_gap_score":
-            key = "open_internal_insertion_score"
-        elif key not in dir(_pairwisealigner.PairwiseAligner):
-            # To prevent confusion, don't allow users to create new attributes.
-            # On CPython, __slots__ can be used for this, but currently
-            # __slots__ does not behave the same way on PyPy at least.
-            raise AttributeError("'PairwiseAligner' object has no attribute '%s'" % key)
+        try:
+            key = self.new_keys[key]
+        except KeyError:
+            if key not in dir(_pairwisealigner.PairwiseAligner):
+                # To prevent confusion, don't allow users to create new attributes.
+                # On CPython, __slots__ can be used for this, but currently
+                # __slots__ does not behave the same way on PyPy at least.
+                raise AttributeError("'PairwiseAligner' object has no attribute '%s'" % key)
+        else:
+            # raise deprecation
+            pass
         _pairwisealigner.PairwiseAligner.__setattr__(self, key, value)
 
     def __getattr__(self, key):
-        if key == "target_internal_extend_gap_score":
-            key = "extend_internal_insertion_score"
-        elif key == "target_internal_open_gap_score":
-            key = "open_internal_insertion_score"
+        try:
+            key = self.new_keys[key]
+        except KeyError:
+            pass
+        else:
+            # raise deprecation
+            pass
         return _pairwisealigner.PairwiseAligner.__getattribute__(self, key)
 
     def align(self, seqA, seqB, strand="+"):
@@ -4002,7 +4011,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             "wildcard": self.wildcard,
             "open_internal_insertion_score": self.open_internal_insertion_score,
             "extend_internal_insertion_score": self.extend_internal_insertion_score,
-            "target_left_open_gap_score": self.target_left_open_gap_score,
+            "open_left_insertion_score": self.open_left_insertion_score,
             "target_left_extend_gap_score": self.target_left_extend_gap_score,
             "target_right_open_gap_score": self.target_right_open_gap_score,
             "target_right_extend_gap_score": self.target_right_extend_gap_score,
@@ -4025,7 +4034,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         self.wildcard = state["wildcard"]
         self.open_internal_insertion_score = state["open_internal_insertion_score"]
         self.extend_internal_insertion_score = state["extend_internal_insertion_score"]
-        self.target_left_open_gap_score = state["target_left_open_gap_score"]
+        self.open_left_insertion_score = state["open_left_insertion_score"]
         self.target_left_extend_gap_score = state["target_left_extend_gap_score"]
         self.target_right_open_gap_score = state["target_right_open_gap_score"]
         self.target_right_extend_gap_score = state["target_right_extend_gap_score"]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3988,6 +3988,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         "query_open_gap_score": "open_deletion_score",
         "query_extend_gap_score": "extend_deletion_score",
         "query_end_gap_score": "end_deletion_score",
+        "query_end_open_gap_score": "open_end_deletion_score",
     }
 
     def __setattr__(self, key, value):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3961,6 +3961,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "query_left_open_gap_score": "open_left_deletion_score",
                  "query_left_extend_gap_score": "extend_left_deletion_score",
                  "query_internal_open_gap_score": "open_internal_deletion_score",
+                 "query_internal_extend_gap_score": "extend_internal_deletion_score",
                }
     def __setattr__(self, key, value):
         try:
@@ -4022,7 +4023,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             "open_right_insertion_score": self.open_right_insertion_score,
             "extend_right_insertion_score": self.extend_right_insertion_score,
             "open_internal_deletion_score": self.open_internal_deletion_score,
-            "query_internal_extend_gap_score": self.query_internal_extend_gap_score,
+            "extend_internal_deletion_score": self.extend_internal_deletion_score,
             "open_left_deletion_score": self.open_left_deletion_score,
             "extend_left_deletion_score": self.extend_left_deletion_score,
             "query_right_open_gap_score": self.query_right_open_gap_score,
@@ -4045,7 +4046,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         self.open_right_insertion_score = state["open_right_insertion_score"]
         self.extend_right_insertion_score = state["extend_right_insertion_score"]
         self.open_internal_deletion_score = state["open_internal_deletion_score"]
-        self.query_internal_extend_gap_score = state["query_internal_extend_gap_score"]
+        self.extend_internal_deletion_score = state["extend_internal_deletion_score"]
         self.open_left_deletion_score = state["open_left_deletion_score"]
         self.extend_left_deletion_score = state["extend_left_deletion_score"]
         self.query_right_open_gap_score = state["query_right_open_gap_score"]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3968,6 +3968,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "query_gap_function": "deletion_score_function",
                  "internal_open_gap_score": "open_internal_gap_score",
                  "internal_extend_gap_score": "extend_internal_gap_score",
+                 "left_open_gap_score": "open_left_gap_score",
                }
     def __setattr__(self, key, value):
         try:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3975,6 +3975,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "end_open_gap_score": "open_end_gap_score",
                  "end_extend_gap_score": "extend_end_gap_score",
                  "target_open_gap_score": "open_insertion_score",
+                 "target_extend_gap_score": "extend_insertion_score",
                }
     def __setattr__(self, key, value):
         try:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3955,6 +3955,8 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
     def __setattr__(self, key, value):
         if key == "target_internal_extend_gap_score":
             key = "extend_internal_insertion_score"
+        elif key == "target_internal_open_gap_score":
+            key = "open_internal_insertion_score"
         elif key not in dir(_pairwisealigner.PairwiseAligner):
             # To prevent confusion, don't allow users to create new attributes.
             # On CPython, __slots__ can be used for this, but currently
@@ -3965,6 +3967,8 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
     def __getattr__(self, key):
         if key == "target_internal_extend_gap_score":
             key = "extend_internal_insertion_score"
+        elif key == "target_internal_open_gap_score":
+            key = "open_internal_insertion_score"
         return _pairwisealigner.PairwiseAligner.__getattribute__(self, key)
 
     def align(self, seqA, seqB, strand="+"):
@@ -3996,7 +4000,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
     def __getstate__(self):
         state = {
             "wildcard": self.wildcard,
-            "target_internal_open_gap_score": self.target_internal_open_gap_score,
+            "open_internal_insertion_score": self.open_internal_insertion_score,
             "extend_internal_insertion_score": self.extend_internal_insertion_score,
             "target_left_open_gap_score": self.target_left_open_gap_score,
             "target_left_extend_gap_score": self.target_left_extend_gap_score,
@@ -4019,7 +4023,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
 
     def __setstate__(self, state):
         self.wildcard = state["wildcard"]
-        self.target_internal_open_gap_score = state["target_internal_open_gap_score"]
+        self.open_internal_insertion_score = state["open_internal_insertion_score"]
         self.extend_internal_insertion_score = state["extend_internal_insertion_score"]
         self.target_left_open_gap_score = state["target_left_open_gap_score"]
         self.target_left_extend_gap_score = state["target_left_extend_gap_score"]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3958,6 +3958,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         "target_internal_gap_score": "internal_insertion_score",
         "target_left_open_gap_score": "open_left_insertion_score",
         "target_left_extend_gap_score": "extend_left_insertion_score",
+        "target_left_gap_score": "left_insertion_score",
         "target_right_open_gap_score": "open_right_insertion_score",
         "target_right_extend_gap_score": "extend_right_insertion_score",
         "query_internal_open_gap_score": "open_internal_deletion_score",

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3990,6 +3990,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         "query_end_gap_score": "end_deletion_score",
         "query_end_open_gap_score": "open_end_deletion_score",
         "query_end_extend_gap_score": "extend_end_deletion_score",
+        "query_internal_gap_score": "internal_deletion_score",
     }
 
     def __setattr__(self, key, value):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3964,6 +3964,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "query_left_extend_gap_score": "extend_left_deletion_score",
                  "query_right_open_gap_score": "open_right_deletion_score",
                  "query_right_extend_gap_score": "extend_right_deletion_score",
+                 "target_gap_function": "insertion_score_function",
                }
     def __setattr__(self, key, value):
         try:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3955,6 +3955,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
     _new_keys = {
         "target_internal_open_gap_score": "open_internal_insertion_score",
         "target_internal_extend_gap_score": "extend_internal_insertion_score",
+        "target_internal_gap_score": "internal_insertion_score",
         "target_left_open_gap_score": "open_left_insertion_score",
         "target_left_extend_gap_score": "extend_left_insertion_score",
         "target_right_open_gap_score": "open_right_insertion_score",

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3952,32 +3952,35 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         for name, value in kwargs.items():
             setattr(self, name, value)
 
-    _new_keys = {"target_internal_open_gap_score": "open_internal_insertion_score",
-                 "target_internal_extend_gap_score": "extend_internal_insertion_score",
-                 "target_left_open_gap_score": "open_left_insertion_score",
-                 "target_left_extend_gap_score": "extend_left_insertion_score",
-                 "target_right_open_gap_score": "open_right_insertion_score",
-                 "target_right_extend_gap_score": "extend_right_insertion_score",
-                 "query_internal_open_gap_score": "open_internal_deletion_score",
-                 "query_internal_extend_gap_score": "extend_internal_deletion_score",
-                 "query_left_open_gap_score": "open_left_deletion_score",
-                 "query_left_extend_gap_score": "extend_left_deletion_score",
-                 "query_right_open_gap_score": "open_right_deletion_score",
-                 "query_right_extend_gap_score": "extend_right_deletion_score",
-                 "target_gap_function": "insertion_score_function",
-                 "query_gap_function": "deletion_score_function",
-                 "internal_open_gap_score": "open_internal_gap_score",
-                 "internal_extend_gap_score": "extend_internal_gap_score",
-                 "left_open_gap_score": "open_left_gap_score",
-                 "left_extend_gap_score": "extend_left_gap_score",
-                 "right_open_gap_score": "open_right_gap_score",
-                 "right_extend_gap_score": "extend_right_gap_score",
-                 "end_open_gap_score": "open_end_gap_score",
-                 "end_extend_gap_score": "extend_end_gap_score",
-                 "target_open_gap_score": "open_insertion_score",
-                 "target_extend_gap_score": "extend_insertion_score",
-                 "query_open_gap_score": "open_deletion_score",
-               }
+    _new_keys = {
+        "target_internal_open_gap_score": "open_internal_insertion_score",
+        "target_internal_extend_gap_score": "extend_internal_insertion_score",
+        "target_left_open_gap_score": "open_left_insertion_score",
+        "target_left_extend_gap_score": "extend_left_insertion_score",
+        "target_right_open_gap_score": "open_right_insertion_score",
+        "target_right_extend_gap_score": "extend_right_insertion_score",
+        "query_internal_open_gap_score": "open_internal_deletion_score",
+        "query_internal_extend_gap_score": "extend_internal_deletion_score",
+        "query_left_open_gap_score": "open_left_deletion_score",
+        "query_left_extend_gap_score": "extend_left_deletion_score",
+        "query_right_open_gap_score": "open_right_deletion_score",
+        "query_right_extend_gap_score": "extend_right_deletion_score",
+        "target_gap_function": "insertion_score_function",
+        "query_gap_function": "deletion_score_function",
+        "internal_open_gap_score": "open_internal_gap_score",
+        "internal_extend_gap_score": "extend_internal_gap_score",
+        "left_open_gap_score": "open_left_gap_score",
+        "left_extend_gap_score": "extend_left_gap_score",
+        "right_open_gap_score": "open_right_gap_score",
+        "right_extend_gap_score": "extend_right_gap_score",
+        "end_open_gap_score": "open_end_gap_score",
+        "end_extend_gap_score": "extend_end_gap_score",
+        "target_gap_score": "insertion_score",
+        "target_open_gap_score": "open_insertion_score",
+        "target_extend_gap_score": "extend_insertion_score",
+        "query_open_gap_score": "open_deletion_score",
+    }
+
     def __setattr__(self, key, value):
         try:
             key = self._new_keys[key]
@@ -3986,7 +3989,9 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                 # To prevent confusion, don't allow users to create new attributes.
                 # On CPython, __slots__ can be used for this, but currently
                 # __slots__ does not behave the same way on PyPy at least.
-                raise AttributeError("'PairwiseAligner' object has no attribute '%s'" % key)
+                raise AttributeError(
+                    "'PairwiseAligner' object has no attribute '%s'" % key
+                )
         else:
             # raise deprecation
             pass

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3959,6 +3959,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "target_right_open_gap_score": "open_right_insertion_score",
                  "target_right_extend_gap_score": "extend_right_insertion_score",
                  "query_left_open_gap_score": "open_left_deletion_score",
+                 "query_left_extend_gap_score": "extend_left_deletion_score",
                }
     def __setattr__(self, key, value):
         try:
@@ -4022,7 +4023,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             "query_internal_open_gap_score": self.query_internal_open_gap_score,
             "query_internal_extend_gap_score": self.query_internal_extend_gap_score,
             "open_left_deletion_score": self.open_left_deletion_score,
-            "query_left_extend_gap_score": self.query_left_extend_gap_score,
+            "extend_left_deletion_score": self.extend_left_deletion_score,
             "query_right_open_gap_score": self.query_right_open_gap_score,
             "query_right_extend_gap_score": self.query_right_extend_gap_score,
             "mode": self.mode,
@@ -4045,7 +4046,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         self.query_internal_open_gap_score = state["query_internal_open_gap_score"]
         self.query_internal_extend_gap_score = state["query_internal_extend_gap_score"]
         self.open_left_deletion_score = state["open_left_deletion_score"]
-        self.query_left_extend_gap_score = state["query_left_extend_gap_score"]
+        self.extend_left_deletion_score = state["extend_left_deletion_score"]
         self.query_right_open_gap_score = state["query_right_open_gap_score"]
         self.query_right_extend_gap_score = state["query_right_extend_gap_score"]
         self.mode = state["mode"]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3961,6 +3961,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         "target_left_gap_score": "left_insertion_score",
         "target_right_open_gap_score": "open_right_insertion_score",
         "target_right_extend_gap_score": "extend_right_insertion_score",
+        "target_right_gap_score": "right_insertion_score",
         "query_internal_open_gap_score": "open_internal_deletion_score",
         "query_internal_extend_gap_score": "extend_internal_deletion_score",
         "query_left_open_gap_score": "open_left_deletion_score",

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3958,6 +3958,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "target_left_extend_gap_score": "extend_left_insertion_score",
                  "target_right_open_gap_score": "open_right_insertion_score",
                  "target_right_extend_gap_score": "extend_right_insertion_score",
+                 "query_left_open_gap_score": "open_left_deletion_score",
                }
     def __setattr__(self, key, value):
         try:
@@ -4020,7 +4021,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             "extend_right_insertion_score": self.extend_right_insertion_score,
             "query_internal_open_gap_score": self.query_internal_open_gap_score,
             "query_internal_extend_gap_score": self.query_internal_extend_gap_score,
-            "query_left_open_gap_score": self.query_left_open_gap_score,
+            "open_left_deletion_score": self.open_left_deletion_score,
             "query_left_extend_gap_score": self.query_left_extend_gap_score,
             "query_right_open_gap_score": self.query_right_open_gap_score,
             "query_right_extend_gap_score": self.query_right_extend_gap_score,
@@ -4043,7 +4044,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         self.extend_right_insertion_score = state["extend_right_insertion_score"]
         self.query_internal_open_gap_score = state["query_internal_open_gap_score"]
         self.query_internal_extend_gap_score = state["query_internal_extend_gap_score"]
-        self.query_left_open_gap_score = state["query_left_open_gap_score"]
+        self.open_left_deletion_score = state["open_left_deletion_score"]
         self.query_left_extend_gap_score = state["query_left_extend_gap_score"]
         self.query_right_open_gap_score = state["query_right_open_gap_score"]
         self.query_right_extend_gap_score = state["query_right_extend_gap_score"]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3980,6 +3980,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         "target_extend_gap_score": "extend_insertion_score",
         "target_end_gap_score": "end_insertion_score",
         "target_end_open_gap_score": "open_end_insertion_score",
+        "target_end_extend_gap_score": "extend_end_insertion_score",
         "query_open_gap_score": "open_deletion_score",
     }
 

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3965,6 +3965,9 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "query_right_open_gap_score": "open_right_deletion_score",
                  "query_right_extend_gap_score": "extend_right_deletion_score",
                  "target_gap_function": "insertion_score_function",
+                 "query_gap_function": "deletion_score_function",
+                 "internal_open_gap_score": "open_internal_gap_score",
+                 "internal_extend_gap_score": "extend_internal_gap_score",
                }
     def __setattr__(self, key, value):
         try:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3859,8 +3859,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
 
     >>> aligner.open_gap_score = -0.5
     >>> aligner.extend_gap_score = -0.1
-    >>> aligner.target_end_gap_score = 0.0
-    >>> aligner.query_end_gap_score = 0.0
+    >>> aligner.end_gap_score = 0.0
     >>> for alignment in aligner.align("TACCG", "ACG"):
     ...     print("Score = %.1f:" % alignment.score)
     ...     print(alignment)

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3991,6 +3991,8 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         "query_end_open_gap_score": "open_end_deletion_score",
         "query_end_extend_gap_score": "extend_end_deletion_score",
         "query_internal_gap_score": "internal_deletion_score",
+        "query_left_gap_score": "left_deletion_score",
+        "query_right_gap_score": "right_deletion_score",
     }
 
     def __setattr__(self, key, value):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3976,6 +3976,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "end_extend_gap_score": "extend_end_gap_score",
                  "target_open_gap_score": "open_insertion_score",
                  "target_extend_gap_score": "extend_insertion_score",
+                 "query_open_gap_score": "open_deletion_score",
                }
     def __setattr__(self, key, value):
         try:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3969,6 +3969,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "internal_open_gap_score": "open_internal_gap_score",
                  "internal_extend_gap_score": "extend_internal_gap_score",
                  "left_open_gap_score": "open_left_gap_score",
+                 "left_extend_gap_score": "extend_left_gap_score",
                }
     def __setattr__(self, key, value):
         try:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3984,7 +3984,9 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         "target_end_gap_score": "end_insertion_score",
         "target_end_open_gap_score": "open_end_insertion_score",
         "target_end_extend_gap_score": "extend_end_insertion_score",
+        "query_gap_score": "deletion_score",
         "query_open_gap_score": "open_deletion_score",
+        "query_extend_gap_score": "extend_deletion_score",
     }
 
     def __setattr__(self, key, value):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3972,6 +3972,8 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "left_extend_gap_score": "extend_left_gap_score",
                  "right_open_gap_score": "open_right_gap_score",
                  "right_extend_gap_score": "extend_right_gap_score",
+                 "end_open_gap_score": "open_end_gap_score",
+                 "end_extend_gap_score": "extend_end_gap_score",
                }
     def __setattr__(self, key, value):
         try:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3996,7 +3996,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
 
     def __setattr__(self, key, value):
         try:
-            key = self._new_keys[key]
+            new_key = self._new_keys[key]
         except KeyError:
             if key not in dir(_pairwisealigner.PairwiseAligner):
                 # To prevent confusion, don't allow users to create new attributes.
@@ -4006,18 +4006,26 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                     "'PairwiseAligner' object has no attribute '%s'" % key
                 )
         else:
-            # raise deprecation
-            pass
+            warnings.warn("""\
+The attribute '%s' was renamed to '%s'. This was done to be consistent with the
+AlignmentCounts object returned by the .counts method of an Alignment object.""" % (key, new_key),
+                BiopythonDeprecationWarning,
+            )
+            key = new_key
         _pairwisealigner.PairwiseAligner.__setattr__(self, key, value)
 
     def __getattr__(self, key):
         try:
-            key = self._new_keys[key]
+            new_key = self._new_keys[key]
         except KeyError:
             pass
         else:
-            # raise deprecation
-            pass
+            warnings.warn("""\
+The attribute '%s' was renamed to '%s'. This was done to be consistent with the
+AlignmentCounts object returned by the .counts method of an Alignment object.""" % (key, new_key),
+                BiopythonDeprecationWarning,
+            )
+            key = new_key
         return _pairwisealigner.PairwiseAligner.__getattribute__(self, key)
 
     def align(self, seqA, seqB, strand="+"):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3958,10 +3958,11 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "target_left_extend_gap_score": "extend_left_insertion_score",
                  "target_right_open_gap_score": "open_right_insertion_score",
                  "target_right_extend_gap_score": "extend_right_insertion_score",
-                 "query_left_open_gap_score": "open_left_deletion_score",
-                 "query_left_extend_gap_score": "extend_left_deletion_score",
                  "query_internal_open_gap_score": "open_internal_deletion_score",
                  "query_internal_extend_gap_score": "extend_internal_deletion_score",
+                 "query_left_open_gap_score": "open_left_deletion_score",
+                 "query_left_extend_gap_score": "extend_left_deletion_score",
+                 "query_right_open_gap_score": "open_right_deletion_score",
                }
     def __setattr__(self, key, value):
         try:
@@ -4026,7 +4027,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             "extend_internal_deletion_score": self.extend_internal_deletion_score,
             "open_left_deletion_score": self.open_left_deletion_score,
             "extend_left_deletion_score": self.extend_left_deletion_score,
-            "query_right_open_gap_score": self.query_right_open_gap_score,
+            "open_right_deletion_score": self.open_right_deletion_score,
             "query_right_extend_gap_score": self.query_right_extend_gap_score,
             "mode": self.mode,
         }
@@ -4049,7 +4050,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         self.extend_internal_deletion_score = state["extend_internal_deletion_score"]
         self.open_left_deletion_score = state["open_left_deletion_score"]
         self.extend_left_deletion_score = state["extend_left_deletion_score"]
-        self.query_right_open_gap_score = state["query_right_open_gap_score"]
+        self.open_right_deletion_score = state["open_right_deletion_score"]
         self.query_right_extend_gap_score = state["query_right_extend_gap_score"]
         self.mode = state["mode"]
         substitution_matrix = state.get("substitution_matrix")

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3970,6 +3970,8 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "internal_extend_gap_score": "extend_internal_gap_score",
                  "left_open_gap_score": "open_left_gap_score",
                  "left_extend_gap_score": "extend_left_gap_score",
+                 "right_open_gap_score": "open_right_gap_score",
+                 "right_extend_gap_score": "extend_right_gap_score",
                }
     def __setattr__(self, key, value):
         try:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3952,13 +3952,14 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         for name, value in kwargs.items():
             setattr(self, name, value)
 
-    new_keys = {"target_internal_open_gap_score": "open_internal_insertion_score",
-                "target_internal_extend_gap_score": "extend_internal_insertion_score",
-                "target_left_open_gap_score": "open_left_insertion_score",
+    _new_keys = {"target_internal_open_gap_score": "open_internal_insertion_score",
+                 "target_internal_extend_gap_score": "extend_internal_insertion_score",
+                 "target_left_open_gap_score": "open_left_insertion_score",
+                 "target_left_extend_gap_score": "extend_left_insertion_score",
                }
     def __setattr__(self, key, value):
         try:
-            key = self.new_keys[key]
+            key = self._new_keys[key]
         except KeyError:
             if key not in dir(_pairwisealigner.PairwiseAligner):
                 # To prevent confusion, don't allow users to create new attributes.
@@ -3972,7 +3973,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
 
     def __getattr__(self, key):
         try:
-            key = self.new_keys[key]
+            key = self._new_keys[key]
         except KeyError:
             pass
         else:
@@ -4012,7 +4013,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             "open_internal_insertion_score": self.open_internal_insertion_score,
             "extend_internal_insertion_score": self.extend_internal_insertion_score,
             "open_left_insertion_score": self.open_left_insertion_score,
-            "target_left_extend_gap_score": self.target_left_extend_gap_score,
+            "extend_left_insertion_score": self.extend_left_insertion_score,
             "target_right_open_gap_score": self.target_right_open_gap_score,
             "target_right_extend_gap_score": self.target_right_extend_gap_score,
             "query_internal_open_gap_score": self.query_internal_open_gap_score,
@@ -4035,7 +4036,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         self.open_internal_insertion_score = state["open_internal_insertion_score"]
         self.extend_internal_insertion_score = state["extend_internal_insertion_score"]
         self.open_left_insertion_score = state["open_left_insertion_score"]
-        self.target_left_extend_gap_score = state["target_left_extend_gap_score"]
+        self.extend_left_insertion_score = state["extend_left_insertion_score"]
         self.target_right_open_gap_score = state["target_right_open_gap_score"]
         self.target_right_extend_gap_score = state["target_right_extend_gap_score"]
         self.query_internal_open_gap_score = state["query_internal_open_gap_score"]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3974,6 +3974,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "right_extend_gap_score": "extend_right_gap_score",
                  "end_open_gap_score": "open_end_gap_score",
                  "end_extend_gap_score": "extend_end_gap_score",
+                 "target_open_gap_score": "open_insertion_score",
                }
     def __setattr__(self, key, value):
         try:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -4006,9 +4006,11 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                     "'PairwiseAligner' object has no attribute '%s'" % key
                 )
         else:
-            warnings.warn("""\
+            warnings.warn(
+                """\
 The attribute '%s' was renamed to '%s'. This was done to be consistent with the
-AlignmentCounts object returned by the .counts method of an Alignment object.""" % (key, new_key),
+AlignmentCounts object returned by the .counts method of an Alignment object."""
+                % (key, new_key),
                 BiopythonDeprecationWarning,
             )
             key = new_key
@@ -4020,9 +4022,11 @@ AlignmentCounts object returned by the .counts method of an Alignment object."""
         except KeyError:
             pass
         else:
-            warnings.warn("""\
+            warnings.warn(
+                """\
 The attribute '%s' was renamed to '%s'. This was done to be consistent with the
-AlignmentCounts object returned by the .counts method of an Alignment object.""" % (key, new_key),
+AlignmentCounts object returned by the .counts method of an Alignment object."""
+                % (key, new_key),
                 BiopythonDeprecationWarning,
             )
             key = new_key

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3953,12 +3953,19 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             setattr(self, name, value)
 
     def __setattr__(self, key, value):
-        if key not in dir(_pairwisealigner.PairwiseAligner):
+        if key == "target_internal_extend_gap_score":
+            key = "extend_internal_insertion_score"
+        elif key not in dir(_pairwisealigner.PairwiseAligner):
             # To prevent confusion, don't allow users to create new attributes.
             # On CPython, __slots__ can be used for this, but currently
             # __slots__ does not behave the same way on PyPy at least.
             raise AttributeError("'PairwiseAligner' object has no attribute '%s'" % key)
         _pairwisealigner.PairwiseAligner.__setattr__(self, key, value)
+
+    def __getattr__(self, key):
+        if key == "target_internal_extend_gap_score":
+            key = "extend_internal_insertion_score"
+        return _pairwisealigner.PairwiseAligner.__getattribute__(self, key)
 
     def align(self, seqA, seqB, strand="+"):
         """Return the alignments of two sequences using PairwiseAligner."""
@@ -3990,7 +3997,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         state = {
             "wildcard": self.wildcard,
             "target_internal_open_gap_score": self.target_internal_open_gap_score,
-            "target_internal_extend_gap_score": self.target_internal_extend_gap_score,
+            "extend_internal_insertion_score": self.extend_internal_insertion_score,
             "target_left_open_gap_score": self.target_left_open_gap_score,
             "target_left_extend_gap_score": self.target_left_extend_gap_score,
             "target_right_open_gap_score": self.target_right_open_gap_score,
@@ -4013,9 +4020,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
     def __setstate__(self, state):
         self.wildcard = state["wildcard"]
         self.target_internal_open_gap_score = state["target_internal_open_gap_score"]
-        self.target_internal_extend_gap_score = state[
-            "target_internal_extend_gap_score"
-        ]
+        self.extend_internal_insertion_score = state["extend_internal_insertion_score"]
         self.target_left_open_gap_score = state["target_left_open_gap_score"]
         self.target_left_extend_gap_score = state["target_left_extend_gap_score"]
         self.target_right_open_gap_score = state["target_right_open_gap_score"]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3957,6 +3957,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "target_left_open_gap_score": "open_left_insertion_score",
                  "target_left_extend_gap_score": "extend_left_insertion_score",
                  "target_right_open_gap_score": "open_right_insertion_score",
+                 "target_right_extend_gap_score": "extend_right_insertion_score",
                }
     def __setattr__(self, key, value):
         try:
@@ -4016,7 +4017,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             "open_left_insertion_score": self.open_left_insertion_score,
             "extend_left_insertion_score": self.extend_left_insertion_score,
             "open_right_insertion_score": self.open_right_insertion_score,
-            "target_right_extend_gap_score": self.target_right_extend_gap_score,
+            "extend_right_insertion_score": self.extend_right_insertion_score,
             "query_internal_open_gap_score": self.query_internal_open_gap_score,
             "query_internal_extend_gap_score": self.query_internal_extend_gap_score,
             "query_left_open_gap_score": self.query_left_open_gap_score,
@@ -4039,7 +4040,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         self.open_left_insertion_score = state["open_left_insertion_score"]
         self.extend_left_insertion_score = state["extend_left_insertion_score"]
         self.open_right_insertion_score = state["open_right_insertion_score"]
-        self.target_right_extend_gap_score = state["target_right_extend_gap_score"]
+        self.extend_right_insertion_score = state["extend_right_insertion_score"]
         self.query_internal_open_gap_score = state["query_internal_open_gap_score"]
         self.query_internal_extend_gap_score = state["query_internal_extend_gap_score"]
         self.query_left_open_gap_score = state["query_left_open_gap_score"]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3979,6 +3979,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         "target_open_gap_score": "open_insertion_score",
         "target_extend_gap_score": "extend_insertion_score",
         "target_end_gap_score": "end_insertion_score",
+        "target_end_open_gap_score": "open_end_insertion_score",
         "query_open_gap_score": "open_deletion_score",
     }
 

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3960,6 +3960,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                  "target_right_extend_gap_score": "extend_right_insertion_score",
                  "query_left_open_gap_score": "open_left_deletion_score",
                  "query_left_extend_gap_score": "extend_left_deletion_score",
+                 "query_internal_open_gap_score": "open_internal_deletion_score",
                }
     def __setattr__(self, key, value):
         try:
@@ -4020,7 +4021,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             "extend_left_insertion_score": self.extend_left_insertion_score,
             "open_right_insertion_score": self.open_right_insertion_score,
             "extend_right_insertion_score": self.extend_right_insertion_score,
-            "query_internal_open_gap_score": self.query_internal_open_gap_score,
+            "open_internal_deletion_score": self.open_internal_deletion_score,
             "query_internal_extend_gap_score": self.query_internal_extend_gap_score,
             "open_left_deletion_score": self.open_left_deletion_score,
             "extend_left_deletion_score": self.extend_left_deletion_score,
@@ -4043,7 +4044,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         self.extend_left_insertion_score = state["extend_left_insertion_score"]
         self.open_right_insertion_score = state["open_right_insertion_score"]
         self.extend_right_insertion_score = state["extend_right_insertion_score"]
-        self.query_internal_open_gap_score = state["query_internal_open_gap_score"]
+        self.open_internal_deletion_score = state["open_internal_deletion_score"]
         self.query_internal_extend_gap_score = state["query_internal_extend_gap_score"]
         self.open_left_deletion_score = state["open_left_deletion_score"]
         self.extend_left_deletion_score = state["extend_left_deletion_score"]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3987,6 +3987,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         "query_gap_score": "deletion_score",
         "query_open_gap_score": "open_deletion_score",
         "query_extend_gap_score": "extend_deletion_score",
+        "query_end_gap_score": "end_deletion_score",
     }
 
     def __setattr__(self, key, value):

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3978,6 +3978,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         "target_gap_score": "insertion_score",
         "target_open_gap_score": "open_insertion_score",
         "target_extend_gap_score": "extend_insertion_score",
+        "target_end_gap_score": "end_insertion_score",
         "query_open_gap_score": "open_deletion_score",
     }
 

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -3989,6 +3989,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
         "query_extend_gap_score": "extend_deletion_score",
         "query_end_gap_score": "end_deletion_score",
         "query_end_open_gap_score": "open_end_deletion_score",
+        "query_end_extend_gap_score": "extend_end_deletion_score",
     }
 
     def __setattr__(self, key, value):

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3140,10 +3140,10 @@ Aligner_set_extend_internal_insertion_score(Aligner* self,
     return 0;
 }
 
-static char Aligner_target_internal_gap_score__doc__[] = "target internal gap score";
+static char Aligner_internal_insertion_score__doc__[] = "internal insertion score";
 
 static PyObject*
-Aligner_get_target_internal_gap_score(Aligner* self, void* closure)
+Aligner_get_internal_insertion_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -3159,8 +3159,8 @@ Aligner_get_target_internal_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_target_internal_gap_score(Aligner* self, PyObject* value,
-                                      void* closure)
+Aligner_set_internal_insertion_score(Aligner* self, PyObject* value,
+                                     void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_internal_insertion_score = score;
@@ -4021,10 +4021,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_extend_internal_insertion_score,
         (setter)Aligner_set_extend_internal_insertion_score,
         Aligner_extend_internal_insertion_score__doc__, NULL},
-    {"target_internal_gap_score",
-        (getter)Aligner_get_target_internal_gap_score,
-        (setter)Aligner_set_target_internal_gap_score,
-        Aligner_target_internal_gap_score__doc__, NULL},
+    {"internal_insertion_score",
+        (getter)Aligner_get_internal_insertion_score,
+        (setter)Aligner_set_internal_insertion_score,
+        Aligner_internal_insertion_score__doc__, NULL},
     {"open_left_insertion_score",
         (getter)Aligner_get_open_left_insertion_score,
         (setter)Aligner_set_open_left_insertion_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -2971,10 +2971,10 @@ Aligner_set_target_gap_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_query_open_gap_score__doc__[] = "query gap open score";
+static char Aligner_open_deletion_score__doc__[] = "open deletion score";
 
 static PyObject*
-Aligner_get_query_open_gap_score(Aligner* self, void* closure)
+Aligner_get_open_deletion_score(Aligner* self, void* closure)
 {   if (self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -2991,7 +2991,7 @@ Aligner_get_query_open_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_query_open_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_open_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_internal_deletion_score = score;
@@ -3989,10 +3989,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_target_gap_score,
         (setter)Aligner_set_target_gap_score,
         Aligner_target_gap_score__doc__, NULL},
-    {"query_open_gap_score",
-        (getter)Aligner_get_query_open_gap_score,
-        (setter)Aligner_set_query_open_gap_score,
-        Aligner_query_open_gap_score__doc__, NULL},
+    {"open_deletion_score",
+        (getter)Aligner_get_open_deletion_score,
+        (setter)Aligner_set_open_deletion_score,
+        Aligner_open_deletion_score__doc__, NULL},
     {"query_extend_gap_score",
         (getter)Aligner_get_query_extend_gap_score,
         (setter)Aligner_set_query_extend_gap_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -1771,7 +1771,7 @@ typedef struct {
     double open_left_insertion_score;
     double extend_left_insertion_score;
     double open_right_insertion_score;
-    double target_right_extend_gap_score;
+    double extend_right_insertion_score;
     double query_internal_open_gap_score;
     double query_internal_extend_gap_score;
     double query_left_open_gap_score;
@@ -1885,7 +1885,7 @@ static Algorithm _get_algorithm(Aligner* self)
         const double query_left_open = self->query_left_open_gap_score;
         const double open_right_insertion_score = self->open_right_insertion_score;
         const double query_right_open = self->query_right_open_gap_score;
-        const double target_right_extend = self->target_right_extend_gap_score;
+        const double target_right_extend = self->extend_right_insertion_score;
         const double query_left_extend = self->query_left_extend_gap_score;
         const double query_right_extend = self->query_right_extend_gap_score;
         if (self->mode == FOGSAA_Mode)
@@ -1920,7 +1920,7 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->open_left_insertion_score = 0;
     self->extend_left_insertion_score = 0;
     self->open_right_insertion_score = 0;
-    self->target_right_extend_gap_score = 0;
+    self->extend_right_insertion_score = 0;
     self->query_left_open_gap_score = 0;
     self->query_left_extend_gap_score = 0;
     self->query_right_open_gap_score = 0;
@@ -2001,8 +2001,8 @@ Aligner_str(Aligner* self)
                      self->extend_left_insertion_score);
         p += sprintf(p, "  open_right_insertion_score: %f\n",
                      self->open_right_insertion_score);
-        p += sprintf(p, "  target_right_extend_gap_score: %f\n",
-                     self->target_right_extend_gap_score);
+        p += sprintf(p, "  extend_right_insertion_score: %f\n",
+                     self->extend_right_insertion_score);
     }
     if (self->query_gap_function) {
         p += sprintf(p, "  query_gap_function: %%R\n");
@@ -2244,7 +2244,7 @@ Aligner_get_gap_score(Aligner* self, void* closure)
          || score != self->open_left_insertion_score
          || score != self->extend_left_insertion_score
          || score != self->open_right_insertion_score
-         || score != self->target_right_extend_gap_score
+         || score != self->extend_right_insertion_score
          || score != self->query_internal_open_gap_score
          || score != self->query_internal_extend_gap_score
          || score != self->query_left_open_gap_score
@@ -2284,7 +2284,7 @@ Aligner_set_gap_score(Aligner* self, PyObject* value, void* closure)
         self->open_left_insertion_score = score;
         self->extend_left_insertion_score = score;
         self->open_right_insertion_score = score;
-        self->target_right_extend_gap_score = score;
+        self->extend_right_insertion_score = score;
         self->query_internal_open_gap_score = score;
         self->query_internal_extend_gap_score = score;
         self->query_left_open_gap_score = score;
@@ -2353,7 +2353,7 @@ Aligner_get_extend_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->extend_internal_insertion_score;
         if (score != self->extend_left_insertion_score
-         || score != self->target_right_extend_gap_score
+         || score != self->extend_right_insertion_score
          || score != self->query_internal_extend_gap_score
          || score != self->query_left_extend_gap_score
          || score != self->query_right_extend_gap_score) {
@@ -2378,7 +2378,7 @@ Aligner_set_extend_gap_score(Aligner* self, PyObject* value, void* closure)
     }
     self->extend_internal_insertion_score = score;
     self->extend_left_insertion_score = score;
-    self->target_right_extend_gap_score = score;
+    self->extend_right_insertion_score = score;
     self->query_internal_extend_gap_score = score;
     self->query_left_extend_gap_score = score;
     self->query_right_extend_gap_score = score;
@@ -2511,7 +2511,7 @@ Aligner_get_end_gap_score(Aligner* self, void* closure)
         const double score = self->open_left_insertion_score;
         if (score != self->extend_left_insertion_score
          || score != self->open_right_insertion_score
-         || score != self->target_right_extend_gap_score
+         || score != self->extend_right_insertion_score
          || score != self->query_left_open_gap_score
          || score != self->query_left_extend_gap_score
          || score != self->query_right_open_gap_score
@@ -2538,7 +2538,7 @@ Aligner_set_end_gap_score(Aligner* self, PyObject* value, void* closure)
     self->open_left_insertion_score = score;
     self->extend_left_insertion_score = score;
     self->open_right_insertion_score = score;
-    self->target_right_extend_gap_score = score;
+    self->extend_right_insertion_score = score;
     self->query_left_open_gap_score = score;
     self->query_left_extend_gap_score = score;
     self->query_right_open_gap_score = score;
@@ -2597,7 +2597,7 @@ Aligner_get_end_extend_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->extend_left_insertion_score;
-        if (score != self->target_right_extend_gap_score
+        if (score != self->extend_right_insertion_score
          || score != self->query_left_extend_gap_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2620,7 +2620,7 @@ Aligner_set_end_extend_gap_score(Aligner* self, PyObject* value, void* closure)
         self->query_gap_function = NULL;
     }
     self->extend_left_insertion_score = score;
-    self->target_right_extend_gap_score = score;
+    self->extend_right_insertion_score = score;
     self->query_left_extend_gap_score = score;
     self->query_right_extend_gap_score = score;
     self->algorithm = Unknown;
@@ -2677,7 +2677,7 @@ Aligner_get_right_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_right_insertion_score;
-        if (score != self->target_right_extend_gap_score
+        if (score != self->extend_right_insertion_score
          || score != self->query_right_open_gap_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2700,7 +2700,7 @@ Aligner_set_right_gap_score(Aligner* self, PyObject* value, void* closure)
         self->query_gap_function = NULL;
     }
     self->open_right_insertion_score = score;
-    self->target_right_extend_gap_score = score;
+    self->extend_right_insertion_score = score;
     self->query_right_open_gap_score = score;
     self->query_right_extend_gap_score = score;
     self->algorithm = Unknown;
@@ -2824,7 +2824,7 @@ Aligner_get_right_extend_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_right_extend_gap_score;
+        const double score = self->extend_right_insertion_score;
         if (score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2845,7 +2845,7 @@ Aligner_set_right_extend_gap_score(Aligner* self, PyObject* value, void* closure
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_right_extend_gap_score = score;
+    self->extend_right_insertion_score = score;
     self->query_right_extend_gap_score = score;
     self->algorithm = Unknown;
     return 0;
@@ -2896,7 +2896,7 @@ Aligner_get_target_extend_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->extend_internal_insertion_score;
         if (score != self->extend_left_insertion_score
-         || score != self->target_right_extend_gap_score) {
+         || score != self->extend_right_insertion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2910,7 +2910,7 @@ Aligner_set_target_extend_gap_score(Aligner* self, PyObject* value, void* closur
     if (PyErr_Occurred()) return -1;
     self->extend_internal_insertion_score = score;
     self->extend_left_insertion_score = score;
-    self->target_right_extend_gap_score = score;
+    self->extend_right_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -2933,7 +2933,7 @@ Aligner_get_target_gap_score(Aligner* self, void* closure)
          || score != self->open_left_insertion_score
          || score != self->extend_left_insertion_score
          || score != self->open_right_insertion_score
-         || score != self->target_right_extend_gap_score) {
+         || score != self->extend_right_insertion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2961,7 +2961,7 @@ Aligner_set_target_gap_score(Aligner* self, PyObject* value, void* closure)
         self->open_left_insertion_score = score;
         self->extend_left_insertion_score = score;
         self->open_right_insertion_score = score;
-        self->target_right_extend_gap_score = score;
+        self->extend_right_insertion_score = score;
         if (self->target_gap_function) {
             Py_DECREF(self->target_gap_function);
             self->target_gap_function = NULL;
@@ -3185,7 +3185,7 @@ Aligner_get_target_end_gap_score(Aligner* self, void* closure)
         const double score = self->open_left_insertion_score;
         if (score != self->extend_left_insertion_score
          || score != self->open_right_insertion_score
-         || score != self->target_right_extend_gap_score) {
+         || score != self->extend_right_insertion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3200,7 +3200,7 @@ Aligner_set_target_end_gap_score(Aligner* self, PyObject* value, void* closure) 
     self->open_left_insertion_score = score;
     self->extend_left_insertion_score = score;
     self->open_right_insertion_score = score;
-    self->target_right_extend_gap_score = score;
+    self->extend_right_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -3252,7 +3252,7 @@ Aligner_get_target_end_extend_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->extend_left_insertion_score;
-        if (score != self->target_right_extend_gap_score) {
+        if (score != self->extend_right_insertion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3265,7 +3265,7 @@ Aligner_set_target_end_extend_gap_score(Aligner* self, PyObject* value, void* cl
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_left_insertion_score = score;
-    self->target_right_extend_gap_score = score;
+    self->extend_right_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -3378,22 +3378,22 @@ Aligner_set_open_right_insertion_score(Aligner* self, PyObject* value, void* clo
     return 0;
 }
 
-static char Aligner_target_right_extend_gap_score__doc__[] = "target right extend score";
+static char Aligner_extend_right_insertion_score__doc__[] = "target right extend score";
 
 static PyObject*
-Aligner_get_target_right_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_right_insertion_score(Aligner* self, void* closure)
 {   if (self->target_gap_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->target_right_extend_gap_score);
+    return PyFloat_FromDouble(self->extend_right_insertion_score);
 }
 
 static int
-Aligner_set_target_right_extend_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_extend_right_insertion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_right_extend_gap_score = score;
+    self->extend_right_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -3412,7 +3412,7 @@ Aligner_get_target_right_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_right_insertion_score;
-        if (score != self->target_right_extend_gap_score) {
+        if (score != self->extend_right_insertion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3425,7 +3425,7 @@ Aligner_set_target_right_gap_score(Aligner* self, PyObject* value, void* closure
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_right_insertion_score = score;
-    self->target_right_extend_gap_score = score;
+    self->extend_right_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -4041,10 +4041,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_open_right_insertion_score,
         (setter)Aligner_set_open_right_insertion_score,
         Aligner_target_right_gap_score_open__doc__, NULL},
-    {"target_right_extend_gap_score",
-        (getter)Aligner_get_target_right_extend_gap_score,
-        (setter)Aligner_set_target_right_extend_gap_score,
-        Aligner_target_right_extend_gap_score__doc__, NULL},
+    {"extend_right_insertion_score",
+        (getter)Aligner_get_extend_right_insertion_score,
+        (setter)Aligner_set_extend_right_insertion_score,
+        Aligner_extend_right_insertion_score__doc__, NULL},
     {"target_right_gap_score",
         (getter)Aligner_get_target_right_gap_score,
         (setter)Aligner_set_target_right_gap_score,
@@ -4550,12 +4550,12 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     switch (strand) { \
         case '+': \
             left_gap_extend_A = self->extend_left_insertion_score; \
-            right_gap_extend_A = self->target_right_extend_gap_score; \
+            right_gap_extend_A = self->extend_right_insertion_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
-            left_gap_extend_A = self->target_right_extend_gap_score; \
+            left_gap_extend_A = self->extend_right_insertion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
@@ -4684,12 +4684,12 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     switch (strand) { \
         case '+': \
             left_gap_extend_A = self->extend_left_insertion_score; \
-            right_gap_extend_A = self->target_right_extend_gap_score; \
+            right_gap_extend_A = self->extend_right_insertion_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
-            left_gap_extend_A = self->target_right_extend_gap_score; \
+            left_gap_extend_A = self->extend_right_insertion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
@@ -4852,13 +4852,13 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
             left_gap_extend_B = self->query_left_extend_gap_score; \
             right_gap_open_A = self->open_right_insertion_score; \
             right_gap_open_B = self->query_right_open_gap_score; \
-            right_gap_extend_A = self->target_right_extend_gap_score; \
+            right_gap_extend_A = self->extend_right_insertion_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
             left_gap_open_A = self->open_right_insertion_score; \
             left_gap_open_B = self->query_right_open_gap_score; \
-            left_gap_extend_A = self->target_right_extend_gap_score; \
+            left_gap_extend_A = self->extend_right_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->query_left_open_gap_score; \
@@ -5137,13 +5137,13 @@ exit: \
             left_gap_extend_B = self->query_left_extend_gap_score; \
             right_gap_open_A = self->open_right_insertion_score; \
             right_gap_open_B = self->query_right_open_gap_score; \
-            right_gap_extend_A = self->target_right_extend_gap_score; \
+            right_gap_extend_A = self->extend_right_insertion_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
             left_gap_open_A = self->open_right_insertion_score; \
             left_gap_open_B = self->query_right_open_gap_score; \
-            left_gap_extend_A = self->target_right_extend_gap_score; \
+            left_gap_extend_A = self->extend_right_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->query_left_open_gap_score; \
@@ -6028,13 +6028,13 @@ exit: \
             left_gap_extend_B = self->query_left_extend_gap_score; \
             right_gap_open_A = self->open_right_insertion_score; \
             right_gap_open_B = self->query_right_open_gap_score; \
-            right_gap_extend_A = self->target_right_extend_gap_score; \
+            right_gap_extend_A = self->extend_right_insertion_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
             left_gap_open_A = self->open_right_insertion_score; \
             left_gap_open_B = self->query_right_open_gap_score; \
-            left_gap_extend_A = self->target_right_extend_gap_score; \
+            left_gap_extend_A = self->extend_right_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->query_left_open_gap_score; \
@@ -7085,7 +7085,7 @@ Aligner_watermansmithbeyer_local_align_matrix(Aligner* self,
             self->query_right_extend_gap_score > mismatch || \
             self->extend_left_insertion_score > mismatch || \
             self->extend_internal_insertion_score > mismatch || \
-            self->target_right_extend_gap_score > mismatch) { \
+            self->extend_right_insertion_score > mismatch) { \
         PyObject *Bio_module = PyImport_ImportModule("Bio"); \
         PyObject *BiopythonWarning = PyObject_GetAttrString(Bio_module, "BiopythonWarning"); \
         Py_DECREF(Bio_module); \

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -2587,10 +2587,10 @@ Aligner_set_open_end_gap_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_end_extend_gap_score__doc__[] = "end extend gap score";
+static char Aligner_extend_end_gap_score__doc__[] = "extend end gap score";
 
 static PyObject*
-Aligner_get_end_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_end_gap_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function || self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -2608,7 +2608,7 @@ Aligner_get_end_extend_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_end_extend_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_extend_end_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     if (self->insertion_score_function) {
@@ -3949,10 +3949,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_open_end_gap_score,
         (setter)Aligner_set_open_end_gap_score,
         Aligner_open_end_gap_score__doc__, NULL},
-    {"end_extend_gap_score",
-        (getter)Aligner_get_end_extend_gap_score,
-        (setter)Aligner_set_end_extend_gap_score,
-        Aligner_end_extend_gap_score__doc__, NULL},
+    {"extend_end_gap_score",
+        (getter)Aligner_get_extend_end_gap_score,
+        (setter)Aligner_set_extend_end_gap_score,
+        Aligner_extend_end_gap_score__doc__, NULL},
     {"left_gap_score",
         (getter)Aligner_get_left_gap_score,
         (setter)Aligner_set_left_gap_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -2919,10 +2919,10 @@ Aligner_set_extend_insertion_score(Aligner* self, PyObject* value, void* closure
     return 0;
 }
 
-static char Aligner_target_gap_score__doc__[] = "target gap score";
+static char Aligner_insertion_score__doc__[] = "insertion score";
 
 static PyObject*
-Aligner_get_target_gap_score(Aligner* self, void* closure)
+Aligner_get_insertion_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function) {
         Py_INCREF(self->insertion_score_function);
         return self->insertion_score_function;
@@ -2942,7 +2942,7 @@ Aligner_get_target_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_target_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_insertion_score(Aligner* self, PyObject* value, void* closure)
 {
     if (PyCallable_Check(value)) {
         Py_XDECREF(self->insertion_score_function);
@@ -3985,10 +3985,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_extend_insertion_score,
         (setter)Aligner_set_extend_insertion_score,
         Aligner_extend_insertion_score__doc__, NULL},
-    {"target_gap_score",
-        (getter)Aligner_get_target_gap_score,
-        (setter)Aligner_set_target_gap_score,
-        Aligner_target_gap_score__doc__, NULL},
+    {"insertion_score",
+        (getter)Aligner_get_insertion_score,
+        (setter)Aligner_set_insertion_score,
+        Aligner_insertion_score__doc__, NULL},
     {"open_deletion_score",
         (getter)Aligner_get_open_deletion_score,
         (setter)Aligner_set_open_deletion_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3173,10 +3173,10 @@ Aligner_set_target_internal_gap_score(Aligner* self, PyObject* value,
     return 0;
 }
 
-static char Aligner_target_end_gap_score__doc__[] = "target end gap score";
+static char Aligner_end_insertion_score__doc__[] = "end insertion score";
 
 static PyObject*
-Aligner_get_target_end_gap_score(Aligner* self, void* closure)
+Aligner_get_end_insertion_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -3194,7 +3194,7 @@ Aligner_get_target_end_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_target_end_gap_score(Aligner* self, PyObject* value, void* closure) {
+Aligner_set_end_insertion_score(Aligner* self, PyObject* value, void* closure) {
     const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_insertion_score = score;
@@ -4001,10 +4001,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_query_gap_score,
         (setter)Aligner_set_query_gap_score,
         Aligner_query_gap_score__doc__, NULL},
-    {"target_end_gap_score",
-        (getter)Aligner_get_target_end_gap_score,
-        (setter)Aligner_set_target_end_gap_score,
-        Aligner_target_end_gap_score__doc__, NULL},
+    {"end_insertion_score",
+        (getter)Aligner_get_end_insertion_score,
+        (setter)Aligner_set_end_insertion_score,
+        Aligner_end_insertion_score__doc__, NULL},
     {"target_end_open_gap_score",
         (getter)Aligner_get_target_end_open_gap_score,
         (setter)Aligner_set_target_end_open_gap_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -1775,7 +1775,7 @@ typedef struct {
     double query_internal_open_gap_score;
     double query_internal_extend_gap_score;
     double open_left_deletion_score;
-    double query_left_extend_gap_score;
+    double extend_left_deletion_score;
     double query_right_open_gap_score;
     double query_right_extend_gap_score;
     PyObject* target_gap_function;
@@ -1886,7 +1886,7 @@ static Algorithm _get_algorithm(Aligner* self)
         const double open_right_insertion_score = self->open_right_insertion_score;
         const double query_right_open = self->query_right_open_gap_score;
         const double extend_right_insertion_score = self->extend_right_insertion_score;
-        const double query_left_extend = self->query_left_extend_gap_score;
+        const double extend_left_deletion_score = self->extend_left_deletion_score;
         const double query_right_extend = self->query_right_extend_gap_score;
         if (self->mode == FOGSAA_Mode)
             algorithm = FOGSAA;
@@ -1896,7 +1896,7 @@ static Algorithm _get_algorithm(Aligner* self)
               && query_gap_open == query_gap_extend
               && open_left_insertion_score == extend_left_insertion_score
               && open_right_insertion_score == extend_right_insertion_score
-              && open_left_deletion_score == query_left_extend
+              && open_left_deletion_score == extend_left_deletion_score
               && query_right_open == query_right_extend)
             algorithm = NeedlemanWunschSmithWaterman;
         else
@@ -1922,7 +1922,7 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->open_right_insertion_score = 0;
     self->extend_right_insertion_score = 0;
     self->open_left_deletion_score = 0;
-    self->query_left_extend_gap_score = 0;
+    self->extend_left_deletion_score = 0;
     self->query_right_open_gap_score = 0;
     self->query_right_extend_gap_score = 0;
     self->target_gap_function = NULL;
@@ -2015,8 +2015,8 @@ Aligner_str(Aligner* self)
                      self->query_internal_extend_gap_score);
         p += sprintf(p, "  open_left_deletion_score: %f\n",
                      self->open_left_deletion_score);
-        p += sprintf(p, "  query_left_extend_gap_score: %f\n",
-                     self->query_left_extend_gap_score);
+        p += sprintf(p, "  extend_left_deletion_score: %f\n",
+                     self->extend_left_deletion_score);
         p += sprintf(p, "  query_right_open_gap_score: %f\n",
                      self->query_right_open_gap_score);
         p += sprintf(p, "  query_right_extend_gap_score: %f\n",
@@ -2248,7 +2248,7 @@ Aligner_get_gap_score(Aligner* self, void* closure)
          || score != self->query_internal_open_gap_score
          || score != self->query_internal_extend_gap_score
          || score != self->open_left_deletion_score
-         || score != self->query_left_extend_gap_score
+         || score != self->extend_left_deletion_score
          || score != self->query_right_open_gap_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2288,7 +2288,7 @@ Aligner_set_gap_score(Aligner* self, PyObject* value, void* closure)
         self->query_internal_open_gap_score = score;
         self->query_internal_extend_gap_score = score;
         self->open_left_deletion_score = score;
-        self->query_left_extend_gap_score = score;
+        self->extend_left_deletion_score = score;
         self->query_right_open_gap_score = score;
         self->query_right_extend_gap_score = score;
     }
@@ -2355,7 +2355,7 @@ Aligner_get_extend_gap_score(Aligner* self, void* closure)
         if (score != self->extend_left_insertion_score
          || score != self->extend_right_insertion_score
          || score != self->query_internal_extend_gap_score
-         || score != self->query_left_extend_gap_score
+         || score != self->extend_left_deletion_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2380,7 +2380,7 @@ Aligner_set_extend_gap_score(Aligner* self, PyObject* value, void* closure)
     self->extend_left_insertion_score = score;
     self->extend_right_insertion_score = score;
     self->query_internal_extend_gap_score = score;
-    self->query_left_extend_gap_score = score;
+    self->extend_left_deletion_score = score;
     self->query_right_extend_gap_score = score;
     self->algorithm = Unknown;
     return 0;
@@ -2513,7 +2513,7 @@ Aligner_get_end_gap_score(Aligner* self, void* closure)
          || score != self->open_right_insertion_score
          || score != self->extend_right_insertion_score
          || score != self->open_left_deletion_score
-         || score != self->query_left_extend_gap_score
+         || score != self->extend_left_deletion_score
          || score != self->query_right_open_gap_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2540,7 +2540,7 @@ Aligner_set_end_gap_score(Aligner* self, PyObject* value, void* closure)
     self->open_right_insertion_score = score;
     self->extend_right_insertion_score = score;
     self->open_left_deletion_score = score;
-    self->query_left_extend_gap_score = score;
+    self->extend_left_deletion_score = score;
     self->query_right_open_gap_score = score;
     self->query_right_extend_gap_score = score;
     self->algorithm = Unknown;
@@ -2598,7 +2598,7 @@ Aligner_get_end_extend_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->extend_left_insertion_score;
         if (score != self->extend_right_insertion_score
-         || score != self->query_left_extend_gap_score
+         || score != self->extend_left_deletion_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2621,7 +2621,7 @@ Aligner_set_end_extend_gap_score(Aligner* self, PyObject* value, void* closure)
     }
     self->extend_left_insertion_score = score;
     self->extend_right_insertion_score = score;
-    self->query_left_extend_gap_score = score;
+    self->extend_left_deletion_score = score;
     self->query_right_extend_gap_score = score;
     self->algorithm = Unknown;
     return 0;
@@ -2639,7 +2639,7 @@ Aligner_get_left_gap_score(Aligner* self, void* closure)
         const double score = self->open_left_insertion_score;
         if (score != self->extend_left_insertion_score
          || score != self->open_left_deletion_score
-         || score != self->query_left_extend_gap_score) {
+         || score != self->extend_left_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2662,7 +2662,7 @@ Aligner_set_left_gap_score(Aligner* self, PyObject* value, void* closure)
     self->open_left_insertion_score = score;
     self->extend_left_insertion_score = score;
     self->open_left_deletion_score = score;
-    self->query_left_extend_gap_score = score;
+    self->extend_left_deletion_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2753,7 +2753,7 @@ Aligner_get_left_extend_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->extend_left_insertion_score;
-        if (score != self->query_left_extend_gap_score) {
+        if (score != self->extend_left_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2774,7 +2774,7 @@ Aligner_set_left_extend_gap_score(Aligner* self, PyObject* value, void* closure)
         self->query_gap_function = NULL;
     }
     self->extend_left_insertion_score = score;
-    self->query_left_extend_gap_score = score;
+    self->extend_left_deletion_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -3015,7 +3015,7 @@ Aligner_get_query_extend_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->query_internal_extend_gap_score;
-        if (score != self->query_left_extend_gap_score
+        if (score != self->extend_left_deletion_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -3029,7 +3029,7 @@ Aligner_set_query_extend_gap_score(Aligner* self, PyObject* value, void* closure
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->query_internal_extend_gap_score = score;
-    self->query_left_extend_gap_score = score;
+    self->extend_left_deletion_score = score;
     self->query_right_extend_gap_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
@@ -3052,7 +3052,7 @@ Aligner_get_query_gap_score(Aligner* self, void* closure)
         if (score != self->open_left_deletion_score
          || score != self->query_right_open_gap_score
          || score != self->query_internal_extend_gap_score
-         || score != self->query_left_extend_gap_score
+         || score != self->extend_left_deletion_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -3078,7 +3078,7 @@ Aligner_set_query_gap_score(Aligner* self, PyObject* value, void* closure)
         self->query_internal_open_gap_score = score;
         self->query_internal_extend_gap_score = score;
         self->open_left_deletion_score = score;
-        self->query_left_extend_gap_score = score;
+        self->extend_left_deletion_score = score;
         self->query_right_open_gap_score = score;
         self->query_right_extend_gap_score = score;
         if (self->query_gap_function) {
@@ -3444,7 +3444,7 @@ Aligner_get_query_end_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_left_deletion_score;
-        if (score != self->query_left_extend_gap_score
+        if (score != self->extend_left_deletion_score
          || score != self->query_right_open_gap_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -3459,7 +3459,7 @@ Aligner_set_query_end_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_deletion_score = score;
-    self->query_left_extend_gap_score = score;
+    self->extend_left_deletion_score = score;
     self->query_right_open_gap_score = score;
     self->query_right_extend_gap_score = score;
     if (self->query_gap_function) {
@@ -3511,7 +3511,7 @@ Aligner_get_query_end_extend_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->query_left_extend_gap_score;
+        const double score = self->extend_left_deletion_score;
         if (score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -3524,7 +3524,7 @@ static int
 Aligner_set_query_end_extend_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_left_extend_gap_score = score;
+    self->extend_left_deletion_score = score;
     self->query_right_extend_gap_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
@@ -3641,22 +3641,22 @@ Aligner_set_open_left_deletion_score(Aligner* self, PyObject* value, void* closu
     return 0;
 }
 
-static char Aligner_query_left_extend_gap_score__doc__[] = "query left extend score";
+static char Aligner_extend_left_deletion_score__doc__[] = "query left extend score";
 
 static PyObject*
-Aligner_get_query_left_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_left_deletion_score(Aligner* self, void* closure)
 {   if (self->query_gap_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->query_left_extend_gap_score);
+    return PyFloat_FromDouble(self->extend_left_deletion_score);
 }
 
 static int
-Aligner_set_query_left_extend_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_extend_left_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_left_extend_gap_score = score;
+    self->extend_left_deletion_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -3675,7 +3675,7 @@ Aligner_get_query_left_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_left_deletion_score;
-        if (score != self->query_left_extend_gap_score) {
+        if (score != self->extend_left_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3688,7 +3688,7 @@ Aligner_set_query_left_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_deletion_score = score;
-    self->query_left_extend_gap_score = score;
+    self->extend_left_deletion_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -4077,10 +4077,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_open_left_deletion_score,
         (setter)Aligner_set_open_left_deletion_score,
         Aligner_open_left_deletion_score__doc__, NULL},
-    {"query_left_extend_gap_score",
-        (getter)Aligner_get_query_left_extend_gap_score,
-        (setter)Aligner_set_query_left_extend_gap_score,
-        Aligner_query_left_extend_gap_score__doc__, NULL},
+    {"extend_left_deletion_score",
+        (getter)Aligner_get_extend_left_deletion_score,
+        (setter)Aligner_set_extend_left_deletion_score,
+        Aligner_extend_left_deletion_score__doc__, NULL},
     {"query_left_gap_score",
         (getter)Aligner_get_query_left_gap_score,
         (setter)Aligner_set_query_left_gap_score,
@@ -4551,14 +4551,14 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
         case '+': \
             left_gap_extend_A = self->extend_left_insertion_score; \
             right_gap_extend_A = self->extend_right_insertion_score; \
-            left_gap_extend_B = self->query_left_extend_gap_score; \
+            left_gap_extend_B = self->extend_left_deletion_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
             left_gap_extend_A = self->extend_right_insertion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
-            right_gap_extend_B = self->query_left_extend_gap_score; \
+            right_gap_extend_B = self->extend_left_deletion_score; \
             break; \
         default: \
             PyErr_SetString(PyExc_RuntimeError, "strand was neither '+' nor '-'"); \
@@ -4685,14 +4685,14 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
         case '+': \
             left_gap_extend_A = self->extend_left_insertion_score; \
             right_gap_extend_A = self->extend_right_insertion_score; \
-            left_gap_extend_B = self->query_left_extend_gap_score; \
+            left_gap_extend_B = self->extend_left_deletion_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
             left_gap_extend_A = self->extend_right_insertion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
-            right_gap_extend_B = self->query_left_extend_gap_score; \
+            right_gap_extend_B = self->extend_left_deletion_score; \
             break; \
         default: \
             PyErr_SetString(PyExc_RuntimeError, "strand was neither '+' nor '-'"); \
@@ -4849,7 +4849,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
             left_gap_open_A = self->open_left_insertion_score; \
             left_gap_open_B = self->open_left_deletion_score; \
             left_gap_extend_A = self->extend_left_insertion_score; \
-            left_gap_extend_B = self->query_left_extend_gap_score; \
+            left_gap_extend_B = self->extend_left_deletion_score; \
             right_gap_open_A = self->open_right_insertion_score; \
             right_gap_open_B = self->query_right_open_gap_score; \
             right_gap_extend_A = self->extend_right_insertion_score; \
@@ -4863,7 +4863,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
             right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->open_left_deletion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
-            right_gap_extend_B = self->query_left_extend_gap_score; \
+            right_gap_extend_B = self->extend_left_deletion_score; \
             break; \
         default: \
             PyErr_SetString(PyExc_RuntimeError, "strand was neither '+' nor '-'"); \
@@ -5134,7 +5134,7 @@ exit: \
             left_gap_open_A = self->open_left_insertion_score; \
             left_gap_open_B = self->open_left_deletion_score; \
             left_gap_extend_A = self->extend_left_insertion_score; \
-            left_gap_extend_B = self->query_left_extend_gap_score; \
+            left_gap_extend_B = self->extend_left_deletion_score; \
             right_gap_open_A = self->open_right_insertion_score; \
             right_gap_open_B = self->query_right_open_gap_score; \
             right_gap_extend_A = self->extend_right_insertion_score; \
@@ -5148,7 +5148,7 @@ exit: \
             right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->open_left_deletion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
-            right_gap_extend_B = self->query_left_extend_gap_score; \
+            right_gap_extend_B = self->extend_left_deletion_score; \
             break; \
         default: \
             PyErr_SetString(PyExc_RuntimeError, "strand was neither '+' nor '-'"); \
@@ -6025,7 +6025,7 @@ exit: \
             left_gap_open_A = self->open_left_insertion_score; \
             left_gap_open_B = self->open_left_deletion_score; \
             left_gap_extend_A = self->extend_left_insertion_score; \
-            left_gap_extend_B = self->query_left_extend_gap_score; \
+            left_gap_extend_B = self->extend_left_deletion_score; \
             right_gap_open_A = self->open_right_insertion_score; \
             right_gap_open_B = self->query_right_open_gap_score; \
             right_gap_extend_A = self->extend_right_insertion_score; \
@@ -6039,7 +6039,7 @@ exit: \
             right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->open_left_deletion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
-            right_gap_extend_B = self->query_left_extend_gap_score; \
+            right_gap_extend_B = self->extend_left_deletion_score; \
             break; \
         default: \
             PyErr_SetString(PyExc_RuntimeError, "strand was neither '+' nor '-'"); \
@@ -7080,7 +7080,7 @@ Aligner_watermansmithbeyer_local_align_matrix(Aligner* self,
             self->open_left_insertion_score > mismatch || \
             self->open_internal_insertion_score > mismatch || \
             self->open_right_insertion_score > mismatch || \
-            self->query_left_extend_gap_score > mismatch || \
+            self->extend_left_deletion_score > mismatch || \
             self->query_internal_extend_gap_score > mismatch || \
             self->query_right_extend_gap_score > mismatch || \
             self->extend_left_insertion_score > mismatch || \

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -1768,7 +1768,7 @@ typedef struct {
     double epsilon;
     double open_internal_insertion_score;
     double extend_internal_insertion_score;
-    double target_left_open_gap_score;
+    double open_left_insertion_score;
     double target_left_extend_gap_score;
     double target_right_open_gap_score;
     double target_right_extend_gap_score;
@@ -1880,7 +1880,7 @@ static Algorithm _get_algorithm(Aligner* self)
         const double query_gap_open = self->query_internal_open_gap_score;
         const double extend_internal_insertion_score = self->extend_internal_insertion_score;
         const double query_gap_extend = self->query_internal_extend_gap_score;
-        const double target_left_open = self->target_left_open_gap_score;
+        const double target_left_open = self->open_left_insertion_score;
         const double target_left_extend = self->target_left_extend_gap_score;
         const double query_left_open = self->query_left_open_gap_score;
         const double target_right_open = self->target_right_open_gap_score;
@@ -1917,7 +1917,7 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->extend_internal_insertion_score = 0;
     self->query_internal_open_gap_score = 0;
     self->query_internal_extend_gap_score = 0;
-    self->target_left_open_gap_score = 0;
+    self->open_left_insertion_score = 0;
     self->target_left_extend_gap_score = 0;
     self->target_right_open_gap_score = 0;
     self->target_right_extend_gap_score = 0;
@@ -1995,8 +1995,8 @@ Aligner_str(Aligner* self)
                      self->open_internal_insertion_score);
         p += sprintf(p, "  extend_internal_insertion_score: %f\n",
                      self->extend_internal_insertion_score);
-        p += sprintf(p, "  target_left_open_gap_score: %f\n",
-                     self->target_left_open_gap_score);
+        p += sprintf(p, "  open_left_insertion_score: %f\n",
+                     self->open_left_insertion_score);
         p += sprintf(p, "  target_left_extend_gap_score: %f\n",
                      self->target_left_extend_gap_score);
         p += sprintf(p, "  target_right_open_gap_score: %f\n",
@@ -2241,7 +2241,7 @@ Aligner_get_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->open_internal_insertion_score;
         if (score != self->extend_internal_insertion_score
-         || score != self->target_left_open_gap_score
+         || score != self->open_left_insertion_score
          || score != self->target_left_extend_gap_score
          || score != self->target_right_open_gap_score
          || score != self->target_right_extend_gap_score
@@ -2281,7 +2281,7 @@ Aligner_set_gap_score(Aligner* self, PyObject* value, void* closure)
         }
         self->open_internal_insertion_score = score;
         self->extend_internal_insertion_score = score;
-        self->target_left_open_gap_score = score;
+        self->open_left_insertion_score = score;
         self->target_left_extend_gap_score = score;
         self->target_right_open_gap_score = score;
         self->target_right_extend_gap_score = score;
@@ -2307,7 +2307,7 @@ Aligner_get_open_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_internal_insertion_score;
-        if (score != self->target_left_open_gap_score
+        if (score != self->open_left_insertion_score
          || score != self->target_right_open_gap_score
          || score != self->query_internal_open_gap_score
          || score != self->query_left_open_gap_score
@@ -2332,7 +2332,7 @@ Aligner_set_open_gap_score(Aligner* self, PyObject* value, void* closure)
         self->query_gap_function = NULL;
     }
     self->open_internal_insertion_score = score;
-    self->target_left_open_gap_score = score;
+    self->open_left_insertion_score = score;
     self->target_right_open_gap_score = score;
     self->query_internal_open_gap_score = score;
     self->query_left_open_gap_score = score;
@@ -2508,7 +2508,7 @@ Aligner_get_end_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_left_open_gap_score;
+        const double score = self->open_left_insertion_score;
         if (score != self->target_left_extend_gap_score
          || score != self->target_right_open_gap_score
          || score != self->target_right_extend_gap_score
@@ -2535,7 +2535,7 @@ Aligner_set_end_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_left_open_gap_score = score;
+    self->open_left_insertion_score = score;
     self->target_left_extend_gap_score = score;
     self->target_right_open_gap_score = score;
     self->target_right_extend_gap_score = score;
@@ -2556,7 +2556,7 @@ Aligner_get_end_open_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_left_open_gap_score;
+        const double score = self->open_left_insertion_score;
         if (score != self->target_right_open_gap_score
          || score != self->query_left_open_gap_score
          || score != self->query_right_open_gap_score) {
@@ -2579,7 +2579,7 @@ Aligner_set_end_open_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_left_open_gap_score = score;
+    self->open_left_insertion_score = score;
     self->target_right_open_gap_score = score;
     self->query_left_open_gap_score = score;
     self->query_right_open_gap_score = score;
@@ -2636,7 +2636,7 @@ Aligner_get_left_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_left_open_gap_score;
+        const double score = self->open_left_insertion_score;
         if (score != self->target_left_extend_gap_score
          || score != self->query_left_open_gap_score
          || score != self->query_left_extend_gap_score) {
@@ -2659,7 +2659,7 @@ Aligner_set_left_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_left_open_gap_score = score;
+    self->open_left_insertion_score = score;
     self->target_left_extend_gap_score = score;
     self->query_left_open_gap_score = score;
     self->query_left_extend_gap_score = score;
@@ -2716,7 +2716,7 @@ Aligner_get_left_open_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_left_open_gap_score;
+        const double score = self->open_left_insertion_score;
         if (score != self->query_left_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2737,7 +2737,7 @@ Aligner_set_left_open_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_left_open_gap_score = score;
+    self->open_left_insertion_score = score;
     self->query_left_open_gap_score = score;
     self->algorithm = Unknown;
     return 0;
@@ -2861,7 +2861,7 @@ Aligner_get_target_open_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_internal_insertion_score;
-        if (score != self->target_left_open_gap_score
+        if (score != self->open_left_insertion_score
          || score != self->target_right_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2875,7 +2875,7 @@ Aligner_set_target_open_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_internal_insertion_score = score;
-    self->target_left_open_gap_score = score;
+    self->open_left_insertion_score = score;
     self->target_right_open_gap_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
@@ -2930,7 +2930,7 @@ Aligner_get_target_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->open_internal_insertion_score;
         if (score != self->extend_internal_insertion_score
-         || score != self->target_left_open_gap_score
+         || score != self->open_left_insertion_score
          || score != self->target_left_extend_gap_score
          || score != self->target_right_open_gap_score
          || score != self->target_right_extend_gap_score) {
@@ -2958,7 +2958,7 @@ Aligner_set_target_gap_score(Aligner* self, PyObject* value, void* closure)
         }
         self->open_internal_insertion_score = score;
         self->extend_internal_insertion_score = score;
-        self->target_left_open_gap_score = score;
+        self->open_left_insertion_score = score;
         self->target_left_extend_gap_score = score;
         self->target_right_open_gap_score = score;
         self->target_right_extend_gap_score = score;
@@ -3182,7 +3182,7 @@ Aligner_get_target_end_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_left_open_gap_score;
+        const double score = self->open_left_insertion_score;
         if (score != self->target_left_extend_gap_score
          || score != self->target_right_open_gap_score
          || score != self->target_right_extend_gap_score) {
@@ -3197,7 +3197,7 @@ static int
 Aligner_set_target_end_gap_score(Aligner* self, PyObject* value, void* closure) {
     const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_left_open_gap_score = score;
+    self->open_left_insertion_score = score;
     self->target_left_extend_gap_score = score;
     self->target_right_open_gap_score = score;
     self->target_right_extend_gap_score = score;
@@ -3218,7 +3218,7 @@ Aligner_get_target_end_open_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_left_open_gap_score;
+        const double score = self->open_left_insertion_score;
         if (score != self->target_right_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -3232,7 +3232,7 @@ Aligner_set_target_end_open_gap_score(Aligner* self, PyObject* value,
                                       void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_left_open_gap_score = score;
+    self->open_left_insertion_score = score;
     self->target_right_open_gap_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
@@ -3274,22 +3274,22 @@ Aligner_set_target_end_extend_gap_score(Aligner* self, PyObject* value, void* cl
     return 0;
 }
 
-static char Aligner_target_left_open_gap_score__doc__[] = "target left open score";
+static char Aligner_open_left_insertion_score__doc__[] = "target left open score";
 
 static PyObject*
-Aligner_get_target_left_open_gap_score(Aligner* self, void* closure)
+Aligner_get_open_left_insertion_score(Aligner* self, void* closure)
 {   if (self->target_gap_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->target_left_open_gap_score);
+    return PyFloat_FromDouble(self->open_left_insertion_score);
 }
 
 static int
-Aligner_set_target_left_open_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_open_left_insertion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_left_open_gap_score = score;
+    self->open_left_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -3331,7 +3331,7 @@ Aligner_get_target_left_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_left_open_gap_score;
+        const double score = self->open_left_insertion_score;
         if (score != self->target_left_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -3344,7 +3344,7 @@ static int
 Aligner_set_target_left_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_left_open_gap_score = score;
+    self->open_left_insertion_score = score;
     self->target_left_extend_gap_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
@@ -4025,10 +4025,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_target_internal_gap_score,
         (setter)Aligner_set_target_internal_gap_score,
         Aligner_target_internal_gap_score__doc__, NULL},
-    {"target_left_open_gap_score",
-        (getter)Aligner_get_target_left_open_gap_score,
-        (setter)Aligner_set_target_left_open_gap_score,
-        Aligner_target_left_open_gap_score__doc__, NULL},
+    {"open_left_insertion_score",
+        (getter)Aligner_get_open_left_insertion_score,
+        (setter)Aligner_set_open_left_insertion_score,
+        Aligner_open_left_insertion_score__doc__, NULL},
     {"target_left_extend_gap_score",
         (getter)Aligner_get_target_left_extend_gap_score,
         (setter)Aligner_set_target_left_extend_gap_score,
@@ -4846,7 +4846,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     double Iy_temp; \
     switch (strand) { \
         case '+': \
-            left_gap_open_A = self->target_left_open_gap_score; \
+            left_gap_open_A = self->open_left_insertion_score; \
             left_gap_open_B = self->query_left_open_gap_score; \
             left_gap_extend_A = self->target_left_extend_gap_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
@@ -4860,7 +4860,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
             left_gap_open_B = self->query_right_open_gap_score; \
             left_gap_extend_A = self->target_right_extend_gap_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
-            right_gap_open_A = self->target_left_open_gap_score; \
+            right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->query_left_open_gap_score; \
             right_gap_extend_A = self->target_left_extend_gap_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
@@ -5131,7 +5131,7 @@ exit: \
     PathGenerator* paths; \
     switch (strand) { \
         case '+': \
-            left_gap_open_A = self->target_left_open_gap_score; \
+            left_gap_open_A = self->open_left_insertion_score; \
             left_gap_open_B = self->query_left_open_gap_score; \
             left_gap_extend_A = self->target_left_extend_gap_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
@@ -5145,7 +5145,7 @@ exit: \
             left_gap_open_B = self->query_right_open_gap_score; \
             left_gap_extend_A = self->target_right_extend_gap_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
-            right_gap_open_A = self->target_left_open_gap_score; \
+            right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->query_left_open_gap_score; \
             right_gap_extend_A = self->target_left_extend_gap_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
@@ -6022,7 +6022,7 @@ exit: \
     double right_gap_extend_B; \
     switch (strand) { \
         case '+': \
-            left_gap_open_A = self->target_left_open_gap_score; \
+            left_gap_open_A = self->open_left_insertion_score; \
             left_gap_open_B = self->query_left_open_gap_score; \
             left_gap_extend_A = self->target_left_extend_gap_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
@@ -6036,7 +6036,7 @@ exit: \
             left_gap_open_B = self->query_right_open_gap_score; \
             left_gap_extend_A = self->target_right_extend_gap_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
-            right_gap_open_A = self->target_left_open_gap_score; \
+            right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->query_left_open_gap_score; \
             right_gap_extend_A = self->target_left_extend_gap_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
@@ -7077,7 +7077,7 @@ Aligner_watermansmithbeyer_local_align_matrix(Aligner* self,
     if (self->query_left_open_gap_score > mismatch || \
             self->query_internal_open_gap_score > mismatch || \
             self->query_right_open_gap_score > mismatch || \
-            self->target_left_open_gap_score > mismatch || \
+            self->open_left_insertion_score > mismatch || \
             self->open_internal_insertion_score > mismatch || \
             self->target_right_open_gap_score > mismatch || \
             self->query_left_extend_gap_score > mismatch || \

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -1776,7 +1776,7 @@ typedef struct {
     double extend_internal_deletion_score;
     double open_left_deletion_score;
     double extend_left_deletion_score;
-    double query_right_open_gap_score;
+    double open_right_deletion_score;
     double query_right_extend_gap_score;
     PyObject* target_gap_function;
     PyObject* query_gap_function;
@@ -1884,7 +1884,7 @@ static Algorithm _get_algorithm(Aligner* self)
         const double extend_left_insertion_score = self->extend_left_insertion_score;
         const double open_left_deletion_score = self->open_left_deletion_score;
         const double open_right_insertion_score = self->open_right_insertion_score;
-        const double query_right_open = self->query_right_open_gap_score;
+        const double open_right_deletion_score = self->open_right_deletion_score;
         const double extend_right_insertion_score = self->extend_right_insertion_score;
         const double extend_left_deletion_score = self->extend_left_deletion_score;
         const double query_right_extend = self->query_right_extend_gap_score;
@@ -1897,7 +1897,7 @@ static Algorithm _get_algorithm(Aligner* self)
               && open_left_insertion_score == extend_left_insertion_score
               && open_right_insertion_score == extend_right_insertion_score
               && open_left_deletion_score == extend_left_deletion_score
-              && query_right_open == query_right_extend)
+              && open_right_deletion_score == query_right_extend)
             algorithm = NeedlemanWunschSmithWaterman;
         else
             algorithm = Gotoh;
@@ -1923,7 +1923,7 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->extend_right_insertion_score = 0;
     self->open_left_deletion_score = 0;
     self->extend_left_deletion_score = 0;
-    self->query_right_open_gap_score = 0;
+    self->open_right_deletion_score = 0;
     self->query_right_extend_gap_score = 0;
     self->target_gap_function = NULL;
     self->query_gap_function = NULL;
@@ -2017,8 +2017,8 @@ Aligner_str(Aligner* self)
                      self->open_left_deletion_score);
         p += sprintf(p, "  extend_left_deletion_score: %f\n",
                      self->extend_left_deletion_score);
-        p += sprintf(p, "  query_right_open_gap_score: %f\n",
-                     self->query_right_open_gap_score);
+        p += sprintf(p, "  open_right_deletion_score: %f\n",
+                     self->open_right_deletion_score);
         p += sprintf(p, "  query_right_extend_gap_score: %f\n",
                      self->query_right_extend_gap_score);
     }
@@ -2249,7 +2249,7 @@ Aligner_get_gap_score(Aligner* self, void* closure)
          || score != self->extend_internal_deletion_score
          || score != self->open_left_deletion_score
          || score != self->extend_left_deletion_score
-         || score != self->query_right_open_gap_score
+         || score != self->open_right_deletion_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2289,7 +2289,7 @@ Aligner_set_gap_score(Aligner* self, PyObject* value, void* closure)
         self->extend_internal_deletion_score = score;
         self->open_left_deletion_score = score;
         self->extend_left_deletion_score = score;
-        self->query_right_open_gap_score = score;
+        self->open_right_deletion_score = score;
         self->query_right_extend_gap_score = score;
     }
     self->algorithm = Unknown;
@@ -2311,7 +2311,7 @@ Aligner_get_open_gap_score(Aligner* self, void* closure)
          || score != self->open_right_insertion_score
          || score != self->open_internal_deletion_score
          || score != self->open_left_deletion_score
-         || score != self->query_right_open_gap_score) {
+         || score != self->open_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2336,7 +2336,7 @@ Aligner_set_open_gap_score(Aligner* self, PyObject* value, void* closure)
     self->open_right_insertion_score = score;
     self->open_internal_deletion_score = score;
     self->open_left_deletion_score = score;
-    self->query_right_open_gap_score = score;
+    self->open_right_deletion_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2514,7 +2514,7 @@ Aligner_get_end_gap_score(Aligner* self, void* closure)
          || score != self->extend_right_insertion_score
          || score != self->open_left_deletion_score
          || score != self->extend_left_deletion_score
-         || score != self->query_right_open_gap_score
+         || score != self->open_right_deletion_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2541,7 +2541,7 @@ Aligner_set_end_gap_score(Aligner* self, PyObject* value, void* closure)
     self->extend_right_insertion_score = score;
     self->open_left_deletion_score = score;
     self->extend_left_deletion_score = score;
-    self->query_right_open_gap_score = score;
+    self->open_right_deletion_score = score;
     self->query_right_extend_gap_score = score;
     self->algorithm = Unknown;
     return 0;
@@ -2559,7 +2559,7 @@ Aligner_get_end_open_gap_score(Aligner* self, void* closure)
         const double score = self->open_left_insertion_score;
         if (score != self->open_right_insertion_score
          || score != self->open_left_deletion_score
-         || score != self->query_right_open_gap_score) {
+         || score != self->open_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2582,7 +2582,7 @@ Aligner_set_end_open_gap_score(Aligner* self, PyObject* value, void* closure)
     self->open_left_insertion_score = score;
     self->open_right_insertion_score = score;
     self->open_left_deletion_score = score;
-    self->query_right_open_gap_score = score;
+    self->open_right_deletion_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2678,7 +2678,7 @@ Aligner_get_right_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->open_right_insertion_score;
         if (score != self->extend_right_insertion_score
-         || score != self->query_right_open_gap_score
+         || score != self->open_right_deletion_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2701,7 +2701,7 @@ Aligner_set_right_gap_score(Aligner* self, PyObject* value, void* closure)
     }
     self->open_right_insertion_score = score;
     self->extend_right_insertion_score = score;
-    self->query_right_open_gap_score = score;
+    self->open_right_deletion_score = score;
     self->query_right_extend_gap_score = score;
     self->algorithm = Unknown;
     return 0;
@@ -2789,7 +2789,7 @@ Aligner_get_right_open_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_right_insertion_score;
-        if (score != self->query_right_open_gap_score) {
+        if (score != self->open_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2810,7 +2810,7 @@ Aligner_set_right_open_gap_score(Aligner* self, PyObject* value, void* closure)
         self->query_gap_function = NULL;
     }
     self->open_right_insertion_score = score;
-    self->query_right_open_gap_score = score;
+    self->open_right_deletion_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2982,7 +2982,7 @@ Aligner_get_query_open_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->open_internal_deletion_score;
         if (score != self->open_left_deletion_score
-         || score != self->query_right_open_gap_score) {
+         || score != self->open_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2996,7 +2996,7 @@ Aligner_set_query_open_gap_score(Aligner* self, PyObject* value, void* closure)
     if (PyErr_Occurred()) return -1;
     self->open_internal_deletion_score = score;
     self->open_left_deletion_score = score;
-    self->query_right_open_gap_score = score;
+    self->open_right_deletion_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -3050,7 +3050,7 @@ Aligner_get_query_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->open_internal_deletion_score;
         if (score != self->open_left_deletion_score
-         || score != self->query_right_open_gap_score
+         || score != self->open_right_deletion_score
          || score != self->extend_internal_deletion_score
          || score != self->extend_left_deletion_score
          || score != self->query_right_extend_gap_score) {
@@ -3079,7 +3079,7 @@ Aligner_set_query_gap_score(Aligner* self, PyObject* value, void* closure)
         self->extend_internal_deletion_score = score;
         self->open_left_deletion_score = score;
         self->extend_left_deletion_score = score;
-        self->query_right_open_gap_score = score;
+        self->open_right_deletion_score = score;
         self->query_right_extend_gap_score = score;
         if (self->query_gap_function) {
             Py_DECREF(self->query_gap_function);
@@ -3445,7 +3445,7 @@ Aligner_get_query_end_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->open_left_deletion_score;
         if (score != self->extend_left_deletion_score
-         || score != self->query_right_open_gap_score
+         || score != self->open_right_deletion_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -3460,7 +3460,7 @@ Aligner_set_query_end_gap_score(Aligner* self, PyObject* value, void* closure)
     if (PyErr_Occurred()) return -1;
     self->open_left_deletion_score = score;
     self->extend_left_deletion_score = score;
-    self->query_right_open_gap_score = score;
+    self->open_right_deletion_score = score;
     self->query_right_extend_gap_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
@@ -3480,7 +3480,7 @@ Aligner_get_query_end_open_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_left_deletion_score;
-        if (score != self->query_right_open_gap_score) {
+        if (score != self->open_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3493,7 +3493,7 @@ Aligner_set_query_end_open_gap_score(Aligner* self, PyObject* value, void* closu
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_deletion_score = score;
-    self->query_right_open_gap_score = score;
+    self->open_right_deletion_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -3697,22 +3697,22 @@ Aligner_set_query_left_gap_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_query_right_open_gap_score__doc__[] = "query right open score";
+static char Aligner_open_right_deletion_score__doc__[] = "query right open score";
 
 static PyObject*
-Aligner_get_query_right_open_gap_score(Aligner* self, void* closure)
+Aligner_get_open_right_deletion_score(Aligner* self, void* closure)
 {   if (self->query_gap_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->query_right_open_gap_score);
+    return PyFloat_FromDouble(self->open_right_deletion_score);
 }
 
 static int
-Aligner_set_query_right_open_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_open_right_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_right_open_gap_score = score;
+    self->open_right_deletion_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -3754,7 +3754,7 @@ Aligner_get_query_right_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->query_right_open_gap_score;
+        const double score = self->open_right_deletion_score;
         if (score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -3767,7 +3767,7 @@ static int
 Aligner_set_query_right_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_right_open_gap_score = score;
+    self->open_right_deletion_score = score;
     self->query_right_extend_gap_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
@@ -4085,10 +4085,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_query_left_gap_score,
         (setter)Aligner_set_query_left_gap_score,
          Aligner_query_left_gap_score__doc__, NULL},
-    {"query_right_open_gap_score",
-        (getter)Aligner_get_query_right_open_gap_score,
-        (setter)Aligner_set_query_right_open_gap_score,
-        Aligner_query_right_open_gap_score__doc__, NULL},
+    {"open_right_deletion_score",
+        (getter)Aligner_get_open_right_deletion_score,
+        (setter)Aligner_set_open_right_deletion_score,
+        Aligner_open_right_deletion_score__doc__, NULL},
     {"query_right_extend_gap_score",
         (getter)Aligner_get_query_right_extend_gap_score,
         (setter)Aligner_set_query_right_extend_gap_score,
@@ -4851,13 +4851,13 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
             left_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->extend_left_deletion_score; \
             right_gap_open_A = self->open_right_insertion_score; \
-            right_gap_open_B = self->query_right_open_gap_score; \
+            right_gap_open_B = self->open_right_deletion_score; \
             right_gap_extend_A = self->extend_right_insertion_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
             left_gap_open_A = self->open_right_insertion_score; \
-            left_gap_open_B = self->query_right_open_gap_score; \
+            left_gap_open_B = self->open_right_deletion_score; \
             left_gap_extend_A = self->extend_right_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_open_A = self->open_left_insertion_score; \
@@ -5136,13 +5136,13 @@ exit: \
             left_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->extend_left_deletion_score; \
             right_gap_open_A = self->open_right_insertion_score; \
-            right_gap_open_B = self->query_right_open_gap_score; \
+            right_gap_open_B = self->open_right_deletion_score; \
             right_gap_extend_A = self->extend_right_insertion_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
             left_gap_open_A = self->open_right_insertion_score; \
-            left_gap_open_B = self->query_right_open_gap_score; \
+            left_gap_open_B = self->open_right_deletion_score; \
             left_gap_extend_A = self->extend_right_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_open_A = self->open_left_insertion_score; \
@@ -6027,13 +6027,13 @@ exit: \
             left_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->extend_left_deletion_score; \
             right_gap_open_A = self->open_right_insertion_score; \
-            right_gap_open_B = self->query_right_open_gap_score; \
+            right_gap_open_B = self->open_right_deletion_score; \
             right_gap_extend_A = self->extend_right_insertion_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
             left_gap_open_A = self->open_right_insertion_score; \
-            left_gap_open_B = self->query_right_open_gap_score; \
+            left_gap_open_B = self->open_right_deletion_score; \
             left_gap_extend_A = self->extend_right_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_open_A = self->open_left_insertion_score; \
@@ -7074,9 +7074,9 @@ Aligner_watermansmithbeyer_local_align_matrix(Aligner* self,
         } \
         Py_DECREF(BiopythonWarning); \
     } \
-    if (self->open_left_deletion_score > mismatch || \
+    if (    self->open_left_deletion_score > mismatch || \
             self->open_internal_deletion_score > mismatch || \
-            self->query_right_open_gap_score > mismatch || \
+            self->open_right_deletion_score > mismatch || \
             self->open_left_insertion_score > mismatch || \
             self->open_internal_insertion_score > mismatch || \
             self->open_right_insertion_score > mismatch || \

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -2707,10 +2707,10 @@ Aligner_set_right_gap_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_left_open_gap_score__doc__[] = "left open gap score";
+static char Aligner_open_left_gap_score__doc__[] = "open left gap score";
 
 static PyObject*
-Aligner_get_left_open_gap_score(Aligner* self, void* closure)
+Aligner_get_open_left_gap_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function || self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -2726,7 +2726,7 @@ Aligner_get_left_open_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_left_open_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_open_left_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     if (self->insertion_score_function) {
@@ -3957,10 +3957,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_left_gap_score,
         (setter)Aligner_set_left_gap_score,
         Aligner_left_gap_score__doc__, NULL},
-    {"left_open_gap_score",
-        (getter)Aligner_get_left_open_gap_score,
-        (setter)Aligner_set_left_open_gap_score,
-        Aligner_left_open_gap_score__doc__, NULL},
+    {"open_left_gap_score",
+        (getter)Aligner_get_open_left_gap_score,
+        (setter)Aligner_set_open_left_gap_score,
+        Aligner_open_left_gap_score__doc__, NULL},
     {"left_extend_gap_score",
         (getter)Aligner_get_left_extend_gap_score,
         (setter)Aligner_set_left_extend_gap_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3534,7 +3534,7 @@ Aligner_set_extend_end_deletion_score(Aligner* self, PyObject* value, void* clos
     return 0;
 }
 
-static char Aligner_open_internal_deletion_score__doc__[] = "query internal open gap score";
+static char Aligner_open_internal_deletion_score__doc__[] = "open internal deletion score";
 
 static PyObject*
 Aligner_get_open_internal_deletion_score(Aligner* self, void* closure)
@@ -3559,7 +3559,7 @@ Aligner_set_open_internal_deletion_score(Aligner* self, PyObject* value,
     return 0;
 }
 
-static char Aligner_extend_internal_deletion_score__doc__[] = "query internal extend gap score";
+static char Aligner_extend_internal_deletion_score__doc__[] = "extend internal deletion score";
 
 static PyObject*
 Aligner_get_extend_internal_deletion_score(Aligner* self, void* closure)
@@ -3617,7 +3617,7 @@ Aligner_set_internal_deletion_score(Aligner* self, PyObject* value,
     return 0;
 }
 
-static char Aligner_open_left_deletion_score__doc__[] = "query left open score";
+static char Aligner_open_left_deletion_score__doc__[] = "open left deletion score";
 
 static PyObject*
 Aligner_get_open_left_deletion_score(Aligner* self, void* closure)
@@ -3641,7 +3641,7 @@ Aligner_set_open_left_deletion_score(Aligner* self, PyObject* value, void* closu
     return 0;
 }
 
-static char Aligner_extend_left_deletion_score__doc__[] = "query left extend score";
+static char Aligner_extend_left_deletion_score__doc__[] = "extend left deletion score";
 
 static PyObject*
 Aligner_get_extend_left_deletion_score(Aligner* self, void* closure)
@@ -3697,7 +3697,7 @@ Aligner_set_left_deletion_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_open_right_deletion_score__doc__[] = "query right open score";
+static char Aligner_open_right_deletion_score__doc__[] = "open right deletion score";
 
 static PyObject*
 Aligner_get_open_right_deletion_score(Aligner* self, void* closure)
@@ -3721,7 +3721,7 @@ Aligner_set_open_right_deletion_score(Aligner* self, PyObject* value, void* clos
     return 0;
 }
 
-static char Aligner_extend_right_deletion_score__doc__[] = "query right extend score";
+static char Aligner_extend_right_deletion_score__doc__[] = "extend right deletion score";
 
 static PyObject*
 Aligner_get_extend_right_deletion_score(Aligner* self, void* closure)

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -1766,7 +1766,7 @@ typedef struct {
     double match;
     double mismatch;
     double epsilon;
-    double target_internal_open_gap_score;
+    double open_internal_insertion_score;
     double extend_internal_insertion_score;
     double target_left_open_gap_score;
     double target_left_extend_gap_score;
@@ -1876,9 +1876,9 @@ static Algorithm _get_algorithm(Aligner* self)
 {
     Algorithm algorithm = self->algorithm;
     if (algorithm == Unknown) {
-        const double target_gap_open = self->target_internal_open_gap_score;
+        const double open_internal_insertion_score = self->open_internal_insertion_score;
         const double query_gap_open = self->query_internal_open_gap_score;
-        const double target_gap_extend = self->extend_internal_insertion_score;
+        const double extend_internal_insertion_score = self->extend_internal_insertion_score;
         const double query_gap_extend = self->query_internal_extend_gap_score;
         const double target_left_open = self->target_left_open_gap_score;
         const double target_left_extend = self->target_left_extend_gap_score;
@@ -1892,7 +1892,7 @@ static Algorithm _get_algorithm(Aligner* self)
             algorithm = FOGSAA;
         else if (self->target_gap_function || self->query_gap_function)
             algorithm = WatermanSmithBeyer;
-        else if (target_gap_open == target_gap_extend
+        else if (open_internal_insertion_score == extend_internal_insertion_score
               && query_gap_open == query_gap_extend
               && target_left_open == target_left_extend
               && target_right_open == target_right_extend
@@ -1913,7 +1913,7 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->match = 1.0;
     self->mismatch = 0.0;
     self->epsilon = 1.e-6;
-    self->target_internal_open_gap_score = 0;
+    self->open_internal_insertion_score = 0;
     self->extend_internal_insertion_score = 0;
     self->query_internal_open_gap_score = 0;
     self->query_internal_extend_gap_score = 0;
@@ -1991,8 +1991,8 @@ Aligner_str(Aligner* self)
         args[n++] = self->target_gap_function;
     }
     else {
-        p += sprintf(p, "  target_internal_open_gap_score: %f\n",
-                     self->target_internal_open_gap_score);
+        p += sprintf(p, "  open_internal_insertion_score: %f\n",
+                     self->open_internal_insertion_score);
         p += sprintf(p, "  extend_internal_insertion_score: %f\n",
                      self->extend_internal_insertion_score);
         p += sprintf(p, "  target_left_open_gap_score: %f\n",
@@ -2239,7 +2239,7 @@ Aligner_get_gap_score(Aligner* self, void* closure)
         return self->target_gap_function;
     }
     else {
-        const double score = self->target_internal_open_gap_score;
+        const double score = self->open_internal_insertion_score;
         if (score != self->extend_internal_insertion_score
          || score != self->target_left_open_gap_score
          || score != self->target_left_extend_gap_score
@@ -2279,7 +2279,7 @@ Aligner_set_gap_score(Aligner* self, PyObject* value, void* closure)
             Py_DECREF(self->query_gap_function);
             self->query_gap_function = NULL;
         }
-        self->target_internal_open_gap_score = score;
+        self->open_internal_insertion_score = score;
         self->extend_internal_insertion_score = score;
         self->target_left_open_gap_score = score;
         self->target_left_extend_gap_score = score;
@@ -2306,7 +2306,7 @@ Aligner_get_open_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_internal_open_gap_score;
+        const double score = self->open_internal_insertion_score;
         if (score != self->target_left_open_gap_score
          || score != self->target_right_open_gap_score
          || score != self->query_internal_open_gap_score
@@ -2331,7 +2331,7 @@ Aligner_set_open_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_internal_open_gap_score = score;
+    self->open_internal_insertion_score = score;
     self->target_left_open_gap_score = score;
     self->target_right_open_gap_score = score;
     self->query_internal_open_gap_score = score;
@@ -2395,7 +2395,7 @@ Aligner_get_internal_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_internal_open_gap_score;
+        const double score = self->open_internal_insertion_score;
         if (score != self->extend_internal_insertion_score
          || score != self->query_internal_open_gap_score
          || score != self->query_internal_extend_gap_score) {
@@ -2418,7 +2418,7 @@ Aligner_set_internal_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_internal_open_gap_score = score;
+    self->open_internal_insertion_score = score;
     self->extend_internal_insertion_score = score;
     self->query_internal_open_gap_score = score;
     self->query_internal_extend_gap_score = score;
@@ -2435,7 +2435,7 @@ Aligner_get_internal_open_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_internal_open_gap_score;
+        const double score = self->open_internal_insertion_score;
         if (score != self->query_internal_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2456,7 +2456,7 @@ Aligner_set_internal_open_gap_score(Aligner* self, PyObject* value, void* closur
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_internal_open_gap_score = score;
+    self->open_internal_insertion_score = score;
     self->query_internal_open_gap_score = score;
     self->algorithm = Unknown;
     return 0;
@@ -2860,7 +2860,7 @@ Aligner_get_target_open_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_internal_open_gap_score;
+        const double score = self->open_internal_insertion_score;
         if (score != self->target_left_open_gap_score
          || score != self->target_right_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2874,7 +2874,7 @@ static int
 Aligner_set_target_open_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_internal_open_gap_score = score;
+    self->open_internal_insertion_score = score;
     self->target_left_open_gap_score = score;
     self->target_right_open_gap_score = score;
     if (self->target_gap_function) {
@@ -2928,7 +2928,7 @@ Aligner_get_target_gap_score(Aligner* self, void* closure)
         return self->target_gap_function;
     }
     else {
-        const double score = self->target_internal_open_gap_score;
+        const double score = self->open_internal_insertion_score;
         if (score != self->extend_internal_insertion_score
          || score != self->target_left_open_gap_score
          || score != self->target_left_extend_gap_score
@@ -2956,7 +2956,7 @@ Aligner_set_target_gap_score(Aligner* self, PyObject* value, void* closure)
                             "gap score should be numerical or callable");
             return -1;
         }
-        self->target_internal_open_gap_score = score;
+        self->open_internal_insertion_score = score;
         self->extend_internal_insertion_score = score;
         self->target_left_open_gap_score = score;
         self->target_left_extend_gap_score = score;
@@ -3090,23 +3090,23 @@ Aligner_set_query_gap_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_target_internal_open_gap_score__doc__[] = "target internal open gap score";
+static char Aligner_open_internal_insertion_score__doc__[] = "target internal open gap score";
 
 static PyObject*
-Aligner_get_target_internal_open_gap_score(Aligner* self, void* closure)
+Aligner_get_open_internal_insertion_score(Aligner* self, void* closure)
 {   if (self->target_gap_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->target_internal_open_gap_score);
+    return PyFloat_FromDouble(self->open_internal_insertion_score);
 }
 
 static int
-Aligner_set_target_internal_open_gap_score(Aligner* self,
+Aligner_set_open_internal_insertion_score(Aligner* self,
                                            PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_internal_open_gap_score = score;
+    self->open_internal_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -3149,7 +3149,7 @@ Aligner_get_target_internal_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_internal_open_gap_score;
+        const double score = self->open_internal_insertion_score;
         if (score != self->extend_internal_insertion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -3163,7 +3163,7 @@ Aligner_set_target_internal_gap_score(Aligner* self, PyObject* value,
                                       void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_internal_open_gap_score = score;
+    self->open_internal_insertion_score = score;
     self->extend_internal_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
@@ -4013,10 +4013,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_target_end_extend_gap_score,
         (setter)Aligner_set_target_end_extend_gap_score,
         Aligner_target_end_extend_gap_score__doc__, NULL},
-    {"target_internal_open_gap_score",
-        (getter)Aligner_get_target_internal_open_gap_score,
-        (setter)Aligner_set_target_internal_open_gap_score,
-        Aligner_target_internal_open_gap_score__doc__, NULL},
+    {"open_internal_insertion_score",
+        (getter)Aligner_get_open_internal_insertion_score,
+        (setter)Aligner_set_open_internal_insertion_score,
+        Aligner_open_internal_insertion_score__doc__, NULL},
     {"extend_internal_insertion_score",
         (getter)Aligner_get_extend_internal_insertion_score,
         (setter)Aligner_set_extend_internal_insertion_score,
@@ -4824,7 +4824,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     int j; \
     int kA; \
     int kB; \
-    const double gap_open_A = self->target_internal_open_gap_score; \
+    const double gap_open_A = self->open_internal_insertion_score; \
     const double gap_open_B = self->query_internal_open_gap_score; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
@@ -4993,7 +4993,7 @@ exit: \
     int j; \
     int kA; \
     int kB; \
-    const double gap_open_A = self->target_internal_open_gap_score; \
+    const double gap_open_A = self->open_internal_insertion_score; \
     const double gap_open_B = self->query_internal_open_gap_score; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
@@ -5104,7 +5104,7 @@ exit: \
     int j; \
     int kA; \
     int kB; \
-    const double gap_open_A = self->target_internal_open_gap_score; \
+    const double gap_open_A = self->open_internal_insertion_score; \
     const double gap_open_B = self->query_internal_open_gap_score; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
@@ -5284,7 +5284,7 @@ exit: \
     int jm = nB; \
     int kA; \
     int kB; \
-    const double gap_open_A = self->target_internal_open_gap_score; \
+    const double gap_open_A = self->open_internal_insertion_score; \
     const double gap_open_B = self->query_internal_open_gap_score; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
@@ -6006,7 +6006,7 @@ exit: \
     int new_type = 0, npA = 0, npB = 0; \
     double new_score = 0, new_lower = 0, new_upper = 0, next_lower = 0, \
         next_upper = 0; \
-    const double gap_open_A = self->target_internal_open_gap_score; \
+    const double gap_open_A = self->open_internal_insertion_score; \
     const double gap_open_B = self->query_internal_open_gap_score; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
@@ -6863,7 +6863,7 @@ _call_target_gap_function(Aligner* aligner, int i, int j, double* score)
     PyObject* result;
     PyObject* function = aligner->target_gap_function;
     if (!function)
-        value = aligner->target_internal_open_gap_score
+        value = aligner->open_internal_insertion_score
               + (j-1) * aligner->extend_internal_insertion_score;
     else {
         result = PyObject_CallFunction(function, "ii", i, j);
@@ -7078,7 +7078,7 @@ Aligner_watermansmithbeyer_local_align_matrix(Aligner* self,
             self->query_internal_open_gap_score > mismatch || \
             self->query_right_open_gap_score > mismatch || \
             self->target_left_open_gap_score > mismatch || \
-            self->target_internal_open_gap_score > mismatch || \
+            self->open_internal_insertion_score > mismatch || \
             self->target_right_open_gap_score > mismatch || \
             self->query_left_extend_gap_score > mismatch || \
             self->query_internal_extend_gap_score > mismatch || \

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -1774,7 +1774,7 @@ typedef struct {
     double extend_right_insertion_score;
     double query_internal_open_gap_score;
     double query_internal_extend_gap_score;
-    double query_left_open_gap_score;
+    double open_left_deletion_score;
     double query_left_extend_gap_score;
     double query_right_open_gap_score;
     double query_right_extend_gap_score;
@@ -1882,10 +1882,10 @@ static Algorithm _get_algorithm(Aligner* self)
         const double query_gap_extend = self->query_internal_extend_gap_score;
         const double open_left_insertion_score = self->open_left_insertion_score;
         const double extend_left_insertion_score = self->extend_left_insertion_score;
-        const double query_left_open = self->query_left_open_gap_score;
+        const double open_left_deletion_score = self->open_left_deletion_score;
         const double open_right_insertion_score = self->open_right_insertion_score;
         const double query_right_open = self->query_right_open_gap_score;
-        const double target_right_extend = self->extend_right_insertion_score;
+        const double extend_right_insertion_score = self->extend_right_insertion_score;
         const double query_left_extend = self->query_left_extend_gap_score;
         const double query_right_extend = self->query_right_extend_gap_score;
         if (self->mode == FOGSAA_Mode)
@@ -1895,8 +1895,8 @@ static Algorithm _get_algorithm(Aligner* self)
         else if (open_internal_insertion_score == extend_internal_insertion_score
               && query_gap_open == query_gap_extend
               && open_left_insertion_score == extend_left_insertion_score
-              && open_right_insertion_score == target_right_extend
-              && query_left_open == query_left_extend
+              && open_right_insertion_score == extend_right_insertion_score
+              && open_left_deletion_score == query_left_extend
               && query_right_open == query_right_extend)
             algorithm = NeedlemanWunschSmithWaterman;
         else
@@ -1921,7 +1921,7 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->extend_left_insertion_score = 0;
     self->open_right_insertion_score = 0;
     self->extend_right_insertion_score = 0;
-    self->query_left_open_gap_score = 0;
+    self->open_left_deletion_score = 0;
     self->query_left_extend_gap_score = 0;
     self->query_right_open_gap_score = 0;
     self->query_right_extend_gap_score = 0;
@@ -2013,8 +2013,8 @@ Aligner_str(Aligner* self)
                      self->query_internal_open_gap_score);
         p += sprintf(p, "  query_internal_extend_gap_score: %f\n",
                      self->query_internal_extend_gap_score);
-        p += sprintf(p, "  query_left_open_gap_score: %f\n",
-                     self->query_left_open_gap_score);
+        p += sprintf(p, "  open_left_deletion_score: %f\n",
+                     self->open_left_deletion_score);
         p += sprintf(p, "  query_left_extend_gap_score: %f\n",
                      self->query_left_extend_gap_score);
         p += sprintf(p, "  query_right_open_gap_score: %f\n",
@@ -2247,7 +2247,7 @@ Aligner_get_gap_score(Aligner* self, void* closure)
          || score != self->extend_right_insertion_score
          || score != self->query_internal_open_gap_score
          || score != self->query_internal_extend_gap_score
-         || score != self->query_left_open_gap_score
+         || score != self->open_left_deletion_score
          || score != self->query_left_extend_gap_score
          || score != self->query_right_open_gap_score
          || score != self->query_right_extend_gap_score) {
@@ -2287,7 +2287,7 @@ Aligner_set_gap_score(Aligner* self, PyObject* value, void* closure)
         self->extend_right_insertion_score = score;
         self->query_internal_open_gap_score = score;
         self->query_internal_extend_gap_score = score;
-        self->query_left_open_gap_score = score;
+        self->open_left_deletion_score = score;
         self->query_left_extend_gap_score = score;
         self->query_right_open_gap_score = score;
         self->query_right_extend_gap_score = score;
@@ -2310,7 +2310,7 @@ Aligner_get_open_gap_score(Aligner* self, void* closure)
         if (score != self->open_left_insertion_score
          || score != self->open_right_insertion_score
          || score != self->query_internal_open_gap_score
-         || score != self->query_left_open_gap_score
+         || score != self->open_left_deletion_score
          || score != self->query_right_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2335,7 +2335,7 @@ Aligner_set_open_gap_score(Aligner* self, PyObject* value, void* closure)
     self->open_left_insertion_score = score;
     self->open_right_insertion_score = score;
     self->query_internal_open_gap_score = score;
-    self->query_left_open_gap_score = score;
+    self->open_left_deletion_score = score;
     self->query_right_open_gap_score = score;
     self->algorithm = Unknown;
     return 0;
@@ -2512,7 +2512,7 @@ Aligner_get_end_gap_score(Aligner* self, void* closure)
         if (score != self->extend_left_insertion_score
          || score != self->open_right_insertion_score
          || score != self->extend_right_insertion_score
-         || score != self->query_left_open_gap_score
+         || score != self->open_left_deletion_score
          || score != self->query_left_extend_gap_score
          || score != self->query_right_open_gap_score
          || score != self->query_right_extend_gap_score) {
@@ -2539,7 +2539,7 @@ Aligner_set_end_gap_score(Aligner* self, PyObject* value, void* closure)
     self->extend_left_insertion_score = score;
     self->open_right_insertion_score = score;
     self->extend_right_insertion_score = score;
-    self->query_left_open_gap_score = score;
+    self->open_left_deletion_score = score;
     self->query_left_extend_gap_score = score;
     self->query_right_open_gap_score = score;
     self->query_right_extend_gap_score = score;
@@ -2558,7 +2558,7 @@ Aligner_get_end_open_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->open_left_insertion_score;
         if (score != self->open_right_insertion_score
-         || score != self->query_left_open_gap_score
+         || score != self->open_left_deletion_score
          || score != self->query_right_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2581,7 +2581,7 @@ Aligner_set_end_open_gap_score(Aligner* self, PyObject* value, void* closure)
     }
     self->open_left_insertion_score = score;
     self->open_right_insertion_score = score;
-    self->query_left_open_gap_score = score;
+    self->open_left_deletion_score = score;
     self->query_right_open_gap_score = score;
     self->algorithm = Unknown;
     return 0;
@@ -2638,7 +2638,7 @@ Aligner_get_left_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->open_left_insertion_score;
         if (score != self->extend_left_insertion_score
-         || score != self->query_left_open_gap_score
+         || score != self->open_left_deletion_score
          || score != self->query_left_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2661,7 +2661,7 @@ Aligner_set_left_gap_score(Aligner* self, PyObject* value, void* closure)
     }
     self->open_left_insertion_score = score;
     self->extend_left_insertion_score = score;
-    self->query_left_open_gap_score = score;
+    self->open_left_deletion_score = score;
     self->query_left_extend_gap_score = score;
     self->algorithm = Unknown;
     return 0;
@@ -2717,7 +2717,7 @@ Aligner_get_left_open_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_left_insertion_score;
-        if (score != self->query_left_open_gap_score) {
+        if (score != self->open_left_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2738,7 +2738,7 @@ Aligner_set_left_open_gap_score(Aligner* self, PyObject* value, void* closure)
         self->query_gap_function = NULL;
     }
     self->open_left_insertion_score = score;
-    self->query_left_open_gap_score = score;
+    self->open_left_deletion_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2981,7 +2981,7 @@ Aligner_get_query_open_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->query_internal_open_gap_score;
-        if (score != self->query_left_open_gap_score
+        if (score != self->open_left_deletion_score
          || score != self->query_right_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2995,7 +2995,7 @@ Aligner_set_query_open_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->query_internal_open_gap_score = score;
-    self->query_left_open_gap_score = score;
+    self->open_left_deletion_score = score;
     self->query_right_open_gap_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
@@ -3049,7 +3049,7 @@ Aligner_get_query_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->query_internal_open_gap_score;
-        if (score != self->query_left_open_gap_score
+        if (score != self->open_left_deletion_score
          || score != self->query_right_open_gap_score
          || score != self->query_internal_extend_gap_score
          || score != self->query_left_extend_gap_score
@@ -3077,7 +3077,7 @@ Aligner_set_query_gap_score(Aligner* self, PyObject* value, void* closure)
         }
         self->query_internal_open_gap_score = score;
         self->query_internal_extend_gap_score = score;
-        self->query_left_open_gap_score = score;
+        self->open_left_deletion_score = score;
         self->query_left_extend_gap_score = score;
         self->query_right_open_gap_score = score;
         self->query_right_extend_gap_score = score;
@@ -3443,7 +3443,7 @@ Aligner_get_query_end_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->query_left_open_gap_score;
+        const double score = self->open_left_deletion_score;
         if (score != self->query_left_extend_gap_score
          || score != self->query_right_open_gap_score
          || score != self->query_right_extend_gap_score) {
@@ -3458,7 +3458,7 @@ static int
 Aligner_set_query_end_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_left_open_gap_score = score;
+    self->open_left_deletion_score = score;
     self->query_left_extend_gap_score = score;
     self->query_right_open_gap_score = score;
     self->query_right_extend_gap_score = score;
@@ -3479,7 +3479,7 @@ Aligner_get_query_end_open_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->query_left_open_gap_score;
+        const double score = self->open_left_deletion_score;
         if (score != self->query_right_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -3492,7 +3492,7 @@ static int
 Aligner_set_query_end_open_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_left_open_gap_score = score;
+    self->open_left_deletion_score = score;
     self->query_right_open_gap_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
@@ -3617,22 +3617,22 @@ Aligner_set_query_internal_gap_score(Aligner* self, PyObject* value,
     return 0;
 }
 
-static char Aligner_query_left_open_gap_score__doc__[] = "query left open score";
+static char Aligner_open_left_deletion_score__doc__[] = "query left open score";
 
 static PyObject*
-Aligner_get_query_left_open_gap_score(Aligner* self, void* closure)
+Aligner_get_open_left_deletion_score(Aligner* self, void* closure)
 {   if (self->query_gap_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->query_left_open_gap_score);
+    return PyFloat_FromDouble(self->open_left_deletion_score);
 }
 
 static int
-Aligner_set_query_left_open_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_open_left_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_left_open_gap_score = score;
+    self->open_left_deletion_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -3674,7 +3674,7 @@ Aligner_get_query_left_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->query_left_open_gap_score;
+        const double score = self->open_left_deletion_score;
         if (score != self->query_left_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -3687,7 +3687,7 @@ static int
 Aligner_set_query_left_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_left_open_gap_score = score;
+    self->open_left_deletion_score = score;
     self->query_left_extend_gap_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
@@ -4073,10 +4073,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_query_internal_gap_score,
         (setter)Aligner_set_query_internal_gap_score,
         Aligner_query_internal_gap_score__doc__, NULL},
-    {"query_left_open_gap_score",
-        (getter)Aligner_get_query_left_open_gap_score,
-        (setter)Aligner_set_query_left_open_gap_score,
-        Aligner_query_left_open_gap_score__doc__, NULL},
+    {"open_left_deletion_score",
+        (getter)Aligner_get_open_left_deletion_score,
+        (setter)Aligner_set_open_left_deletion_score,
+        Aligner_open_left_deletion_score__doc__, NULL},
     {"query_left_extend_gap_score",
         (getter)Aligner_get_query_left_extend_gap_score,
         (setter)Aligner_set_query_left_extend_gap_score,
@@ -4847,7 +4847,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     switch (strand) { \
         case '+': \
             left_gap_open_A = self->open_left_insertion_score; \
-            left_gap_open_B = self->query_left_open_gap_score; \
+            left_gap_open_B = self->open_left_deletion_score; \
             left_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
             right_gap_open_A = self->open_right_insertion_score; \
@@ -4861,7 +4861,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
             left_gap_extend_A = self->extend_right_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_open_A = self->open_left_insertion_score; \
-            right_gap_open_B = self->query_left_open_gap_score; \
+            right_gap_open_B = self->open_left_deletion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
             break; \
@@ -5132,7 +5132,7 @@ exit: \
     switch (strand) { \
         case '+': \
             left_gap_open_A = self->open_left_insertion_score; \
-            left_gap_open_B = self->query_left_open_gap_score; \
+            left_gap_open_B = self->open_left_deletion_score; \
             left_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
             right_gap_open_A = self->open_right_insertion_score; \
@@ -5146,7 +5146,7 @@ exit: \
             left_gap_extend_A = self->extend_right_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_open_A = self->open_left_insertion_score; \
-            right_gap_open_B = self->query_left_open_gap_score; \
+            right_gap_open_B = self->open_left_deletion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
             break; \
@@ -6023,7 +6023,7 @@ exit: \
     switch (strand) { \
         case '+': \
             left_gap_open_A = self->open_left_insertion_score; \
-            left_gap_open_B = self->query_left_open_gap_score; \
+            left_gap_open_B = self->open_left_deletion_score; \
             left_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
             right_gap_open_A = self->open_right_insertion_score; \
@@ -6037,7 +6037,7 @@ exit: \
             left_gap_extend_A = self->extend_right_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_open_A = self->open_left_insertion_score; \
-            right_gap_open_B = self->query_left_open_gap_score; \
+            right_gap_open_B = self->open_left_deletion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
             break; \
@@ -7074,7 +7074,7 @@ Aligner_watermansmithbeyer_local_align_matrix(Aligner* self,
         } \
         Py_DECREF(BiopythonWarning); \
     } \
-    if (self->query_left_open_gap_score > mismatch || \
+    if (self->open_left_deletion_score > mismatch || \
             self->query_internal_open_gap_score > mismatch || \
             self->query_right_open_gap_score > mismatch || \
             self->open_left_insertion_score > mismatch || \

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -1767,7 +1767,7 @@ typedef struct {
     double mismatch;
     double epsilon;
     double target_internal_open_gap_score;
-    double target_internal_extend_gap_score;
+    double extend_internal_insertion_score;
     double target_left_open_gap_score;
     double target_left_extend_gap_score;
     double target_right_open_gap_score;
@@ -1878,7 +1878,7 @@ static Algorithm _get_algorithm(Aligner* self)
     if (algorithm == Unknown) {
         const double target_gap_open = self->target_internal_open_gap_score;
         const double query_gap_open = self->query_internal_open_gap_score;
-        const double target_gap_extend = self->target_internal_extend_gap_score;
+        const double target_gap_extend = self->extend_internal_insertion_score;
         const double query_gap_extend = self->query_internal_extend_gap_score;
         const double target_left_open = self->target_left_open_gap_score;
         const double target_left_extend = self->target_left_extend_gap_score;
@@ -1914,7 +1914,7 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->mismatch = 0.0;
     self->epsilon = 1.e-6;
     self->target_internal_open_gap_score = 0;
-    self->target_internal_extend_gap_score = 0;
+    self->extend_internal_insertion_score = 0;
     self->query_internal_open_gap_score = 0;
     self->query_internal_extend_gap_score = 0;
     self->target_left_open_gap_score = 0;
@@ -1993,8 +1993,8 @@ Aligner_str(Aligner* self)
     else {
         p += sprintf(p, "  target_internal_open_gap_score: %f\n",
                      self->target_internal_open_gap_score);
-        p += sprintf(p, "  target_internal_extend_gap_score: %f\n",
-                     self->target_internal_extend_gap_score);
+        p += sprintf(p, "  extend_internal_insertion_score: %f\n",
+                     self->extend_internal_insertion_score);
         p += sprintf(p, "  target_left_open_gap_score: %f\n",
                      self->target_left_open_gap_score);
         p += sprintf(p, "  target_left_extend_gap_score: %f\n",
@@ -2240,7 +2240,7 @@ Aligner_get_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->target_internal_open_gap_score;
-        if (score != self->target_internal_extend_gap_score
+        if (score != self->extend_internal_insertion_score
          || score != self->target_left_open_gap_score
          || score != self->target_left_extend_gap_score
          || score != self->target_right_open_gap_score
@@ -2280,7 +2280,7 @@ Aligner_set_gap_score(Aligner* self, PyObject* value, void* closure)
             self->query_gap_function = NULL;
         }
         self->target_internal_open_gap_score = score;
-        self->target_internal_extend_gap_score = score;
+        self->extend_internal_insertion_score = score;
         self->target_left_open_gap_score = score;
         self->target_left_extend_gap_score = score;
         self->target_right_open_gap_score = score;
@@ -2351,7 +2351,7 @@ Aligner_get_extend_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_internal_extend_gap_score;
+        const double score = self->extend_internal_insertion_score;
         if (score != self->target_left_extend_gap_score
          || score != self->target_right_extend_gap_score
          || score != self->query_internal_extend_gap_score
@@ -2376,7 +2376,7 @@ Aligner_set_extend_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_internal_extend_gap_score = score;
+    self->extend_internal_insertion_score = score;
     self->target_left_extend_gap_score = score;
     self->target_right_extend_gap_score = score;
     self->query_internal_extend_gap_score = score;
@@ -2396,7 +2396,7 @@ Aligner_get_internal_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->target_internal_open_gap_score;
-        if (score != self->target_internal_extend_gap_score
+        if (score != self->extend_internal_insertion_score
          || score != self->query_internal_open_gap_score
          || score != self->query_internal_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2419,7 +2419,7 @@ Aligner_set_internal_gap_score(Aligner* self, PyObject* value, void* closure)
         self->query_gap_function = NULL;
     }
     self->target_internal_open_gap_score = score;
-    self->target_internal_extend_gap_score = score;
+    self->extend_internal_insertion_score = score;
     self->query_internal_open_gap_score = score;
     self->query_internal_extend_gap_score = score;
     self->algorithm = Unknown;
@@ -2471,7 +2471,7 @@ Aligner_get_internal_extend_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_internal_extend_gap_score;
+        const double score = self->extend_internal_insertion_score;
         if (score != self->query_internal_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2493,7 +2493,7 @@ Aligner_set_internal_extend_gap_score(Aligner* self, PyObject* value,
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_internal_extend_gap_score = score;
+    self->extend_internal_insertion_score = score;
     self->query_internal_extend_gap_score = score;
     self->algorithm = Unknown;
     return 0;
@@ -2894,7 +2894,7 @@ Aligner_get_target_extend_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_internal_extend_gap_score;
+        const double score = self->extend_internal_insertion_score;
         if (score != self->target_left_extend_gap_score
          || score != self->target_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2908,7 +2908,7 @@ static int
 Aligner_set_target_extend_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_internal_extend_gap_score = score;
+    self->extend_internal_insertion_score = score;
     self->target_left_extend_gap_score = score;
     self->target_right_extend_gap_score = score;
     if (self->target_gap_function) {
@@ -2929,7 +2929,7 @@ Aligner_get_target_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->target_internal_open_gap_score;
-        if (score != self->target_internal_extend_gap_score
+        if (score != self->extend_internal_insertion_score
          || score != self->target_left_open_gap_score
          || score != self->target_left_extend_gap_score
          || score != self->target_right_open_gap_score
@@ -2957,7 +2957,7 @@ Aligner_set_target_gap_score(Aligner* self, PyObject* value, void* closure)
             return -1;
         }
         self->target_internal_open_gap_score = score;
-        self->target_internal_extend_gap_score = score;
+        self->extend_internal_insertion_score = score;
         self->target_left_open_gap_score = score;
         self->target_left_extend_gap_score = score;
         self->target_right_open_gap_score = score;
@@ -3115,23 +3115,23 @@ Aligner_set_target_internal_open_gap_score(Aligner* self,
     return 0;
 }
 
-static char Aligner_target_internal_extend_gap_score__doc__[] = "target internal extend gap score";
+static char Aligner_extend_internal_insertion_score__doc__[] = "target internal extend gap score";
 
 static PyObject*
-Aligner_get_target_internal_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_internal_insertion_score(Aligner* self, void* closure)
 {   if (self->target_gap_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->target_internal_extend_gap_score);
+    return PyFloat_FromDouble(self->extend_internal_insertion_score);
 }
 
 static int
-Aligner_set_target_internal_extend_gap_score(Aligner* self,
+Aligner_set_extend_internal_insertion_score(Aligner* self,
                                              PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_internal_extend_gap_score = score;
+    self->extend_internal_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -3150,7 +3150,7 @@ Aligner_get_target_internal_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->target_internal_open_gap_score;
-        if (score != self->target_internal_extend_gap_score) {
+        if (score != self->extend_internal_insertion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3164,7 +3164,7 @@ Aligner_set_target_internal_gap_score(Aligner* self, PyObject* value,
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->target_internal_open_gap_score = score;
-    self->target_internal_extend_gap_score = score;
+    self->extend_internal_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -4017,10 +4017,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_target_internal_open_gap_score,
         (setter)Aligner_set_target_internal_open_gap_score,
         Aligner_target_internal_open_gap_score__doc__, NULL},
-    {"target_internal_extend_gap_score",
-        (getter)Aligner_get_target_internal_extend_gap_score,
-        (setter)Aligner_set_target_internal_extend_gap_score,
-        Aligner_target_internal_extend_gap_score__doc__, NULL},
+    {"extend_internal_insertion_score",
+        (getter)Aligner_get_extend_internal_insertion_score,
+        (setter)Aligner_set_extend_internal_insertion_score,
+        Aligner_extend_internal_insertion_score__doc__, NULL},
     {"target_internal_gap_score",
         (getter)Aligner_get_target_internal_gap_score,
         (setter)Aligner_set_target_internal_gap_score,
@@ -4538,7 +4538,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     int j; \
     int kA; \
     int kB; \
-    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
     double score; \
     double temp; \
@@ -4617,7 +4617,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     int j; \
     int kA; \
     int kB; \
-    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
     double score; \
     double* row; \
@@ -4668,7 +4668,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     int j; \
     int kA; \
     int kB; \
-    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
     const double epsilon = self->epsilon; \
     Trace** M; \
@@ -4742,7 +4742,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     int jm = nB; \
     int kA; \
     int kB; \
-    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
     const double epsilon = self->epsilon; \
     Trace** M = NULL; \
@@ -4826,7 +4826,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     int kB; \
     const double gap_open_A = self->target_internal_open_gap_score; \
     const double gap_open_B = self->query_internal_open_gap_score; \
-    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
     double left_gap_open_A; \
     double left_gap_open_B; \
@@ -4995,7 +4995,7 @@ exit: \
     int kB; \
     const double gap_open_A = self->target_internal_open_gap_score; \
     const double gap_open_B = self->query_internal_open_gap_score; \
-    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
     double* M_row = NULL; \
     double* Ix_row = NULL; \
@@ -5106,7 +5106,7 @@ exit: \
     int kB; \
     const double gap_open_A = self->target_internal_open_gap_score; \
     const double gap_open_B = self->query_internal_open_gap_score; \
-    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
     double left_gap_open_A; \
     double left_gap_open_B; \
@@ -5286,7 +5286,7 @@ exit: \
     int kB; \
     const double gap_open_A = self->target_internal_open_gap_score; \
     const double gap_open_B = self->query_internal_open_gap_score; \
-    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
     const double epsilon = self->epsilon; \
     Trace** M = NULL; \
@@ -6008,7 +6008,7 @@ exit: \
         next_upper = 0; \
     const double gap_open_A = self->target_internal_open_gap_score; \
     const double gap_open_B = self->query_internal_open_gap_score; \
-    const double gap_extend_A = self->target_internal_extend_gap_score; \
+    const double gap_extend_A = self->extend_internal_insertion_score; \
     const double gap_extend_B = self->query_internal_extend_gap_score; \
     struct fogsaa_cell* matrix = NULL; \
     struct fogsaa_queue queue; \
@@ -6864,7 +6864,7 @@ _call_target_gap_function(Aligner* aligner, int i, int j, double* score)
     PyObject* function = aligner->target_gap_function;
     if (!function)
         value = aligner->target_internal_open_gap_score
-              + (j-1) * aligner->target_internal_extend_gap_score;
+              + (j-1) * aligner->extend_internal_insertion_score;
     else {
         result = PyObject_CallFunction(function, "ii", i, j);
         if (result == NULL) return 0;
@@ -7084,7 +7084,7 @@ Aligner_watermansmithbeyer_local_align_matrix(Aligner* self,
             self->query_internal_extend_gap_score > mismatch || \
             self->query_right_extend_gap_score > mismatch || \
             self->target_left_extend_gap_score > mismatch || \
-            self->target_internal_extend_gap_score > mismatch || \
+            self->extend_internal_insertion_score > mismatch || \
             self->target_right_extend_gap_score > mismatch) { \
         PyObject *Bio_module = PyImport_ImportModule("Bio"); \
         PyObject *BiopythonWarning = PyObject_GetAttrString(Bio_module, "BiopythonWarning"); \

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3242,10 +3242,10 @@ Aligner_set_open_end_insertion_score(Aligner* self, PyObject* value,
     return 0;
 }
 
-static char Aligner_target_end_extend_gap_score__doc__[] = "target end extend gap score";
+static char Aligner_extend_end_insertion_score__doc__[] = "extend end insertion score";
 
 static PyObject*
-Aligner_get_target_end_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_end_insertion_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -3261,7 +3261,7 @@ Aligner_get_target_end_extend_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_target_end_extend_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_extend_end_insertion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_left_insertion_score = score;
@@ -4009,10 +4009,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_open_end_insertion_score,
         (setter)Aligner_set_open_end_insertion_score,
         Aligner_open_end_insertion_score__doc__, NULL},
-    {"target_end_extend_gap_score",
-        (getter)Aligner_get_target_end_extend_gap_score,
-        (setter)Aligner_set_target_end_extend_gap_score,
-        Aligner_target_end_extend_gap_score__doc__, NULL},
+    {"extend_end_insertion_score",
+        (getter)Aligner_get_extend_end_insertion_score,
+        (setter)Aligner_set_extend_end_insertion_score,
+        Aligner_extend_end_insertion_score__doc__, NULL},
     {"open_internal_insertion_score",
         (getter)Aligner_get_open_internal_insertion_score,
         (setter)Aligner_set_open_internal_insertion_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -2743,10 +2743,10 @@ Aligner_set_open_left_gap_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_left_extend_gap_score__doc__[] = "left extend gap score";
+static char Aligner_extend_left_gap_score__doc__[] = "extend left gap score";
 
 static PyObject*
-Aligner_get_left_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_left_gap_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function || self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -2762,7 +2762,7 @@ Aligner_get_left_extend_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_left_extend_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_extend_left_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     if (self->insertion_score_function) {
@@ -3961,10 +3961,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_open_left_gap_score,
         (setter)Aligner_set_open_left_gap_score,
         Aligner_open_left_gap_score__doc__, NULL},
-    {"left_extend_gap_score",
-        (getter)Aligner_get_left_extend_gap_score,
-        (setter)Aligner_set_left_extend_gap_score,
-        Aligner_left_extend_gap_score__doc__, NULL},
+    {"extend_left_gap_score",
+        (getter)Aligner_get_extend_left_gap_score,
+        (setter)Aligner_set_extend_left_gap_score,
+        Aligner_extend_left_gap_score__doc__, NULL},
     {"right_gap_score",
         (getter)Aligner_get_right_gap_score,
         (setter)Aligner_set_right_gap_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -1770,7 +1770,7 @@ typedef struct {
     double extend_internal_insertion_score;
     double open_left_insertion_score;
     double extend_left_insertion_score;
-    double target_right_open_gap_score;
+    double open_right_insertion_score;
     double target_right_extend_gap_score;
     double query_internal_open_gap_score;
     double query_internal_extend_gap_score;
@@ -1883,7 +1883,7 @@ static Algorithm _get_algorithm(Aligner* self)
         const double open_left_insertion_score = self->open_left_insertion_score;
         const double extend_left_insertion_score = self->extend_left_insertion_score;
         const double query_left_open = self->query_left_open_gap_score;
-        const double target_right_open = self->target_right_open_gap_score;
+        const double open_right_insertion_score = self->open_right_insertion_score;
         const double query_right_open = self->query_right_open_gap_score;
         const double target_right_extend = self->target_right_extend_gap_score;
         const double query_left_extend = self->query_left_extend_gap_score;
@@ -1895,7 +1895,7 @@ static Algorithm _get_algorithm(Aligner* self)
         else if (open_internal_insertion_score == extend_internal_insertion_score
               && query_gap_open == query_gap_extend
               && open_left_insertion_score == extend_left_insertion_score
-              && target_right_open == target_right_extend
+              && open_right_insertion_score == target_right_extend
               && query_left_open == query_left_extend
               && query_right_open == query_right_extend)
             algorithm = NeedlemanWunschSmithWaterman;
@@ -1919,7 +1919,7 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->query_internal_extend_gap_score = 0;
     self->open_left_insertion_score = 0;
     self->extend_left_insertion_score = 0;
-    self->target_right_open_gap_score = 0;
+    self->open_right_insertion_score = 0;
     self->target_right_extend_gap_score = 0;
     self->query_left_open_gap_score = 0;
     self->query_left_extend_gap_score = 0;
@@ -1999,8 +1999,8 @@ Aligner_str(Aligner* self)
                      self->open_left_insertion_score);
         p += sprintf(p, "  extend_left_insertion_score: %f\n",
                      self->extend_left_insertion_score);
-        p += sprintf(p, "  target_right_open_gap_score: %f\n",
-                     self->target_right_open_gap_score);
+        p += sprintf(p, "  open_right_insertion_score: %f\n",
+                     self->open_right_insertion_score);
         p += sprintf(p, "  target_right_extend_gap_score: %f\n",
                      self->target_right_extend_gap_score);
     }
@@ -2243,7 +2243,7 @@ Aligner_get_gap_score(Aligner* self, void* closure)
         if (score != self->extend_internal_insertion_score
          || score != self->open_left_insertion_score
          || score != self->extend_left_insertion_score
-         || score != self->target_right_open_gap_score
+         || score != self->open_right_insertion_score
          || score != self->target_right_extend_gap_score
          || score != self->query_internal_open_gap_score
          || score != self->query_internal_extend_gap_score
@@ -2283,7 +2283,7 @@ Aligner_set_gap_score(Aligner* self, PyObject* value, void* closure)
         self->extend_internal_insertion_score = score;
         self->open_left_insertion_score = score;
         self->extend_left_insertion_score = score;
-        self->target_right_open_gap_score = score;
+        self->open_right_insertion_score = score;
         self->target_right_extend_gap_score = score;
         self->query_internal_open_gap_score = score;
         self->query_internal_extend_gap_score = score;
@@ -2308,7 +2308,7 @@ Aligner_get_open_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->open_internal_insertion_score;
         if (score != self->open_left_insertion_score
-         || score != self->target_right_open_gap_score
+         || score != self->open_right_insertion_score
          || score != self->query_internal_open_gap_score
          || score != self->query_left_open_gap_score
          || score != self->query_right_open_gap_score) {
@@ -2333,7 +2333,7 @@ Aligner_set_open_gap_score(Aligner* self, PyObject* value, void* closure)
     }
     self->open_internal_insertion_score = score;
     self->open_left_insertion_score = score;
-    self->target_right_open_gap_score = score;
+    self->open_right_insertion_score = score;
     self->query_internal_open_gap_score = score;
     self->query_left_open_gap_score = score;
     self->query_right_open_gap_score = score;
@@ -2510,7 +2510,7 @@ Aligner_get_end_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->open_left_insertion_score;
         if (score != self->extend_left_insertion_score
-         || score != self->target_right_open_gap_score
+         || score != self->open_right_insertion_score
          || score != self->target_right_extend_gap_score
          || score != self->query_left_open_gap_score
          || score != self->query_left_extend_gap_score
@@ -2537,7 +2537,7 @@ Aligner_set_end_gap_score(Aligner* self, PyObject* value, void* closure)
     }
     self->open_left_insertion_score = score;
     self->extend_left_insertion_score = score;
-    self->target_right_open_gap_score = score;
+    self->open_right_insertion_score = score;
     self->target_right_extend_gap_score = score;
     self->query_left_open_gap_score = score;
     self->query_left_extend_gap_score = score;
@@ -2557,7 +2557,7 @@ Aligner_get_end_open_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_left_insertion_score;
-        if (score != self->target_right_open_gap_score
+        if (score != self->open_right_insertion_score
          || score != self->query_left_open_gap_score
          || score != self->query_right_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2580,7 +2580,7 @@ Aligner_set_end_open_gap_score(Aligner* self, PyObject* value, void* closure)
         self->query_gap_function = NULL;
     }
     self->open_left_insertion_score = score;
-    self->target_right_open_gap_score = score;
+    self->open_right_insertion_score = score;
     self->query_left_open_gap_score = score;
     self->query_right_open_gap_score = score;
     self->algorithm = Unknown;
@@ -2676,7 +2676,7 @@ Aligner_get_right_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_right_open_gap_score;
+        const double score = self->open_right_insertion_score;
         if (score != self->target_right_extend_gap_score
          || score != self->query_right_open_gap_score
          || score != self->query_right_extend_gap_score) {
@@ -2699,7 +2699,7 @@ Aligner_set_right_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_right_open_gap_score = score;
+    self->open_right_insertion_score = score;
     self->target_right_extend_gap_score = score;
     self->query_right_open_gap_score = score;
     self->query_right_extend_gap_score = score;
@@ -2788,7 +2788,7 @@ Aligner_get_right_open_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_right_open_gap_score;
+        const double score = self->open_right_insertion_score;
         if (score != self->query_right_open_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2809,7 +2809,7 @@ Aligner_set_right_open_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_right_open_gap_score = score;
+    self->open_right_insertion_score = score;
     self->query_right_open_gap_score = score;
     self->algorithm = Unknown;
     return 0;
@@ -2862,7 +2862,7 @@ Aligner_get_target_open_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->open_internal_insertion_score;
         if (score != self->open_left_insertion_score
-         || score != self->target_right_open_gap_score) {
+         || score != self->open_right_insertion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2876,7 +2876,7 @@ Aligner_set_target_open_gap_score(Aligner* self, PyObject* value, void* closure)
     if (PyErr_Occurred()) return -1;
     self->open_internal_insertion_score = score;
     self->open_left_insertion_score = score;
-    self->target_right_open_gap_score = score;
+    self->open_right_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -2932,7 +2932,7 @@ Aligner_get_target_gap_score(Aligner* self, void* closure)
         if (score != self->extend_internal_insertion_score
          || score != self->open_left_insertion_score
          || score != self->extend_left_insertion_score
-         || score != self->target_right_open_gap_score
+         || score != self->open_right_insertion_score
          || score != self->target_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2960,7 +2960,7 @@ Aligner_set_target_gap_score(Aligner* self, PyObject* value, void* closure)
         self->extend_internal_insertion_score = score;
         self->open_left_insertion_score = score;
         self->extend_left_insertion_score = score;
-        self->target_right_open_gap_score = score;
+        self->open_right_insertion_score = score;
         self->target_right_extend_gap_score = score;
         if (self->target_gap_function) {
             Py_DECREF(self->target_gap_function);
@@ -3184,7 +3184,7 @@ Aligner_get_target_end_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->open_left_insertion_score;
         if (score != self->extend_left_insertion_score
-         || score != self->target_right_open_gap_score
+         || score != self->open_right_insertion_score
          || score != self->target_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -3199,7 +3199,7 @@ Aligner_set_target_end_gap_score(Aligner* self, PyObject* value, void* closure) 
     if (PyErr_Occurred()) return -1;
     self->open_left_insertion_score = score;
     self->extend_left_insertion_score = score;
-    self->target_right_open_gap_score = score;
+    self->open_right_insertion_score = score;
     self->target_right_extend_gap_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
@@ -3219,7 +3219,7 @@ Aligner_get_target_end_open_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_left_insertion_score;
-        if (score != self->target_right_open_gap_score) {
+        if (score != self->open_right_insertion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3233,7 +3233,7 @@ Aligner_set_target_end_open_gap_score(Aligner* self, PyObject* value,
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_insertion_score = score;
-    self->target_right_open_gap_score = score;
+    self->open_right_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -3357,19 +3357,19 @@ Aligner_set_target_left_gap_score(Aligner* self, PyObject* value, void* closure)
 static char Aligner_target_right_gap_score_open__doc__[] = "target right open score";
 
 static PyObject*
-Aligner_get_target_right_open_gap_score(Aligner* self, void* closure)
+Aligner_get_open_right_insertion_score(Aligner* self, void* closure)
 {   if (self->target_gap_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->target_right_open_gap_score);
+    return PyFloat_FromDouble(self->open_right_insertion_score);
 }
 
 static int
-Aligner_set_target_right_open_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_open_right_insertion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_right_open_gap_score = score;
+    self->open_right_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -3411,7 +3411,7 @@ Aligner_get_target_right_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_right_open_gap_score;
+        const double score = self->open_right_insertion_score;
         if (score != self->target_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -3424,7 +3424,7 @@ static int
 Aligner_set_target_right_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_right_open_gap_score = score;
+    self->open_right_insertion_score = score;
     self->target_right_extend_gap_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
@@ -4037,9 +4037,9 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_target_left_gap_score,
         (setter)Aligner_set_target_left_gap_score,
         Aligner_target_left_gap_score__doc__, NULL},
-    {"target_right_open_gap_score",
-        (getter)Aligner_get_target_right_open_gap_score,
-        (setter)Aligner_set_target_right_open_gap_score,
+    {"open_right_insertion_score",
+        (getter)Aligner_get_open_right_insertion_score,
+        (setter)Aligner_set_open_right_insertion_score,
         Aligner_target_right_gap_score_open__doc__, NULL},
     {"target_right_extend_gap_score",
         (getter)Aligner_get_target_right_extend_gap_score,
@@ -4850,13 +4850,13 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
             left_gap_open_B = self->query_left_open_gap_score; \
             left_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
-            right_gap_open_A = self->target_right_open_gap_score; \
+            right_gap_open_A = self->open_right_insertion_score; \
             right_gap_open_B = self->query_right_open_gap_score; \
             right_gap_extend_A = self->target_right_extend_gap_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
-            left_gap_open_A = self->target_right_open_gap_score; \
+            left_gap_open_A = self->open_right_insertion_score; \
             left_gap_open_B = self->query_right_open_gap_score; \
             left_gap_extend_A = self->target_right_extend_gap_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
@@ -5135,13 +5135,13 @@ exit: \
             left_gap_open_B = self->query_left_open_gap_score; \
             left_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
-            right_gap_open_A = self->target_right_open_gap_score; \
+            right_gap_open_A = self->open_right_insertion_score; \
             right_gap_open_B = self->query_right_open_gap_score; \
             right_gap_extend_A = self->target_right_extend_gap_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
-            left_gap_open_A = self->target_right_open_gap_score; \
+            left_gap_open_A = self->open_right_insertion_score; \
             left_gap_open_B = self->query_right_open_gap_score; \
             left_gap_extend_A = self->target_right_extend_gap_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
@@ -6026,13 +6026,13 @@ exit: \
             left_gap_open_B = self->query_left_open_gap_score; \
             left_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
-            right_gap_open_A = self->target_right_open_gap_score; \
+            right_gap_open_A = self->open_right_insertion_score; \
             right_gap_open_B = self->query_right_open_gap_score; \
             right_gap_extend_A = self->target_right_extend_gap_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
-            left_gap_open_A = self->target_right_open_gap_score; \
+            left_gap_open_A = self->open_right_insertion_score; \
             left_gap_open_B = self->query_right_open_gap_score; \
             left_gap_extend_A = self->target_right_extend_gap_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
@@ -7079,7 +7079,7 @@ Aligner_watermansmithbeyer_local_align_matrix(Aligner* self,
             self->query_right_open_gap_score > mismatch || \
             self->open_left_insertion_score > mismatch || \
             self->open_internal_insertion_score > mismatch || \
-            self->target_right_open_gap_score > mismatch || \
+            self->open_right_insertion_score > mismatch || \
             self->query_left_extend_gap_score > mismatch || \
             self->query_internal_extend_gap_score > mismatch || \
             self->query_right_extend_gap_score > mismatch || \

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3090,7 +3090,7 @@ Aligner_set_query_gap_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_open_internal_insertion_score__doc__[] = "target internal open gap score";
+static char Aligner_open_internal_insertion_score__doc__[] = "open internal insertion score";
 
 static PyObject*
 Aligner_get_open_internal_insertion_score(Aligner* self, void* closure)
@@ -3115,7 +3115,7 @@ Aligner_set_open_internal_insertion_score(Aligner* self,
     return 0;
 }
 
-static char Aligner_extend_internal_insertion_score__doc__[] = "target internal extend gap score";
+static char Aligner_extend_internal_insertion_score__doc__[] = "extend internal insertion score";
 
 static PyObject*
 Aligner_get_extend_internal_insertion_score(Aligner* self, void* closure)
@@ -3274,7 +3274,7 @@ Aligner_set_extend_end_insertion_score(Aligner* self, PyObject* value, void* clo
     return 0;
 }
 
-static char Aligner_open_left_insertion_score__doc__[] = "target left open score";
+static char Aligner_open_left_insertion_score__doc__[] = "open left insertion score";
 
 static PyObject*
 Aligner_get_open_left_insertion_score(Aligner* self, void* closure)
@@ -3298,7 +3298,7 @@ Aligner_set_open_left_insertion_score(Aligner* self, PyObject* value, void* clos
     return 0;
 }
 
-static char Aligner_extend_left_insertion_score__doc__[] = "target left extend score";
+static char Aligner_extend_left_insertion_score__doc__[] = "extend left insertion score";
 
 static PyObject*
 Aligner_get_extend_left_insertion_score(Aligner* self, void* closure)
@@ -3354,7 +3354,7 @@ Aligner_set_left_insertion_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_target_right_gap_score_open__doc__[] = "target right open score";
+static char Aligner_open_right_insertion_score__doc__[] = "open right insertion score";
 
 static PyObject*
 Aligner_get_open_right_insertion_score(Aligner* self, void* closure)
@@ -3378,7 +3378,7 @@ Aligner_set_open_right_insertion_score(Aligner* self, PyObject* value, void* clo
     return 0;
 }
 
-static char Aligner_extend_right_insertion_score__doc__[] = "target right extend score";
+static char Aligner_extend_right_insertion_score__doc__[] = "extend right insertion score";
 
 static PyObject*
 Aligner_get_extend_right_insertion_score(Aligner* self, void* closure)
@@ -4040,7 +4040,7 @@ static PyGetSetDef Aligner_getset[] = {
     {"open_right_insertion_score",
         (getter)Aligner_get_open_right_insertion_score,
         (setter)Aligner_set_open_right_insertion_score,
-        Aligner_target_right_gap_score_open__doc__, NULL},
+        Aligner_open_right_insertion_score__doc__, NULL},
     {"extend_right_insertion_score",
         (getter)Aligner_get_extend_right_insertion_score,
         (setter)Aligner_set_extend_right_insertion_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3209,10 +3209,10 @@ Aligner_set_end_insertion_score(Aligner* self, PyObject* value, void* closure) {
     return 0;
 }
 
-static char Aligner_target_end_open_gap_score__doc__[] = "target end open gap score";
+static char Aligner_open_end_insertion_score__doc__[] = "open end insertion score";
 
 static PyObject*
-Aligner_get_target_end_open_gap_score(Aligner* self, void* closure)
+Aligner_get_open_end_insertion_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -3228,8 +3228,8 @@ Aligner_get_target_end_open_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_target_end_open_gap_score(Aligner* self, PyObject* value,
-                                      void* closure)
+Aligner_set_open_end_insertion_score(Aligner* self, PyObject* value,
+                                     void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_insertion_score = score;
@@ -4005,10 +4005,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_end_insertion_score,
         (setter)Aligner_set_end_insertion_score,
         Aligner_end_insertion_score__doc__, NULL},
-    {"target_end_open_gap_score",
-        (getter)Aligner_get_target_end_open_gap_score,
-        (setter)Aligner_set_target_end_open_gap_score,
-        Aligner_target_end_open_gap_score__doc__, NULL},
+    {"open_end_insertion_score",
+        (getter)Aligner_get_open_end_insertion_score,
+        (setter)Aligner_set_open_end_insertion_score,
+        Aligner_open_end_insertion_score__doc__, NULL},
     {"target_end_extend_gap_score",
         (getter)Aligner_get_target_end_extend_gap_score,
         (setter)Aligner_set_target_end_extend_gap_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3665,10 +3665,10 @@ Aligner_set_extend_left_deletion_score(Aligner* self, PyObject* value, void* clo
     return 0;
 }
 
-static char Aligner_query_left_gap_score__doc__[] = "query left score";
+static char Aligner_left_deletion_score__doc__[] = "left deletion score";
 
 static PyObject*
-Aligner_get_query_left_gap_score(Aligner* self, void* closure)
+Aligner_get_left_deletion_score(Aligner* self, void* closure)
 {   if (self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -3684,7 +3684,7 @@ Aligner_get_query_left_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_query_left_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_left_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_deletion_score = score;
@@ -3745,10 +3745,10 @@ Aligner_set_extend_right_deletion_score(Aligner* self, PyObject* value, void* cl
     return 0;
 }
 
-static char Aligner_query_right_gap_score__doc__[] = "query right score";
+static char Aligner_right_deletion_score__doc__[] = "right deletion score";
 
 static PyObject*
-Aligner_get_query_right_gap_score(Aligner* self, void* closure)
+Aligner_get_right_deletion_score(Aligner* self, void* closure)
 {   if (self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -3764,7 +3764,7 @@ Aligner_get_query_right_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_query_right_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_right_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_right_deletion_score = score;
@@ -4081,10 +4081,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_extend_left_deletion_score,
         (setter)Aligner_set_extend_left_deletion_score,
         Aligner_extend_left_deletion_score__doc__, NULL},
-    {"query_left_gap_score",
-        (getter)Aligner_get_query_left_gap_score,
-        (setter)Aligner_set_query_left_gap_score,
-         Aligner_query_left_gap_score__doc__, NULL},
+    {"left_deletion_score",
+        (getter)Aligner_get_left_deletion_score,
+        (setter)Aligner_set_left_deletion_score,
+         Aligner_left_deletion_score__doc__, NULL},
     {"open_right_deletion_score",
         (getter)Aligner_get_open_right_deletion_score,
         (setter)Aligner_set_open_right_deletion_score,
@@ -4093,10 +4093,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_extend_right_deletion_score,
         (setter)Aligner_set_extend_right_deletion_score,
         Aligner_extend_right_deletion_score__doc__, NULL},
-    {"query_right_gap_score",
-        (getter)Aligner_get_query_right_gap_score,
-        (setter)Aligner_set_query_right_gap_score,
-        Aligner_query_right_gap_score__doc__, NULL},
+    {"right_deletion_score",
+        (getter)Aligner_get_right_deletion_score,
+        (setter)Aligner_set_right_deletion_score,
+        Aligner_right_deletion_score__doc__, NULL},
     {"epsilon",
         (getter)Aligner_get_epsilon,
         (setter)Aligner_set_epsilon,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3470,10 +3470,10 @@ Aligner_set_end_deletion_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_query_end_open_gap_score__doc__[] = "query end open score";
+static char Aligner_open_end_deletion_score__doc__[] = "open end deletion score";
 
 static PyObject*
-Aligner_get_query_end_open_gap_score(Aligner* self, void* closure)
+Aligner_get_open_end_deletion_score(Aligner* self, void* closure)
 {   if (self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -3489,7 +3489,7 @@ Aligner_get_query_end_open_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_query_end_open_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_open_end_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_deletion_score = score;
@@ -4053,10 +4053,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_end_deletion_score,
         (setter)Aligner_set_end_deletion_score,
         Aligner_end_deletion_score__doc__, NULL},
-    {"query_end_open_gap_score",
-        (getter)Aligner_get_query_end_open_gap_score,
-        (setter)Aligner_set_query_end_open_gap_score,
-        Aligner_query_end_open_gap_score__doc__, NULL},
+    {"open_end_deletion_score",
+        (getter)Aligner_get_open_end_deletion_score,
+        (setter)Aligner_set_open_end_deletion_score,
+        Aligner_open_end_deletion_score__doc__, NULL},
     {"query_end_extend_gap_score",
         (getter)Aligner_get_query_end_extend_gap_score,
         (setter)Aligner_set_query_end_extend_gap_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -2885,10 +2885,10 @@ Aligner_set_open_insertion_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_target_extend_gap_score__doc__[] = "target extend gap score";
+static char Aligner_extend_insertion_score__doc__[] = "extend insertion score";
 
 static PyObject*
-Aligner_get_target_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_insertion_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -2905,7 +2905,7 @@ Aligner_get_target_extend_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_target_extend_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_extend_insertion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_internal_insertion_score = score;
@@ -3981,10 +3981,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_open_insertion_score,
         (setter)Aligner_set_open_insertion_score,
         Aligner_open_insertion_score__doc__, NULL},
-    {"target_extend_gap_score",
-        (getter)Aligner_get_target_extend_gap_score,
-        (setter)Aligner_set_target_extend_gap_score,
-        Aligner_target_extend_gap_score__doc__, NULL},
+    {"extend_insertion_score",
+        (getter)Aligner_get_extend_insertion_score,
+        (setter)Aligner_set_extend_insertion_score,
+        Aligner_extend_insertion_score__doc__, NULL},
     {"target_gap_score",
         (getter)Aligner_get_target_gap_score,
         (setter)Aligner_set_target_gap_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3502,10 +3502,10 @@ Aligner_set_open_end_deletion_score(Aligner* self, PyObject* value, void* closur
     return 0;
 }
 
-static char Aligner_query_end_extend_gap_score__doc__[] = "query end extend score";
+static char Aligner_extend_end_deletion_score__doc__[] = "extend end deletion score";
 
 static PyObject*
-Aligner_get_query_end_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_end_deletion_score(Aligner* self, void* closure)
 {   if (self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -3521,7 +3521,7 @@ Aligner_get_query_end_extend_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_query_end_extend_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_extend_end_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_left_deletion_score = score;
@@ -4057,10 +4057,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_open_end_deletion_score,
         (setter)Aligner_set_open_end_deletion_score,
         Aligner_open_end_deletion_score__doc__, NULL},
-    {"query_end_extend_gap_score",
-        (getter)Aligner_get_query_end_extend_gap_score,
-        (setter)Aligner_set_query_end_extend_gap_score,
-        Aligner_query_end_extend_gap_score__doc__, NULL},
+    {"extend_end_deletion_score",
+        (getter)Aligner_get_extend_end_deletion_score,
+        (setter)Aligner_set_extend_end_deletion_score,
+        Aligner_extend_end_deletion_score__doc__, NULL},
     {"open_internal_deletion_score",
         (getter)Aligner_get_open_internal_deletion_score,
         (setter)Aligner_set_open_internal_deletion_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3584,10 +3584,10 @@ Aligner_set_extend_internal_deletion_score(Aligner* self, PyObject* value,
     return 0;
 }
 
-static char Aligner_query_internal_gap_score__doc__[] = "query internal gap score";
+static char Aligner_internal_deletion_score__doc__[] = "internal deletion score";
 
 static PyObject*
-Aligner_get_query_internal_gap_score(Aligner* self, void* closure)
+Aligner_get_internal_deletion_score(Aligner* self, void* closure)
 {   if (self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -3603,7 +3603,7 @@ Aligner_get_query_internal_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_query_internal_gap_score(Aligner* self, PyObject* value,
+Aligner_set_internal_deletion_score(Aligner* self, PyObject* value,
                                      void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
@@ -4069,10 +4069,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_extend_internal_deletion_score,
         (setter)Aligner_set_extend_internal_deletion_score,
         Aligner_extend_internal_deletion_score__doc__, NULL},
-    {"query_internal_gap_score",
-        (getter)Aligner_get_query_internal_gap_score,
-        (setter)Aligner_set_query_internal_gap_score,
-        Aligner_query_internal_gap_score__doc__, NULL},
+    {"internal_deletion_score",
+        (getter)Aligner_get_internal_deletion_score,
+        (setter)Aligner_set_internal_deletion_score,
+        Aligner_internal_deletion_score__doc__, NULL},
     {"open_left_deletion_score",
         (getter)Aligner_get_open_left_deletion_score,
         (setter)Aligner_set_open_left_deletion_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3322,10 +3322,10 @@ Aligner_set_extend_left_insertion_score(Aligner* self, PyObject* value, void* cl
     return 0;
 }
 
-static char Aligner_target_left_gap_score__doc__[] = "target left score";
+static char Aligner_left_insertion_score__doc__[] = "left insertion score";
 
 static PyObject*
-Aligner_get_target_left_gap_score(Aligner* self, void* closure)
+Aligner_get_left_insertion_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -3341,7 +3341,7 @@ Aligner_get_target_left_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_target_left_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_left_insertion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_insertion_score = score;
@@ -4033,10 +4033,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_extend_left_insertion_score,
         (setter)Aligner_set_extend_left_insertion_score,
         Aligner_extend_left_insertion_score__doc__, NULL},
-    {"target_left_gap_score",
-        (getter)Aligner_get_target_left_gap_score,
-        (setter)Aligner_set_target_left_gap_score,
-        Aligner_target_left_gap_score__doc__, NULL},
+    {"left_insertion_score",
+        (getter)Aligner_get_left_insertion_score,
+        (setter)Aligner_set_left_insertion_score,
+        Aligner_left_insertion_score__doc__, NULL},
     {"open_right_insertion_score",
         (getter)Aligner_get_open_right_insertion_score,
         (setter)Aligner_set_open_right_insertion_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -1773,7 +1773,7 @@ typedef struct {
     double open_right_insertion_score;
     double extend_right_insertion_score;
     double open_internal_deletion_score;
-    double query_internal_extend_gap_score;
+    double extend_internal_deletion_score;
     double open_left_deletion_score;
     double extend_left_deletion_score;
     double query_right_open_gap_score;
@@ -1879,7 +1879,7 @@ static Algorithm _get_algorithm(Aligner* self)
         const double open_internal_insertion_score = self->open_internal_insertion_score;
         const double open_internal_deletion_score = self->open_internal_deletion_score;
         const double extend_internal_insertion_score = self->extend_internal_insertion_score;
-        const double query_gap_extend = self->query_internal_extend_gap_score;
+        const double extend_internal_deletion_score = self->extend_internal_deletion_score;
         const double open_left_insertion_score = self->open_left_insertion_score;
         const double extend_left_insertion_score = self->extend_left_insertion_score;
         const double open_left_deletion_score = self->open_left_deletion_score;
@@ -1893,7 +1893,7 @@ static Algorithm _get_algorithm(Aligner* self)
         else if (self->target_gap_function || self->query_gap_function)
             algorithm = WatermanSmithBeyer;
         else if (open_internal_insertion_score == extend_internal_insertion_score
-              && open_internal_deletion_score == query_gap_extend
+              && open_internal_deletion_score == extend_internal_deletion_score
               && open_left_insertion_score == extend_left_insertion_score
               && open_right_insertion_score == extend_right_insertion_score
               && open_left_deletion_score == extend_left_deletion_score
@@ -1916,7 +1916,7 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->open_internal_insertion_score = 0;
     self->extend_internal_insertion_score = 0;
     self->open_internal_deletion_score = 0;
-    self->query_internal_extend_gap_score = 0;
+    self->extend_internal_deletion_score = 0;
     self->open_left_insertion_score = 0;
     self->extend_left_insertion_score = 0;
     self->open_right_insertion_score = 0;
@@ -2011,8 +2011,8 @@ Aligner_str(Aligner* self)
     else {
         p += sprintf(p, "  open_internal_deletion_score: %f\n",
                      self->open_internal_deletion_score);
-        p += sprintf(p, "  query_internal_extend_gap_score: %f\n",
-                     self->query_internal_extend_gap_score);
+        p += sprintf(p, "  extend_internal_deletion_score: %f\n",
+                     self->extend_internal_deletion_score);
         p += sprintf(p, "  open_left_deletion_score: %f\n",
                      self->open_left_deletion_score);
         p += sprintf(p, "  extend_left_deletion_score: %f\n",
@@ -2246,7 +2246,7 @@ Aligner_get_gap_score(Aligner* self, void* closure)
          || score != self->open_right_insertion_score
          || score != self->extend_right_insertion_score
          || score != self->open_internal_deletion_score
-         || score != self->query_internal_extend_gap_score
+         || score != self->extend_internal_deletion_score
          || score != self->open_left_deletion_score
          || score != self->extend_left_deletion_score
          || score != self->query_right_open_gap_score
@@ -2286,7 +2286,7 @@ Aligner_set_gap_score(Aligner* self, PyObject* value, void* closure)
         self->open_right_insertion_score = score;
         self->extend_right_insertion_score = score;
         self->open_internal_deletion_score = score;
-        self->query_internal_extend_gap_score = score;
+        self->extend_internal_deletion_score = score;
         self->open_left_deletion_score = score;
         self->extend_left_deletion_score = score;
         self->query_right_open_gap_score = score;
@@ -2354,7 +2354,7 @@ Aligner_get_extend_gap_score(Aligner* self, void* closure)
         const double score = self->extend_internal_insertion_score;
         if (score != self->extend_left_insertion_score
          || score != self->extend_right_insertion_score
-         || score != self->query_internal_extend_gap_score
+         || score != self->extend_internal_deletion_score
          || score != self->extend_left_deletion_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2379,7 +2379,7 @@ Aligner_set_extend_gap_score(Aligner* self, PyObject* value, void* closure)
     self->extend_internal_insertion_score = score;
     self->extend_left_insertion_score = score;
     self->extend_right_insertion_score = score;
-    self->query_internal_extend_gap_score = score;
+    self->extend_internal_deletion_score = score;
     self->extend_left_deletion_score = score;
     self->query_right_extend_gap_score = score;
     self->algorithm = Unknown;
@@ -2398,7 +2398,7 @@ Aligner_get_internal_gap_score(Aligner* self, void* closure)
         const double score = self->open_internal_insertion_score;
         if (score != self->extend_internal_insertion_score
          || score != self->open_internal_deletion_score
-         || score != self->query_internal_extend_gap_score) {
+         || score != self->extend_internal_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2421,7 +2421,7 @@ Aligner_set_internal_gap_score(Aligner* self, PyObject* value, void* closure)
     self->open_internal_insertion_score = score;
     self->extend_internal_insertion_score = score;
     self->open_internal_deletion_score = score;
-    self->query_internal_extend_gap_score = score;
+    self->extend_internal_deletion_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2472,7 +2472,7 @@ Aligner_get_internal_extend_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->extend_internal_insertion_score;
-        if (score != self->query_internal_extend_gap_score) {
+        if (score != self->extend_internal_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2494,7 +2494,7 @@ Aligner_set_internal_extend_gap_score(Aligner* self, PyObject* value,
         self->query_gap_function = NULL;
     }
     self->extend_internal_insertion_score = score;
-    self->query_internal_extend_gap_score = score;
+    self->extend_internal_deletion_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -3014,7 +3014,7 @@ Aligner_get_query_extend_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->query_internal_extend_gap_score;
+        const double score = self->extend_internal_deletion_score;
         if (score != self->extend_left_deletion_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -3028,7 +3028,7 @@ static int
 Aligner_set_query_extend_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_internal_extend_gap_score = score;
+    self->extend_internal_deletion_score = score;
     self->extend_left_deletion_score = score;
     self->query_right_extend_gap_score = score;
     if (self->query_gap_function) {
@@ -3051,7 +3051,7 @@ Aligner_get_query_gap_score(Aligner* self, void* closure)
         const double score = self->open_internal_deletion_score;
         if (score != self->open_left_deletion_score
          || score != self->query_right_open_gap_score
-         || score != self->query_internal_extend_gap_score
+         || score != self->extend_internal_deletion_score
          || score != self->extend_left_deletion_score
          || score != self->query_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -3076,7 +3076,7 @@ Aligner_set_query_gap_score(Aligner* self, PyObject* value, void* closure)
             return -1;
         }
         self->open_internal_deletion_score = score;
-        self->query_internal_extend_gap_score = score;
+        self->extend_internal_deletion_score = score;
         self->open_left_deletion_score = score;
         self->extend_left_deletion_score = score;
         self->query_right_open_gap_score = score;
@@ -3559,23 +3559,23 @@ Aligner_set_open_internal_deletion_score(Aligner* self, PyObject* value,
     return 0;
 }
 
-static char Aligner_query_internal_extend_gap_score__doc__[] = "query internal extend gap score";
+static char Aligner_extend_internal_deletion_score__doc__[] = "query internal extend gap score";
 
 static PyObject*
-Aligner_get_query_internal_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_internal_deletion_score(Aligner* self, void* closure)
 {   if (self->query_gap_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->query_internal_extend_gap_score);
+    return PyFloat_FromDouble(self->extend_internal_deletion_score);
 }
 
 static int
-Aligner_set_query_internal_extend_gap_score(Aligner* self, PyObject* value,
+Aligner_set_extend_internal_deletion_score(Aligner* self, PyObject* value,
                                             void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_internal_extend_gap_score = score;
+    self->extend_internal_deletion_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -3594,7 +3594,7 @@ Aligner_get_query_internal_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_internal_deletion_score;
-        if (score != self->query_internal_extend_gap_score) {
+        if (score != self->extend_internal_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3608,7 +3608,7 @@ Aligner_set_query_internal_gap_score(Aligner* self, PyObject* value,
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_internal_deletion_score = score;
-    self->query_internal_extend_gap_score = score;
+    self->extend_internal_deletion_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -4065,10 +4065,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_open_internal_deletion_score,
         (setter)Aligner_set_open_internal_deletion_score,
         Aligner_open_internal_deletion_score__doc__, NULL},
-    {"query_internal_extend_gap_score",
-        (getter)Aligner_get_query_internal_extend_gap_score,
-        (setter)Aligner_set_query_internal_extend_gap_score,
-        Aligner_query_internal_extend_gap_score__doc__, NULL},
+    {"extend_internal_deletion_score",
+        (getter)Aligner_get_extend_internal_deletion_score,
+        (setter)Aligner_set_extend_internal_deletion_score,
+        Aligner_extend_internal_deletion_score__doc__, NULL},
     {"query_internal_gap_score",
         (getter)Aligner_get_query_internal_gap_score,
         (setter)Aligner_set_query_internal_gap_score,
@@ -4539,7 +4539,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     int kA; \
     int kB; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
-    const double gap_extend_B = self->query_internal_extend_gap_score; \
+    const double gap_extend_B = self->extend_internal_deletion_score; \
     double score; \
     double temp; \
     double* row; \
@@ -4618,7 +4618,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     int kA; \
     int kB; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
-    const double gap_extend_B = self->query_internal_extend_gap_score; \
+    const double gap_extend_B = self->extend_internal_deletion_score; \
     double score; \
     double* row; \
     double temp; \
@@ -4669,7 +4669,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     int kA; \
     int kB; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
-    const double gap_extend_B = self->query_internal_extend_gap_score; \
+    const double gap_extend_B = self->extend_internal_deletion_score; \
     const double epsilon = self->epsilon; \
     Trace** M; \
     double score; \
@@ -4743,7 +4743,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     int kA; \
     int kB; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
-    const double gap_extend_B = self->query_internal_extend_gap_score; \
+    const double gap_extend_B = self->extend_internal_deletion_score; \
     const double epsilon = self->epsilon; \
     Trace** M = NULL; \
     double maximum = 0; \
@@ -4827,7 +4827,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     const double gap_open_A = self->open_internal_insertion_score; \
     const double gap_open_B = self->open_internal_deletion_score; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
-    const double gap_extend_B = self->query_internal_extend_gap_score; \
+    const double gap_extend_B = self->extend_internal_deletion_score; \
     double left_gap_open_A; \
     double left_gap_open_B; \
     double left_gap_extend_A; \
@@ -4996,7 +4996,7 @@ exit: \
     const double gap_open_A = self->open_internal_insertion_score; \
     const double gap_open_B = self->open_internal_deletion_score; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
-    const double gap_extend_B = self->query_internal_extend_gap_score; \
+    const double gap_extend_B = self->extend_internal_deletion_score; \
     double* M_row = NULL; \
     double* Ix_row = NULL; \
     double* Iy_row = NULL; \
@@ -5107,7 +5107,7 @@ exit: \
     const double gap_open_A = self->open_internal_insertion_score; \
     const double gap_open_B = self->open_internal_deletion_score; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
-    const double gap_extend_B = self->query_internal_extend_gap_score; \
+    const double gap_extend_B = self->extend_internal_deletion_score; \
     double left_gap_open_A; \
     double left_gap_open_B; \
     double left_gap_extend_A; \
@@ -5287,7 +5287,7 @@ exit: \
     const double gap_open_A = self->open_internal_insertion_score; \
     const double gap_open_B = self->open_internal_deletion_score; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
-    const double gap_extend_B = self->query_internal_extend_gap_score; \
+    const double gap_extend_B = self->extend_internal_deletion_score; \
     const double epsilon = self->epsilon; \
     Trace** M = NULL; \
     TraceGapsGotoh** gaps = NULL; \
@@ -6009,7 +6009,7 @@ exit: \
     const double gap_open_A = self->open_internal_insertion_score; \
     const double gap_open_B = self->open_internal_deletion_score; \
     const double gap_extend_A = self->extend_internal_insertion_score; \
-    const double gap_extend_B = self->query_internal_extend_gap_score; \
+    const double gap_extend_B = self->extend_internal_deletion_score; \
     struct fogsaa_cell* matrix = NULL; \
     struct fogsaa_queue queue; \
     double left_gap_open_A; \
@@ -6844,7 +6844,7 @@ _call_query_gap_function(Aligner* aligner, int i, int j, double* score)
     PyObject* function = aligner->query_gap_function;
     if (!function)
         value = aligner->open_internal_deletion_score
-              + (j-1) * aligner->query_internal_extend_gap_score;
+              + (j-1) * aligner->extend_internal_deletion_score;
     else {
         result = PyObject_CallFunction(function, "ii", i, j);
         if (result == NULL) return 0;
@@ -7081,7 +7081,7 @@ Aligner_watermansmithbeyer_local_align_matrix(Aligner* self,
             self->open_internal_insertion_score > mismatch || \
             self->open_right_insertion_score > mismatch || \
             self->extend_left_deletion_score > mismatch || \
-            self->query_internal_extend_gap_score > mismatch || \
+            self->extend_internal_deletion_score > mismatch || \
             self->query_right_extend_gap_score > mismatch || \
             self->extend_left_insertion_score > mismatch || \
             self->extend_internal_insertion_score > mismatch || \

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -1769,7 +1769,7 @@ typedef struct {
     double open_internal_insertion_score;
     double extend_internal_insertion_score;
     double open_left_insertion_score;
-    double target_left_extend_gap_score;
+    double extend_left_insertion_score;
     double target_right_open_gap_score;
     double target_right_extend_gap_score;
     double query_internal_open_gap_score;
@@ -1880,8 +1880,8 @@ static Algorithm _get_algorithm(Aligner* self)
         const double query_gap_open = self->query_internal_open_gap_score;
         const double extend_internal_insertion_score = self->extend_internal_insertion_score;
         const double query_gap_extend = self->query_internal_extend_gap_score;
-        const double target_left_open = self->open_left_insertion_score;
-        const double target_left_extend = self->target_left_extend_gap_score;
+        const double open_left_insertion_score = self->open_left_insertion_score;
+        const double extend_left_insertion_score = self->extend_left_insertion_score;
         const double query_left_open = self->query_left_open_gap_score;
         const double target_right_open = self->target_right_open_gap_score;
         const double query_right_open = self->query_right_open_gap_score;
@@ -1894,7 +1894,7 @@ static Algorithm _get_algorithm(Aligner* self)
             algorithm = WatermanSmithBeyer;
         else if (open_internal_insertion_score == extend_internal_insertion_score
               && query_gap_open == query_gap_extend
-              && target_left_open == target_left_extend
+              && open_left_insertion_score == extend_left_insertion_score
               && target_right_open == target_right_extend
               && query_left_open == query_left_extend
               && query_right_open == query_right_extend)
@@ -1918,7 +1918,7 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->query_internal_open_gap_score = 0;
     self->query_internal_extend_gap_score = 0;
     self->open_left_insertion_score = 0;
-    self->target_left_extend_gap_score = 0;
+    self->extend_left_insertion_score = 0;
     self->target_right_open_gap_score = 0;
     self->target_right_extend_gap_score = 0;
     self->query_left_open_gap_score = 0;
@@ -1997,8 +1997,8 @@ Aligner_str(Aligner* self)
                      self->extend_internal_insertion_score);
         p += sprintf(p, "  open_left_insertion_score: %f\n",
                      self->open_left_insertion_score);
-        p += sprintf(p, "  target_left_extend_gap_score: %f\n",
-                     self->target_left_extend_gap_score);
+        p += sprintf(p, "  extend_left_insertion_score: %f\n",
+                     self->extend_left_insertion_score);
         p += sprintf(p, "  target_right_open_gap_score: %f\n",
                      self->target_right_open_gap_score);
         p += sprintf(p, "  target_right_extend_gap_score: %f\n",
@@ -2242,7 +2242,7 @@ Aligner_get_gap_score(Aligner* self, void* closure)
         const double score = self->open_internal_insertion_score;
         if (score != self->extend_internal_insertion_score
          || score != self->open_left_insertion_score
-         || score != self->target_left_extend_gap_score
+         || score != self->extend_left_insertion_score
          || score != self->target_right_open_gap_score
          || score != self->target_right_extend_gap_score
          || score != self->query_internal_open_gap_score
@@ -2282,7 +2282,7 @@ Aligner_set_gap_score(Aligner* self, PyObject* value, void* closure)
         self->open_internal_insertion_score = score;
         self->extend_internal_insertion_score = score;
         self->open_left_insertion_score = score;
-        self->target_left_extend_gap_score = score;
+        self->extend_left_insertion_score = score;
         self->target_right_open_gap_score = score;
         self->target_right_extend_gap_score = score;
         self->query_internal_open_gap_score = score;
@@ -2352,7 +2352,7 @@ Aligner_get_extend_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->extend_internal_insertion_score;
-        if (score != self->target_left_extend_gap_score
+        if (score != self->extend_left_insertion_score
          || score != self->target_right_extend_gap_score
          || score != self->query_internal_extend_gap_score
          || score != self->query_left_extend_gap_score
@@ -2377,7 +2377,7 @@ Aligner_set_extend_gap_score(Aligner* self, PyObject* value, void* closure)
         self->query_gap_function = NULL;
     }
     self->extend_internal_insertion_score = score;
-    self->target_left_extend_gap_score = score;
+    self->extend_left_insertion_score = score;
     self->target_right_extend_gap_score = score;
     self->query_internal_extend_gap_score = score;
     self->query_left_extend_gap_score = score;
@@ -2509,7 +2509,7 @@ Aligner_get_end_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_left_insertion_score;
-        if (score != self->target_left_extend_gap_score
+        if (score != self->extend_left_insertion_score
          || score != self->target_right_open_gap_score
          || score != self->target_right_extend_gap_score
          || score != self->query_left_open_gap_score
@@ -2536,7 +2536,7 @@ Aligner_set_end_gap_score(Aligner* self, PyObject* value, void* closure)
         self->query_gap_function = NULL;
     }
     self->open_left_insertion_score = score;
-    self->target_left_extend_gap_score = score;
+    self->extend_left_insertion_score = score;
     self->target_right_open_gap_score = score;
     self->target_right_extend_gap_score = score;
     self->query_left_open_gap_score = score;
@@ -2596,7 +2596,7 @@ Aligner_get_end_extend_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_left_extend_gap_score;
+        const double score = self->extend_left_insertion_score;
         if (score != self->target_right_extend_gap_score
          || score != self->query_left_extend_gap_score
          || score != self->query_right_extend_gap_score) {
@@ -2619,7 +2619,7 @@ Aligner_set_end_extend_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_left_extend_gap_score = score;
+    self->extend_left_insertion_score = score;
     self->target_right_extend_gap_score = score;
     self->query_left_extend_gap_score = score;
     self->query_right_extend_gap_score = score;
@@ -2637,7 +2637,7 @@ Aligner_get_left_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_left_insertion_score;
-        if (score != self->target_left_extend_gap_score
+        if (score != self->extend_left_insertion_score
          || score != self->query_left_open_gap_score
          || score != self->query_left_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2660,7 +2660,7 @@ Aligner_set_left_gap_score(Aligner* self, PyObject* value, void* closure)
         self->query_gap_function = NULL;
     }
     self->open_left_insertion_score = score;
-    self->target_left_extend_gap_score = score;
+    self->extend_left_insertion_score = score;
     self->query_left_open_gap_score = score;
     self->query_left_extend_gap_score = score;
     self->algorithm = Unknown;
@@ -2752,7 +2752,7 @@ Aligner_get_left_extend_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_left_extend_gap_score;
+        const double score = self->extend_left_insertion_score;
         if (score != self->query_left_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2773,7 +2773,7 @@ Aligner_set_left_extend_gap_score(Aligner* self, PyObject* value, void* closure)
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
     }
-    self->target_left_extend_gap_score = score;
+    self->extend_left_insertion_score = score;
     self->query_left_extend_gap_score = score;
     self->algorithm = Unknown;
     return 0;
@@ -2895,7 +2895,7 @@ Aligner_get_target_extend_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->extend_internal_insertion_score;
-        if (score != self->target_left_extend_gap_score
+        if (score != self->extend_left_insertion_score
          || score != self->target_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -2909,7 +2909,7 @@ Aligner_set_target_extend_gap_score(Aligner* self, PyObject* value, void* closur
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_internal_insertion_score = score;
-    self->target_left_extend_gap_score = score;
+    self->extend_left_insertion_score = score;
     self->target_right_extend_gap_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
@@ -2931,7 +2931,7 @@ Aligner_get_target_gap_score(Aligner* self, void* closure)
         const double score = self->open_internal_insertion_score;
         if (score != self->extend_internal_insertion_score
          || score != self->open_left_insertion_score
-         || score != self->target_left_extend_gap_score
+         || score != self->extend_left_insertion_score
          || score != self->target_right_open_gap_score
          || score != self->target_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -2959,7 +2959,7 @@ Aligner_set_target_gap_score(Aligner* self, PyObject* value, void* closure)
         self->open_internal_insertion_score = score;
         self->extend_internal_insertion_score = score;
         self->open_left_insertion_score = score;
-        self->target_left_extend_gap_score = score;
+        self->extend_left_insertion_score = score;
         self->target_right_open_gap_score = score;
         self->target_right_extend_gap_score = score;
         if (self->target_gap_function) {
@@ -3183,7 +3183,7 @@ Aligner_get_target_end_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_left_insertion_score;
-        if (score != self->target_left_extend_gap_score
+        if (score != self->extend_left_insertion_score
          || score != self->target_right_open_gap_score
          || score != self->target_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
@@ -3198,7 +3198,7 @@ Aligner_set_target_end_gap_score(Aligner* self, PyObject* value, void* closure) 
     const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_insertion_score = score;
-    self->target_left_extend_gap_score = score;
+    self->extend_left_insertion_score = score;
     self->target_right_open_gap_score = score;
     self->target_right_extend_gap_score = score;
     if (self->target_gap_function) {
@@ -3251,7 +3251,7 @@ Aligner_get_target_end_extend_gap_score(Aligner* self, void* closure)
         return NULL;
     }
     else {
-        const double score = self->target_left_extend_gap_score;
+        const double score = self->extend_left_insertion_score;
         if (score != self->target_right_extend_gap_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
@@ -3264,7 +3264,7 @@ static int
 Aligner_set_target_end_extend_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_left_extend_gap_score = score;
+    self->extend_left_insertion_score = score;
     self->target_right_extend_gap_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
@@ -3298,22 +3298,22 @@ Aligner_set_open_left_insertion_score(Aligner* self, PyObject* value, void* clos
     return 0;
 }
 
-static char Aligner_target_left_extend_gap_score__doc__[] = "target left extend score";
+static char Aligner_extend_left_insertion_score__doc__[] = "target left extend score";
 
 static PyObject*
-Aligner_get_target_left_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_left_insertion_score(Aligner* self, void* closure)
 {   if (self->target_gap_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->target_left_extend_gap_score);
+    return PyFloat_FromDouble(self->extend_left_insertion_score);
 }
 
 static int
-Aligner_set_target_left_extend_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_extend_left_insertion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->target_left_extend_gap_score = score;
+    self->extend_left_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -3332,7 +3332,7 @@ Aligner_get_target_left_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_left_insertion_score;
-        if (score != self->target_left_extend_gap_score) {
+        if (score != self->extend_left_insertion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3345,7 +3345,7 @@ Aligner_set_target_left_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_insertion_score = score;
-    self->target_left_extend_gap_score = score;
+    self->extend_left_insertion_score = score;
     if (self->target_gap_function) {
         Py_DECREF(self->target_gap_function);
         self->target_gap_function = NULL;
@@ -4029,10 +4029,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_open_left_insertion_score,
         (setter)Aligner_set_open_left_insertion_score,
         Aligner_open_left_insertion_score__doc__, NULL},
-    {"target_left_extend_gap_score",
-        (getter)Aligner_get_target_left_extend_gap_score,
-        (setter)Aligner_set_target_left_extend_gap_score,
-        Aligner_target_left_extend_gap_score__doc__, NULL},
+    {"extend_left_insertion_score",
+        (getter)Aligner_get_extend_left_insertion_score,
+        (setter)Aligner_set_extend_left_insertion_score,
+        Aligner_extend_left_insertion_score__doc__, NULL},
     {"target_left_gap_score",
         (getter)Aligner_get_target_left_gap_score,
         (setter)Aligner_set_target_left_gap_score,
@@ -4549,14 +4549,14 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     double right_gap_extend_B; \
     switch (strand) { \
         case '+': \
-            left_gap_extend_A = self->target_left_extend_gap_score; \
+            left_gap_extend_A = self->extend_left_insertion_score; \
             right_gap_extend_A = self->target_right_extend_gap_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
             left_gap_extend_A = self->target_right_extend_gap_score; \
-            right_gap_extend_A = self->target_left_extend_gap_score; \
+            right_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
             break; \
@@ -4683,14 +4683,14 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     double right_gap_extend_B; \
     switch (strand) { \
         case '+': \
-            left_gap_extend_A = self->target_left_extend_gap_score; \
+            left_gap_extend_A = self->extend_left_insertion_score; \
             right_gap_extend_A = self->target_right_extend_gap_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
             right_gap_extend_B = self->query_right_extend_gap_score; \
             break; \
         case '-': \
             left_gap_extend_A = self->target_right_extend_gap_score; \
-            right_gap_extend_A = self->target_left_extend_gap_score; \
+            right_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
             break; \
@@ -4848,7 +4848,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
         case '+': \
             left_gap_open_A = self->open_left_insertion_score; \
             left_gap_open_B = self->query_left_open_gap_score; \
-            left_gap_extend_A = self->target_left_extend_gap_score; \
+            left_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
             right_gap_open_A = self->target_right_open_gap_score; \
             right_gap_open_B = self->query_right_open_gap_score; \
@@ -4862,7 +4862,7 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->query_left_open_gap_score; \
-            right_gap_extend_A = self->target_left_extend_gap_score; \
+            right_gap_extend_A = self->extend_left_insertion_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
             break; \
         default: \
@@ -5133,7 +5133,7 @@ exit: \
         case '+': \
             left_gap_open_A = self->open_left_insertion_score; \
             left_gap_open_B = self->query_left_open_gap_score; \
-            left_gap_extend_A = self->target_left_extend_gap_score; \
+            left_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
             right_gap_open_A = self->target_right_open_gap_score; \
             right_gap_open_B = self->query_right_open_gap_score; \
@@ -5147,7 +5147,7 @@ exit: \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->query_left_open_gap_score; \
-            right_gap_extend_A = self->target_left_extend_gap_score; \
+            right_gap_extend_A = self->extend_left_insertion_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
             break; \
         default: \
@@ -6024,7 +6024,7 @@ exit: \
         case '+': \
             left_gap_open_A = self->open_left_insertion_score; \
             left_gap_open_B = self->query_left_open_gap_score; \
-            left_gap_extend_A = self->target_left_extend_gap_score; \
+            left_gap_extend_A = self->extend_left_insertion_score; \
             left_gap_extend_B = self->query_left_extend_gap_score; \
             right_gap_open_A = self->target_right_open_gap_score; \
             right_gap_open_B = self->query_right_open_gap_score; \
@@ -6038,7 +6038,7 @@ exit: \
             left_gap_extend_B = self->query_right_extend_gap_score; \
             right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->query_left_open_gap_score; \
-            right_gap_extend_A = self->target_left_extend_gap_score; \
+            right_gap_extend_A = self->extend_left_insertion_score; \
             right_gap_extend_B = self->query_left_extend_gap_score; \
             break; \
         default: \
@@ -7083,7 +7083,7 @@ Aligner_watermansmithbeyer_local_align_matrix(Aligner* self,
             self->query_left_extend_gap_score > mismatch || \
             self->query_internal_extend_gap_score > mismatch || \
             self->query_right_extend_gap_score > mismatch || \
-            self->target_left_extend_gap_score > mismatch || \
+            self->extend_left_insertion_score > mismatch || \
             self->extend_internal_insertion_score > mismatch || \
             self->target_right_extend_gap_score > mismatch) { \
         PyObject *Bio_module = PyImport_ImportModule("Bio"); \

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -2851,10 +2851,10 @@ Aligner_set_extend_right_gap_score(Aligner* self, PyObject* value, void* closure
     return 0;
 }
 
-static char Aligner_target_open_gap_score__doc__[] = "target open gap score";
+static char Aligner_open_insertion_score__doc__[] = "open insertion score";
 
 static PyObject*
-Aligner_get_target_open_gap_score(Aligner* self, void* closure)
+Aligner_get_open_insertion_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -2871,7 +2871,7 @@ Aligner_get_target_open_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_target_open_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_open_insertion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_internal_insertion_score = score;
@@ -3977,10 +3977,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_extend_right_gap_score,
         (setter)Aligner_set_extend_right_gap_score,
         Aligner_extend_right_gap_score__doc__, NULL},
-    {"target_open_gap_score",
-        (getter)Aligner_get_target_open_gap_score,
-        (setter)Aligner_set_target_open_gap_score,
-        Aligner_target_open_gap_score__doc__, NULL},
+    {"open_insertion_score",
+        (getter)Aligner_get_open_insertion_score,
+        (setter)Aligner_set_open_insertion_score,
+        Aligner_open_insertion_score__doc__, NULL},
     {"target_extend_gap_score",
         (getter)Aligner_get_target_extend_gap_score,
         (setter)Aligner_set_target_extend_gap_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3005,10 +3005,10 @@ Aligner_set_open_deletion_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_query_extend_gap_score__doc__[] = "query gap extend score";
+static char Aligner_extend_deletion_score__doc__[] = "extend deletion score";
 
 static PyObject*
-Aligner_get_query_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_deletion_score(Aligner* self, void* closure)
 {   if (self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -3025,7 +3025,7 @@ Aligner_get_query_extend_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_query_extend_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_extend_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_internal_deletion_score = score;
@@ -3039,10 +3039,10 @@ Aligner_set_query_extend_gap_score(Aligner* self, PyObject* value, void* closure
     return 0;
 }
 
-static char Aligner_query_gap_score__doc__[] = "query gap score";
+static char Aligner_deletion_score__doc__[] = "deletion score";
 
 static PyObject*
-Aligner_get_query_gap_score(Aligner* self, void* closure)
+Aligner_get_deletion_score(Aligner* self, void* closure)
 {   if (self->deletion_score_function) {
         Py_INCREF(self->deletion_score_function);
         return self->deletion_score_function;
@@ -3062,7 +3062,7 @@ Aligner_get_query_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_query_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   if (PyCallable_Check(value)) {
         Py_XDECREF(self->deletion_score_function);
         Py_INCREF(value);
@@ -3993,14 +3993,14 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_open_deletion_score,
         (setter)Aligner_set_open_deletion_score,
         Aligner_open_deletion_score__doc__, NULL},
-    {"query_extend_gap_score",
-        (getter)Aligner_get_query_extend_gap_score,
-        (setter)Aligner_set_query_extend_gap_score,
-        Aligner_query_extend_gap_score__doc__, NULL},
-    {"query_gap_score",
-        (getter)Aligner_get_query_gap_score,
-        (setter)Aligner_set_query_gap_score,
-        Aligner_query_gap_score__doc__, NULL},
+    {"extend_deletion_score",
+        (getter)Aligner_get_extend_deletion_score,
+        (setter)Aligner_set_extend_deletion_score,
+        Aligner_extend_deletion_score__doc__, NULL},
+    {"deletion_score",
+        (getter)Aligner_get_deletion_score,
+        (setter)Aligner_set_deletion_score,
+        Aligner_deletion_score__doc__, NULL},
     {"end_insertion_score",
         (getter)Aligner_get_end_insertion_score,
         (setter)Aligner_set_end_insertion_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -2779,10 +2779,10 @@ Aligner_set_extend_left_gap_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_right_open_gap_score__doc__[] = "right open gap score";
+static char Aligner_open_right_gap_score__doc__[] = "open right gap score";
 
 static PyObject*
-Aligner_get_right_open_gap_score(Aligner* self, void* closure)
+Aligner_get_open_right_gap_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function || self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -2798,7 +2798,7 @@ Aligner_get_right_open_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_right_open_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_open_right_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     if (self->insertion_score_function) {
@@ -2815,10 +2815,10 @@ Aligner_set_right_open_gap_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_right_extend_gap_score__doc__[] = "right extend gap score";
+static char Aligner_extend_right_gap_score__doc__[] = "extend right gap score";
 
 static PyObject*
-Aligner_get_right_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_right_gap_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function || self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -2834,7 +2834,7 @@ Aligner_get_right_extend_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_right_extend_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_extend_right_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     if (self->insertion_score_function) {
@@ -3969,14 +3969,14 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_right_gap_score,
         (setter)Aligner_set_right_gap_score,
         Aligner_right_gap_score__doc__, NULL},
-    {"right_open_gap_score",
-        (getter)Aligner_get_right_open_gap_score,
-        (setter)Aligner_set_right_open_gap_score,
-        Aligner_right_open_gap_score__doc__, NULL},
-    {"right_extend_gap_score",
-        (getter)Aligner_get_right_extend_gap_score,
-        (setter)Aligner_set_right_extend_gap_score,
-        Aligner_right_extend_gap_score__doc__, NULL},
+    {"open_right_gap_score",
+        (getter)Aligner_get_open_right_gap_score,
+        (setter)Aligner_set_open_right_gap_score,
+        Aligner_open_right_gap_score__doc__, NULL},
+    {"extend_right_gap_score",
+        (getter)Aligner_get_extend_right_gap_score,
+        (setter)Aligner_set_extend_right_gap_score,
+        Aligner_extend_right_gap_score__doc__, NULL},
     {"target_open_gap_score",
         (getter)Aligner_get_target_open_gap_score,
         (setter)Aligner_set_target_open_gap_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -2426,10 +2426,10 @@ Aligner_set_internal_gap_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_internal_open_gap_score__doc__[] = "internal open gap score";
+static char Aligner_open_internal_gap_score__doc__[] = "open internal gap score";
 
 static PyObject*
-Aligner_get_internal_open_gap_score(Aligner* self, void* closure)
+Aligner_get_open_internal_gap_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function || self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -2445,7 +2445,7 @@ Aligner_get_internal_open_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_internal_open_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_open_internal_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     if (self->insertion_score_function) {
@@ -2462,10 +2462,10 @@ Aligner_set_internal_open_gap_score(Aligner* self, PyObject* value, void* closur
     return 0;
 }
 
-static char Aligner_internal_extend_gap_score__doc__[] = "internal extend gap score";
+static char Aligner_extend_internal_gap_score__doc__[] = "extend internal gap score";
 
 static PyObject*
-Aligner_get_internal_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_internal_gap_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function || self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -2481,7 +2481,7 @@ Aligner_get_internal_extend_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_internal_extend_gap_score(Aligner* self, PyObject* value,
+Aligner_set_extend_internal_gap_score(Aligner* self, PyObject* value,
                                       void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
@@ -2547,10 +2547,10 @@ Aligner_set_end_gap_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_end_open_gap_score__doc__[] = "end open gap score";
+static char Aligner_open_end_gap_score__doc__[] = "open end gap score";
 
 static PyObject*
-Aligner_get_end_open_gap_score(Aligner* self, void* closure)
+Aligner_get_open_end_gap_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function || self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -2568,7 +2568,7 @@ Aligner_get_end_open_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_end_open_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_open_end_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     if (self->insertion_score_function) {
@@ -3933,22 +3933,22 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_internal_gap_score,
         (setter)Aligner_set_internal_gap_score,
         Aligner_internal_gap_score__doc__, NULL},
-    {"internal_open_gap_score",
-        (getter)Aligner_get_internal_open_gap_score,
-        (setter)Aligner_set_internal_open_gap_score,
-        Aligner_internal_open_gap_score__doc__, NULL},
-    {"internal_extend_gap_score",
-        (getter)Aligner_get_internal_extend_gap_score,
-        (setter)Aligner_set_internal_extend_gap_score,
-        Aligner_internal_extend_gap_score__doc__, NULL},
+    {"open_internal_gap_score",
+        (getter)Aligner_get_open_internal_gap_score,
+        (setter)Aligner_set_open_internal_gap_score,
+        Aligner_open_internal_gap_score__doc__, NULL},
+    {"extend_internal_gap_score",
+        (getter)Aligner_get_extend_internal_gap_score,
+        (setter)Aligner_set_extend_internal_gap_score,
+        Aligner_extend_internal_gap_score__doc__, NULL},
     {"end_gap_score",
         (getter)Aligner_get_end_gap_score,
         (setter)Aligner_set_end_gap_score,
         Aligner_end_gap_score__doc__, NULL},
-    {"end_open_gap_score",
-        (getter)Aligner_get_end_open_gap_score,
-        (setter)Aligner_set_end_open_gap_score,
-        Aligner_end_open_gap_score__doc__, NULL},
+    {"open_end_gap_score",
+        (getter)Aligner_get_open_end_gap_score,
+        (setter)Aligner_set_open_end_gap_score,
+        Aligner_open_end_gap_score__doc__, NULL},
     {"end_extend_gap_score",
         (getter)Aligner_get_end_extend_gap_score,
         (setter)Aligner_set_end_extend_gap_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -1777,7 +1777,7 @@ typedef struct {
     double open_left_deletion_score;
     double extend_left_deletion_score;
     double open_right_deletion_score;
-    double query_right_extend_gap_score;
+    double extend_right_deletion_score;
     PyObject* target_gap_function;
     PyObject* query_gap_function;
     Py_buffer substitution_matrix;
@@ -1887,7 +1887,7 @@ static Algorithm _get_algorithm(Aligner* self)
         const double open_right_deletion_score = self->open_right_deletion_score;
         const double extend_right_insertion_score = self->extend_right_insertion_score;
         const double extend_left_deletion_score = self->extend_left_deletion_score;
-        const double query_right_extend = self->query_right_extend_gap_score;
+        const double extend_right_deletion_score = self->extend_right_deletion_score;
         if (self->mode == FOGSAA_Mode)
             algorithm = FOGSAA;
         else if (self->target_gap_function || self->query_gap_function)
@@ -1897,7 +1897,7 @@ static Algorithm _get_algorithm(Aligner* self)
               && open_left_insertion_score == extend_left_insertion_score
               && open_right_insertion_score == extend_right_insertion_score
               && open_left_deletion_score == extend_left_deletion_score
-              && open_right_deletion_score == query_right_extend)
+              && open_right_deletion_score == extend_right_deletion_score)
             algorithm = NeedlemanWunschSmithWaterman;
         else
             algorithm = Gotoh;
@@ -1924,7 +1924,7 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->open_left_deletion_score = 0;
     self->extend_left_deletion_score = 0;
     self->open_right_deletion_score = 0;
-    self->query_right_extend_gap_score = 0;
+    self->extend_right_deletion_score = 0;
     self->target_gap_function = NULL;
     self->query_gap_function = NULL;
     self->substitution_matrix.obj = NULL;
@@ -2019,8 +2019,8 @@ Aligner_str(Aligner* self)
                      self->extend_left_deletion_score);
         p += sprintf(p, "  open_right_deletion_score: %f\n",
                      self->open_right_deletion_score);
-        p += sprintf(p, "  query_right_extend_gap_score: %f\n",
-                     self->query_right_extend_gap_score);
+        p += sprintf(p, "  extend_right_deletion_score: %f\n",
+                     self->extend_right_deletion_score);
     }
     switch (self->mode) {
         case Global: sprintf(p, "  mode: global\n"); break;
@@ -2250,7 +2250,7 @@ Aligner_get_gap_score(Aligner* self, void* closure)
          || score != self->open_left_deletion_score
          || score != self->extend_left_deletion_score
          || score != self->open_right_deletion_score
-         || score != self->query_right_extend_gap_score) {
+         || score != self->extend_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2290,7 +2290,7 @@ Aligner_set_gap_score(Aligner* self, PyObject* value, void* closure)
         self->open_left_deletion_score = score;
         self->extend_left_deletion_score = score;
         self->open_right_deletion_score = score;
-        self->query_right_extend_gap_score = score;
+        self->extend_right_deletion_score = score;
     }
     self->algorithm = Unknown;
     return 0;
@@ -2356,7 +2356,7 @@ Aligner_get_extend_gap_score(Aligner* self, void* closure)
          || score != self->extend_right_insertion_score
          || score != self->extend_internal_deletion_score
          || score != self->extend_left_deletion_score
-         || score != self->query_right_extend_gap_score) {
+         || score != self->extend_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2381,7 +2381,7 @@ Aligner_set_extend_gap_score(Aligner* self, PyObject* value, void* closure)
     self->extend_right_insertion_score = score;
     self->extend_internal_deletion_score = score;
     self->extend_left_deletion_score = score;
-    self->query_right_extend_gap_score = score;
+    self->extend_right_deletion_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2515,7 +2515,7 @@ Aligner_get_end_gap_score(Aligner* self, void* closure)
          || score != self->open_left_deletion_score
          || score != self->extend_left_deletion_score
          || score != self->open_right_deletion_score
-         || score != self->query_right_extend_gap_score) {
+         || score != self->extend_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2542,7 +2542,7 @@ Aligner_set_end_gap_score(Aligner* self, PyObject* value, void* closure)
     self->open_left_deletion_score = score;
     self->extend_left_deletion_score = score;
     self->open_right_deletion_score = score;
-    self->query_right_extend_gap_score = score;
+    self->extend_right_deletion_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2599,7 +2599,7 @@ Aligner_get_end_extend_gap_score(Aligner* self, void* closure)
         const double score = self->extend_left_insertion_score;
         if (score != self->extend_right_insertion_score
          || score != self->extend_left_deletion_score
-         || score != self->query_right_extend_gap_score) {
+         || score != self->extend_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2622,7 +2622,7 @@ Aligner_set_end_extend_gap_score(Aligner* self, PyObject* value, void* closure)
     self->extend_left_insertion_score = score;
     self->extend_right_insertion_score = score;
     self->extend_left_deletion_score = score;
-    self->query_right_extend_gap_score = score;
+    self->extend_right_deletion_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2679,7 +2679,7 @@ Aligner_get_right_gap_score(Aligner* self, void* closure)
         const double score = self->open_right_insertion_score;
         if (score != self->extend_right_insertion_score
          || score != self->open_right_deletion_score
-         || score != self->query_right_extend_gap_score) {
+         || score != self->extend_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2702,7 +2702,7 @@ Aligner_set_right_gap_score(Aligner* self, PyObject* value, void* closure)
     self->open_right_insertion_score = score;
     self->extend_right_insertion_score = score;
     self->open_right_deletion_score = score;
-    self->query_right_extend_gap_score = score;
+    self->extend_right_deletion_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2825,7 +2825,7 @@ Aligner_get_right_extend_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->extend_right_insertion_score;
-        if (score != self->query_right_extend_gap_score) {
+        if (score != self->extend_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -2846,7 +2846,7 @@ Aligner_set_right_extend_gap_score(Aligner* self, PyObject* value, void* closure
         self->query_gap_function = NULL;
     }
     self->extend_right_insertion_score = score;
-    self->query_right_extend_gap_score = score;
+    self->extend_right_deletion_score = score;
     self->algorithm = Unknown;
     return 0;
 }
@@ -3016,7 +3016,7 @@ Aligner_get_query_extend_gap_score(Aligner* self, void* closure)
     else {
         const double score = self->extend_internal_deletion_score;
         if (score != self->extend_left_deletion_score
-         || score != self->query_right_extend_gap_score) {
+         || score != self->extend_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3030,7 +3030,7 @@ Aligner_set_query_extend_gap_score(Aligner* self, PyObject* value, void* closure
     if (PyErr_Occurred()) return -1;
     self->extend_internal_deletion_score = score;
     self->extend_left_deletion_score = score;
-    self->query_right_extend_gap_score = score;
+    self->extend_right_deletion_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -3053,7 +3053,7 @@ Aligner_get_query_gap_score(Aligner* self, void* closure)
          || score != self->open_right_deletion_score
          || score != self->extend_internal_deletion_score
          || score != self->extend_left_deletion_score
-         || score != self->query_right_extend_gap_score) {
+         || score != self->extend_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3080,7 +3080,7 @@ Aligner_set_query_gap_score(Aligner* self, PyObject* value, void* closure)
         self->open_left_deletion_score = score;
         self->extend_left_deletion_score = score;
         self->open_right_deletion_score = score;
-        self->query_right_extend_gap_score = score;
+        self->extend_right_deletion_score = score;
         if (self->query_gap_function) {
             Py_DECREF(self->query_gap_function);
             self->query_gap_function = NULL;
@@ -3446,7 +3446,7 @@ Aligner_get_query_end_gap_score(Aligner* self, void* closure)
         const double score = self->open_left_deletion_score;
         if (score != self->extend_left_deletion_score
          || score != self->open_right_deletion_score
-         || score != self->query_right_extend_gap_score) {
+         || score != self->extend_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3461,7 +3461,7 @@ Aligner_set_query_end_gap_score(Aligner* self, PyObject* value, void* closure)
     self->open_left_deletion_score = score;
     self->extend_left_deletion_score = score;
     self->open_right_deletion_score = score;
-    self->query_right_extend_gap_score = score;
+    self->extend_right_deletion_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -3512,7 +3512,7 @@ Aligner_get_query_end_extend_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->extend_left_deletion_score;
-        if (score != self->query_right_extend_gap_score) {
+        if (score != self->extend_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3525,7 +3525,7 @@ Aligner_set_query_end_extend_gap_score(Aligner* self, PyObject* value, void* clo
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_left_deletion_score = score;
-    self->query_right_extend_gap_score = score;
+    self->extend_right_deletion_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -3721,22 +3721,22 @@ Aligner_set_open_right_deletion_score(Aligner* self, PyObject* value, void* clos
     return 0;
 }
 
-static char Aligner_query_right_extend_gap_score__doc__[] = "query right extend score";
+static char Aligner_extend_right_deletion_score__doc__[] = "query right extend score";
 
 static PyObject*
-Aligner_get_query_right_extend_gap_score(Aligner* self, void* closure)
+Aligner_get_extend_right_deletion_score(Aligner* self, void* closure)
 {   if (self->query_gap_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
     }
-    return PyFloat_FromDouble(self->query_right_extend_gap_score);
+    return PyFloat_FromDouble(self->extend_right_deletion_score);
 }
 
 static int
-Aligner_set_query_right_extend_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_extend_right_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
-    self->query_right_extend_gap_score = score;
+    self->extend_right_deletion_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -3755,7 +3755,7 @@ Aligner_get_query_right_gap_score(Aligner* self, void* closure)
     }
     else {
         const double score = self->open_right_deletion_score;
-        if (score != self->query_right_extend_gap_score) {
+        if (score != self->extend_right_deletion_score) {
             PyErr_SetString(PyExc_ValueError, "gap scores are different");
             return NULL;
         }
@@ -3768,7 +3768,7 @@ Aligner_set_query_right_gap_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_right_deletion_score = score;
-    self->query_right_extend_gap_score = score;
+    self->extend_right_deletion_score = score;
     if (self->query_gap_function) {
         Py_DECREF(self->query_gap_function);
         self->query_gap_function = NULL;
@@ -4089,10 +4089,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_open_right_deletion_score,
         (setter)Aligner_set_open_right_deletion_score,
         Aligner_open_right_deletion_score__doc__, NULL},
-    {"query_right_extend_gap_score",
-        (getter)Aligner_get_query_right_extend_gap_score,
-        (setter)Aligner_set_query_right_extend_gap_score,
-        Aligner_query_right_extend_gap_score__doc__, NULL},
+    {"extend_right_deletion_score",
+        (getter)Aligner_get_extend_right_deletion_score,
+        (setter)Aligner_set_extend_right_deletion_score,
+        Aligner_extend_right_deletion_score__doc__, NULL},
     {"query_right_gap_score",
         (getter)Aligner_get_query_right_gap_score,
         (setter)Aligner_set_query_right_gap_score,
@@ -4552,12 +4552,12 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
             left_gap_extend_A = self->extend_left_insertion_score; \
             right_gap_extend_A = self->extend_right_insertion_score; \
             left_gap_extend_B = self->extend_left_deletion_score; \
-            right_gap_extend_B = self->query_right_extend_gap_score; \
+            right_gap_extend_B = self->extend_right_deletion_score; \
             break; \
         case '-': \
             left_gap_extend_A = self->extend_right_insertion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
-            left_gap_extend_B = self->query_right_extend_gap_score; \
+            left_gap_extend_B = self->extend_right_deletion_score; \
             right_gap_extend_B = self->extend_left_deletion_score; \
             break; \
         default: \
@@ -4686,12 +4686,12 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
             left_gap_extend_A = self->extend_left_insertion_score; \
             right_gap_extend_A = self->extend_right_insertion_score; \
             left_gap_extend_B = self->extend_left_deletion_score; \
-            right_gap_extend_B = self->query_right_extend_gap_score; \
+            right_gap_extend_B = self->extend_right_deletion_score; \
             break; \
         case '-': \
             left_gap_extend_A = self->extend_right_insertion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
-            left_gap_extend_B = self->query_right_extend_gap_score; \
+            left_gap_extend_B = self->extend_right_deletion_score; \
             right_gap_extend_B = self->extend_left_deletion_score; \
             break; \
         default: \
@@ -4853,13 +4853,13 @@ struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
             right_gap_open_A = self->open_right_insertion_score; \
             right_gap_open_B = self->open_right_deletion_score; \
             right_gap_extend_A = self->extend_right_insertion_score; \
-            right_gap_extend_B = self->query_right_extend_gap_score; \
+            right_gap_extend_B = self->extend_right_deletion_score; \
             break; \
         case '-': \
             left_gap_open_A = self->open_right_insertion_score; \
             left_gap_open_B = self->open_right_deletion_score; \
             left_gap_extend_A = self->extend_right_insertion_score; \
-            left_gap_extend_B = self->query_right_extend_gap_score; \
+            left_gap_extend_B = self->extend_right_deletion_score; \
             right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->open_left_deletion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
@@ -5138,13 +5138,13 @@ exit: \
             right_gap_open_A = self->open_right_insertion_score; \
             right_gap_open_B = self->open_right_deletion_score; \
             right_gap_extend_A = self->extend_right_insertion_score; \
-            right_gap_extend_B = self->query_right_extend_gap_score; \
+            right_gap_extend_B = self->extend_right_deletion_score; \
             break; \
         case '-': \
             left_gap_open_A = self->open_right_insertion_score; \
             left_gap_open_B = self->open_right_deletion_score; \
             left_gap_extend_A = self->extend_right_insertion_score; \
-            left_gap_extend_B = self->query_right_extend_gap_score; \
+            left_gap_extend_B = self->extend_right_deletion_score; \
             right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->open_left_deletion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
@@ -6029,13 +6029,13 @@ exit: \
             right_gap_open_A = self->open_right_insertion_score; \
             right_gap_open_B = self->open_right_deletion_score; \
             right_gap_extend_A = self->extend_right_insertion_score; \
-            right_gap_extend_B = self->query_right_extend_gap_score; \
+            right_gap_extend_B = self->extend_right_deletion_score; \
             break; \
         case '-': \
             left_gap_open_A = self->open_right_insertion_score; \
             left_gap_open_B = self->open_right_deletion_score; \
             left_gap_extend_A = self->extend_right_insertion_score; \
-            left_gap_extend_B = self->query_right_extend_gap_score; \
+            left_gap_extend_B = self->extend_right_deletion_score; \
             right_gap_open_A = self->open_left_insertion_score; \
             right_gap_open_B = self->open_left_deletion_score; \
             right_gap_extend_A = self->extend_left_insertion_score; \
@@ -7082,7 +7082,7 @@ Aligner_watermansmithbeyer_local_align_matrix(Aligner* self,
             self->open_right_insertion_score > mismatch || \
             self->extend_left_deletion_score > mismatch || \
             self->extend_internal_deletion_score > mismatch || \
-            self->query_right_extend_gap_score > mismatch || \
+            self->extend_right_deletion_score > mismatch || \
             self->extend_left_insertion_score > mismatch || \
             self->extend_internal_insertion_score > mismatch || \
             self->extend_right_insertion_score > mismatch) { \

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3434,10 +3434,10 @@ Aligner_set_right_insertion_score(Aligner* self, PyObject* value, void* closure)
     return 0;
 }
 
-static char Aligner_query_end_gap_score__doc__[] = "query end score";
+static char Aligner_end_deletion_score__doc__[] = "end deletion score";
 
 static PyObject*
-Aligner_get_query_end_gap_score(Aligner* self, void* closure)
+Aligner_get_end_deletion_score(Aligner* self, void* closure)
 {   if (self->deletion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -3455,7 +3455,7 @@ Aligner_get_query_end_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_query_end_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_end_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_deletion_score = score;
@@ -4049,10 +4049,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_right_insertion_score,
         (setter)Aligner_set_right_insertion_score,
         Aligner_right_insertion_score__doc__, NULL},
-    {"query_end_gap_score",
-        (getter)Aligner_get_query_end_gap_score,
-        (setter)Aligner_set_query_end_gap_score,
-        Aligner_query_end_gap_score__doc__, NULL},
+    {"end_deletion_score",
+        (getter)Aligner_get_end_deletion_score,
+        (setter)Aligner_set_end_deletion_score,
+        Aligner_end_deletion_score__doc__, NULL},
     {"query_end_open_gap_score",
         (getter)Aligner_get_query_end_open_gap_score,
         (setter)Aligner_set_query_end_open_gap_score,

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -3402,10 +3402,10 @@ Aligner_set_extend_right_insertion_score(Aligner* self, PyObject* value, void* c
     return 0;
 }
 
-static char Aligner_target_right_gap_score__doc__[] = "target right score";
+static char Aligner_right_insertion_score__doc__[] = "right insertion score";
 
 static PyObject*
-Aligner_get_target_right_gap_score(Aligner* self, void* closure)
+Aligner_get_right_insertion_score(Aligner* self, void* closure)
 {   if (self->insertion_score_function) {
         PyErr_SetString(PyExc_ValueError, "using a gap score function");
         return NULL;
@@ -3421,7 +3421,7 @@ Aligner_get_target_right_gap_score(Aligner* self, void* closure)
 }
 
 static int
-Aligner_set_target_right_gap_score(Aligner* self, PyObject* value, void* closure)
+Aligner_set_right_insertion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_right_insertion_score = score;
@@ -4045,10 +4045,10 @@ static PyGetSetDef Aligner_getset[] = {
         (getter)Aligner_get_extend_right_insertion_score,
         (setter)Aligner_set_extend_right_insertion_score,
         Aligner_extend_right_insertion_score__doc__, NULL},
-    {"target_right_gap_score",
-        (getter)Aligner_get_target_right_gap_score,
-        (setter)Aligner_set_target_right_gap_score,
-        Aligner_target_right_gap_score__doc__, NULL},
+    {"right_insertion_score",
+        (getter)Aligner_get_right_insertion_score,
+        (setter)Aligner_set_right_insertion_score,
+        Aligner_right_insertion_score__doc__, NULL},
     {"query_end_gap_score",
         (getter)Aligner_get_query_end_gap_score,
         (setter)Aligner_set_query_end_gap_score,

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -633,6 +633,11 @@ was deprecated in Release 1.79.
 The PairwiseAlignment class was deprecated in Release 1.80, and removed in
 Release 1.82. Please use the new Alignment class instead.
 
+Attributes of the PairwiseAligner class referring to gap scores were renamed in
+Release 1.86, with the original name still available with a deprecation warning.
+These attributes were renamed to be consistent with the AlignmentCounts class
+and with the common nomenclature in the literature.
+
 Bio.Align.Generic
 -----------------
 This module which defined to original (Multiple-Sequence) Alignment class was

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -622,7 +622,7 @@ that refer to a number of these values collectively, as shown
    | ``end_gap_score``               | ``target_end_gap_score``,             |
    |                                 | ``query_end_gap_score``               |
    +---------------------------------+---------------------------------------+
-   | ``end_open_gap_score``          | ``target_end_open_gap_score``,        |
+   | ``open_end_gap_score``          | ``target_end_open_gap_score``,        |
    |                                 | ``query_end_open_gap_score``          |
    +---------------------------------+---------------------------------------+
    | ``end_extend_gap_score``        | ``target_end_extend_gap_score``,      |

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -380,7 +380,7 @@ all parameters, use
      open_left_deletion_score: 0.000000
      extend_left_deletion_score: 0.000000
      open_right_deletion_score: 0.000000
-     query_right_extend_gap_score: 0.000000
+     extend_right_deletion_score: 0.000000
      mode: local
    <BLANKLINE>
 
@@ -555,7 +555,7 @@ object:
 ================================== ====================================
 ``open_left_deletion_score``       ``extend_left_deletion_score``
 ``open_internal_deletion_score``   ``extend_internal_deletion_score``
-``open_right_deletion_score``      ``query_right_extend_gap_score``
+``open_right_deletion_score``      ``extend_right_deletion_score``
 ``open_left_insertion_score``      ``extend_left_insertion_score``
 ``open_internal_insertion_score``  ``extend_internal_insertion_score``
 ``open_right_insertion_score``     ``extend_right_insertion_score``
@@ -617,7 +617,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``open_internal_deletion_score``      |
    +---------------------------------+---------------------------------------+
    | ``internal_extend_gap_score``   | ``extend_internal_insertion_score``,  |
-   |                                 | ``extend_internal_deletion_score``   |
+   |                                 | ``extend_internal_deletion_score``    |
    +---------------------------------+---------------------------------------+
    | ``end_gap_score``               | ``target_end_gap_score``,             |
    |                                 | ``query_end_gap_score``               |
@@ -644,7 +644,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``open_right_deletion_score``         |
    +---------------------------------+---------------------------------------+
    | ``right_extend_gap_score``      | ``extend_right_insertion_score``,     |
-   |                                 | ``query_right_extend_gap_score``      |
+   |                                 | ``extend_right_deletion_score``       |
    +---------------------------------+---------------------------------------+
    | ``target_open_gap_score``       | ``open_internal_insertion_score``,    |
    |                                 | ``open_left_insertion_score``,        |
@@ -661,9 +661,9 @@ that refer to a number of these values collectively, as shown
    |                                 | ``open_left_deletion_score``,         |
    |                                 | ``open_right_deletion_score``         |
    +---------------------------------+---------------------------------------+
-   | ``query_extend_gap_score``      | ``extend_internal_deletion_score``,  |
+   | ``query_extend_gap_score``      | ``extend_internal_deletion_score``,   |
    |                                 | ``extend_left_deletion_score``,       |
-   |                                 | ``query_right_extend_gap_score``      |
+   |                                 | ``extend_right_deletion_score``       |
    +---------------------------------+---------------------------------------+
    | ``query_gap_score``             | ``query_open_gap_score``,             |
    |                                 | ``query_extend_gap_score``            |
@@ -678,7 +678,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``open_right_insertion_score``        |
    +---------------------------------+---------------------------------------+
    | ``target_end_extend_gap_score`` | ``extend_left_insertion_score``,      |
-   |                                 | ``extend_right_insertion_score``     |
+   |                                 | ``extend_right_insertion_score``      |
    +---------------------------------+---------------------------------------+
    | ``target_left_gap_score``       | ``open_left_insertion_score``,        |
    |                                 | ``extend_left_insertion_score``       |
@@ -693,7 +693,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``open_right_deletionp_score``        |
    +---------------------------------+---------------------------------------+
    | ``query_end_extend_gap_score``  | ``extend_left_deletion_score``,       |
-   |                                 | ``query_right_extend_gap_score``      |
+   |                                 | ``extend_right_deletion_score``       |
    +---------------------------------+---------------------------------------+
    | ``query_internal_gap_score``    | ``open_internal_deletion_score``,     |
    |                                 | ``extend_internal_deletion_score``    |
@@ -702,7 +702,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``extend_left_deletion_score``        |
    +---------------------------------+---------------------------------------+
    | ``query_right_gap_score``       | ``open_right_deletionp_score``,       |
-   |                                 | ``query_right_extend_gap_score``      |
+   |                                 | ``extend_right_deletion_score``       |
    +---------------------------------+---------------------------------------+
 
 .. _`sec:pairwise-general-gapscores`:
@@ -785,7 +785,7 @@ BLASTP, respectively.
      open_left_deletion_score: -7.000000
      extend_left_deletion_score: -2.000000
      open_right_deletion_score: -7.000000
-     query_right_extend_gap_score: -2.000000
+     extend_right_deletion_score: -2.000000
      mode: global
    <BLANKLINE>
    >>> print(aligner.substitution_matrix[:, :])

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -374,7 +374,7 @@ all parameters, use
      open_left_insertion_score: 0.000000
      extend_left_insertion_score: 0.000000
      open_right_insertion_score: 0.000000
-     target_right_extend_gap_score: 0.000000
+     extend_right_insertion_score: 0.000000
      query_internal_open_gap_score: 0.000000
      query_internal_extend_gap_score: 0.000000
      query_left_open_gap_score: 0.000000
@@ -558,7 +558,7 @@ object:
 ``query_right_open_gap_score``     ``query_right_extend_gap_score``
 ``open_left_insertion_score``      ``extend_left_insertion_score``
 ``open_internal_insertion_score``  ``extend_internal_insertion_score``
-``open_right_insertion_score``     ``target_right_extend_gap_score``
+``open_right_insertion_score``     ``extend_right_insertion_score``
 ================================== ====================================
 
 These attributes allow for different gap scores for internal gaps and on
@@ -643,7 +643,7 @@ that refer to a number of these values collectively, as shown
    | ``right_open_gap_score``        | ``open_right_insertion_score``,       |
    |                                 | ``query_right_open_gap_score``        |
    +---------------------------------+---------------------------------------+
-   | ``right_extend_gap_score``      | ``target_right_extend_gap_score``,    |
+   | ``right_extend_gap_score``      | ``extend_right_insertion_score``,    |
    |                                 | ``query_right_extend_gap_score``      |
    +---------------------------------+---------------------------------------+
    | ``target_open_gap_score``       | ``open_internal_insertion_score``,    |
@@ -652,7 +652,7 @@ that refer to a number of these values collectively, as shown
    +---------------------------------+---------------------------------------+
    | ``target_extend_gap_score``     | ``extend_internal_insertion_score``,  |
    |                                 | ``extend_left_insertion_score``,      |
-   |                                 | ``target_right_extend_gap_score``     |
+   |                                 | ``extend_right_insertion_score``     |
    +---------------------------------+---------------------------------------+
    | ``target_gap_score``            | ``target_open_gap_score``,            |
    |                                 | ``target_extend_gap_score``           |
@@ -678,13 +678,13 @@ that refer to a number of these values collectively, as shown
    |                                 | ``open_right_insertion_score``        |
    +---------------------------------+---------------------------------------+
    | ``target_end_extend_gap_score`` | ``extend_left_insertion_score``,      |
-   |                                 | ``target_right_extend_gap_score``     |
+   |                                 | ``extend_right_insertion_score``     |
    +---------------------------------+---------------------------------------+
    | ``target_left_gap_score``       | ``open_left_insertion_score``,        |
    |                                 | ``extend_left_insertion_score``       |
    +---------------------------------+---------------------------------------+
    | ``target_right_gap_score``      | ``open_right_insertion_score``,       |
-   |                                 | ``target_right_extend_gap_score``     |
+   |                                 | ``extend_right_insertion_score``     |
    +---------------------------------+---------------------------------------+
    | ``query_end_gap_score``         | ``query_end_open_gap_score``,         |
    |                                 | ``query_end_extend_gap_score``        |
@@ -779,7 +779,7 @@ BLASTP, respectively.
      open_left_insertion_score: -7.000000
      extend_left_insertion_score: -2.000000
      open_right_insertion_score: -7.000000
-     target_right_extend_gap_score: -2.000000
+     extend_right_insertion_score: -2.000000
      query_internal_open_gap_score: -7.000000
      query_internal_extend_gap_score: -2.000000
      query_left_open_gap_score: -7.000000

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -376,7 +376,7 @@ all parameters, use
      open_right_insertion_score: 0.000000
      extend_right_insertion_score: 0.000000
      open_internal_deletion_score: 0.000000
-     query_internal_extend_gap_score: 0.000000
+     extend_internal_deletion_score: 0.000000
      open_left_deletion_score: 0.000000
      extend_left_deletion_score: 0.000000
      query_right_open_gap_score: 0.000000
@@ -554,7 +554,7 @@ object:
 **Opening scores**                 **Extending scores**
 ================================== ====================================
 ``open_left_deletion_score``       ``extend_left_deletion_score``
-``open_internal_deletion_score``   ``query_internal_extend_gap_score``
+``open_internal_deletion_score``   ``extend_internal_deletion_score``
 ``query_right_open_gap_score``     ``query_right_extend_gap_score``
 ``open_left_insertion_score``      ``extend_left_insertion_score``
 ``open_internal_insertion_score``  ``extend_internal_insertion_score``
@@ -617,7 +617,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``open_internal_deletion_score``      |
    +---------------------------------+---------------------------------------+
    | ``internal_extend_gap_score``   | ``extend_internal_insertion_score``,  |
-   |                                 | ``query_internal_extend_gap_score``   |
+   |                                 | ``extend_internal_deletion_score``   |
    +---------------------------------+---------------------------------------+
    | ``end_gap_score``               | ``target_end_gap_score``,             |
    |                                 | ``query_end_gap_score``               |
@@ -661,7 +661,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``open_left_deletion_score``,         |
    |                                 | ``query_right_open_gap_score``        |
    +---------------------------------+---------------------------------------+
-   | ``query_extend_gap_score``      | ``query_internal_extend_gap_score``,  |
+   | ``query_extend_gap_score``      | ``extend_internal_deletion_score``,  |
    |                                 | ``extend_left_deletion_score``,       |
    |                                 | ``query_right_extend_gap_score``      |
    +---------------------------------+---------------------------------------+
@@ -696,7 +696,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``query_right_extend_gap_score``      |
    +---------------------------------+---------------------------------------+
    | ``query_internal_gap_score``    | ``open_internal_deletion_score``,     |
-   |                                 | ``query_internal_extend_gap_score``   |
+   |                                 | ``extend_internal_deletion_score``   |
    +---------------------------------+---------------------------------------+
    | ``query_left_gap_score``        | ``open_left_deletion_score``,         |
    |                                 | ``extend_left_deletion_score``        |
@@ -781,7 +781,7 @@ BLASTP, respectively.
      open_right_insertion_score: -7.000000
      extend_right_insertion_score: -2.000000
      open_internal_deletion_score: -7.000000
-     query_internal_extend_gap_score: -2.000000
+     extend_internal_deletion_score: -2.000000
      open_left_deletion_score: -7.000000
      extend_left_deletion_score: -2.000000
      query_right_open_gap_score: -7.000000

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -130,7 +130,7 @@ blocks:
 -  ``target[0:2]`` aligned to ``query[0:2]``;
 
 -  ``target[2:4]`` aligned to a gap, since ``query[2:2]`` is an empty
-   string;
+   string (i.e., a deletion);
 
 -  ``target[4:5]`` aligned to ``query[2:3]``.
 
@@ -564,32 +564,32 @@ object:
 These attributes allow for different gap scores for internal gaps and on
 either end of the sequence, as shown in this example:
 
-========== ========= ================================
+========== ========= ===============================
 **target** **query** **score**
-========== ========= ================================
-A          -         query left open gap score
-C          -         query left extend gap score
-C          -         query left extend gap score
+========== ========= ===============================
+A          -         open left deletion score
+C          -         extend left deletion score
+C          -         extend left deletion score
 G          G         match score
 G          T         mismatch score
-G          -         query internal open gap score
-A          -         query internal extend gap score
-A          -         query internal extend gap score
+G          -         open internal deletion score
+A          -         extend internal deletion score
+A          -         extend internal deletion score
 T          T         match score
 A          A         match score
-G          -         query internal open gap score
+G          -         open internal deletion score
 C          C         match score
--          C         target internal open gap score
+-          C         open internal insertion score
 -          C         extend internal insertion score
 C          C         match score
 T          G         mismatch score
 C          C         match score
--          C         target internal open gap score
+-          C         open internal insertion score
 A          A         match score
--          T         target right open gap score
--          A         target right extend gap score
--          A         target right extend gap score
-========== ========= ================================
+-          T         open right insertion score
+-          A         extend right insertion score
+-          A         extend right insertion score
+========== ========= ===============================
 
 For convenience, ``PairwiseAligner`` objects have additional attributes
 that refer to a number of these values collectively, as shown
@@ -598,112 +598,112 @@ that refer to a number of these values collectively, as shown
 .. table:: Meta-attributes of the pairwise aligner objects.
    :name: table:align-meta-attributes
 
-   +---------------------------------+---------------------------------------+
-   | Meta-attribute                  | Attributes it maps to                 |
-   +=================================+=======================================+
-   | ``gap_score``                   | ``target_gap_score``,                 |
-   |                                 | ``query_gap_score``                   |
-   +---------------------------------+---------------------------------------+
-   | ``open_gap_score``              | ``target_open_gap_score``,            |
-   |                                 | ``query_open_gap_score``              |
-   +---------------------------------+---------------------------------------+
-   | ``extend_gap_score``            | ``target_extend_gap_score``,          |
-   |                                 | ``query_extend_gap_score``            |
-   +---------------------------------+---------------------------------------+
-   | ``internal_gap_score``          | ``target_internal_gap_score``,        |
-   |                                 | ``query_internal_gap_score``          |
-   +---------------------------------+---------------------------------------+
-   | ``internal_open_gap_score``     | ``open_internal_insertion_score``,    |
-   |                                 | ``open_internal_deletion_score``      |
-   +---------------------------------+---------------------------------------+
-   | ``internal_extend_gap_score``   | ``extend_internal_insertion_score``,  |
-   |                                 | ``extend_internal_deletion_score``    |
-   +---------------------------------+---------------------------------------+
-   | ``end_gap_score``               | ``target_end_gap_score``,             |
-   |                                 | ``query_end_gap_score``               |
-   +---------------------------------+---------------------------------------+
-   | ``open_end_gap_score``          | ``target_end_open_gap_score``,        |
-   |                                 | ``query_end_open_gap_score``          |
-   +---------------------------------+---------------------------------------+
-   | ``end_extend_gap_score``        | ``target_end_extend_gap_score``,      |
-   |                                 | ``query_end_extend_gap_score``        |
-   +---------------------------------+---------------------------------------+
-   | ``left_gap_score``              | ``target_left_gap_score``,            |
-   |                                 | ``query_left_gap_score``              |
-   +---------------------------------+---------------------------------------+
-   | ``right_gap_score``             | ``target_right_gap_score``,           |
-   |                                 | ``query_right_gap_score``             |
-   +---------------------------------+---------------------------------------+
-   | ``left_open_gap_score``         | ``open_left_insertion_score``,        |
-   |                                 | ``open_left_deletion_score``          |
-   +---------------------------------+---------------------------------------+
-   | ``left_extend_gap_score``       | ``extend_left_insertion_score``,      |
-   |                                 | ``extend_left_deletion_score``        |
-   +---------------------------------+---------------------------------------+
-   | ``right_open_gap_score``        | ``open_right_insertion_score``,       |
-   |                                 | ``open_right_deletion_score``         |
-   +---------------------------------+---------------------------------------+
-   | ``right_extend_gap_score``      | ``extend_right_insertion_score``,     |
-   |                                 | ``extend_right_deletion_score``       |
-   +---------------------------------+---------------------------------------+
-   | ``target_open_gap_score``       | ``open_internal_insertion_score``,    |
-   |                                 | ``open_left_insertion_score``,        |
-   |                                 | ``open_right_insertion_score``        |
-   +---------------------------------+---------------------------------------+
-   | ``target_extend_gap_score``     | ``extend_internal_insertion_score``,  |
-   |                                 | ``extend_left_insertion_score``,      |
-   |                                 | ``extend_right_insertion_score``      |
-   +---------------------------------+---------------------------------------+
-   | ``target_gap_score``            | ``target_open_gap_score``,            |
-   |                                 | ``target_extend_gap_score``           |
-   +---------------------------------+---------------------------------------+
-   | ``query_open_gap_score``        | ``open_internal_deletion_score``,     |
-   |                                 | ``open_left_deletion_score``,         |
-   |                                 | ``open_right_deletion_score``         |
-   +---------------------------------+---------------------------------------+
-   | ``query_extend_gap_score``      | ``extend_internal_deletion_score``,   |
-   |                                 | ``extend_left_deletion_score``,       |
-   |                                 | ``extend_right_deletion_score``       |
-   +---------------------------------+---------------------------------------+
-   | ``query_gap_score``             | ``query_open_gap_score``,             |
-   |                                 | ``query_extend_gap_score``            |
-   +---------------------------------+---------------------------------------+
-   | ``target_internal_gap_score``   | ``open_internal_insertion_score``,    |
-   |                                 | ``extend_internal_insertion_score``   |
-   +---------------------------------+---------------------------------------+
-   | ``target_end_gap_score``        | ``target_end_open_gap_score``,        |
-   |                                 | ``target_end_extend_gap_score``       |
-   +---------------------------------+---------------------------------------+
-   | ``target_end_open_gap_score``   | ``open_left_insertion_score``,        |
-   |                                 | ``open_right_insertion_score``        |
-   +---------------------------------+---------------------------------------+
-   | ``target_end_extend_gap_score`` | ``extend_left_insertion_score``,      |
-   |                                 | ``extend_right_insertion_score``      |
-   +---------------------------------+---------------------------------------+
-   | ``target_left_gap_score``       | ``open_left_insertion_score``,        |
-   |                                 | ``extend_left_insertion_score``       |
-   +---------------------------------+---------------------------------------+
-   | ``target_right_gap_score``      | ``open_right_insertion_score``,       |
-   |                                 | ``extend_right_insertion_score``      |
-   +---------------------------------+---------------------------------------+
-   | ``query_end_gap_score``         | ``query_end_open_gap_score``,         |
-   |                                 | ``query_end_extend_gap_score``        |
-   +---------------------------------+---------------------------------------+
-   | ``query_end_open_gap_score``    | ``open_left_deletion_score``,         |
-   |                                 | ``open_right_deletionp_score``        |
-   +---------------------------------+---------------------------------------+
-   | ``query_end_extend_gap_score``  | ``extend_left_deletion_score``,       |
-   |                                 | ``extend_right_deletion_score``       |
-   +---------------------------------+---------------------------------------+
-   | ``query_internal_gap_score``    | ``open_internal_deletion_score``,     |
-   |                                 | ``extend_internal_deletion_score``    |
-   +---------------------------------+---------------------------------------+
-   | ``query_left_gap_score``        | ``open_left_deletion_score``,         |
-   |                                 | ``extend_left_deletion_score``        |
-   +---------------------------------+---------------------------------------+
-   | ``query_right_gap_score``       | ``open_right_deletionp_score``,       |
-   |                                 | ``extend_right_deletion_score``       |
-   +---------------------------------+---------------------------------------+
+   +--------------------------------+--------------------------------------+
+   | Meta-attribute                 | Attributes it maps to                |
+   +================================+======================================+
+   | ``gap_score``                  | ``insertion_score``,                 |
+   |                                | ``deletion_score``                   |
+   +--------------------------------+--------------------------------------+
+   | ``open_gap_score``             | ``open_insertion_score``,            |
+   |                                | ``open_deletion_score``              |
+   +--------------------------------+--------------------------------------+
+   | ``extend_gap_score``           | ``extend_insertion_score``,          |
+   |                                | ``extend_deletion_score``            |
+   +--------------------------------+--------------------------------------+
+   | ``internal_gap_score``         | ``internal_insertion_score``,        |
+   |                                | ``internal_deletion_score``          |
+   +--------------------------------+--------------------------------------+
+   | ``open_internal_gap_score``    | ``open_internal_insertion_score``,   |
+   |                                | ``open_internal_deletion_score``     |
+   +--------------------------------+--------------------------------------+
+   | ``extend_internal_gap_score``  | ``extend_internal_insertion_score``, |
+   |                                | ``extend_internal_deletion_score``   |
+   +--------------------------------+--------------------------------------+
+   | ``end_gap_score``              | ``end_insertion_score``,             |
+   |                                | ``end_deletion_score``               |
+   +--------------------------------+--------------------------------------+
+   | ``open_end_gap_score``         | ``open_end_insertion_score``,        |
+   |                                | ``open_end_deletion_score``          |
+   +--------------------------------+--------------------------------------+
+   | ``extend_end_gap_score``       | ``extend_end_insertion_score``,      |
+   |                                | ``extend_end_deletion_score``        |
+   +--------------------------------+--------------------------------------+
+   | ``left_gap_score``             | ``left_insertion_score``,            |
+   |                                | ``left_deletion_score``              |
+   +--------------------------------+--------------------------------------+
+   | ``right_gap_score``            | ``right_insertion_score``,           |
+   |                                | ``right_deletion_score``             |
+   +--------------------------------+--------------------------------------+
+   | ``open_left_gap_score``        | ``open_left_insertion_score``,       |
+   |                                | ``open_left_deletion_score``         |
+   +--------------------------------+--------------------------------------+
+   | ``extend_left_gap_score``      | ``extend_left_insertion_score``,     |
+   |                                | ``extend_left_deletion_score``       |
+   +--------------------------------+--------------------------------------+
+   | ``open_right_gap_score``       | ``open_right_insertion_score``,      |
+   |                                | ``open_right_deletion_score``        |
+   +--------------------------------+--------------------------------------+
+   | ``extend_right_gap_score``     | ``extend_right_insertion_score``,    |
+   |                                | ``extend_right_deletion_score``      |
+   +--------------------------------+--------------------------------------+
+   | ``open_insertion_score``       | ``open_internal_insertion_score``,   |
+   |                                | ``open_left_insertion_score``,       |
+   |                                | ``open_right_insertion_score``       |
+   +--------------------------------+--------------------------------------+
+   | ``extend_insertion_score``     | ``extend_internal_insertion_score``, |
+   |                                | ``extend_left_insertion_score``,     |
+   |                                | ``extend_right_insertion_score``     |
+   +--------------------------------+--------------------------------------+
+   | ``insertion_score``            | ``open_insertion_score``,            |
+   |                                | ``extend_insertion_score``           |
+   +--------------------------------+--------------------------------------+
+   | ``open_deletion_score``        | ``open_internal_deletion_score``,    |
+   |                                | ``open_left_deletion_score``,        |
+   |                                | ``open_right_deletion_score``        |
+   +--------------------------------+--------------------------------------+
+   | ``extend_deletion_score``      | ``extend_internal_deletion_score``,  |
+   |                                | ``extend_left_deletion_score``,      |
+   |                                | ``extend_right_deletion_score``      |
+   +--------------------------------+--------------------------------------+
+   | ``deletion_score``             | ``open_deletion_score``,             |
+   |                                | ``extend_deletion_score``            |
+   +--------------------------------+--------------------------------------+
+   | ``internal_insertion_score``   | ``open_internal_insertion_score``,   |
+   |                                | ``extend_internal_insertion_score``  |
+   +--------------------------------+--------------------------------------+
+   | ``end_insertion_score``        | ``open_end_insertion_score``,        |
+   |                                | ``extend_end_insertion_score``       |
+   +--------------------------------+--------------------------------------+
+   | ``open_end_insertion_score``   | ``open_left_insertion_score``,       |
+   |                                | ``open_right_insertion_score``       |
+   +--------------------------------+--------------------------------------+
+   | ``extend_end_insertion_score`` | ``extend_left_insertion_score``,     |
+   |                                | ``extend_right_insertion_score``     |
+   +--------------------------------+--------------------------------------+
+   | ``left_insertion_score``       | ``open_left_insertion_score``,       |
+   |                                | ``extend_left_insertion_score``      |
+   +--------------------------------+--------------------------------------+
+   | ``right_insertion_score``      | ``open_right_insertion_score``,      |
+   |                                | ``extend_right_insertion_score``     |
+   +--------------------------------+--------------------------------------+
+   | ``end_deletion_score``         | ``open_end_deletion_score``,         |
+   |                                | ``extend_end_deletion_score``        |
+   +--------------------------------+--------------------------------------+
+   | ``open_end_deletion_score``    | ``open_left_deletion_score``,        |
+   |                                | ``open_right_deletionp_score``       |
+   +--------------------------------+--------------------------------------+
+   | ``extend_end_deletion_score``  | ``extend_left_deletion_score``,      |
+   |                                | ``extend_right_deletion_score``      |
+   +--------------------------------+--------------------------------------+
+   | ``internal_deletion_score``    | ``open_internal_deletion_score``,    |
+   |                                | ``extend_internal_deletion_score``   |
+   +--------------------------------+--------------------------------------+
+   | ``left_deletion_score``        | ``open_left_deletion_score``,        |
+   |                                | ``extend_left_deletion_score``       |
+   +--------------------------------+--------------------------------------+
+   | ``right_deletion_score``       | ``open_right_deletion_score``,       |
+   |                                | ``extend_right_deletion_score``      |
+   +--------------------------------+--------------------------------------+
 
 .. _`sec:pairwise-general-gapscores`:
 
@@ -712,7 +712,7 @@ General gap scores
 
 For even more fine-grained control over the gap scores, you can specify
 a gap scoring function. For example, the gap scoring function below
-disallows a gap after two nucleotides in the query sequence:
+disallows a deletion after two nucleotides in the query sequence:
 
 .. doctest
 
@@ -726,7 +726,7 @@ disallows a gap after two nucleotides in the query sequence:
    ...     else:
    ...         return -1 * length
    ...
-   >>> aligner.query_gap_score = my_gap_score_function
+   >>> aligner.deletion_score = my_gap_score_function
    >>> alignments = aligner.align("AACTT", "AATT")
    >>> for alignment in alignments:
    ...     print(alignment)

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -369,7 +369,7 @@ all parameters, use
      wildcard: None
      match_score: 1.000000
      mismatch_score: 0.000000
-     target_internal_open_gap_score: 0.000000
+     open_internal_insertion_score: 0.000000
      extend_internal_insertion_score: 0.000000
      target_left_open_gap_score: 0.000000
      target_left_extend_gap_score: 0.000000
@@ -557,7 +557,7 @@ object:
 ``query_internal_open_gap_score``  ``query_internal_extend_gap_score``
 ``query_right_open_gap_score``     ``query_right_extend_gap_score``
 ``target_left_open_gap_score``     ``target_left_extend_gap_score``
-``target_internal_open_gap_score`` ``extend_internal_insertion_score``
+``open_internal_insertion_score``  ``extend_internal_insertion_score``
 ``target_right_open_gap_score``    ``target_right_extend_gap_score``
 ================================== ====================================
 
@@ -613,7 +613,7 @@ that refer to a number of these values collectively, as shown
    | ``internal_gap_score``          | ``target_internal_gap_score``,        |
    |                                 | ``query_internal_gap_score``          |
    +---------------------------------+---------------------------------------+
-   | ``internal_open_gap_score``     | ``target_internal_open_gap_score``,   |
+   | ``internal_open_gap_score``     | ``open_internal_insertion_score``,    |
    |                                 | ``query_internal_open_gap_score``     |
    +---------------------------------+---------------------------------------+
    | ``internal_extend_gap_score``   | ``extend_internal_insertion_score``, |
@@ -646,7 +646,7 @@ that refer to a number of these values collectively, as shown
    | ``right_extend_gap_score``      | ``target_right_extend_gap_score``,    |
    |                                 | ``query_right_extend_gap_score``      |
    +---------------------------------+---------------------------------------+
-   | ``target_open_gap_score``       | ``target_internal_open_gap_score``,   |
+   | ``target_open_gap_score``       | ``open_internal_insertion_score``,   |
    |                                 | ``target_left_open_gap_score``,       |
    |                                 | ``target_right_open_gap_score``       |
    +---------------------------------+---------------------------------------+
@@ -668,8 +668,8 @@ that refer to a number of these values collectively, as shown
    | ``query_gap_score``             | ``query_open_gap_score``,             |
    |                                 | ``query_extend_gap_score``            |
    +---------------------------------+---------------------------------------+
-   | ``target_internal_gap_score``   | ``target_internal_open_gap_score``,   |
-   |                                 | ``extend_internal_insertion_score``  |
+   | ``target_internal_gap_score``   | ``open_internal_insertion_score``,    |
+   |                                 | ``extend_internal_insertion_score``   |
    +---------------------------------+---------------------------------------+
    | ``target_end_gap_score``        | ``target_end_open_gap_score``,        |
    |                                 | ``target_end_extend_gap_score``       |
@@ -774,7 +774,7 @@ BLASTP, respectively.
    >>> print(aligner)  # doctest:+ELLIPSIS
    Pairwise sequence aligner with parameters
      substitution_matrix: <Array object at ...>
-     target_internal_open_gap_score: -7.000000
+     open_internal_insertion_score: -7.000000
      extend_internal_insertion_score: -2.000000
      target_left_open_gap_score: -7.000000
      target_left_extend_gap_score: -2.000000

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -371,7 +371,7 @@ all parameters, use
      mismatch_score: 0.000000
      open_internal_insertion_score: 0.000000
      extend_internal_insertion_score: 0.000000
-     target_left_open_gap_score: 0.000000
+     open_left_insertion_score: 0.000000
      target_left_extend_gap_score: 0.000000
      target_right_open_gap_score: 0.000000
      target_right_extend_gap_score: 0.000000
@@ -556,7 +556,7 @@ object:
 ``query_left_open_gap_score``      ``query_left_extend_gap_score``
 ``query_internal_open_gap_score``  ``query_internal_extend_gap_score``
 ``query_right_open_gap_score``     ``query_right_extend_gap_score``
-``target_left_open_gap_score``     ``target_left_extend_gap_score``
+``open_left_insertion_score``      ``target_left_extend_gap_score``
 ``open_internal_insertion_score``  ``extend_internal_insertion_score``
 ``target_right_open_gap_score``    ``target_right_extend_gap_score``
 ================================== ====================================
@@ -634,7 +634,7 @@ that refer to a number of these values collectively, as shown
    | ``right_gap_score``             | ``target_right_gap_score``,           |
    |                                 | ``query_right_gap_score``             |
    +---------------------------------+---------------------------------------+
-   | ``left_open_gap_score``         | ``target_left_open_gap_score``,       |
+   | ``left_open_gap_score``         | ``open_left_insertion_score``,        |
    |                                 | ``query_left_open_gap_score``         |
    +---------------------------------+---------------------------------------+
    | ``left_extend_gap_score``       | ``target_left_extend_gap_score``,     |
@@ -646,8 +646,8 @@ that refer to a number of these values collectively, as shown
    | ``right_extend_gap_score``      | ``target_right_extend_gap_score``,    |
    |                                 | ``query_right_extend_gap_score``      |
    +---------------------------------+---------------------------------------+
-   | ``target_open_gap_score``       | ``open_internal_insertion_score``,   |
-   |                                 | ``target_left_open_gap_score``,       |
+   | ``target_open_gap_score``       | ``open_internal_insertion_score``,    |
+   |                                 | ``open_left_insertion_score``,        |
    |                                 | ``target_right_open_gap_score``       |
    +---------------------------------+---------------------------------------+
    | ``target_extend_gap_score``     | ``extend_internal_insertion_score``, |
@@ -674,13 +674,13 @@ that refer to a number of these values collectively, as shown
    | ``target_end_gap_score``        | ``target_end_open_gap_score``,        |
    |                                 | ``target_end_extend_gap_score``       |
    +---------------------------------+---------------------------------------+
-   | ``target_end_open_gap_score``   | ``target_left_open_gap_score``,       |
+   | ``target_end_open_gap_score``   | ``open_left_insertion_score``,        |
    |                                 | ``target_right_open_gap_score``       |
    +---------------------------------+---------------------------------------+
    | ``target_end_extend_gap_score`` | ``target_left_extend_gap_score``,     |
    |                                 | ``target_right_extend_gap_score``     |
    +---------------------------------+---------------------------------------+
-   | ``target_left_gap_score``       | ``target_left_open_gap_score``,       |
+   | ``target_left_gap_score``       | ``open_left_insertion_score``,        |
    |                                 | ``target_left_extend_gap_score``      |
    +---------------------------------+---------------------------------------+
    | ``target_right_gap_score``      | ``target_right_open_gap_score``,      |
@@ -776,7 +776,7 @@ BLASTP, respectively.
      substitution_matrix: <Array object at ...>
      open_internal_insertion_score: -7.000000
      extend_internal_insertion_score: -2.000000
-     target_left_open_gap_score: -7.000000
+     open_left_insertion_score: -7.000000
      target_left_extend_gap_score: -2.000000
      target_right_open_gap_score: -7.000000
      target_right_extend_gap_score: -2.000000

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -379,7 +379,7 @@ all parameters, use
      extend_internal_deletion_score: 0.000000
      open_left_deletion_score: 0.000000
      extend_left_deletion_score: 0.000000
-     query_right_open_gap_score: 0.000000
+     open_right_deletion_score: 0.000000
      query_right_extend_gap_score: 0.000000
      mode: local
    <BLANKLINE>
@@ -555,7 +555,7 @@ object:
 ================================== ====================================
 ``open_left_deletion_score``       ``extend_left_deletion_score``
 ``open_internal_deletion_score``   ``extend_internal_deletion_score``
-``query_right_open_gap_score``     ``query_right_extend_gap_score``
+``open_right_deletion_score``      ``query_right_extend_gap_score``
 ``open_left_insertion_score``      ``extend_left_insertion_score``
 ``open_internal_insertion_score``  ``extend_internal_insertion_score``
 ``open_right_insertion_score``     ``extend_right_insertion_score``
@@ -635,15 +635,15 @@ that refer to a number of these values collectively, as shown
    |                                 | ``query_right_gap_score``             |
    +---------------------------------+---------------------------------------+
    | ``left_open_gap_score``         | ``open_left_insertion_score``,        |
-   |                                 | ``open_left_deletion_score``         |
+   |                                 | ``open_left_deletion_score``          |
    +---------------------------------+---------------------------------------+
    | ``left_extend_gap_score``       | ``extend_left_insertion_score``,      |
-   |                                 | ``extend_left_deletion_score``       |
+   |                                 | ``extend_left_deletion_score``        |
    +---------------------------------+---------------------------------------+
    | ``right_open_gap_score``        | ``open_right_insertion_score``,       |
-   |                                 | ``query_right_open_gap_score``        |
+   |                                 | ``open_right_deletion_score``         |
    +---------------------------------+---------------------------------------+
-   | ``right_extend_gap_score``      | ``extend_right_insertion_score``,    |
+   | ``right_extend_gap_score``      | ``extend_right_insertion_score``,     |
    |                                 | ``query_right_extend_gap_score``      |
    +---------------------------------+---------------------------------------+
    | ``target_open_gap_score``       | ``open_internal_insertion_score``,    |
@@ -659,7 +659,7 @@ that refer to a number of these values collectively, as shown
    +---------------------------------+---------------------------------------+
    | ``query_open_gap_score``        | ``open_internal_deletion_score``,     |
    |                                 | ``open_left_deletion_score``,         |
-   |                                 | ``query_right_open_gap_score``        |
+   |                                 | ``open_right_deletion_score``         |
    +---------------------------------+---------------------------------------+
    | ``query_extend_gap_score``      | ``extend_internal_deletion_score``,  |
    |                                 | ``extend_left_deletion_score``,       |
@@ -684,24 +684,24 @@ that refer to a number of these values collectively, as shown
    |                                 | ``extend_left_insertion_score``       |
    +---------------------------------+---------------------------------------+
    | ``target_right_gap_score``      | ``open_right_insertion_score``,       |
-   |                                 | ``extend_right_insertion_score``     |
+   |                                 | ``extend_right_insertion_score``      |
    +---------------------------------+---------------------------------------+
    | ``query_end_gap_score``         | ``query_end_open_gap_score``,         |
    |                                 | ``query_end_extend_gap_score``        |
    +---------------------------------+---------------------------------------+
    | ``query_end_open_gap_score``    | ``open_left_deletion_score``,         |
-   |                                 | ``query_right_open_gap_score``        |
+   |                                 | ``open_right_deletionp_score``        |
    +---------------------------------+---------------------------------------+
    | ``query_end_extend_gap_score``  | ``extend_left_deletion_score``,       |
    |                                 | ``query_right_extend_gap_score``      |
    +---------------------------------+---------------------------------------+
    | ``query_internal_gap_score``    | ``open_internal_deletion_score``,     |
-   |                                 | ``extend_internal_deletion_score``   |
+   |                                 | ``extend_internal_deletion_score``    |
    +---------------------------------+---------------------------------------+
    | ``query_left_gap_score``        | ``open_left_deletion_score``,         |
    |                                 | ``extend_left_deletion_score``        |
    +---------------------------------+---------------------------------------+
-   | ``query_right_gap_score``       | ``query_right_open_gap_score``,       |
+   | ``query_right_gap_score``       | ``open_right_deletionp_score``,       |
    |                                 | ``query_right_extend_gap_score``      |
    +---------------------------------+---------------------------------------+
 
@@ -784,7 +784,7 @@ BLASTP, respectively.
      extend_internal_deletion_score: -2.000000
      open_left_deletion_score: -7.000000
      extend_left_deletion_score: -2.000000
-     query_right_open_gap_score: -7.000000
+     open_right_deletion_score: -7.000000
      query_right_extend_gap_score: -2.000000
      mode: global
    <BLANKLINE>

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -370,7 +370,7 @@ all parameters, use
      match_score: 1.000000
      mismatch_score: 0.000000
      target_internal_open_gap_score: 0.000000
-     target_internal_extend_gap_score: 0.000000
+     extend_internal_insertion_score: 0.000000
      target_left_open_gap_score: 0.000000
      target_left_extend_gap_score: 0.000000
      target_right_open_gap_score: 0.000000
@@ -557,7 +557,7 @@ object:
 ``query_internal_open_gap_score``  ``query_internal_extend_gap_score``
 ``query_right_open_gap_score``     ``query_right_extend_gap_score``
 ``target_left_open_gap_score``     ``target_left_extend_gap_score``
-``target_internal_open_gap_score`` ``target_internal_extend_gap_score``
+``target_internal_open_gap_score`` ``extend_internal_insertion_score``
 ``target_right_open_gap_score``    ``target_right_extend_gap_score``
 ================================== ====================================
 
@@ -580,7 +580,7 @@ A          A         match score
 G          -         query internal open gap score
 C          C         match score
 -          C         target internal open gap score
--          C         target internal extend gap score
+-          C         extend internal insertion score
 C          C         match score
 T          G         mismatch score
 C          C         match score
@@ -616,7 +616,7 @@ that refer to a number of these values collectively, as shown
    | ``internal_open_gap_score``     | ``target_internal_open_gap_score``,   |
    |                                 | ``query_internal_open_gap_score``     |
    +---------------------------------+---------------------------------------+
-   | ``internal_extend_gap_score``   | ``target_internal_extend_gap_score``, |
+   | ``internal_extend_gap_score``   | ``extend_internal_insertion_score``, |
    |                                 | ``query_internal_extend_gap_score``   |
    +---------------------------------+---------------------------------------+
    | ``end_gap_score``               | ``target_end_gap_score``,             |
@@ -650,7 +650,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``target_left_open_gap_score``,       |
    |                                 | ``target_right_open_gap_score``       |
    +---------------------------------+---------------------------------------+
-   | ``target_extend_gap_score``     | ``target_internal_extend_gap_score``, |
+   | ``target_extend_gap_score``     | ``extend_internal_insertion_score``, |
    |                                 | ``target_left_extend_gap_score``,     |
    |                                 | ``target_right_extend_gap_score``     |
    +---------------------------------+---------------------------------------+
@@ -669,7 +669,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``query_extend_gap_score``            |
    +---------------------------------+---------------------------------------+
    | ``target_internal_gap_score``   | ``target_internal_open_gap_score``,   |
-   |                                 | ``target_internal_extend_gap_score``  |
+   |                                 | ``extend_internal_insertion_score``  |
    +---------------------------------+---------------------------------------+
    | ``target_end_gap_score``        | ``target_end_open_gap_score``,        |
    |                                 | ``target_end_extend_gap_score``       |
@@ -775,7 +775,7 @@ BLASTP, respectively.
    Pairwise sequence aligner with parameters
      substitution_matrix: <Array object at ...>
      target_internal_open_gap_score: -7.000000
-     target_internal_extend_gap_score: -2.000000
+     extend_internal_insertion_score: -2.000000
      target_left_open_gap_score: -7.000000
      target_left_extend_gap_score: -2.000000
      target_right_open_gap_score: -7.000000

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -372,7 +372,7 @@ all parameters, use
      open_internal_insertion_score: 0.000000
      extend_internal_insertion_score: 0.000000
      open_left_insertion_score: 0.000000
-     target_left_extend_gap_score: 0.000000
+     extend_left_insertion_score: 0.000000
      target_right_open_gap_score: 0.000000
      target_right_extend_gap_score: 0.000000
      query_internal_open_gap_score: 0.000000
@@ -556,7 +556,7 @@ object:
 ``query_left_open_gap_score``      ``query_left_extend_gap_score``
 ``query_internal_open_gap_score``  ``query_internal_extend_gap_score``
 ``query_right_open_gap_score``     ``query_right_extend_gap_score``
-``open_left_insertion_score``      ``target_left_extend_gap_score``
+``open_left_insertion_score``      ``extend_left_insertion_score``
 ``open_internal_insertion_score``  ``extend_internal_insertion_score``
 ``target_right_open_gap_score``    ``target_right_extend_gap_score``
 ================================== ====================================
@@ -637,7 +637,7 @@ that refer to a number of these values collectively, as shown
    | ``left_open_gap_score``         | ``open_left_insertion_score``,        |
    |                                 | ``query_left_open_gap_score``         |
    +---------------------------------+---------------------------------------+
-   | ``left_extend_gap_score``       | ``target_left_extend_gap_score``,     |
+   | ``left_extend_gap_score``       | ``extend_left_insertion_score``,     |
    |                                 | ``query_left_extend_gap_score``       |
    +---------------------------------+---------------------------------------+
    | ``right_open_gap_score``        | ``target_right_open_gap_score``,      |
@@ -651,7 +651,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``target_right_open_gap_score``       |
    +---------------------------------+---------------------------------------+
    | ``target_extend_gap_score``     | ``extend_internal_insertion_score``, |
-   |                                 | ``target_left_extend_gap_score``,     |
+   |                                 | ``extend_left_insertion_score``,     |
    |                                 | ``target_right_extend_gap_score``     |
    +---------------------------------+---------------------------------------+
    | ``target_gap_score``            | ``target_open_gap_score``,            |
@@ -677,11 +677,11 @@ that refer to a number of these values collectively, as shown
    | ``target_end_open_gap_score``   | ``open_left_insertion_score``,        |
    |                                 | ``target_right_open_gap_score``       |
    +---------------------------------+---------------------------------------+
-   | ``target_end_extend_gap_score`` | ``target_left_extend_gap_score``,     |
+   | ``target_end_extend_gap_score`` | ``extend_left_insertion_score``,     |
    |                                 | ``target_right_extend_gap_score``     |
    +---------------------------------+---------------------------------------+
    | ``target_left_gap_score``       | ``open_left_insertion_score``,        |
-   |                                 | ``target_left_extend_gap_score``      |
+   |                                 | ``extend_left_insertion_score``      |
    +---------------------------------+---------------------------------------+
    | ``target_right_gap_score``      | ``target_right_open_gap_score``,      |
    |                                 | ``target_right_extend_gap_score``     |
@@ -777,7 +777,7 @@ BLASTP, respectively.
      open_internal_insertion_score: -7.000000
      extend_internal_insertion_score: -2.000000
      open_left_insertion_score: -7.000000
-     target_left_extend_gap_score: -2.000000
+     extend_left_insertion_score: -2.000000
      target_right_open_gap_score: -7.000000
      target_right_extend_gap_score: -2.000000
      query_internal_open_gap_score: -7.000000

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -375,7 +375,7 @@ all parameters, use
      extend_left_insertion_score: 0.000000
      open_right_insertion_score: 0.000000
      extend_right_insertion_score: 0.000000
-     query_internal_open_gap_score: 0.000000
+     open_internal_deletion_score: 0.000000
      query_internal_extend_gap_score: 0.000000
      open_left_deletion_score: 0.000000
      extend_left_deletion_score: 0.000000
@@ -554,7 +554,7 @@ object:
 **Opening scores**                 **Extending scores**
 ================================== ====================================
 ``open_left_deletion_score``       ``extend_left_deletion_score``
-``query_internal_open_gap_score``  ``query_internal_extend_gap_score``
+``open_internal_deletion_score``   ``query_internal_extend_gap_score``
 ``query_right_open_gap_score``     ``query_right_extend_gap_score``
 ``open_left_insertion_score``      ``extend_left_insertion_score``
 ``open_internal_insertion_score``  ``extend_internal_insertion_score``
@@ -614,9 +614,9 @@ that refer to a number of these values collectively, as shown
    |                                 | ``query_internal_gap_score``          |
    +---------------------------------+---------------------------------------+
    | ``internal_open_gap_score``     | ``open_internal_insertion_score``,    |
-   |                                 | ``query_internal_open_gap_score``     |
+   |                                 | ``open_internal_deletion_score``      |
    +---------------------------------+---------------------------------------+
-   | ``internal_extend_gap_score``   | ``extend_internal_insertion_score``, |
+   | ``internal_extend_gap_score``   | ``extend_internal_insertion_score``,  |
    |                                 | ``query_internal_extend_gap_score``   |
    +---------------------------------+---------------------------------------+
    | ``end_gap_score``               | ``target_end_gap_score``,             |
@@ -652,17 +652,17 @@ that refer to a number of these values collectively, as shown
    +---------------------------------+---------------------------------------+
    | ``target_extend_gap_score``     | ``extend_internal_insertion_score``,  |
    |                                 | ``extend_left_insertion_score``,      |
-   |                                 | ``extend_right_insertion_score``     |
+   |                                 | ``extend_right_insertion_score``      |
    +---------------------------------+---------------------------------------+
    | ``target_gap_score``            | ``target_open_gap_score``,            |
    |                                 | ``target_extend_gap_score``           |
    +---------------------------------+---------------------------------------+
-   | ``query_open_gap_score``        | ``query_internal_open_gap_score``,    |
-   |                                 | ``open_left_deletion_score``,        |
+   | ``query_open_gap_score``        | ``open_internal_deletion_score``,     |
+   |                                 | ``open_left_deletion_score``,         |
    |                                 | ``query_right_open_gap_score``        |
    +---------------------------------+---------------------------------------+
    | ``query_extend_gap_score``      | ``query_internal_extend_gap_score``,  |
-   |                                 | ``extend_left_deletion_score``,      |
+   |                                 | ``extend_left_deletion_score``,       |
    |                                 | ``query_right_extend_gap_score``      |
    +---------------------------------+---------------------------------------+
    | ``query_gap_score``             | ``query_open_gap_score``,             |
@@ -689,17 +689,17 @@ that refer to a number of these values collectively, as shown
    | ``query_end_gap_score``         | ``query_end_open_gap_score``,         |
    |                                 | ``query_end_extend_gap_score``        |
    +---------------------------------+---------------------------------------+
-   | ``query_end_open_gap_score``    | ``open_left_deletion_score``,        |
+   | ``query_end_open_gap_score``    | ``open_left_deletion_score``,         |
    |                                 | ``query_right_open_gap_score``        |
    +---------------------------------+---------------------------------------+
-   | ``query_end_extend_gap_score``  | ``extend_left_deletion_score``,      |
+   | ``query_end_extend_gap_score``  | ``extend_left_deletion_score``,       |
    |                                 | ``query_right_extend_gap_score``      |
    +---------------------------------+---------------------------------------+
-   | ``query_internal_gap_score``    | ``query_internal_open_gap_score``,    |
+   | ``query_internal_gap_score``    | ``open_internal_deletion_score``,     |
    |                                 | ``query_internal_extend_gap_score``   |
    +---------------------------------+---------------------------------------+
-   | ``query_left_gap_score``        | ``open_left_deletion_score``,        |
-   |                                 | ``extend_left_deletion_score``       |
+   | ``query_left_gap_score``        | ``open_left_deletion_score``,         |
+   |                                 | ``extend_left_deletion_score``        |
    +---------------------------------+---------------------------------------+
    | ``query_right_gap_score``       | ``query_right_open_gap_score``,       |
    |                                 | ``query_right_extend_gap_score``      |
@@ -780,7 +780,7 @@ BLASTP, respectively.
      extend_left_insertion_score: -2.000000
      open_right_insertion_score: -7.000000
      extend_right_insertion_score: -2.000000
-     query_internal_open_gap_score: -7.000000
+     open_internal_deletion_score: -7.000000
      query_internal_extend_gap_score: -2.000000
      open_left_deletion_score: -7.000000
      extend_left_deletion_score: -2.000000

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -378,7 +378,7 @@ all parameters, use
      query_internal_open_gap_score: 0.000000
      query_internal_extend_gap_score: 0.000000
      open_left_deletion_score: 0.000000
-     query_left_extend_gap_score: 0.000000
+     extend_left_deletion_score: 0.000000
      query_right_open_gap_score: 0.000000
      query_right_extend_gap_score: 0.000000
      mode: local
@@ -553,7 +553,7 @@ object:
 ================================== ====================================
 **Opening scores**                 **Extending scores**
 ================================== ====================================
-``open_left_deletion_score``      ``query_left_extend_gap_score``
+``open_left_deletion_score``       ``extend_left_deletion_score``
 ``query_internal_open_gap_score``  ``query_internal_extend_gap_score``
 ``query_right_open_gap_score``     ``query_right_extend_gap_score``
 ``open_left_insertion_score``      ``extend_left_insertion_score``
@@ -638,7 +638,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``open_left_deletion_score``         |
    +---------------------------------+---------------------------------------+
    | ``left_extend_gap_score``       | ``extend_left_insertion_score``,      |
-   |                                 | ``query_left_extend_gap_score``       |
+   |                                 | ``extend_left_deletion_score``       |
    +---------------------------------+---------------------------------------+
    | ``right_open_gap_score``        | ``open_right_insertion_score``,       |
    |                                 | ``query_right_open_gap_score``        |
@@ -662,7 +662,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``query_right_open_gap_score``        |
    +---------------------------------+---------------------------------------+
    | ``query_extend_gap_score``      | ``query_internal_extend_gap_score``,  |
-   |                                 | ``query_left_extend_gap_score``,      |
+   |                                 | ``extend_left_deletion_score``,      |
    |                                 | ``query_right_extend_gap_score``      |
    +---------------------------------+---------------------------------------+
    | ``query_gap_score``             | ``query_open_gap_score``,             |
@@ -692,14 +692,14 @@ that refer to a number of these values collectively, as shown
    | ``query_end_open_gap_score``    | ``open_left_deletion_score``,        |
    |                                 | ``query_right_open_gap_score``        |
    +---------------------------------+---------------------------------------+
-   | ``query_end_extend_gap_score``  | ``query_left_extend_gap_score``,      |
+   | ``query_end_extend_gap_score``  | ``extend_left_deletion_score``,      |
    |                                 | ``query_right_extend_gap_score``      |
    +---------------------------------+---------------------------------------+
    | ``query_internal_gap_score``    | ``query_internal_open_gap_score``,    |
    |                                 | ``query_internal_extend_gap_score``   |
    +---------------------------------+---------------------------------------+
    | ``query_left_gap_score``        | ``open_left_deletion_score``,        |
-   |                                 | ``query_left_extend_gap_score``       |
+   |                                 | ``extend_left_deletion_score``       |
    +---------------------------------+---------------------------------------+
    | ``query_right_gap_score``       | ``query_right_open_gap_score``,       |
    |                                 | ``query_right_extend_gap_score``      |
@@ -783,7 +783,7 @@ BLASTP, respectively.
      query_internal_open_gap_score: -7.000000
      query_internal_extend_gap_score: -2.000000
      open_left_deletion_score: -7.000000
-     query_left_extend_gap_score: -2.000000
+     extend_left_deletion_score: -2.000000
      query_right_open_gap_score: -7.000000
      query_right_extend_gap_score: -2.000000
      mode: global

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -373,7 +373,7 @@ all parameters, use
      extend_internal_insertion_score: 0.000000
      open_left_insertion_score: 0.000000
      extend_left_insertion_score: 0.000000
-     target_right_open_gap_score: 0.000000
+     open_right_insertion_score: 0.000000
      target_right_extend_gap_score: 0.000000
      query_internal_open_gap_score: 0.000000
      query_internal_extend_gap_score: 0.000000
@@ -558,7 +558,7 @@ object:
 ``query_right_open_gap_score``     ``query_right_extend_gap_score``
 ``open_left_insertion_score``      ``extend_left_insertion_score``
 ``open_internal_insertion_score``  ``extend_internal_insertion_score``
-``target_right_open_gap_score``    ``target_right_extend_gap_score``
+``open_right_insertion_score``     ``target_right_extend_gap_score``
 ================================== ====================================
 
 These attributes allow for different gap scores for internal gaps and on
@@ -637,10 +637,10 @@ that refer to a number of these values collectively, as shown
    | ``left_open_gap_score``         | ``open_left_insertion_score``,        |
    |                                 | ``query_left_open_gap_score``         |
    +---------------------------------+---------------------------------------+
-   | ``left_extend_gap_score``       | ``extend_left_insertion_score``,     |
+   | ``left_extend_gap_score``       | ``extend_left_insertion_score``,      |
    |                                 | ``query_left_extend_gap_score``       |
    +---------------------------------+---------------------------------------+
-   | ``right_open_gap_score``        | ``target_right_open_gap_score``,      |
+   | ``right_open_gap_score``        | ``open_right_insertion_score``,       |
    |                                 | ``query_right_open_gap_score``        |
    +---------------------------------+---------------------------------------+
    | ``right_extend_gap_score``      | ``target_right_extend_gap_score``,    |
@@ -648,10 +648,10 @@ that refer to a number of these values collectively, as shown
    +---------------------------------+---------------------------------------+
    | ``target_open_gap_score``       | ``open_internal_insertion_score``,    |
    |                                 | ``open_left_insertion_score``,        |
-   |                                 | ``target_right_open_gap_score``       |
+   |                                 | ``open_right_insertion_score``        |
    +---------------------------------+---------------------------------------+
-   | ``target_extend_gap_score``     | ``extend_internal_insertion_score``, |
-   |                                 | ``extend_left_insertion_score``,     |
+   | ``target_extend_gap_score``     | ``extend_internal_insertion_score``,  |
+   |                                 | ``extend_left_insertion_score``,      |
    |                                 | ``target_right_extend_gap_score``     |
    +---------------------------------+---------------------------------------+
    | ``target_gap_score``            | ``target_open_gap_score``,            |
@@ -675,15 +675,15 @@ that refer to a number of these values collectively, as shown
    |                                 | ``target_end_extend_gap_score``       |
    +---------------------------------+---------------------------------------+
    | ``target_end_open_gap_score``   | ``open_left_insertion_score``,        |
-   |                                 | ``target_right_open_gap_score``       |
+   |                                 | ``open_right_insertion_score``        |
    +---------------------------------+---------------------------------------+
-   | ``target_end_extend_gap_score`` | ``extend_left_insertion_score``,     |
+   | ``target_end_extend_gap_score`` | ``extend_left_insertion_score``,      |
    |                                 | ``target_right_extend_gap_score``     |
    +---------------------------------+---------------------------------------+
    | ``target_left_gap_score``       | ``open_left_insertion_score``,        |
-   |                                 | ``extend_left_insertion_score``      |
+   |                                 | ``extend_left_insertion_score``       |
    +---------------------------------+---------------------------------------+
-   | ``target_right_gap_score``      | ``target_right_open_gap_score``,      |
+   | ``target_right_gap_score``      | ``open_right_insertion_score``,       |
    |                                 | ``target_right_extend_gap_score``     |
    +---------------------------------+---------------------------------------+
    | ``query_end_gap_score``         | ``query_end_open_gap_score``,         |
@@ -778,7 +778,7 @@ BLASTP, respectively.
      extend_internal_insertion_score: -2.000000
      open_left_insertion_score: -7.000000
      extend_left_insertion_score: -2.000000
-     target_right_open_gap_score: -7.000000
+     open_right_insertion_score: -7.000000
      target_right_extend_gap_score: -2.000000
      query_internal_open_gap_score: -7.000000
      query_internal_extend_gap_score: -2.000000

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -377,7 +377,7 @@ all parameters, use
      extend_right_insertion_score: 0.000000
      query_internal_open_gap_score: 0.000000
      query_internal_extend_gap_score: 0.000000
-     query_left_open_gap_score: 0.000000
+     open_left_deletion_score: 0.000000
      query_left_extend_gap_score: 0.000000
      query_right_open_gap_score: 0.000000
      query_right_extend_gap_score: 0.000000
@@ -553,7 +553,7 @@ object:
 ================================== ====================================
 **Opening scores**                 **Extending scores**
 ================================== ====================================
-``query_left_open_gap_score``      ``query_left_extend_gap_score``
+``open_left_deletion_score``      ``query_left_extend_gap_score``
 ``query_internal_open_gap_score``  ``query_internal_extend_gap_score``
 ``query_right_open_gap_score``     ``query_right_extend_gap_score``
 ``open_left_insertion_score``      ``extend_left_insertion_score``
@@ -635,7 +635,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``query_right_gap_score``             |
    +---------------------------------+---------------------------------------+
    | ``left_open_gap_score``         | ``open_left_insertion_score``,        |
-   |                                 | ``query_left_open_gap_score``         |
+   |                                 | ``open_left_deletion_score``         |
    +---------------------------------+---------------------------------------+
    | ``left_extend_gap_score``       | ``extend_left_insertion_score``,      |
    |                                 | ``query_left_extend_gap_score``       |
@@ -658,7 +658,7 @@ that refer to a number of these values collectively, as shown
    |                                 | ``target_extend_gap_score``           |
    +---------------------------------+---------------------------------------+
    | ``query_open_gap_score``        | ``query_internal_open_gap_score``,    |
-   |                                 | ``query_left_open_gap_score``,        |
+   |                                 | ``open_left_deletion_score``,        |
    |                                 | ``query_right_open_gap_score``        |
    +---------------------------------+---------------------------------------+
    | ``query_extend_gap_score``      | ``query_internal_extend_gap_score``,  |
@@ -689,7 +689,7 @@ that refer to a number of these values collectively, as shown
    | ``query_end_gap_score``         | ``query_end_open_gap_score``,         |
    |                                 | ``query_end_extend_gap_score``        |
    +---------------------------------+---------------------------------------+
-   | ``query_end_open_gap_score``    | ``query_left_open_gap_score``,        |
+   | ``query_end_open_gap_score``    | ``open_left_deletion_score``,        |
    |                                 | ``query_right_open_gap_score``        |
    +---------------------------------+---------------------------------------+
    | ``query_end_extend_gap_score``  | ``query_left_extend_gap_score``,      |
@@ -698,7 +698,7 @@ that refer to a number of these values collectively, as shown
    | ``query_internal_gap_score``    | ``query_internal_open_gap_score``,    |
    |                                 | ``query_internal_extend_gap_score``   |
    +---------------------------------+---------------------------------------+
-   | ``query_left_gap_score``        | ``query_left_open_gap_score``,        |
+   | ``query_left_gap_score``        | ``open_left_deletion_score``,        |
    |                                 | ``query_left_extend_gap_score``       |
    +---------------------------------+---------------------------------------+
    | ``query_right_gap_score``       | ``query_right_open_gap_score``,       |
@@ -782,7 +782,7 @@ BLASTP, respectively.
      extend_right_insertion_score: -2.000000
      query_internal_open_gap_score: -7.000000
      query_internal_extend_gap_score: -2.000000
-     query_left_open_gap_score: -7.000000
+     open_left_deletion_score: -7.000000
      query_left_extend_gap_score: -2.000000
      query_right_open_gap_score: -7.000000
      query_right_extend_gap_score: -2.000000

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -69,7 +69,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: 0.000000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: 0.000000
+  open_right_insertion_score: 0.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: 0.000000
   query_internal_extend_gap_score: 0.000000
@@ -112,7 +112,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -1.000000
   open_left_insertion_score: -3.000000
   extend_left_insertion_score: -9.000000
-  target_right_open_gap_score: -3.000000
+  open_right_insertion_score: -3.000000
   target_right_extend_gap_score: -9.000000
   query_internal_open_gap_score: -6.000000
   query_internal_extend_gap_score: -7.000000
@@ -168,7 +168,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -3.000000
   open_left_insertion_score: -4.000000
   extend_left_insertion_score: -4.000000
-  target_right_open_gap_score: -4.000000
+  open_right_insertion_score: -4.000000
   target_right_extend_gap_score: -4.000000
   query_internal_open_gap_score: -2.000000
   query_internal_extend_gap_score: -2.000000
@@ -221,7 +221,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: 0.000000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: 0.000000
+  open_right_insertion_score: 0.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: 0.000000
   query_internal_extend_gap_score: 0.000000
@@ -329,7 +329,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -1.000000
   open_left_insertion_score: -5.000000
   extend_left_insertion_score: -1.000000
-  target_right_open_gap_score: -5.000000
+  open_right_insertion_score: -5.000000
   target_right_extend_gap_score: -1.000000
   query_internal_open_gap_score: -5.000000
   query_internal_extend_gap_score: -1.000000
@@ -461,7 +461,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.100000
   extend_left_insertion_score: -0.100000
-  target_right_open_gap_score: -0.100000
+  open_right_insertion_score: -0.100000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: -0.100000
@@ -510,7 +510,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.100000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: -0.100000
+  open_right_insertion_score: -0.100000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
@@ -873,7 +873,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.100000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: -0.100000
+  open_right_insertion_score: -0.100000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
@@ -970,7 +970,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.100000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: -0.100000
+  open_right_insertion_score: -0.100000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
@@ -1069,7 +1069,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: 0.000000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: 0.000000
+  open_right_insertion_score: 0.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
@@ -1142,7 +1142,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: 0.000000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: 0.000000
+  open_right_insertion_score: 0.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
@@ -1214,7 +1214,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.100000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: -0.100000
+  open_right_insertion_score: -0.100000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
@@ -1319,7 +1319,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -0.500000
   open_left_insertion_score: -0.200000
   extend_left_insertion_score: -0.500000
-  target_right_open_gap_score: -0.200000
+  open_right_insertion_score: -0.200000
   target_right_extend_gap_score: -0.500000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -0.500000
@@ -1390,7 +1390,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -1.500000
   open_left_insertion_score: -0.200000
   extend_left_insertion_score: -1.500000
-  target_right_open_gap_score: -0.200000
+  open_right_insertion_score: -0.200000
   target_right_extend_gap_score: -1.500000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -1.500000
@@ -1495,7 +1495,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -1.500000
   open_left_insertion_score: -0.200000
   extend_left_insertion_score: -1.500000
-  target_right_open_gap_score: -0.200000
+  open_right_insertion_score: -0.200000
   target_right_extend_gap_score: -1.500000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -1.500000
@@ -1568,7 +1568,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -1.500000
   open_left_insertion_score: -1.700000
   extend_left_insertion_score: -1.500000
-  target_right_open_gap_score: -1.700000
+  open_right_insertion_score: -1.700000
   target_right_extend_gap_score: -1.500000
   query_internal_open_gap_score: -1.700000
   query_internal_extend_gap_score: -1.500000
@@ -1641,7 +1641,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -1.500000
   open_left_insertion_score: -1.700000
   extend_left_insertion_score: -1.500000
-  target_right_open_gap_score: -1.700000
+  open_right_insertion_score: -1.700000
   target_right_extend_gap_score: -1.500000
   query_internal_open_gap_score: -1.700000
   query_internal_extend_gap_score: -1.500000
@@ -1716,7 +1716,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -0.800000
   open_left_insertion_score: 0.000000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: 0.000000
+  open_right_insertion_score: 0.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -0.800000
@@ -1846,7 +1846,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -0.800000
   open_left_insertion_score: 0.000000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: 0.000000
+  open_right_insertion_score: 0.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -0.800000
@@ -1930,7 +1930,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: -0.300000
+  open_right_insertion_score: -0.300000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.800000
   query_internal_extend_gap_score: 0.000000
@@ -2033,7 +2033,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: -0.300000
+  open_right_insertion_score: -0.300000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: 0.000000
@@ -2114,7 +2114,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.100000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: -0.100000
+  open_right_insertion_score: -0.100000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: -0.100000
@@ -2257,7 +2257,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.500000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: -0.500000
+  open_right_insertion_score: -0.500000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.500000
   query_internal_extend_gap_score: 0.000000
@@ -2359,7 +2359,7 @@ query             3 AT-T 0
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -1.000000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: -1.000000
+  open_right_insertion_score: -1.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
@@ -2429,7 +2429,7 @@ query             3 ATT 0
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -1.000000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: -1.000000
+  open_right_insertion_score: -1.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
@@ -2502,7 +2502,7 @@ query             4 ATA 1
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.500000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: -0.500000
+  open_right_insertion_score: -0.500000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.500000
   query_internal_extend_gap_score: 0.000000
@@ -2606,7 +2606,7 @@ query             3 AT-T 0
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -1.000000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: -1.000000
+  open_right_insertion_score: -1.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
@@ -2678,7 +2678,7 @@ query             3 ATT 0
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -1.000000
   extend_left_insertion_score: 0.000000
-  target_right_open_gap_score: -1.000000
+  open_right_insertion_score: -1.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
@@ -2745,7 +2745,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: -0.100000
-  target_right_open_gap_score: -0.300000
+  open_right_insertion_score: -0.300000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
@@ -2792,7 +2792,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: -0.100000
-  target_right_open_gap_score: -0.300000
+  open_right_insertion_score: -0.300000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
@@ -2853,7 +2853,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: -0.100000
-  target_right_open_gap_score: -0.300000
+  open_right_insertion_score: -0.300000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
@@ -2902,7 +2902,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: -0.100000
-  target_right_open_gap_score: -0.300000
+  open_right_insertion_score: -0.300000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
@@ -2935,7 +2935,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: -0.100000
-  target_right_open_gap_score: -0.300000
+  open_right_insertion_score: -0.300000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
@@ -4463,7 +4463,7 @@ Pairwise sequence aligner with parameters
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.200000
   extend_left_insertion_score: -0.100000
-  target_right_open_gap_score: -0.200000
+  open_right_insertion_score: -0.200000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
@@ -4488,7 +4488,7 @@ class TestPredefinedScoringSchemes(unittest.TestCase):
   extend_internal_insertion_score: -2.000000
   open_left_insertion_score: -7.000000
   extend_left_insertion_score: -2.000000
-  target_right_open_gap_score: -7.000000
+  open_right_insertion_score: -7.000000
   target_right_extend_gap_score: -2.000000
   query_internal_open_gap_score: -7.000000
   query_internal_extend_gap_score: -2.000000
@@ -4532,7 +4532,7 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
   extend_internal_insertion_score: -2.500000
   open_left_insertion_score: -2.500000
   extend_left_insertion_score: -2.500000
-  target_right_open_gap_score: -2.500000
+  open_right_insertion_score: -2.500000
   target_right_extend_gap_score: -2.500000
   query_internal_open_gap_score: -2.500000
   query_internal_extend_gap_score: -2.500000
@@ -4576,7 +4576,7 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
   extend_internal_insertion_score: -1.000000
   open_left_insertion_score: -12.000000
   extend_left_insertion_score: -1.000000
-  target_right_open_gap_score: -12.000000
+  open_right_insertion_score: -12.000000
   target_right_extend_gap_score: -1.000000
   query_internal_open_gap_score: -12.000000
   query_internal_extend_gap_score: -1.000000

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -70,7 +70,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: 0.000000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: 0.000000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: 0.000000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: 0.000000
@@ -113,7 +113,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -3.000000
   extend_left_insertion_score: -9.000000
   open_right_insertion_score: -3.000000
-  target_right_extend_gap_score: -9.000000
+  extend_right_insertion_score: -9.000000
   query_internal_open_gap_score: -6.000000
   query_internal_extend_gap_score: -7.000000
   query_left_open_gap_score: -1.000000
@@ -169,7 +169,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -4.000000
   extend_left_insertion_score: -4.000000
   open_right_insertion_score: -4.000000
-  target_right_extend_gap_score: -4.000000
+  extend_right_insertion_score: -4.000000
   query_internal_open_gap_score: -2.000000
   query_internal_extend_gap_score: -2.000000
   query_left_open_gap_score: -5.000000
@@ -222,7 +222,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: 0.000000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: 0.000000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: 0.000000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: 0.000000
@@ -330,7 +330,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -5.000000
   extend_left_insertion_score: -1.000000
   open_right_insertion_score: -5.000000
-  target_right_extend_gap_score: -1.000000
+  extend_right_insertion_score: -1.000000
   query_internal_open_gap_score: -5.000000
   query_internal_extend_gap_score: -1.000000
   query_left_open_gap_score: -5.000000
@@ -462,7 +462,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.100000
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.100000
-  target_right_extend_gap_score: -0.100000
+  extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.100000
@@ -511,7 +511,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.100000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.100000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.100000
@@ -874,7 +874,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.100000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.100000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.100000
@@ -971,7 +971,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.100000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.100000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.100000
@@ -1070,7 +1070,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: 0.000000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: 0.000000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.100000
@@ -1143,7 +1143,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: 0.000000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: 0.000000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.100000
@@ -1215,7 +1215,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.100000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.100000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.100000
@@ -1320,7 +1320,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.200000
   extend_left_insertion_score: -0.500000
   open_right_insertion_score: -0.200000
-  target_right_extend_gap_score: -0.500000
+  extend_right_insertion_score: -0.500000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -0.500000
   query_left_open_gap_score: -0.200000
@@ -1391,7 +1391,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.200000
   extend_left_insertion_score: -1.500000
   open_right_insertion_score: -0.200000
-  target_right_extend_gap_score: -1.500000
+  extend_right_insertion_score: -1.500000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -1.500000
   query_left_open_gap_score: -0.200000
@@ -1496,7 +1496,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.200000
   extend_left_insertion_score: -1.500000
   open_right_insertion_score: -0.200000
-  target_right_extend_gap_score: -1.500000
+  extend_right_insertion_score: -1.500000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -1.500000
   query_left_open_gap_score: -0.200000
@@ -1569,7 +1569,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -1.700000
   extend_left_insertion_score: -1.500000
   open_right_insertion_score: -1.700000
-  target_right_extend_gap_score: -1.500000
+  extend_right_insertion_score: -1.500000
   query_internal_open_gap_score: -1.700000
   query_internal_extend_gap_score: -1.500000
   query_left_open_gap_score: -1.700000
@@ -1642,7 +1642,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -1.700000
   extend_left_insertion_score: -1.500000
   open_right_insertion_score: -1.700000
-  target_right_extend_gap_score: -1.500000
+  extend_right_insertion_score: -1.500000
   query_internal_open_gap_score: -1.700000
   query_internal_extend_gap_score: -1.500000
   query_left_open_gap_score: -1.700000
@@ -1717,7 +1717,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: 0.000000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: 0.000000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -0.800000
   query_left_open_gap_score: 0.000000
@@ -1847,7 +1847,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: 0.000000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: 0.000000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -0.800000
   query_left_open_gap_score: 0.000000
@@ -1931,7 +1931,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.300000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.800000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.800000
@@ -2034,7 +2034,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.300000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.200000
@@ -2115,7 +2115,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.100000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.100000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.100000
@@ -2258,7 +2258,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
   open_left_insertion_score: -0.500000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.500000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.500000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.500000
@@ -2360,7 +2360,7 @@ query             3 AT-T 0
   open_left_insertion_score: -1.000000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -1.000000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -1.000000
@@ -2430,7 +2430,7 @@ query             3 ATT 0
   open_left_insertion_score: -1.000000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -1.000000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -1.000000
@@ -2503,7 +2503,7 @@ query             4 ATA 1
   open_left_insertion_score: -0.500000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.500000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.500000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -0.500000
@@ -2607,7 +2607,7 @@ query             3 AT-T 0
   open_left_insertion_score: -1.000000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -1.000000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -1.000000
@@ -2679,7 +2679,7 @@ query             3 ATT 0
   open_left_insertion_score: -1.000000
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -1.000000
-  target_right_extend_gap_score: 0.000000
+  extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
   query_left_open_gap_score: -1.000000
@@ -2746,7 +2746,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.300000
-  target_right_extend_gap_score: -0.100000
+  extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.300000
@@ -2793,7 +2793,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.300000
-  target_right_extend_gap_score: -0.100000
+  extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.300000
@@ -2854,7 +2854,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.300000
-  target_right_extend_gap_score: -0.100000
+  extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.300000
@@ -2903,7 +2903,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.300000
-  target_right_extend_gap_score: -0.100000
+  extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.300000
@@ -2936,7 +2936,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.300000
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.300000
-  target_right_extend_gap_score: -0.100000
+  extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.300000
@@ -4464,7 +4464,7 @@ Pairwise sequence aligner with parameters
   open_left_insertion_score: -0.200000
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.200000
-  target_right_extend_gap_score: -0.100000
+  extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   query_left_open_gap_score: -0.300000
@@ -4489,7 +4489,7 @@ class TestPredefinedScoringSchemes(unittest.TestCase):
   open_left_insertion_score: -7.000000
   extend_left_insertion_score: -2.000000
   open_right_insertion_score: -7.000000
-  target_right_extend_gap_score: -2.000000
+  extend_right_insertion_score: -2.000000
   query_internal_open_gap_score: -7.000000
   query_internal_extend_gap_score: -2.000000
   query_left_open_gap_score: -7.000000
@@ -4533,7 +4533,7 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
   open_left_insertion_score: -2.500000
   extend_left_insertion_score: -2.500000
   open_right_insertion_score: -2.500000
-  target_right_extend_gap_score: -2.500000
+  extend_right_insertion_score: -2.500000
   query_internal_open_gap_score: -2.500000
   query_internal_extend_gap_score: -2.500000
   query_left_open_gap_score: -2.500000
@@ -4577,7 +4577,7 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
   open_left_insertion_score: -12.000000
   extend_left_insertion_score: -1.000000
   open_right_insertion_score: -12.000000
-  target_right_extend_gap_score: -1.000000
+  extend_right_insertion_score: -1.000000
   query_internal_open_gap_score: -12.000000
   query_internal_extend_gap_score: -1.000000
   query_left_open_gap_score: -12.000000

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -65,7 +65,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 3.000000
   mismatch_score: -2.000000
-  target_internal_open_gap_score: 0.000000
+  open_internal_insertion_score: 0.000000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
@@ -108,7 +108,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -5.000000
+  open_internal_insertion_score: -5.000000
   extend_internal_insertion_score: -1.000000
   target_left_open_gap_score: -3.000000
   target_left_extend_gap_score: -9.000000
@@ -164,7 +164,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -3.000000
+  open_internal_insertion_score: -3.000000
   extend_internal_insertion_score: -3.000000
   target_left_open_gap_score: -4.000000
   target_left_extend_gap_score: -4.000000
@@ -217,7 +217,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: 0.000000
+  open_internal_insertion_score: 0.000000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
@@ -325,7 +325,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 0.000000
   mismatch_score: -1.000000
-  target_internal_open_gap_score: -5.000000
+  open_internal_insertion_score: -5.000000
   extend_internal_insertion_score: -1.000000
   target_left_open_gap_score: -5.000000
   target_left_extend_gap_score: -1.000000
@@ -457,7 +457,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.100000
+  open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: -0.100000
@@ -506,7 +506,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.100000
+  open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
@@ -869,7 +869,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 2.000000
   mismatch_score: -1.000000
-  target_internal_open_gap_score: -0.100000
+  open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
@@ -966,7 +966,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.500000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.100000
+  open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
@@ -1065,7 +1065,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: 0.000000
+  open_internal_insertion_score: 0.000000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
@@ -1138,7 +1138,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: 0.000000
+  open_internal_insertion_score: 0.000000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
@@ -1210,7 +1210,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: -2.000000
-  target_internal_open_gap_score: -0.100000
+  open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
@@ -1315,7 +1315,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.200000
+  open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -0.500000
   target_left_open_gap_score: -0.200000
   target_left_extend_gap_score: -0.500000
@@ -1386,7 +1386,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.200000
+  open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -1.500000
   target_left_open_gap_score: -0.200000
   target_left_extend_gap_score: -1.500000
@@ -1491,7 +1491,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.200000
+  open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -1.500000
   target_left_open_gap_score: -0.200000
   target_left_extend_gap_score: -1.500000
@@ -1564,7 +1564,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -1.700000
+  open_internal_insertion_score: -1.700000
   extend_internal_insertion_score: -1.500000
   target_left_open_gap_score: -1.700000
   target_left_extend_gap_score: -1.500000
@@ -1637,7 +1637,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -1.700000
+  open_internal_insertion_score: -1.700000
   extend_internal_insertion_score: -1.500000
   target_left_open_gap_score: -1.700000
   target_left_extend_gap_score: -1.500000
@@ -1712,7 +1712,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.200000
+  open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -0.800000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
@@ -1842,7 +1842,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.200000
+  open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -0.800000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
@@ -1926,7 +1926,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.300000
+  open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: 0.000000
@@ -2029,7 +2029,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.300000
+  open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: 0.000000
@@ -2110,7 +2110,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.100000
+  open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
@@ -2253,7 +2253,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
             """\
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*>
-  target_internal_open_gap_score: -0.500000
+  open_internal_insertion_score: -0.500000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.500000
   target_left_extend_gap_score: 0.000000
@@ -2355,7 +2355,7 @@ query             3 AT-T 0
             """\
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*>
-  target_internal_open_gap_score: -1.000000
+  open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -1.000000
   target_left_extend_gap_score: 0.000000
@@ -2425,7 +2425,7 @@ query             3 ATT 0
             """\
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*>
-  target_internal_open_gap_score: -1.000000
+  open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -1.000000
   target_left_extend_gap_score: 0.000000
@@ -2498,7 +2498,7 @@ query             4 ATA 1
             """\
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*>
-  target_internal_open_gap_score: -0.500000
+  open_internal_insertion_score: -0.500000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.500000
   target_left_extend_gap_score: 0.000000
@@ -2602,7 +2602,7 @@ query             3 AT-T 0
             """\
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*
-  target_internal_open_gap_score: -1.000000
+  open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -1.000000
   target_left_extend_gap_score: 0.000000
@@ -2674,7 +2674,7 @@ query             3 ATT 0
             """\
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*>
-  target_internal_open_gap_score: -1.000000
+  open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -1.000000
   target_left_extend_gap_score: 0.000000
@@ -2741,7 +2741,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.300000
+  open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
@@ -2788,7 +2788,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.300000
+  open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
@@ -2849,7 +2849,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.300000
+  open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
@@ -2898,7 +2898,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.300000
+  open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
@@ -2931,7 +2931,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.300000
+  open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
@@ -4459,7 +4459,7 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  target_internal_open_gap_score: -0.200000
+  open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.200000
   target_left_extend_gap_score: -0.100000
@@ -4484,7 +4484,7 @@ class TestPredefinedScoringSchemes(unittest.TestCase):
             """\
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*
-  target_internal_open_gap_score: -7.000000
+  open_internal_insertion_score: -7.000000
   extend_internal_insertion_score: -2.000000
   target_left_open_gap_score: -7.000000
   target_left_extend_gap_score: -2.000000
@@ -4528,7 +4528,7 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
             """\
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*
-  target_internal_open_gap_score: -2.500000
+  open_internal_insertion_score: -2.500000
   extend_internal_insertion_score: -2.500000
   target_left_open_gap_score: -2.500000
   target_left_extend_gap_score: -2.500000
@@ -4572,7 +4572,7 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
             """\
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*
-  target_internal_open_gap_score: -12.000000
+  open_internal_insertion_score: -12.000000
   extend_internal_insertion_score: -1.000000
   target_left_open_gap_score: -12.000000
   target_left_extend_gap_score: -1.000000

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2986,7 +2986,7 @@ class TestPerSiteGapPenalties(unittest.TestCase):
   match_score: 1.000000
   mismatch_score: -1.000000
   insertion_score_function: {nogaps}
-  query_gap_function: {specificgaps}
+  deletion_score_function: {specificgaps}
   mode: global
 """,
         )
@@ -3070,7 +3070,7 @@ query            22 --AABBBAAAACC----------CCAAAABBBAA--  0
   match_score: 1.000000
   mismatch_score: -1.000000
   insertion_score_function: {nogaps}
-  query_gap_function: {specificgaps}
+  deletion_score_function: {specificgaps}
   mode: global
 """,
         )
@@ -3234,7 +3234,7 @@ query             6 TTG--GAA 0
   match_score: 1.000000
   mismatch_score: -10.000000
   insertion_score_function: {gap_score}
-  query_gap_function: {gap_score}
+  deletion_score_function: {gap_score}
   mode: global
 """,
         )
@@ -3411,7 +3411,7 @@ query             6 TTG--GAA 0
   match_score: 1.000000
   mismatch_score: -1.000000
   insertion_score_function: {nogaps}
-  query_gap_function: {specificgaps}
+  deletion_score_function: {specificgaps}
   mode: local
 """,
         )
@@ -3514,7 +3514,7 @@ query            13 CCCCAAAABBBAA  0
   match_score: 1.000000
   mismatch_score: -1.000000
   insertion_score_function: {nogaps}
-  query_gap_function: {specificgaps}
+  deletion_score_function: {specificgaps}
   mode: local
 """,
         )
@@ -3694,7 +3694,7 @@ query             2 AA 0
   match_score: 1.000000
   mismatch_score: -10.000000
   insertion_score_function: {gap_score}
-  query_gap_function: {gap_score}
+  deletion_score_function: {gap_score}
   mode: local
 """,
         )

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -1702,9 +1702,7 @@ class TestPairwisePenalizeEndgaps(unittest.TestCase):
         aligner.mode = "global"
         aligner.open_gap_score = -0.2
         aligner.extend_gap_score = -0.8
-        end_score = 0.0
-        aligner.target_end_gap_score = end_score
-        aligner.query_end_gap_score = end_score
+        aligner.end_gap_score = 0.0
         self.assertEqual(
             str(aligner),
             """\
@@ -1832,9 +1830,7 @@ query             2 GT-- 0
         aligner.mode = "fogsaa"
         aligner.open_gap_score = -0.2
         aligner.extend_gap_score = -0.8
-        end_score = 0.0
-        aligner.target_end_gap_score = end_score
-        aligner.query_end_gap_score = end_score
+        aligner.end_gap_score = 0.0
         self.assertEqual(
             str(aligner),
             """\
@@ -1911,13 +1907,9 @@ class TestPairwiseSeparateGapPenalties(unittest.TestCase):
         open_score, extend_score = (-0.3, 0)
         aligner.target_open_gap_score = open_score
         aligner.target_extend_gap_score = extend_score
-        aligner.target_end_open_gap_score = open_score
-        aligner.target_end_extend_gap_score = extend_score
         open_score, extend_score = (-0.8, 0)
         aligner.query_open_gap_score = open_score
         aligner.query_extend_gap_score = extend_score
-        aligner.query_end_open_gap_score = open_score
-        aligner.query_end_extend_gap_score = extend_score
         self.assertEqual(aligner.algorithm, "Gotoh local alignment algorithm")
         self.assertEqual(
             str(aligner),
@@ -2097,8 +2089,6 @@ class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
         open_score, extend_score = (-0.1, 0)
         aligner.target_open_gap_score = open_score
         aligner.target_extend_gap_score = extend_score
-        aligner.target_end_open_gap_score = open_score
-        aligner.target_end_extend_gap_score = extend_score
         score = -0.1
         aligner.query_gap_score = score
         aligner.query_end_gap_score = score

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2012,8 +2012,8 @@ class TestPairwiseSeparateGapPenalties(unittest.TestCase):
         aligner = Align.PairwiseAligner()
         aligner.mode = "local"
         open_score, extend_score = (-0.3, 0)
-        aligner.target_open_gap_score = open_score
-        aligner.target_extend_gap_score = extend_score
+        aligner.open_insertion_score = open_score
+        aligner.extend_insertion_score = extend_score
         open_score, extend_score = (-0.8, 0)
         aligner.query_open_gap_score = open_score
         aligner.query_extend_gap_score = extend_score
@@ -2116,8 +2116,8 @@ query             4 GTCT 0
     def test_separate_gap_penalties2(self):
         aligner = Align.PairwiseAligner()
         aligner.mode = "local"
-        aligner.target_open_gap_score = -0.3
-        aligner.target_extend_gap_score = 0.0
+        aligner.open_insertion_score = -0.3
+        aligner.extend_insertion_score = 0.0
         aligner.query_open_gap_score = -0.2
         aligner.query_extend_gap_score = 0.0
         self.assertEqual(aligner.algorithm, "Gotoh local alignment algorithm")
@@ -2194,8 +2194,8 @@ class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
         aligner = Align.PairwiseAligner()
         aligner.mode = "local"
         open_score, extend_score = (-0.1, 0)
-        aligner.target_open_gap_score = open_score
-        aligner.target_extend_gap_score = extend_score
+        aligner.open_insertion_score = open_score
+        aligner.extend_insertion_score = extend_score
         score = -0.1
         aligner.query_gap_score = score
         aligner.query_end_gap_score = score
@@ -3074,7 +3074,7 @@ class TestPerSiteGapPenalties(unittest.TestCase):
         aligner.mode = "global"
         aligner.match_score = 1
         aligner.mismatch_score = -1
-        aligner.target_gap_score = nogaps
+        aligner.insertion_score = nogaps
         aligner.query_gap_score = specificgaps
         self.assertEqual(
             str(aligner),
@@ -3158,7 +3158,7 @@ query            22 --AABBBAAAACC----------CCAAAABBBAA--  0
         aligner.mode = "global"
         aligner.match_score = 1
         aligner.mismatch_score = -1
-        aligner.target_gap_score = nogaps
+        aligner.insertion_score = nogaps
         aligner.query_gap_score = specificgaps
         self.assertEqual(
             str(aligner),
@@ -3263,7 +3263,7 @@ query            22 --AABBBAAAACCCCAAAABB----------BAA--  0
         aligner.mode = "global"
         aligner.match_score = 1
         aligner.mismatch_score = -10
-        aligner.target_gap_score = gap_score
+        aligner.insertion_score = gap_score
         self.assertEqual(
             aligner.algorithm, "Waterman-Smith-Beyer global alignment algorithm"
         )
@@ -3496,7 +3496,7 @@ query             6 TTG--GAA 0
         aligner.mode = "local"
         aligner.match_score = 1
         aligner.mismatch_score = -1
-        aligner.target_gap_score = nogaps
+        aligner.insertion_score = nogaps
         aligner.query_gap_score = specificgaps
         self.assertEqual(
             aligner.algorithm, "Waterman-Smith-Beyer local alignment algorithm"
@@ -3602,7 +3602,7 @@ query            13 CCCCAAAABBBAA  0
         aligner.mode = "local"
         aligner.match_score = 1
         aligner.mismatch_score = -1
-        aligner.target_gap_score = nogaps
+        aligner.insertion_score = nogaps
         aligner.query_gap_score = specificgaps
         self.assertEqual(
             str(aligner),
@@ -3699,7 +3699,7 @@ query            13 CCCCAAAABBBAA  0
         aligner.mode = "local"
         aligner.match_score = 1
         aligner.mismatch_score = -10
-        aligner.target_gap_score = gap_score
+        aligner.insertion_score = gap_score
         self.assertEqual(
             aligner.algorithm, "Waterman-Smith-Beyer local alignment algorithm"
         )
@@ -3869,7 +3869,7 @@ query             2 AA 0
             raise RuntimeError("broken gap function")
 
         aligner = Align.PairwiseAligner()
-        aligner.target_gap_score = gap_score
+        aligner.insertion_score = gap_score
         aligner.query_gap_score = -1
         aligner.mode = "global"
         with self.assertRaises(RuntimeError):
@@ -3893,7 +3893,7 @@ query             2 AA 0
         with self.assertRaises(RuntimeError):
             alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
             alignments = list(alignments)
-        aligner.target_gap_score = -1
+        aligner.insertion_score = -1
         aligner.query_gap_score = gap_score
         aligner.mode = "global"
         with self.assertRaises(RuntimeError):
@@ -4547,7 +4547,7 @@ class TestKeywordArgumentsConstructor(unittest.TestCase):
             mode="local",
             open_gap_score=-0.3,
             extend_gap_score=-0.1,
-            target_open_gap_score=-0.2,
+            open_insertion_score=-0.2,
         )
         self.assertEqual(
             str(aligner),
@@ -5045,7 +5045,7 @@ class TestAlignmentFormat(unittest.TestCase):
         aligner = Align.PairwiseAligner()
         aligner.query_extend_gap_score = 0
         aligner.query_open_gap_score = -3
-        aligner.target_gap_score = -3
+        aligner.insertion_score = -3
         aligner.end_gap_score = 0
         aligner.mismatch = -1
         alignments = aligner.align(chromosome, transcript)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -84,6 +84,113 @@ Pairwise sequence aligner with parameters
     def test_aligner_property_gapscores(self):
         aligner = Align.PairwiseAligner()
         open_score, extend_score = (-5, -1)
+        aligner.open_insertion_score = open_score
+        aligner.extend_insertion_score = extend_score
+        self.assertAlmostEqual(aligner.open_insertion_score, open_score)
+        self.assertAlmostEqual(aligner.extend_insertion_score, extend_score)
+        open_score, extend_score = (-6, -7)
+        aligner.open_deletion_score = open_score
+        aligner.extend_deletion_score = extend_score
+        self.assertAlmostEqual(aligner.open_deletion_score, open_score)
+        self.assertAlmostEqual(aligner.extend_deletion_score, extend_score)
+        open_score, extend_score = (-3, -9)
+        aligner.open_end_insertion_score = open_score
+        aligner.extend_end_insertion_score = extend_score
+        self.assertAlmostEqual(aligner.open_end_insertion_score, open_score)
+        self.assertAlmostEqual(aligner.extend_end_insertion_score, extend_score)
+        open_score, extend_score = (-1, -2)
+        aligner.open_end_deletion_score = open_score
+        aligner.extend_end_deletion_score = extend_score
+        self.assertEqual(
+            str(aligner),
+            """\
+Pairwise sequence aligner with parameters
+  wildcard: None
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  open_internal_insertion_score: -5.000000
+  extend_internal_insertion_score: -1.000000
+  open_left_insertion_score: -3.000000
+  extend_left_insertion_score: -9.000000
+  open_right_insertion_score: -3.000000
+  extend_right_insertion_score: -9.000000
+  open_internal_deletion_score: -6.000000
+  extend_internal_deletion_score: -7.000000
+  open_left_deletion_score: -1.000000
+  extend_left_deletion_score: -2.000000
+  open_right_deletion_score: -1.000000
+  extend_right_deletion_score: -2.000000
+  mode: global
+""",
+        )
+        self.assertAlmostEqual(aligner.open_end_deletion_score, open_score)
+        self.assertAlmostEqual(aligner.extend_end_deletion_score, extend_score)
+        score = -3
+        aligner.insertion_score = score
+        self.assertAlmostEqual(aligner.insertion_score, score)
+        self.assertAlmostEqual(aligner.open_insertion_score, score)
+        self.assertAlmostEqual(aligner.extend_insertion_score, score)
+        score = -2
+        aligner.deletion_score = score
+        self.assertAlmostEqual(aligner.deletion_score, score)
+        self.assertAlmostEqual(aligner.open_deletion_score, score)
+        self.assertAlmostEqual(aligner.extend_deletion_score, score)
+        score = -4
+        aligner.end_insertion_score = score
+        self.assertAlmostEqual(aligner.end_insertion_score, score)
+        self.assertAlmostEqual(aligner.open_end_insertion_score, score)
+        self.assertAlmostEqual(aligner.extend_end_insertion_score, score)
+        self.assertAlmostEqual(aligner.left_insertion_score, score)
+        self.assertAlmostEqual(aligner.open_left_insertion_score, score)
+        self.assertAlmostEqual(aligner.extend_left_insertion_score, score)
+        self.assertAlmostEqual(aligner.right_insertion_score, score)
+        self.assertAlmostEqual(aligner.open_right_insertion_score, score)
+        self.assertAlmostEqual(aligner.extend_right_insertion_score, score)
+        score = -5
+        aligner.end_deletion_score = score
+        self.assertAlmostEqual(aligner.end_deletion_score, score)
+        self.assertAlmostEqual(aligner.open_end_deletion_score, score)
+        self.assertAlmostEqual(aligner.extend_end_deletion_score, score)
+        self.assertAlmostEqual(aligner.left_deletion_score, score)
+        self.assertAlmostEqual(aligner.open_left_deletion_score, score)
+        self.assertAlmostEqual(aligner.extend_left_deletion_score, score)
+        self.assertAlmostEqual(aligner.right_deletion_score, score)
+        self.assertAlmostEqual(aligner.open_right_deletion_score, score)
+        self.assertAlmostEqual(aligner.extend_right_deletion_score, score)
+        self.assertEqual(
+            str(aligner),
+            """\
+Pairwise sequence aligner with parameters
+  wildcard: None
+  match_score: 1.000000
+  mismatch_score: 0.000000
+  open_internal_insertion_score: -3.000000
+  extend_internal_insertion_score: -3.000000
+  open_left_insertion_score: -4.000000
+  extend_left_insertion_score: -4.000000
+  open_right_insertion_score: -4.000000
+  extend_right_insertion_score: -4.000000
+  open_internal_deletion_score: -2.000000
+  extend_internal_deletion_score: -2.000000
+  open_left_deletion_score: -5.000000
+  extend_left_deletion_score: -5.000000
+  open_right_deletion_score: -5.000000
+  extend_right_deletion_score: -5.000000
+  mode: global
+""",
+        )
+        with self.assertRaises(ValueError):
+            aligner.insertion_score = "wrong"
+        with self.assertRaises(ValueError):
+            aligner.deletion_score = "wrong"
+        with self.assertRaises(TypeError):
+            aligner.end_insertion_score = "wrong"
+        with self.assertRaises(TypeError):
+            aligner.end_deletion_score = "wrong"
+
+    def test_aligner_property_gapscores_deprecated(self):
+        aligner = Align.PairwiseAligner()
+        open_score, extend_score = (-5, -1)
         aligner.target_open_gap_score = open_score
         aligner.target_extend_gap_score = extend_score
         self.assertAlmostEqual(aligner.target_open_gap_score, open_score)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -66,7 +66,7 @@ Pairwise sequence aligner with parameters
   match_score: 3.000000
   mismatch_score: -2.000000
   target_internal_open_gap_score: 0.000000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
@@ -109,7 +109,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -5.000000
-  target_internal_extend_gap_score: -1.000000
+  extend_internal_insertion_score: -1.000000
   target_left_open_gap_score: -3.000000
   target_left_extend_gap_score: -9.000000
   target_right_open_gap_score: -3.000000
@@ -165,7 +165,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -3.000000
-  target_internal_extend_gap_score: -3.000000
+  extend_internal_insertion_score: -3.000000
   target_left_open_gap_score: -4.000000
   target_left_extend_gap_score: -4.000000
   target_right_open_gap_score: -4.000000
@@ -218,7 +218,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: 0.000000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
@@ -326,7 +326,7 @@ Pairwise sequence aligner with parameters
   match_score: 0.000000
   mismatch_score: -1.000000
   target_internal_open_gap_score: -5.000000
-  target_internal_extend_gap_score: -1.000000
+  extend_internal_insertion_score: -1.000000
   target_left_open_gap_score: -5.000000
   target_left_extend_gap_score: -1.000000
   target_right_open_gap_score: -5.000000
@@ -458,7 +458,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.100000
-  target_internal_extend_gap_score: -0.100000
+  extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.100000
@@ -507,7 +507,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.100000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
@@ -870,7 +870,7 @@ Pairwise sequence aligner with parameters
   match_score: 2.000000
   mismatch_score: -1.000000
   target_internal_open_gap_score: -0.100000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
@@ -967,7 +967,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.500000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.100000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
@@ -1066,7 +1066,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: 0.000000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
@@ -1139,7 +1139,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: 0.000000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
@@ -1211,7 +1211,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: -2.000000
   target_internal_open_gap_score: -0.100000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
@@ -1316,7 +1316,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.200000
-  target_internal_extend_gap_score: -0.500000
+  extend_internal_insertion_score: -0.500000
   target_left_open_gap_score: -0.200000
   target_left_extend_gap_score: -0.500000
   target_right_open_gap_score: -0.200000
@@ -1387,7 +1387,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.200000
-  target_internal_extend_gap_score: -1.500000
+  extend_internal_insertion_score: -1.500000
   target_left_open_gap_score: -0.200000
   target_left_extend_gap_score: -1.500000
   target_right_open_gap_score: -0.200000
@@ -1492,7 +1492,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.200000
-  target_internal_extend_gap_score: -1.500000
+  extend_internal_insertion_score: -1.500000
   target_left_open_gap_score: -0.200000
   target_left_extend_gap_score: -1.500000
   target_right_open_gap_score: -0.200000
@@ -1565,7 +1565,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -1.700000
-  target_internal_extend_gap_score: -1.500000
+  extend_internal_insertion_score: -1.500000
   target_left_open_gap_score: -1.700000
   target_left_extend_gap_score: -1.500000
   target_right_open_gap_score: -1.700000
@@ -1638,7 +1638,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -1.700000
-  target_internal_extend_gap_score: -1.500000
+  extend_internal_insertion_score: -1.500000
   target_left_open_gap_score: -1.700000
   target_left_extend_gap_score: -1.500000
   target_right_open_gap_score: -1.700000
@@ -1713,7 +1713,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.200000
-  target_internal_extend_gap_score: -0.800000
+  extend_internal_insertion_score: -0.800000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
@@ -1843,7 +1843,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.200000
-  target_internal_extend_gap_score: -0.800000
+  extend_internal_insertion_score: -0.800000
   target_left_open_gap_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
@@ -1927,7 +1927,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.300000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.300000
@@ -2030,7 +2030,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.300000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.300000
@@ -2111,7 +2111,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.100000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
@@ -2254,7 +2254,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*>
   target_internal_open_gap_score: -0.500000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.500000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.500000
@@ -2356,7 +2356,7 @@ query             3 AT-T 0
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*>
   target_internal_open_gap_score: -1.000000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -1.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -1.000000
@@ -2426,7 +2426,7 @@ query             3 ATT 0
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*>
   target_internal_open_gap_score: -1.000000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -1.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -1.000000
@@ -2499,7 +2499,7 @@ query             4 ATA 1
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*>
   target_internal_open_gap_score: -0.500000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -0.500000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.500000
@@ -2603,7 +2603,7 @@ query             3 AT-T 0
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*
   target_internal_open_gap_score: -1.000000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -1.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -1.000000
@@ -2675,7 +2675,7 @@ query             3 ATT 0
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*>
   target_internal_open_gap_score: -1.000000
-  target_internal_extend_gap_score: 0.000000
+  extend_internal_insertion_score: 0.000000
   target_left_open_gap_score: -1.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -1.000000
@@ -2742,7 +2742,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.300000
-  target_internal_extend_gap_score: -0.100000
+  extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
@@ -2789,7 +2789,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.300000
-  target_internal_extend_gap_score: -0.100000
+  extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
@@ -2850,7 +2850,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.300000
-  target_internal_extend_gap_score: -0.100000
+  extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
@@ -2899,7 +2899,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.300000
-  target_internal_extend_gap_score: -0.100000
+  extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
@@ -2932,7 +2932,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.300000
-  target_internal_extend_gap_score: -0.100000
+  extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
@@ -4460,7 +4460,7 @@ Pairwise sequence aligner with parameters
   match_score: 1.000000
   mismatch_score: 0.000000
   target_internal_open_gap_score: -0.200000
-  target_internal_extend_gap_score: -0.100000
+  extend_internal_insertion_score: -0.100000
   target_left_open_gap_score: -0.200000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.200000
@@ -4485,7 +4485,7 @@ class TestPredefinedScoringSchemes(unittest.TestCase):
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*
   target_internal_open_gap_score: -7.000000
-  target_internal_extend_gap_score: -2.000000
+  extend_internal_insertion_score: -2.000000
   target_left_open_gap_score: -7.000000
   target_left_extend_gap_score: -2.000000
   target_right_open_gap_score: -7.000000
@@ -4529,7 +4529,7 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*
   target_internal_open_gap_score: -2.500000
-  target_internal_extend_gap_score: -2.500000
+  extend_internal_insertion_score: -2.500000
   target_left_open_gap_score: -2.500000
   target_left_extend_gap_score: -2.500000
   target_right_open_gap_score: -2.500000
@@ -4573,7 +4573,7 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
 ^Pairwise sequence aligner with parameters
   substitution_matrix: <Array object at .*
   target_internal_open_gap_score: -12.000000
-  target_internal_extend_gap_score: -1.000000
+  extend_internal_insertion_score: -1.000000
   target_left_open_gap_score: -12.000000
   target_left_extend_gap_score: -1.000000
   target_right_open_gap_score: -12.000000

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -72,7 +72,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: 0.000000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: 0.000000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: 0.000000
@@ -115,7 +115,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -3.000000
   extend_right_insertion_score: -9.000000
   open_internal_deletion_score: -6.000000
-  query_internal_extend_gap_score: -7.000000
+  extend_internal_deletion_score: -7.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: -2.000000
   query_right_open_gap_score: -1.000000
@@ -171,7 +171,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -4.000000
   extend_right_insertion_score: -4.000000
   open_internal_deletion_score: -2.000000
-  query_internal_extend_gap_score: -2.000000
+  extend_internal_deletion_score: -2.000000
   open_left_deletion_score: -5.000000
   extend_left_deletion_score: -5.000000
   query_right_open_gap_score: -5.000000
@@ -224,7 +224,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: 0.000000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: 0.000000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: 0.000000
@@ -332,7 +332,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -5.000000
   extend_right_insertion_score: -1.000000
   open_internal_deletion_score: -5.000000
-  query_internal_extend_gap_score: -1.000000
+  extend_internal_deletion_score: -1.000000
   open_left_deletion_score: -5.000000
   extend_left_deletion_score: -1.000000
   query_right_open_gap_score: -5.000000
@@ -464,7 +464,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.100000
   extend_right_insertion_score: -0.100000
   open_internal_deletion_score: -0.100000
-  query_internal_extend_gap_score: -0.100000
+  extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.100000
@@ -513,7 +513,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.100000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -0.100000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.100000
@@ -876,7 +876,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.100000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -0.100000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.100000
@@ -973,7 +973,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.100000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -0.100000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.100000
@@ -1072,7 +1072,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: 0.000000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -0.100000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.100000
@@ -1145,7 +1145,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: 0.000000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -0.100000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.100000
@@ -1217,7 +1217,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.100000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -0.100000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.100000
@@ -1322,7 +1322,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.200000
   extend_right_insertion_score: -0.500000
   open_internal_deletion_score: -0.200000
-  query_internal_extend_gap_score: -0.500000
+  extend_internal_deletion_score: -0.500000
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: -0.500000
   query_right_open_gap_score: -0.200000
@@ -1393,7 +1393,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.200000
   extend_right_insertion_score: -1.500000
   open_internal_deletion_score: -0.200000
-  query_internal_extend_gap_score: -1.500000
+  extend_internal_deletion_score: -1.500000
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: -1.500000
   query_right_open_gap_score: -0.200000
@@ -1498,7 +1498,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.200000
   extend_right_insertion_score: -1.500000
   open_internal_deletion_score: -0.200000
-  query_internal_extend_gap_score: -1.500000
+  extend_internal_deletion_score: -1.500000
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: -1.500000
   query_right_open_gap_score: -0.200000
@@ -1571,7 +1571,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -1.700000
   extend_right_insertion_score: -1.500000
   open_internal_deletion_score: -1.700000
-  query_internal_extend_gap_score: -1.500000
+  extend_internal_deletion_score: -1.500000
   open_left_deletion_score: -1.700000
   extend_left_deletion_score: -1.500000
   query_right_open_gap_score: -1.700000
@@ -1644,7 +1644,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -1.700000
   extend_right_insertion_score: -1.500000
   open_internal_deletion_score: -1.700000
-  query_internal_extend_gap_score: -1.500000
+  extend_internal_deletion_score: -1.500000
   open_left_deletion_score: -1.700000
   extend_left_deletion_score: -1.500000
   query_right_open_gap_score: -1.700000
@@ -1719,7 +1719,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: 0.000000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -0.200000
-  query_internal_extend_gap_score: -0.800000
+  extend_internal_deletion_score: -0.800000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: 0.000000
@@ -1849,7 +1849,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: 0.000000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -0.200000
-  query_internal_extend_gap_score: -0.800000
+  extend_internal_deletion_score: -0.800000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: 0.000000
@@ -1933,7 +1933,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -0.800000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.800000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.800000
@@ -2036,7 +2036,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -0.200000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.200000
@@ -2117,7 +2117,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.100000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -0.100000
-  query_internal_extend_gap_score: -0.100000
+  extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.100000
@@ -2260,7 +2260,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
   open_right_insertion_score: -0.500000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -0.500000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.500000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.500000
@@ -2362,7 +2362,7 @@ query             3 AT-T 0
   open_right_insertion_score: -1.000000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -1.000000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -1.000000
@@ -2432,7 +2432,7 @@ query             3 ATT 0
   open_right_insertion_score: -1.000000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -1.000000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -1.000000
@@ -2505,7 +2505,7 @@ query             4 ATA 1
   open_right_insertion_score: -0.500000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -0.500000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.500000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.500000
@@ -2609,7 +2609,7 @@ query             3 AT-T 0
   open_right_insertion_score: -1.000000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -1.000000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -1.000000
@@ -2681,7 +2681,7 @@ query             3 ATT 0
   open_right_insertion_score: -1.000000
   extend_right_insertion_score: 0.000000
   open_internal_deletion_score: -1.000000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -1.000000
@@ -2748,7 +2748,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: -0.100000
   open_internal_deletion_score: -0.300000
-  query_internal_extend_gap_score: -0.100000
+  extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.300000
@@ -2795,7 +2795,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: -0.100000
   open_internal_deletion_score: -0.300000
-  query_internal_extend_gap_score: -0.100000
+  extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.300000
@@ -2856,7 +2856,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: -0.100000
   open_internal_deletion_score: -0.300000
-  query_internal_extend_gap_score: -0.100000
+  extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.300000
@@ -2905,7 +2905,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: -0.100000
   open_internal_deletion_score: -0.300000
-  query_internal_extend_gap_score: -0.100000
+  extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.300000
@@ -2938,7 +2938,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: -0.100000
   open_internal_deletion_score: -0.300000
-  query_internal_extend_gap_score: -0.100000
+  extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.300000
@@ -3178,7 +3178,7 @@ query            22 --AABBBAAAACCCCAAAABB----------BAA--  0
   mismatch_score: -10.000000
   target_gap_function: {gap_score}
   open_internal_deletion_score: 0.000000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: 0.000000
@@ -3614,7 +3614,7 @@ query            13 CCCCAAAABBBAA  0
   mismatch_score: -10.000000
   target_gap_function: {gap_score}
   open_internal_deletion_score: 0.000000
-  query_internal_extend_gap_score: 0.000000
+  extend_internal_deletion_score: 0.000000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
   query_right_open_gap_score: 0.000000
@@ -4466,7 +4466,7 @@ Pairwise sequence aligner with parameters
   open_right_insertion_score: -0.200000
   extend_right_insertion_score: -0.100000
   open_internal_deletion_score: -0.300000
-  query_internal_extend_gap_score: -0.100000
+  extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.300000
@@ -4491,7 +4491,7 @@ class TestPredefinedScoringSchemes(unittest.TestCase):
   open_right_insertion_score: -7.000000
   extend_right_insertion_score: -2.000000
   open_internal_deletion_score: -7.000000
-  query_internal_extend_gap_score: -2.000000
+  extend_internal_deletion_score: -2.000000
   open_left_deletion_score: -7.000000
   extend_left_deletion_score: -2.000000
   query_right_open_gap_score: -7.000000
@@ -4535,7 +4535,7 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
   open_right_insertion_score: -2.500000
   extend_right_insertion_score: -2.500000
   open_internal_deletion_score: -2.500000
-  query_internal_extend_gap_score: -2.500000
+  extend_internal_deletion_score: -2.500000
   open_left_deletion_score: -2.500000
   extend_left_deletion_score: -2.500000
   query_right_open_gap_score: -2.500000
@@ -4579,7 +4579,7 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
   open_right_insertion_score: -12.000000
   extend_right_insertion_score: -1.000000
   open_internal_deletion_score: -12.000000
-  query_internal_extend_gap_score: -1.000000
+  extend_internal_deletion_score: -1.000000
   open_left_deletion_score: -12.000000
   extend_left_deletion_score: -1.000000
   query_right_open_gap_score: -12.000000

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -1162,8 +1162,8 @@ query             2 GA- 0
     def test_match_score_open_penalty3(self):
         aligner = Align.PairwiseAligner()
         aligner.mode = "global"
-        aligner.query_open_gap_score = -0.1
-        aligner.query_extend_gap_score = 0.0
+        aligner.open_deletion_score = -0.1
+        aligner.extend_deletion_score = 0.0
         self.assertEqual(aligner.algorithm, "Gotoh global alignment algorithm")
         self.assertEqual(
             str(aligner),
@@ -1233,8 +1233,8 @@ query             3 GA--T 0
     def test_match_score_open_penalty3_fogsaa(self):
         aligner = Align.PairwiseAligner()
         aligner.mode = "fogsaa"
-        aligner.query_open_gap_score = -0.1
-        aligner.query_extend_gap_score = 0.0
+        aligner.open_deletion_score = -0.1
+        aligner.extend_deletion_score = 0.0
         self.assertEqual(
             aligner.algorithm, "Fast Optimal Global Sequence Alignment Algorithm"
         )
@@ -2015,8 +2015,8 @@ class TestPairwiseSeparateGapPenalties(unittest.TestCase):
         aligner.open_insertion_score = open_score
         aligner.extend_insertion_score = extend_score
         open_score, extend_score = (-0.8, 0)
-        aligner.query_open_gap_score = open_score
-        aligner.query_extend_gap_score = extend_score
+        aligner.open_deletion_score = open_score
+        aligner.extend_deletion_score = extend_score
         self.assertEqual(aligner.algorithm, "Gotoh local alignment algorithm")
         self.assertEqual(
             str(aligner),
@@ -2118,8 +2118,8 @@ query             4 GTCT 0
         aligner.mode = "local"
         aligner.open_insertion_score = -0.3
         aligner.extend_insertion_score = 0.0
-        aligner.query_open_gap_score = -0.2
-        aligner.query_extend_gap_score = 0.0
+        aligner.open_deletion_score = -0.2
+        aligner.extend_deletion_score = 0.0
         self.assertEqual(aligner.algorithm, "Gotoh local alignment algorithm")
         self.assertEqual(
             str(aligner),
@@ -2197,8 +2197,7 @@ class TestPairwiseSeparateGapPenaltiesWithExtension(unittest.TestCase):
         aligner.open_insertion_score = open_score
         aligner.extend_insertion_score = extend_score
         score = -0.1
-        aligner.query_gap_score = score
-        aligner.query_end_gap_score = score
+        aligner.deletion_score = score
         self.assertEqual(aligner.algorithm, "Gotoh local alignment algorithm")
         self.assertEqual(
             str(aligner),
@@ -3075,7 +3074,7 @@ class TestPerSiteGapPenalties(unittest.TestCase):
         aligner.match_score = 1
         aligner.mismatch_score = -1
         aligner.insertion_score = nogaps
-        aligner.query_gap_score = specificgaps
+        aligner.deletion_score = specificgaps
         self.assertEqual(
             str(aligner),
             f"""Pairwise sequence aligner with parameters
@@ -3159,7 +3158,7 @@ query            22 --AABBBAAAACC----------CCAAAABBBAA--  0
         aligner.match_score = 1
         aligner.mismatch_score = -1
         aligner.insertion_score = nogaps
-        aligner.query_gap_score = specificgaps
+        aligner.deletion_score = specificgaps
         self.assertEqual(
             str(aligner),
             f"""Pairwise sequence aligner with parameters
@@ -3323,7 +3322,7 @@ query             6 TTG--GAA 0
                 alignment.aligned, np.array([[[0, 2], [4, 6]], [[6, 4], [2, 0]]])
             )
         )
-        aligner.query_gap_score = gap_score
+        aligner.deletion_score = gap_score
         self.assertEqual(
             str(aligner),
             f"""Pairwise sequence aligner with parameters
@@ -3497,7 +3496,7 @@ query             6 TTG--GAA 0
         aligner.match_score = 1
         aligner.mismatch_score = -1
         aligner.insertion_score = nogaps
-        aligner.query_gap_score = specificgaps
+        aligner.deletion_score = specificgaps
         self.assertEqual(
             aligner.algorithm, "Waterman-Smith-Beyer local alignment algorithm"
         )
@@ -3603,7 +3602,7 @@ query            13 CCCCAAAABBBAA  0
         aligner.match_score = 1
         aligner.mismatch_score = -1
         aligner.insertion_score = nogaps
-        aligner.query_gap_score = specificgaps
+        aligner.deletion_score = specificgaps
         self.assertEqual(
             str(aligner),
             f"""Pairwise sequence aligner with parameters
@@ -3783,7 +3782,7 @@ query             2 AA 0
         self.assertTrue(
             np.array_equal(alignment.aligned, np.array([[[4, 6]], [[2, 0]]]))
         )
-        aligner.query_gap_score = gap_score
+        aligner.deletion_score = gap_score
         self.assertEqual(
             str(aligner),
             f"""Pairwise sequence aligner with parameters
@@ -3870,7 +3869,7 @@ query             2 AA 0
 
         aligner = Align.PairwiseAligner()
         aligner.insertion_score = gap_score
-        aligner.query_gap_score = -1
+        aligner.deletion_score = -1
         aligner.mode = "global"
         with self.assertRaises(RuntimeError):
             aligner.score(seq1, seq2)
@@ -3894,7 +3893,7 @@ query             2 AA 0
             alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
             alignments = list(alignments)
         aligner.insertion_score = -1
-        aligner.query_gap_score = gap_score
+        aligner.deletion_score = gap_score
         aligner.mode = "global"
         with self.assertRaises(RuntimeError):
             aligner.score(seq1, seq2)
@@ -5043,8 +5042,8 @@ class TestAlignmentFormat(unittest.TestCase):
         chromosome = "ACGATCAGCGAGCATNGAGCACTACGACAGCGAGTGACCACTATTCGCGATCAGGAGCAGATACTTTACGAGCATCGGC"
         transcript = "AGCATCGAGCGACTTGAGTACTATTCATACTTTCGAGC"
         aligner = Align.PairwiseAligner()
-        aligner.query_extend_gap_score = 0
-        aligner.query_open_gap_score = -3
+        aligner.extend_deletion_score = 0
+        aligner.open_deletion_score = -3
         aligner.insertion_score = -3
         aligner.end_gap_score = 0
         aligner.mismatch = -1

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -67,7 +67,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: -2.000000
   open_internal_insertion_score: 0.000000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: 0.000000
+  open_left_insertion_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
@@ -110,7 +110,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -5.000000
   extend_internal_insertion_score: -1.000000
-  target_left_open_gap_score: -3.000000
+  open_left_insertion_score: -3.000000
   target_left_extend_gap_score: -9.000000
   target_right_open_gap_score: -3.000000
   target_right_extend_gap_score: -9.000000
@@ -141,7 +141,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(aligner.target_end_open_gap_score, score)
         self.assertAlmostEqual(aligner.target_end_extend_gap_score, score)
         self.assertAlmostEqual(aligner.target_left_gap_score, score)
-        self.assertAlmostEqual(aligner.target_left_open_gap_score, score)
+        self.assertAlmostEqual(aligner.open_left_insertion_score, score)
         self.assertAlmostEqual(aligner.target_left_extend_gap_score, score)
         self.assertAlmostEqual(aligner.target_right_gap_score, score)
         self.assertAlmostEqual(aligner.target_right_open_gap_score, score)
@@ -166,7 +166,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -3.000000
   extend_internal_insertion_score: -3.000000
-  target_left_open_gap_score: -4.000000
+  open_left_insertion_score: -4.000000
   target_left_extend_gap_score: -4.000000
   target_right_open_gap_score: -4.000000
   target_right_extend_gap_score: -4.000000
@@ -219,7 +219,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: 0.000000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: 0.000000
+  open_left_insertion_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
@@ -327,7 +327,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: -1.000000
   open_internal_insertion_score: -5.000000
   extend_internal_insertion_score: -1.000000
-  target_left_open_gap_score: -5.000000
+  open_left_insertion_score: -5.000000
   target_left_extend_gap_score: -1.000000
   target_right_open_gap_score: -5.000000
   target_right_extend_gap_score: -1.000000
@@ -459,7 +459,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: -0.100000
-  target_left_open_gap_score: -0.100000
+  open_left_insertion_score: -0.100000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: -0.100000
@@ -508,7 +508,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: -0.100000
+  open_left_insertion_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
@@ -871,7 +871,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: -1.000000
   open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: -0.100000
+  open_left_insertion_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
@@ -968,7 +968,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: -0.100000
+  open_left_insertion_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
@@ -1067,7 +1067,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: 0.000000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: 0.000000
+  open_left_insertion_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
@@ -1140,7 +1140,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: 0.000000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: 0.000000
+  open_left_insertion_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
@@ -1212,7 +1212,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: -2.000000
   open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: -0.100000
+  open_left_insertion_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
@@ -1317,7 +1317,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -0.500000
-  target_left_open_gap_score: -0.200000
+  open_left_insertion_score: -0.200000
   target_left_extend_gap_score: -0.500000
   target_right_open_gap_score: -0.200000
   target_right_extend_gap_score: -0.500000
@@ -1388,7 +1388,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -1.500000
-  target_left_open_gap_score: -0.200000
+  open_left_insertion_score: -0.200000
   target_left_extend_gap_score: -1.500000
   target_right_open_gap_score: -0.200000
   target_right_extend_gap_score: -1.500000
@@ -1493,7 +1493,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -1.500000
-  target_left_open_gap_score: -0.200000
+  open_left_insertion_score: -0.200000
   target_left_extend_gap_score: -1.500000
   target_right_open_gap_score: -0.200000
   target_right_extend_gap_score: -1.500000
@@ -1566,7 +1566,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -1.700000
   extend_internal_insertion_score: -1.500000
-  target_left_open_gap_score: -1.700000
+  open_left_insertion_score: -1.700000
   target_left_extend_gap_score: -1.500000
   target_right_open_gap_score: -1.700000
   target_right_extend_gap_score: -1.500000
@@ -1639,7 +1639,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -1.700000
   extend_internal_insertion_score: -1.500000
-  target_left_open_gap_score: -1.700000
+  open_left_insertion_score: -1.700000
   target_left_extend_gap_score: -1.500000
   target_right_open_gap_score: -1.700000
   target_right_extend_gap_score: -1.500000
@@ -1714,7 +1714,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -0.800000
-  target_left_open_gap_score: 0.000000
+  open_left_insertion_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
@@ -1844,7 +1844,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -0.800000
-  target_left_open_gap_score: 0.000000
+  open_left_insertion_score: 0.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
@@ -1928,7 +1928,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: -0.300000
+  open_left_insertion_score: -0.300000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: 0.000000
@@ -2031,7 +2031,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: -0.300000
+  open_left_insertion_score: -0.300000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: 0.000000
@@ -2112,7 +2112,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: -0.100000
+  open_left_insertion_score: -0.100000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
@@ -2255,7 +2255,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
   substitution_matrix: <Array object at .*>
   open_internal_insertion_score: -0.500000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: -0.500000
+  open_left_insertion_score: -0.500000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.500000
   target_right_extend_gap_score: 0.000000
@@ -2357,7 +2357,7 @@ query             3 AT-T 0
   substitution_matrix: <Array object at .*>
   open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: -1.000000
+  open_left_insertion_score: -1.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -1.000000
   target_right_extend_gap_score: 0.000000
@@ -2427,7 +2427,7 @@ query             3 ATT 0
   substitution_matrix: <Array object at .*>
   open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: -1.000000
+  open_left_insertion_score: -1.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -1.000000
   target_right_extend_gap_score: 0.000000
@@ -2500,7 +2500,7 @@ query             4 ATA 1
   substitution_matrix: <Array object at .*>
   open_internal_insertion_score: -0.500000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: -0.500000
+  open_left_insertion_score: -0.500000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -0.500000
   target_right_extend_gap_score: 0.000000
@@ -2604,7 +2604,7 @@ query             3 AT-T 0
   substitution_matrix: <Array object at .*
   open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: -1.000000
+  open_left_insertion_score: -1.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -1.000000
   target_right_extend_gap_score: 0.000000
@@ -2676,7 +2676,7 @@ query             3 ATT 0
   substitution_matrix: <Array object at .*>
   open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
-  target_left_open_gap_score: -1.000000
+  open_left_insertion_score: -1.000000
   target_left_extend_gap_score: 0.000000
   target_right_open_gap_score: -1.000000
   target_right_extend_gap_score: 0.000000
@@ -2743,7 +2743,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
-  target_left_open_gap_score: -0.300000
+  open_left_insertion_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
@@ -2790,7 +2790,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
-  target_left_open_gap_score: -0.300000
+  open_left_insertion_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
@@ -2851,7 +2851,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
-  target_left_open_gap_score: -0.300000
+  open_left_insertion_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
@@ -2900,7 +2900,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
-  target_left_open_gap_score: -0.300000
+  open_left_insertion_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
@@ -2933,7 +2933,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
-  target_left_open_gap_score: -0.300000
+  open_left_insertion_score: -0.300000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
@@ -4461,7 +4461,7 @@ Pairwise sequence aligner with parameters
   mismatch_score: 0.000000
   open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -0.100000
-  target_left_open_gap_score: -0.200000
+  open_left_insertion_score: -0.200000
   target_left_extend_gap_score: -0.100000
   target_right_open_gap_score: -0.200000
   target_right_extend_gap_score: -0.100000
@@ -4486,7 +4486,7 @@ class TestPredefinedScoringSchemes(unittest.TestCase):
   substitution_matrix: <Array object at .*
   open_internal_insertion_score: -7.000000
   extend_internal_insertion_score: -2.000000
-  target_left_open_gap_score: -7.000000
+  open_left_insertion_score: -7.000000
   target_left_extend_gap_score: -2.000000
   target_right_open_gap_score: -7.000000
   target_right_extend_gap_score: -2.000000
@@ -4530,7 +4530,7 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
   substitution_matrix: <Array object at .*
   open_internal_insertion_score: -2.500000
   extend_internal_insertion_score: -2.500000
-  target_left_open_gap_score: -2.500000
+  open_left_insertion_score: -2.500000
   target_left_extend_gap_score: -2.500000
   target_right_open_gap_score: -2.500000
   target_right_extend_gap_score: -2.500000
@@ -4574,7 +4574,7 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
   substitution_matrix: <Array object at .*
   open_internal_insertion_score: -12.000000
   extend_internal_insertion_score: -1.000000
-  target_left_open_gap_score: -12.000000
+  open_left_insertion_score: -12.000000
   target_left_extend_gap_score: -1.000000
   target_right_open_gap_score: -12.000000
   target_right_extend_gap_score: -1.000000

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2985,7 +2985,7 @@ class TestPerSiteGapPenalties(unittest.TestCase):
   wildcard: None
   match_score: 1.000000
   mismatch_score: -1.000000
-  target_gap_function: {nogaps}
+  insertion_score_function: {nogaps}
   query_gap_function: {specificgaps}
   mode: global
 """,
@@ -3069,7 +3069,7 @@ query            22 --AABBBAAAACC----------CCAAAABBBAA--  0
   wildcard: None
   match_score: 1.000000
   mismatch_score: -1.000000
-  target_gap_function: {nogaps}
+  insertion_score_function: {nogaps}
   query_gap_function: {specificgaps}
   mode: global
 """,
@@ -3176,7 +3176,7 @@ query            22 --AABBBAAAACCCCAAAABB----------BAA--  0
   wildcard: None
   match_score: 1.000000
   mismatch_score: -10.000000
-  target_gap_function: {gap_score}
+  insertion_score_function: {gap_score}
   open_internal_deletion_score: 0.000000
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: 0.000000
@@ -3233,7 +3233,7 @@ query             6 TTG--GAA 0
   wildcard: None
   match_score: 1.000000
   mismatch_score: -10.000000
-  target_gap_function: {gap_score}
+  insertion_score_function: {gap_score}
   query_gap_function: {gap_score}
   mode: global
 """,
@@ -3410,7 +3410,7 @@ query             6 TTG--GAA 0
   wildcard: None
   match_score: 1.000000
   mismatch_score: -1.000000
-  target_gap_function: {nogaps}
+  insertion_score_function: {nogaps}
   query_gap_function: {specificgaps}
   mode: local
 """,
@@ -3513,7 +3513,7 @@ query            13 CCCCAAAABBBAA  0
   wildcard: None
   match_score: 1.000000
   mismatch_score: -1.000000
-  target_gap_function: {nogaps}
+  insertion_score_function: {nogaps}
   query_gap_function: {specificgaps}
   mode: local
 """,
@@ -3612,7 +3612,7 @@ query            13 CCCCAAAABBBAA  0
   wildcard: None
   match_score: 1.000000
   mismatch_score: -10.000000
-  target_gap_function: {gap_score}
+  insertion_score_function: {gap_score}
   open_internal_deletion_score: 0.000000
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: 0.000000
@@ -3693,7 +3693,7 @@ query             2 AA 0
   wildcard: None
   match_score: 1.000000
   mismatch_score: -10.000000
-  target_gap_function: {gap_score}
+  insertion_score_function: {gap_score}
   query_gap_function: {gap_score}
   mode: local
 """,

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4968,12 +4968,12 @@ class TestAlignerPickling(unittest.TestCase):
         aligner.extend_left_insertion_score = -3
         aligner.open_right_insertion_score = -4.5
         aligner.extend_right_insertion_score = -4.3
-        aligner.query_internal_open_gap_score = -2
-        aligner.query_internal_extend_gap_score = -2.5
-        aligner.query_left_open_gap_score = -9.1
-        aligner.query_left_extend_gap_score = +1.7
-        aligner.query_right_open_gap_score = -1.9
-        aligner.query_right_extend_gap_score = -2.0
+        aligner.open_internal_deletion_score = -2
+        aligner.extend_internal_deletion_score = -2.5
+        aligner.open_left_deletion_score = -9.1
+        aligner.extend_left_deletion_score = +1.7
+        aligner.open_right_deletion_score = -1.9
+        aligner.extend_right_deletion_score = -2.0
         aligner.mode = "global"
         state = pickle.dumps(aligner)
         pickled_aligner = pickle.loads(state)
@@ -5012,27 +5012,27 @@ class TestAlignerPickling(unittest.TestCase):
             pickled_aligner.extend_right_insertion_score,
         )
         self.assertAlmostEqual(
-            aligner.query_internal_open_gap_score,
-            pickled_aligner.query_internal_open_gap_score,
+            aligner.open_internal_deletion_score,
+            pickled_aligner.open_internal_deletion_score,
         )
         self.assertAlmostEqual(
-            aligner.query_internal_extend_gap_score,
-            pickled_aligner.query_internal_extend_gap_score,
+            aligner.extend_internal_deletion_score,
+            pickled_aligner.extend_internal_deletion_score,
         )
         self.assertAlmostEqual(
-            aligner.query_left_open_gap_score, pickled_aligner.query_left_open_gap_score
+            aligner.open_left_deletion_score, pickled_aligner.open_left_deletion_score
         )
         self.assertAlmostEqual(
-            aligner.query_left_extend_gap_score,
-            pickled_aligner.query_left_extend_gap_score,
+            aligner.extend_left_deletion_score,
+            pickled_aligner.extend_left_deletion_score,
         )
         self.assertAlmostEqual(
-            aligner.query_right_open_gap_score,
-            pickled_aligner.query_right_open_gap_score,
+            aligner.open_right_deletion_score,
+            pickled_aligner.open_right_deletion_score,
         )
         self.assertAlmostEqual(
-            aligner.query_right_extend_gap_score,
-            pickled_aligner.query_right_extend_gap_score,
+            aligner.extend_right_deletion_score,
+            pickled_aligner.extend_right_deletion_score,
         )
         self.assertEqual(aligner.mode, pickled_aligner.mode)
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -71,7 +71,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: 0.000000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: 0.000000
+  open_internal_deletion_score: 0.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
@@ -114,7 +114,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -9.000000
   open_right_insertion_score: -3.000000
   extend_right_insertion_score: -9.000000
-  query_internal_open_gap_score: -6.000000
+  open_internal_deletion_score: -6.000000
   query_internal_extend_gap_score: -7.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: -2.000000
@@ -170,7 +170,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -4.000000
   open_right_insertion_score: -4.000000
   extend_right_insertion_score: -4.000000
-  query_internal_open_gap_score: -2.000000
+  open_internal_deletion_score: -2.000000
   query_internal_extend_gap_score: -2.000000
   open_left_deletion_score: -5.000000
   extend_left_deletion_score: -5.000000
@@ -223,7 +223,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: 0.000000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: 0.000000
+  open_internal_deletion_score: 0.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
@@ -331,7 +331,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -1.000000
   open_right_insertion_score: -5.000000
   extend_right_insertion_score: -1.000000
-  query_internal_open_gap_score: -5.000000
+  open_internal_deletion_score: -5.000000
   query_internal_extend_gap_score: -1.000000
   open_left_deletion_score: -5.000000
   extend_left_deletion_score: -1.000000
@@ -463,7 +463,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.100000
   extend_right_insertion_score: -0.100000
-  query_internal_open_gap_score: -0.100000
+  open_internal_deletion_score: -0.100000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: -0.100000
@@ -512,7 +512,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.100000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -0.100000
+  open_internal_deletion_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
@@ -875,7 +875,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.100000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -0.100000
+  open_internal_deletion_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
@@ -972,7 +972,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.100000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -0.100000
+  open_internal_deletion_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
@@ -1071,7 +1071,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: 0.000000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -0.100000
+  open_internal_deletion_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
@@ -1144,7 +1144,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: 0.000000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -0.100000
+  open_internal_deletion_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
@@ -1216,7 +1216,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.100000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -0.100000
+  open_internal_deletion_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
@@ -1321,7 +1321,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -0.500000
   open_right_insertion_score: -0.200000
   extend_right_insertion_score: -0.500000
-  query_internal_open_gap_score: -0.200000
+  open_internal_deletion_score: -0.200000
   query_internal_extend_gap_score: -0.500000
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: -0.500000
@@ -1392,7 +1392,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -1.500000
   open_right_insertion_score: -0.200000
   extend_right_insertion_score: -1.500000
-  query_internal_open_gap_score: -0.200000
+  open_internal_deletion_score: -0.200000
   query_internal_extend_gap_score: -1.500000
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: -1.500000
@@ -1497,7 +1497,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -1.500000
   open_right_insertion_score: -0.200000
   extend_right_insertion_score: -1.500000
-  query_internal_open_gap_score: -0.200000
+  open_internal_deletion_score: -0.200000
   query_internal_extend_gap_score: -1.500000
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: -1.500000
@@ -1570,7 +1570,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -1.500000
   open_right_insertion_score: -1.700000
   extend_right_insertion_score: -1.500000
-  query_internal_open_gap_score: -1.700000
+  open_internal_deletion_score: -1.700000
   query_internal_extend_gap_score: -1.500000
   open_left_deletion_score: -1.700000
   extend_left_deletion_score: -1.500000
@@ -1643,7 +1643,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -1.500000
   open_right_insertion_score: -1.700000
   extend_right_insertion_score: -1.500000
-  query_internal_open_gap_score: -1.700000
+  open_internal_deletion_score: -1.700000
   query_internal_extend_gap_score: -1.500000
   open_left_deletion_score: -1.700000
   extend_left_deletion_score: -1.500000
@@ -1718,7 +1718,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: 0.000000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -0.200000
+  open_internal_deletion_score: -0.200000
   query_internal_extend_gap_score: -0.800000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
@@ -1848,7 +1848,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: 0.000000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -0.200000
+  open_internal_deletion_score: -0.200000
   query_internal_extend_gap_score: -0.800000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
@@ -1932,7 +1932,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -0.800000
+  open_internal_deletion_score: -0.800000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.800000
   extend_left_deletion_score: 0.000000
@@ -2035,7 +2035,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -0.200000
+  open_internal_deletion_score: -0.200000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: 0.000000
@@ -2116,7 +2116,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.100000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -0.100000
+  open_internal_deletion_score: -0.100000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: -0.100000
@@ -2259,7 +2259,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.500000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -0.500000
+  open_internal_deletion_score: -0.500000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.500000
   extend_left_deletion_score: 0.000000
@@ -2361,7 +2361,7 @@ query             3 AT-T 0
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -1.000000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -1.000000
+  open_internal_deletion_score: -1.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
@@ -2431,7 +2431,7 @@ query             3 ATT 0
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -1.000000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -1.000000
+  open_internal_deletion_score: -1.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
@@ -2504,7 +2504,7 @@ query             4 ATA 1
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -0.500000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -0.500000
+  open_internal_deletion_score: -0.500000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.500000
   extend_left_deletion_score: 0.000000
@@ -2608,7 +2608,7 @@ query             3 AT-T 0
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -1.000000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -1.000000
+  open_internal_deletion_score: -1.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
@@ -2680,7 +2680,7 @@ query             3 ATT 0
   extend_left_insertion_score: 0.000000
   open_right_insertion_score: -1.000000
   extend_right_insertion_score: 0.000000
-  query_internal_open_gap_score: -1.000000
+  open_internal_deletion_score: -1.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
@@ -2747,7 +2747,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: -0.100000
-  query_internal_open_gap_score: -0.300000
+  open_internal_deletion_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
@@ -2794,7 +2794,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: -0.100000
-  query_internal_open_gap_score: -0.300000
+  open_internal_deletion_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
@@ -2855,7 +2855,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: -0.100000
-  query_internal_open_gap_score: -0.300000
+  open_internal_deletion_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
@@ -2904,7 +2904,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: -0.100000
-  query_internal_open_gap_score: -0.300000
+  open_internal_deletion_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
@@ -2937,7 +2937,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.300000
   extend_right_insertion_score: -0.100000
-  query_internal_open_gap_score: -0.300000
+  open_internal_deletion_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
@@ -3177,7 +3177,7 @@ query            22 --AABBBAAAACCCCAAAABB----------BAA--  0
   match_score: 1.000000
   mismatch_score: -10.000000
   target_gap_function: {gap_score}
-  query_internal_open_gap_score: 0.000000
+  open_internal_deletion_score: 0.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
@@ -3613,7 +3613,7 @@ query            13 CCCCAAAABBBAA  0
   match_score: 1.000000
   mismatch_score: -10.000000
   target_gap_function: {gap_score}
-  query_internal_open_gap_score: 0.000000
+  open_internal_deletion_score: 0.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
@@ -4465,7 +4465,7 @@ Pairwise sequence aligner with parameters
   extend_left_insertion_score: -0.100000
   open_right_insertion_score: -0.200000
   extend_right_insertion_score: -0.100000
-  query_internal_open_gap_score: -0.300000
+  open_internal_deletion_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
@@ -4490,7 +4490,7 @@ class TestPredefinedScoringSchemes(unittest.TestCase):
   extend_left_insertion_score: -2.000000
   open_right_insertion_score: -7.000000
   extend_right_insertion_score: -2.000000
-  query_internal_open_gap_score: -7.000000
+  open_internal_deletion_score: -7.000000
   query_internal_extend_gap_score: -2.000000
   open_left_deletion_score: -7.000000
   extend_left_deletion_score: -2.000000
@@ -4534,7 +4534,7 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
   extend_left_insertion_score: -2.500000
   open_right_insertion_score: -2.500000
   extend_right_insertion_score: -2.500000
-  query_internal_open_gap_score: -2.500000
+  open_internal_deletion_score: -2.500000
   query_internal_extend_gap_score: -2.500000
   open_left_deletion_score: -2.500000
   extend_left_deletion_score: -2.500000
@@ -4578,7 +4578,7 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
   extend_left_insertion_score: -1.000000
   open_right_insertion_score: -12.000000
   extend_right_insertion_score: -1.000000
-  query_internal_open_gap_score: -12.000000
+  open_internal_deletion_score: -12.000000
   query_internal_extend_gap_score: -1.000000
   open_left_deletion_score: -12.000000
   extend_left_deletion_score: -1.000000

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -74,7 +74,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: 0.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: 0.000000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: 0.000000
   query_right_extend_gap_score: 0.000000
   mode: global
@@ -117,7 +117,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -6.000000
   query_internal_extend_gap_score: -7.000000
   open_left_deletion_score: -1.000000
-  query_left_extend_gap_score: -2.000000
+  extend_left_deletion_score: -2.000000
   query_right_open_gap_score: -1.000000
   query_right_extend_gap_score: -2.000000
   mode: global
@@ -173,7 +173,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -2.000000
   query_internal_extend_gap_score: -2.000000
   open_left_deletion_score: -5.000000
-  query_left_extend_gap_score: -5.000000
+  extend_left_deletion_score: -5.000000
   query_right_open_gap_score: -5.000000
   query_right_extend_gap_score: -5.000000
   mode: global
@@ -226,7 +226,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: 0.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: 0.000000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: 0.000000
   query_right_extend_gap_score: 0.000000
   mode: global
@@ -334,7 +334,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -5.000000
   query_internal_extend_gap_score: -1.000000
   open_left_deletion_score: -5.000000
-  query_left_extend_gap_score: -1.000000
+  extend_left_deletion_score: -1.000000
   query_right_open_gap_score: -5.000000
   query_right_extend_gap_score: -1.000000
   mode: global
@@ -466,7 +466,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.100000
-  query_left_extend_gap_score: -0.100000
+  extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: -0.100000
   mode: local
@@ -515,7 +515,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.100000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: 0.000000
   mode: local
@@ -878,7 +878,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.100000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: 0.000000
   mode: global
@@ -975,7 +975,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.100000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: 0.000000
   mode: global
@@ -1074,7 +1074,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.100000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: 0.000000
   mode: global
@@ -1147,7 +1147,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.100000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: 0.000000
   mode: fogsaa
@@ -1219,7 +1219,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.100000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: 0.000000
   mode: global
@@ -1324,7 +1324,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -0.500000
   open_left_deletion_score: -0.200000
-  query_left_extend_gap_score: -0.500000
+  extend_left_deletion_score: -0.500000
   query_right_open_gap_score: -0.200000
   query_right_extend_gap_score: -0.500000
   mode: global
@@ -1395,7 +1395,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -1.500000
   open_left_deletion_score: -0.200000
-  query_left_extend_gap_score: -1.500000
+  extend_left_deletion_score: -1.500000
   query_right_open_gap_score: -0.200000
   query_right_extend_gap_score: -1.500000
   mode: global
@@ -1500,7 +1500,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -1.500000
   open_left_deletion_score: -0.200000
-  query_left_extend_gap_score: -1.500000
+  extend_left_deletion_score: -1.500000
   query_right_open_gap_score: -0.200000
   query_right_extend_gap_score: -1.500000
   mode: fogsaa
@@ -1573,7 +1573,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -1.700000
   query_internal_extend_gap_score: -1.500000
   open_left_deletion_score: -1.700000
-  query_left_extend_gap_score: -1.500000
+  extend_left_deletion_score: -1.500000
   query_right_open_gap_score: -1.700000
   query_right_extend_gap_score: -1.500000
   mode: global
@@ -1646,7 +1646,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -1.700000
   query_internal_extend_gap_score: -1.500000
   open_left_deletion_score: -1.700000
-  query_left_extend_gap_score: -1.500000
+  extend_left_deletion_score: -1.500000
   query_right_open_gap_score: -1.700000
   query_right_extend_gap_score: -1.500000
   mode: fogsaa
@@ -1721,7 +1721,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -0.800000
   open_left_deletion_score: 0.000000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: 0.000000
   query_right_extend_gap_score: 0.000000
   mode: global
@@ -1851,7 +1851,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -0.800000
   open_left_deletion_score: 0.000000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: 0.000000
   query_right_extend_gap_score: 0.000000
   mode: fogsaa
@@ -1935,7 +1935,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.800000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.800000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.800000
   query_right_extend_gap_score: 0.000000
   mode: local
@@ -2038,7 +2038,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.200000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.200000
   query_right_extend_gap_score: 0.000000
   mode: local
@@ -2119,7 +2119,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.100000
-  query_left_extend_gap_score: -0.100000
+  extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: -0.100000
   mode: local
@@ -2262,7 +2262,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
   query_internal_open_gap_score: -0.500000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.500000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.500000
   query_right_extend_gap_score: 0.000000
   mode: local
@@ -2364,7 +2364,7 @@ query             3 AT-T 0
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -1.000000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -1.000000
   query_right_extend_gap_score: 0.000000
   mode: local
@@ -2434,7 +2434,7 @@ query             3 ATT 0
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -1.000000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -1.000000
   query_right_extend_gap_score: 0.000000
   mode: local
@@ -2507,7 +2507,7 @@ query             4 ATA 1
   query_internal_open_gap_score: -0.500000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -0.500000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -0.500000
   query_right_extend_gap_score: 0.000000
   mode: local
@@ -2611,7 +2611,7 @@ query             3 AT-T 0
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -1.000000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -1.000000
   query_right_extend_gap_score: 0.000000
   mode: local
@@ -2683,7 +2683,7 @@ query             3 ATT 0
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: -1.000000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: -1.000000
   query_right_extend_gap_score: 0.000000
   mode: local
@@ -2750,7 +2750,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.300000
-  query_left_extend_gap_score: -0.100000
+  extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.300000
   query_right_extend_gap_score: -0.100000
   mode: local
@@ -2797,7 +2797,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.300000
-  query_left_extend_gap_score: -0.100000
+  extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.300000
   query_right_extend_gap_score: -0.100000
   mode: local
@@ -2858,7 +2858,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.300000
-  query_left_extend_gap_score: -0.100000
+  extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.300000
   query_right_extend_gap_score: -0.100000
   mode: global
@@ -2907,7 +2907,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.300000
-  query_left_extend_gap_score: -0.100000
+  extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.300000
   query_right_extend_gap_score: -0.100000
   mode: global
@@ -2940,7 +2940,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.300000
-  query_left_extend_gap_score: -0.100000
+  extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.300000
   query_right_extend_gap_score: -0.100000
   mode: fogsaa
@@ -3180,7 +3180,7 @@ query            22 --AABBBAAAACCCCAAAABB----------BAA--  0
   query_internal_open_gap_score: 0.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: 0.000000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: 0.000000
   query_right_extend_gap_score: 0.000000
   mode: global
@@ -3616,7 +3616,7 @@ query            13 CCCCAAAABBBAA  0
   query_internal_open_gap_score: 0.000000
   query_internal_extend_gap_score: 0.000000
   open_left_deletion_score: 0.000000
-  query_left_extend_gap_score: 0.000000
+  extend_left_deletion_score: 0.000000
   query_right_open_gap_score: 0.000000
   query_right_extend_gap_score: 0.000000
   mode: local
@@ -4468,7 +4468,7 @@ Pairwise sequence aligner with parameters
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
   open_left_deletion_score: -0.300000
-  query_left_extend_gap_score: -0.100000
+  extend_left_deletion_score: -0.100000
   query_right_open_gap_score: -0.300000
   query_right_extend_gap_score: -0.100000
   mode: local
@@ -4493,7 +4493,7 @@ class TestPredefinedScoringSchemes(unittest.TestCase):
   query_internal_open_gap_score: -7.000000
   query_internal_extend_gap_score: -2.000000
   open_left_deletion_score: -7.000000
-  query_left_extend_gap_score: -2.000000
+  extend_left_deletion_score: -2.000000
   query_right_open_gap_score: -7.000000
   query_right_extend_gap_score: -2.000000
   mode: global
@@ -4537,7 +4537,7 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
   query_internal_open_gap_score: -2.500000
   query_internal_extend_gap_score: -2.500000
   open_left_deletion_score: -2.500000
-  query_left_extend_gap_score: -2.500000
+  extend_left_deletion_score: -2.500000
   query_right_open_gap_score: -2.500000
   query_right_extend_gap_score: -2.500000
   mode: global
@@ -4581,7 +4581,7 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
   query_internal_open_gap_score: -12.000000
   query_internal_extend_gap_score: -1.000000
   open_left_deletion_score: -12.000000
-  query_left_extend_gap_score: -1.000000
+  extend_left_deletion_score: -1.000000
   query_right_open_gap_score: -12.000000
   query_right_extend_gap_score: -1.000000
   mode: global

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -73,7 +73,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: 0.000000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: 0.000000
+  open_left_deletion_score: 0.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: 0.000000
   query_right_extend_gap_score: 0.000000
@@ -116,7 +116,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -9.000000
   query_internal_open_gap_score: -6.000000
   query_internal_extend_gap_score: -7.000000
-  query_left_open_gap_score: -1.000000
+  open_left_deletion_score: -1.000000
   query_left_extend_gap_score: -2.000000
   query_right_open_gap_score: -1.000000
   query_right_extend_gap_score: -2.000000
@@ -172,7 +172,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -4.000000
   query_internal_open_gap_score: -2.000000
   query_internal_extend_gap_score: -2.000000
-  query_left_open_gap_score: -5.000000
+  open_left_deletion_score: -5.000000
   query_left_extend_gap_score: -5.000000
   query_right_open_gap_score: -5.000000
   query_right_extend_gap_score: -5.000000
@@ -225,7 +225,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: 0.000000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: 0.000000
+  open_left_deletion_score: 0.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: 0.000000
   query_right_extend_gap_score: 0.000000
@@ -333,7 +333,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -1.000000
   query_internal_open_gap_score: -5.000000
   query_internal_extend_gap_score: -1.000000
-  query_left_open_gap_score: -5.000000
+  open_left_deletion_score: -5.000000
   query_left_extend_gap_score: -1.000000
   query_right_open_gap_score: -5.000000
   query_right_extend_gap_score: -1.000000
@@ -465,7 +465,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: -0.100000
-  query_left_open_gap_score: -0.100000
+  open_left_deletion_score: -0.100000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: -0.100000
@@ -514,7 +514,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -0.100000
+  open_left_deletion_score: -0.100000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: 0.000000
@@ -877,7 +877,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -0.100000
+  open_left_deletion_score: -0.100000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: 0.000000
@@ -974,7 +974,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -0.100000
+  open_left_deletion_score: -0.100000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: 0.000000
@@ -1073,7 +1073,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -0.100000
+  open_left_deletion_score: -0.100000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: 0.000000
@@ -1146,7 +1146,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -0.100000
+  open_left_deletion_score: -0.100000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: 0.000000
@@ -1218,7 +1218,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -0.100000
+  open_left_deletion_score: -0.100000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: 0.000000
@@ -1323,7 +1323,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -0.500000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -0.500000
-  query_left_open_gap_score: -0.200000
+  open_left_deletion_score: -0.200000
   query_left_extend_gap_score: -0.500000
   query_right_open_gap_score: -0.200000
   query_right_extend_gap_score: -0.500000
@@ -1394,7 +1394,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -1.500000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -1.500000
-  query_left_open_gap_score: -0.200000
+  open_left_deletion_score: -0.200000
   query_left_extend_gap_score: -1.500000
   query_right_open_gap_score: -0.200000
   query_right_extend_gap_score: -1.500000
@@ -1499,7 +1499,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -1.500000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -1.500000
-  query_left_open_gap_score: -0.200000
+  open_left_deletion_score: -0.200000
   query_left_extend_gap_score: -1.500000
   query_right_open_gap_score: -0.200000
   query_right_extend_gap_score: -1.500000
@@ -1572,7 +1572,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -1.500000
   query_internal_open_gap_score: -1.700000
   query_internal_extend_gap_score: -1.500000
-  query_left_open_gap_score: -1.700000
+  open_left_deletion_score: -1.700000
   query_left_extend_gap_score: -1.500000
   query_right_open_gap_score: -1.700000
   query_right_extend_gap_score: -1.500000
@@ -1645,7 +1645,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -1.500000
   query_internal_open_gap_score: -1.700000
   query_internal_extend_gap_score: -1.500000
-  query_left_open_gap_score: -1.700000
+  open_left_deletion_score: -1.700000
   query_left_extend_gap_score: -1.500000
   query_right_open_gap_score: -1.700000
   query_right_extend_gap_score: -1.500000
@@ -1720,7 +1720,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -0.800000
-  query_left_open_gap_score: 0.000000
+  open_left_deletion_score: 0.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: 0.000000
   query_right_extend_gap_score: 0.000000
@@ -1850,7 +1850,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: -0.800000
-  query_left_open_gap_score: 0.000000
+  open_left_deletion_score: 0.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: 0.000000
   query_right_extend_gap_score: 0.000000
@@ -1934,7 +1934,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.800000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -0.800000
+  open_left_deletion_score: -0.800000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.800000
   query_right_extend_gap_score: 0.000000
@@ -2037,7 +2037,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.200000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -0.200000
+  open_left_deletion_score: -0.200000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.200000
   query_right_extend_gap_score: 0.000000
@@ -2118,7 +2118,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.100000
   query_internal_extend_gap_score: -0.100000
-  query_left_open_gap_score: -0.100000
+  open_left_deletion_score: -0.100000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.100000
   query_right_extend_gap_score: -0.100000
@@ -2261,7 +2261,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.500000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -0.500000
+  open_left_deletion_score: -0.500000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.500000
   query_right_extend_gap_score: 0.000000
@@ -2363,7 +2363,7 @@ query             3 AT-T 0
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -1.000000
+  open_left_deletion_score: -1.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -1.000000
   query_right_extend_gap_score: 0.000000
@@ -2433,7 +2433,7 @@ query             3 ATT 0
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -1.000000
+  open_left_deletion_score: -1.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -1.000000
   query_right_extend_gap_score: 0.000000
@@ -2506,7 +2506,7 @@ query             4 ATA 1
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -0.500000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -0.500000
+  open_left_deletion_score: -0.500000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -0.500000
   query_right_extend_gap_score: 0.000000
@@ -2610,7 +2610,7 @@ query             3 AT-T 0
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -1.000000
+  open_left_deletion_score: -1.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -1.000000
   query_right_extend_gap_score: 0.000000
@@ -2682,7 +2682,7 @@ query             3 ATT 0
   extend_right_insertion_score: 0.000000
   query_internal_open_gap_score: -1.000000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: -1.000000
+  open_left_deletion_score: -1.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: -1.000000
   query_right_extend_gap_score: 0.000000
@@ -2749,7 +2749,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
-  query_left_open_gap_score: -0.300000
+  open_left_deletion_score: -0.300000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.300000
   query_right_extend_gap_score: -0.100000
@@ -2796,7 +2796,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
-  query_left_open_gap_score: -0.300000
+  open_left_deletion_score: -0.300000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.300000
   query_right_extend_gap_score: -0.100000
@@ -2857,7 +2857,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
-  query_left_open_gap_score: -0.300000
+  open_left_deletion_score: -0.300000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.300000
   query_right_extend_gap_score: -0.100000
@@ -2906,7 +2906,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
-  query_left_open_gap_score: -0.300000
+  open_left_deletion_score: -0.300000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.300000
   query_right_extend_gap_score: -0.100000
@@ -2939,7 +2939,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
-  query_left_open_gap_score: -0.300000
+  open_left_deletion_score: -0.300000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.300000
   query_right_extend_gap_score: -0.100000
@@ -3179,7 +3179,7 @@ query            22 --AABBBAAAACCCCAAAABB----------BAA--  0
   target_gap_function: {gap_score}
   query_internal_open_gap_score: 0.000000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: 0.000000
+  open_left_deletion_score: 0.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: 0.000000
   query_right_extend_gap_score: 0.000000
@@ -3615,7 +3615,7 @@ query            13 CCCCAAAABBBAA  0
   target_gap_function: {gap_score}
   query_internal_open_gap_score: 0.000000
   query_internal_extend_gap_score: 0.000000
-  query_left_open_gap_score: 0.000000
+  open_left_deletion_score: 0.000000
   query_left_extend_gap_score: 0.000000
   query_right_open_gap_score: 0.000000
   query_right_extend_gap_score: 0.000000
@@ -4467,7 +4467,7 @@ Pairwise sequence aligner with parameters
   extend_right_insertion_score: -0.100000
   query_internal_open_gap_score: -0.300000
   query_internal_extend_gap_score: -0.100000
-  query_left_open_gap_score: -0.300000
+  open_left_deletion_score: -0.300000
   query_left_extend_gap_score: -0.100000
   query_right_open_gap_score: -0.300000
   query_right_extend_gap_score: -0.100000
@@ -4492,7 +4492,7 @@ class TestPredefinedScoringSchemes(unittest.TestCase):
   extend_right_insertion_score: -2.000000
   query_internal_open_gap_score: -7.000000
   query_internal_extend_gap_score: -2.000000
-  query_left_open_gap_score: -7.000000
+  open_left_deletion_score: -7.000000
   query_left_extend_gap_score: -2.000000
   query_right_open_gap_score: -7.000000
   query_right_extend_gap_score: -2.000000
@@ -4536,7 +4536,7 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
   extend_right_insertion_score: -2.500000
   query_internal_open_gap_score: -2.500000
   query_internal_extend_gap_score: -2.500000
-  query_left_open_gap_score: -2.500000
+  open_left_deletion_score: -2.500000
   query_left_extend_gap_score: -2.500000
   query_right_open_gap_score: -2.500000
   query_right_extend_gap_score: -2.500000
@@ -4580,7 +4580,7 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
   extend_right_insertion_score: -1.000000
   query_internal_open_gap_score: -12.000000
   query_internal_extend_gap_score: -1.000000
-  query_left_open_gap_score: -12.000000
+  open_left_deletion_score: -12.000000
   query_left_extend_gap_score: -1.000000
   query_right_open_gap_score: -12.000000
   query_right_extend_gap_score: -1.000000

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -75,7 +75,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: 0.000000
+  open_right_deletion_score: 0.000000
   query_right_extend_gap_score: 0.000000
   mode: global
 """,
@@ -118,7 +118,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -7.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: -2.000000
-  query_right_open_gap_score: -1.000000
+  open_right_deletion_score: -1.000000
   query_right_extend_gap_score: -2.000000
   mode: global
 """,
@@ -174,7 +174,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -2.000000
   open_left_deletion_score: -5.000000
   extend_left_deletion_score: -5.000000
-  query_right_open_gap_score: -5.000000
+  open_right_deletion_score: -5.000000
   query_right_extend_gap_score: -5.000000
   mode: global
 """,
@@ -227,7 +227,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: 0.000000
+  open_right_deletion_score: 0.000000
   query_right_extend_gap_score: 0.000000
   mode: global
 """,
@@ -335,7 +335,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -1.000000
   open_left_deletion_score: -5.000000
   extend_left_deletion_score: -1.000000
-  query_right_open_gap_score: -5.000000
+  open_right_deletion_score: -5.000000
   query_right_extend_gap_score: -1.000000
   mode: global
 """,
@@ -467,7 +467,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: -0.100000
-  query_right_open_gap_score: -0.100000
+  open_right_deletion_score: -0.100000
   query_right_extend_gap_score: -0.100000
   mode: local
 """,
@@ -516,7 +516,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -0.100000
+  open_right_deletion_score: -0.100000
   query_right_extend_gap_score: 0.000000
   mode: local
 """,
@@ -879,7 +879,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -0.100000
+  open_right_deletion_score: -0.100000
   query_right_extend_gap_score: 0.000000
   mode: global
 """,
@@ -976,7 +976,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -0.100000
+  open_right_deletion_score: -0.100000
   query_right_extend_gap_score: 0.000000
   mode: global
 """,
@@ -1075,7 +1075,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -0.100000
+  open_right_deletion_score: -0.100000
   query_right_extend_gap_score: 0.000000
   mode: global
 """,
@@ -1148,7 +1148,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -0.100000
+  open_right_deletion_score: -0.100000
   query_right_extend_gap_score: 0.000000
   mode: fogsaa
 """,
@@ -1220,7 +1220,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -0.100000
+  open_right_deletion_score: -0.100000
   query_right_extend_gap_score: 0.000000
   mode: global
 """,
@@ -1325,7 +1325,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -0.500000
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: -0.500000
-  query_right_open_gap_score: -0.200000
+  open_right_deletion_score: -0.200000
   query_right_extend_gap_score: -0.500000
   mode: global
 """,
@@ -1396,7 +1396,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -1.500000
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: -1.500000
-  query_right_open_gap_score: -0.200000
+  open_right_deletion_score: -0.200000
   query_right_extend_gap_score: -1.500000
   mode: global
 """,
@@ -1501,7 +1501,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -1.500000
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: -1.500000
-  query_right_open_gap_score: -0.200000
+  open_right_deletion_score: -0.200000
   query_right_extend_gap_score: -1.500000
   mode: fogsaa
 """,
@@ -1574,7 +1574,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -1.500000
   open_left_deletion_score: -1.700000
   extend_left_deletion_score: -1.500000
-  query_right_open_gap_score: -1.700000
+  open_right_deletion_score: -1.700000
   query_right_extend_gap_score: -1.500000
   mode: global
 """,
@@ -1647,7 +1647,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -1.500000
   open_left_deletion_score: -1.700000
   extend_left_deletion_score: -1.500000
-  query_right_open_gap_score: -1.700000
+  open_right_deletion_score: -1.700000
   query_right_extend_gap_score: -1.500000
   mode: fogsaa
 """,
@@ -1722,7 +1722,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -0.800000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: 0.000000
+  open_right_deletion_score: 0.000000
   query_right_extend_gap_score: 0.000000
   mode: global
 """,
@@ -1852,7 +1852,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -0.800000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: 0.000000
+  open_right_deletion_score: 0.000000
   query_right_extend_gap_score: 0.000000
   mode: fogsaa
 """,
@@ -1936,7 +1936,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.800000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -0.800000
+  open_right_deletion_score: -0.800000
   query_right_extend_gap_score: 0.000000
   mode: local
 """,
@@ -2039,7 +2039,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -0.200000
+  open_right_deletion_score: -0.200000
   query_right_extend_gap_score: 0.000000
   mode: local
 """,
@@ -2120,7 +2120,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: -0.100000
-  query_right_open_gap_score: -0.100000
+  open_right_deletion_score: -0.100000
   query_right_extend_gap_score: -0.100000
   mode: local
 """,
@@ -2263,7 +2263,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.500000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -0.500000
+  open_right_deletion_score: -0.500000
   query_right_extend_gap_score: 0.000000
   mode: local
 $""",
@@ -2365,7 +2365,7 @@ query             3 AT-T 0
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -1.000000
+  open_right_deletion_score: -1.000000
   query_right_extend_gap_score: 0.000000
   mode: local
 $""",
@@ -2435,7 +2435,7 @@ query             3 ATT 0
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -1.000000
+  open_right_deletion_score: -1.000000
   query_right_extend_gap_score: 0.000000
   mode: local
 $""",
@@ -2508,7 +2508,7 @@ query             4 ATA 1
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -0.500000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -0.500000
+  open_right_deletion_score: -0.500000
   query_right_extend_gap_score: 0.000000
   mode: local
 $""",
@@ -2612,7 +2612,7 @@ query             3 AT-T 0
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -1.000000
+  open_right_deletion_score: -1.000000
   query_right_extend_gap_score: 0.000000
   mode: local
 $""",
@@ -2684,7 +2684,7 @@ query             3 ATT 0
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: -1.000000
+  open_right_deletion_score: -1.000000
   query_right_extend_gap_score: 0.000000
   mode: local
 $""",
@@ -2751,7 +2751,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
-  query_right_open_gap_score: -0.300000
+  open_right_deletion_score: -0.300000
   query_right_extend_gap_score: -0.100000
   mode: local
 """,
@@ -2798,7 +2798,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
-  query_right_open_gap_score: -0.300000
+  open_right_deletion_score: -0.300000
   query_right_extend_gap_score: -0.100000
   mode: local
 """,
@@ -2859,7 +2859,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
-  query_right_open_gap_score: -0.300000
+  open_right_deletion_score: -0.300000
   query_right_extend_gap_score: -0.100000
   mode: global
 """,
@@ -2908,7 +2908,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
-  query_right_open_gap_score: -0.300000
+  open_right_deletion_score: -0.300000
   query_right_extend_gap_score: -0.100000
   mode: global
 """,
@@ -2941,7 +2941,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
-  query_right_open_gap_score: -0.300000
+  open_right_deletion_score: -0.300000
   query_right_extend_gap_score: -0.100000
   mode: fogsaa
 """,
@@ -3181,7 +3181,7 @@ query            22 --AABBBAAAACCCCAAAABB----------BAA--  0
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: 0.000000
+  open_right_deletion_score: 0.000000
   query_right_extend_gap_score: 0.000000
   mode: global
 """,
@@ -3617,7 +3617,7 @@ query            13 CCCCAAAABBBAA  0
   extend_internal_deletion_score: 0.000000
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
-  query_right_open_gap_score: 0.000000
+  open_right_deletion_score: 0.000000
   query_right_extend_gap_score: 0.000000
   mode: local
 """,
@@ -4469,7 +4469,7 @@ Pairwise sequence aligner with parameters
   extend_internal_deletion_score: -0.100000
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
-  query_right_open_gap_score: -0.300000
+  open_right_deletion_score: -0.300000
   query_right_extend_gap_score: -0.100000
   mode: local
 """,
@@ -4494,7 +4494,7 @@ class TestPredefinedScoringSchemes(unittest.TestCase):
   extend_internal_deletion_score: -2.000000
   open_left_deletion_score: -7.000000
   extend_left_deletion_score: -2.000000
-  query_right_open_gap_score: -7.000000
+  open_right_deletion_score: -7.000000
   query_right_extend_gap_score: -2.000000
   mode: global
 $""",
@@ -4538,7 +4538,7 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
   extend_internal_deletion_score: -2.500000
   open_left_deletion_score: -2.500000
   extend_left_deletion_score: -2.500000
-  query_right_open_gap_score: -2.500000
+  open_right_deletion_score: -2.500000
   query_right_extend_gap_score: -2.500000
   mode: global
 $""",
@@ -4582,7 +4582,7 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
   extend_internal_deletion_score: -1.000000
   open_left_deletion_score: -12.000000
   extend_left_deletion_score: -1.000000
-  query_right_open_gap_score: -12.000000
+  open_right_deletion_score: -12.000000
   query_right_extend_gap_score: -1.000000
   mode: global
 $""",

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -76,7 +76,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: 0.000000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: global
 """,
         )
@@ -119,7 +119,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: -2.000000
   open_right_deletion_score: -1.000000
-  query_right_extend_gap_score: -2.000000
+  extend_right_deletion_score: -2.000000
   mode: global
 """,
         )
@@ -175,7 +175,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -5.000000
   extend_left_deletion_score: -5.000000
   open_right_deletion_score: -5.000000
-  query_right_extend_gap_score: -5.000000
+  extend_right_deletion_score: -5.000000
   mode: global
 """,
         )
@@ -228,7 +228,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: 0.000000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: global
 """,
         )
@@ -336,7 +336,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -5.000000
   extend_left_deletion_score: -1.000000
   open_right_deletion_score: -5.000000
-  query_right_extend_gap_score: -1.000000
+  extend_right_deletion_score: -1.000000
   mode: global
 """,
         )
@@ -468,7 +468,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: -0.100000
   open_right_deletion_score: -0.100000
-  query_right_extend_gap_score: -0.100000
+  extend_right_deletion_score: -0.100000
   mode: local
 """,
         )
@@ -517,7 +517,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -0.100000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: local
 """,
         )
@@ -880,7 +880,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -0.100000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: global
 """,
         )
@@ -977,7 +977,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -0.100000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: global
 """,
         )
@@ -1076,7 +1076,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -0.100000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: global
 """,
         )
@@ -1149,7 +1149,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -0.100000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: fogsaa
 """,
         )
@@ -1221,7 +1221,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -0.100000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: global
 """,
         )
@@ -1326,7 +1326,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: -0.500000
   open_right_deletion_score: -0.200000
-  query_right_extend_gap_score: -0.500000
+  extend_right_deletion_score: -0.500000
   mode: global
 """,
         )
@@ -1397,7 +1397,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: -1.500000
   open_right_deletion_score: -0.200000
-  query_right_extend_gap_score: -1.500000
+  extend_right_deletion_score: -1.500000
   mode: global
 """,
         )
@@ -1502,7 +1502,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: -1.500000
   open_right_deletion_score: -0.200000
-  query_right_extend_gap_score: -1.500000
+  extend_right_deletion_score: -1.500000
   mode: fogsaa
 """,
         )
@@ -1575,7 +1575,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -1.700000
   extend_left_deletion_score: -1.500000
   open_right_deletion_score: -1.700000
-  query_right_extend_gap_score: -1.500000
+  extend_right_deletion_score: -1.500000
   mode: global
 """,
         )
@@ -1648,7 +1648,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -1.700000
   extend_left_deletion_score: -1.500000
   open_right_deletion_score: -1.700000
-  query_right_extend_gap_score: -1.500000
+  extend_right_deletion_score: -1.500000
   mode: fogsaa
 """,
         )
@@ -1723,7 +1723,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: 0.000000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: global
 """,
         )
@@ -1853,7 +1853,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: 0.000000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: fogsaa
 """,
         )
@@ -1937,7 +1937,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.800000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -0.800000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: local
 """,
         )
@@ -2040,7 +2040,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.200000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -0.200000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: local
 """,
         )
@@ -2121,7 +2121,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.100000
   extend_left_deletion_score: -0.100000
   open_right_deletion_score: -0.100000
-  query_right_extend_gap_score: -0.100000
+  extend_right_deletion_score: -0.100000
   mode: local
 """,
         )
@@ -2264,7 +2264,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
   open_left_deletion_score: -0.500000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -0.500000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: local
 $""",
         )
@@ -2366,7 +2366,7 @@ query             3 AT-T 0
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -1.000000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: local
 $""",
         )
@@ -2436,7 +2436,7 @@ query             3 ATT 0
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -1.000000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: local
 $""",
         )
@@ -2509,7 +2509,7 @@ query             4 ATA 1
   open_left_deletion_score: -0.500000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -0.500000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: local
 $""",
         )
@@ -2613,7 +2613,7 @@ query             3 AT-T 0
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -1.000000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: local
 $""",
         )
@@ -2685,7 +2685,7 @@ query             3 ATT 0
   open_left_deletion_score: -1.000000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: -1.000000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: local
 $""",
         )
@@ -2752,7 +2752,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
   open_right_deletion_score: -0.300000
-  query_right_extend_gap_score: -0.100000
+  extend_right_deletion_score: -0.100000
   mode: local
 """,
         )
@@ -2799,7 +2799,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
   open_right_deletion_score: -0.300000
-  query_right_extend_gap_score: -0.100000
+  extend_right_deletion_score: -0.100000
   mode: local
 """,
         )
@@ -2860,7 +2860,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
   open_right_deletion_score: -0.300000
-  query_right_extend_gap_score: -0.100000
+  extend_right_deletion_score: -0.100000
   mode: global
 """,
         )
@@ -2909,7 +2909,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
   open_right_deletion_score: -0.300000
-  query_right_extend_gap_score: -0.100000
+  extend_right_deletion_score: -0.100000
   mode: global
 """,
         )
@@ -2942,7 +2942,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
   open_right_deletion_score: -0.300000
-  query_right_extend_gap_score: -0.100000
+  extend_right_deletion_score: -0.100000
   mode: fogsaa
 """,
         )
@@ -3182,7 +3182,7 @@ query            22 --AABBBAAAACCCCAAAABB----------BAA--  0
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: 0.000000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: global
 """,
         )
@@ -3618,7 +3618,7 @@ query            13 CCCCAAAABBBAA  0
   open_left_deletion_score: 0.000000
   extend_left_deletion_score: 0.000000
   open_right_deletion_score: 0.000000
-  query_right_extend_gap_score: 0.000000
+  extend_right_deletion_score: 0.000000
   mode: local
 """,
         )
@@ -4470,7 +4470,7 @@ Pairwise sequence aligner with parameters
   open_left_deletion_score: -0.300000
   extend_left_deletion_score: -0.100000
   open_right_deletion_score: -0.300000
-  query_right_extend_gap_score: -0.100000
+  extend_right_deletion_score: -0.100000
   mode: local
 """,
         )
@@ -4495,7 +4495,7 @@ class TestPredefinedScoringSchemes(unittest.TestCase):
   open_left_deletion_score: -7.000000
   extend_left_deletion_score: -2.000000
   open_right_deletion_score: -7.000000
-  query_right_extend_gap_score: -2.000000
+  extend_right_deletion_score: -2.000000
   mode: global
 $""",
         )
@@ -4539,7 +4539,7 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
   open_left_deletion_score: -2.500000
   extend_left_deletion_score: -2.500000
   open_right_deletion_score: -2.500000
-  query_right_extend_gap_score: -2.500000
+  extend_right_deletion_score: -2.500000
   mode: global
 $""",
         )
@@ -4583,7 +4583,7 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
   open_left_deletion_score: -12.000000
   extend_left_deletion_score: -1.000000
   open_right_deletion_score: -12.000000
-  query_right_extend_gap_score: -1.000000
+  extend_right_deletion_score: -1.000000
   mode: global
 $""",
         )

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -764,6 +764,7 @@ Pairwise sequence aligner with parameters
 
         def gap_function1(x, y):
             return x + y
+
         with self.assertWarns(BiopythonDeprecationWarning):
             aligner.query_gap_score = gap_function1
         gap_function = aligner.deletion_score
@@ -771,11 +772,13 @@ Pairwise sequence aligner with parameters
 
         def gap_function2(x, y):
             return x * y
+
         aligner.deletion_score = gap_function2
         self.assertEqual(aligner.deletion_score, gap_function2)
 
         def gap_function3(x, y):
             return x / y
+
         aligner.deletion_score = gap_function3
         with self.assertWarns(BiopythonDeprecationWarning):
             gap_function = aligner.query_gap_score
@@ -783,6 +786,7 @@ Pairwise sequence aligner with parameters
 
         def gap_function4(x, y):
             return x / y - 9
+
         with self.assertWarns(BiopythonDeprecationWarning):
             aligner.query_gap_score = gap_function4
         with self.assertWarns(BiopythonDeprecationWarning):
@@ -791,6 +795,7 @@ Pairwise sequence aligner with parameters
 
         def gap_function5(x, y):
             return x + 2 * y
+
         with self.assertWarns(BiopythonDeprecationWarning):
             aligner.target_gap_score = gap_function5
         gap_function = aligner.insertion_score
@@ -798,11 +803,13 @@ Pairwise sequence aligner with parameters
 
         def gap_function6(x, y):
             return x * y + 2
+
         aligner.insertion_score = gap_function6
         self.assertEqual(aligner.insertion_score, gap_function6)
 
         def gap_function7(x, y):
             return x / y - 2
+
         aligner.insertion_score = gap_function7
         with self.assertWarns(BiopythonDeprecationWarning):
             gap_function = aligner.target_gap_score
@@ -810,6 +817,7 @@ Pairwise sequence aligner with parameters
 
         def gap_function8(x, y):
             return x / y * 2
+
         with self.assertWarns(BiopythonDeprecationWarning):
             aligner.target_gap_score = gap_function8
         with self.assertWarns(BiopythonDeprecationWarning):
@@ -818,6 +826,7 @@ Pairwise sequence aligner with parameters
 
         def gap_function9(x, y):
             return x + 9 * y
+
         aligner.gap_score = gap_function9
         gap_function = aligner.gap_score
         self.assertEqual(gap_function, gap_function9)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4884,18 +4884,18 @@ class TestAlignerPickling(unittest.TestCase):
         aligner.wildcard = "X"
         aligner.match_score = 3
         aligner.mismatch_score = -2
-        aligner.target_internal_open_gap_score = -2.5
-        aligner.target_internal_extend_gap_score = -3.5
-        aligner.target_left_open_gap_score = -2.5
-        aligner.target_left_extend_gap_score = -3.5
-        aligner.target_right_open_gap_score = -4
-        aligner.target_right_extend_gap_score = -4
-        aligner.query_internal_open_gap_score = -0.1
-        aligner.query_internal_extend_gap_score = -2
-        aligner.query_left_open_gap_score = -9
-        aligner.query_left_extend_gap_score = +1
-        aligner.query_right_open_gap_score = -1
-        aligner.query_right_extend_gap_score = -2
+        aligner.open_internal_insertion_score = -2.5
+        aligner.extend_internal_insertion_score = -3.5
+        aligner.open_left_insertion_score = -2.5
+        aligner.extend_left_insertion_score = -3.5
+        aligner.open_right_insertion_score = -4
+        aligner.extend_right_insertion_score = -4
+        aligner.open_internal_deletion_score = -0.1
+        aligner.extend_internal_deletion_score = -2
+        aligner.open_left_deletion_score = -9
+        aligner.extend_left_deletion_score = +1
+        aligner.open_right_deletion_score = -1
+        aligner.extend_right_deletion_score = -2
         aligner.mode = "local"
         state = pickle.dumps(aligner)
         pickled_aligner = pickle.loads(state)
@@ -4904,51 +4904,51 @@ class TestAlignerPickling(unittest.TestCase):
         self.assertAlmostEqual(aligner.mismatch_score, pickled_aligner.mismatch_score)
         self.assertIsNone(pickled_aligner.substitution_matrix)
         self.assertAlmostEqual(
-            aligner.target_internal_open_gap_score,
-            pickled_aligner.target_internal_open_gap_score,
+            aligner.open_internal_insertion_score,
+            pickled_aligner.open_internal_insertion_score,
         )
         self.assertAlmostEqual(
-            aligner.target_internal_extend_gap_score,
-            pickled_aligner.target_internal_extend_gap_score,
+            aligner.extend_internal_insertion_score,
+            pickled_aligner.extend_internal_insertion_score,
         )
         self.assertAlmostEqual(
-            aligner.target_left_open_gap_score,
-            pickled_aligner.target_left_open_gap_score,
+            aligner.open_left_insertion_score,
+            pickled_aligner.open_left_insertion_score,
         )
         self.assertAlmostEqual(
-            aligner.target_left_extend_gap_score,
-            pickled_aligner.target_left_extend_gap_score,
+            aligner.extend_left_insertion_score,
+            pickled_aligner.extend_left_insertion_score,
         )
         self.assertAlmostEqual(
-            aligner.target_right_open_gap_score,
-            pickled_aligner.target_right_open_gap_score,
+            aligner.open_right_insertion_score,
+            pickled_aligner.open_right_insertion_score,
         )
         self.assertAlmostEqual(
-            aligner.target_right_extend_gap_score,
-            pickled_aligner.target_right_extend_gap_score,
+            aligner.extend_right_insertion_score,
+            pickled_aligner.extend_right_insertion_score,
         )
         self.assertAlmostEqual(
-            aligner.query_internal_open_gap_score,
-            pickled_aligner.query_internal_open_gap_score,
+            aligner.open_internal_deletion_score,
+            pickled_aligner.open_internal_deletion_score,
         )
         self.assertAlmostEqual(
-            aligner.query_internal_extend_gap_score,
-            pickled_aligner.query_internal_extend_gap_score,
+            aligner.extend_internal_deletion_score,
+            pickled_aligner.extend_internal_deletion_score,
         )
         self.assertAlmostEqual(
-            aligner.query_left_open_gap_score, pickled_aligner.query_left_open_gap_score
+            aligner.open_left_deletion_score, pickled_aligner.open_left_deletion_score
         )
         self.assertAlmostEqual(
-            aligner.query_left_extend_gap_score,
-            pickled_aligner.query_left_extend_gap_score,
+            aligner.extend_left_deletion_score,
+            pickled_aligner.extend_left_deletion_score,
         )
         self.assertAlmostEqual(
-            aligner.query_right_open_gap_score,
-            pickled_aligner.query_right_open_gap_score,
+            aligner.open_right_deletion_score,
+            pickled_aligner.open_right_deletion_score,
         )
         self.assertAlmostEqual(
-            aligner.query_right_extend_gap_score,
-            pickled_aligner.query_right_extend_gap_score,
+            aligner.extend_right_deletion_score,
+            pickled_aligner.extend_right_deletion_score,
         )
         self.assertEqual(aligner.mode, pickled_aligner.mode)
 
@@ -4962,12 +4962,12 @@ class TestAlignerPickling(unittest.TestCase):
         aligner = Align.PairwiseAligner()
         aligner.wildcard = "N"
         aligner.substitution_matrix = substitution_matrices.load("BLOSUM80")
-        aligner.target_internal_open_gap_score = -5
-        aligner.target_internal_extend_gap_score = -3
-        aligner.target_left_open_gap_score = -2
-        aligner.target_left_extend_gap_score = -3
-        aligner.target_right_open_gap_score = -4.5
-        aligner.target_right_extend_gap_score = -4.3
+        aligner.open_internal_insertion_score = -5
+        aligner.extend_internal_insertion_score = -3
+        aligner.open_left_insertion_score = -2
+        aligner.extend_left_insertion_score = -3
+        aligner.open_right_insertion_score = -4.5
+        aligner.extend_right_insertion_score = -4.3
         aligner.query_internal_open_gap_score = -2
         aligner.query_internal_extend_gap_score = -2.5
         aligner.query_left_open_gap_score = -9.1
@@ -4988,28 +4988,28 @@ class TestAlignerPickling(unittest.TestCase):
             pickled_aligner.substitution_matrix.alphabet,
         )
         self.assertAlmostEqual(
-            aligner.target_internal_open_gap_score,
-            pickled_aligner.target_internal_open_gap_score,
+            aligner.open_internal_insertion_score,
+            pickled_aligner.open_internal_insertion_score,
         )
         self.assertAlmostEqual(
-            aligner.target_internal_extend_gap_score,
-            pickled_aligner.target_internal_extend_gap_score,
+            aligner.extend_internal_insertion_score,
+            pickled_aligner.extend_internal_insertion_score,
         )
         self.assertAlmostEqual(
-            aligner.target_left_open_gap_score,
-            pickled_aligner.target_left_open_gap_score,
+            aligner.open_left_insertion_score,
+            pickled_aligner.open_left_insertion_score,
         )
         self.assertAlmostEqual(
-            aligner.target_left_extend_gap_score,
-            pickled_aligner.target_left_extend_gap_score,
+            aligner.extend_left_insertion_score,
+            pickled_aligner.extend_left_insertion_score,
         )
         self.assertAlmostEqual(
-            aligner.target_right_open_gap_score,
-            pickled_aligner.target_right_open_gap_score,
+            aligner.open_right_insertion_score,
+            pickled_aligner.open_right_insertion_score,
         )
         self.assertAlmostEqual(
-            aligner.target_right_extend_gap_score,
-            pickled_aligner.target_right_extend_gap_score,
+            aligner.extend_right_insertion_score,
+            pickled_aligner.extend_right_insertion_score,
         )
         self.assertAlmostEqual(
             aligner.query_internal_open_gap_score,

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -761,22 +761,26 @@ Pairwise sequence aligner with parameters
         with self.assertWarns(BiopythonDeprecationWarning):
             aligner.query_gap_score = value
         self.assertAlmostEqual(aligner.deletion_score, value)
+
         def gap_function1(x, y):
             return x + y
         with self.assertWarns(BiopythonDeprecationWarning):
             aligner.query_gap_score = gap_function1
         gap_function = aligner.deletion_score
         self.assertEqual(gap_function, gap_function1)
+
         def gap_function2(x, y):
             return x * y
         aligner.deletion_score = gap_function2
         self.assertEqual(aligner.deletion_score, gap_function2)
+
         def gap_function3(x, y):
             return x / y
         aligner.deletion_score = gap_function3
         with self.assertWarns(BiopythonDeprecationWarning):
             gap_function = aligner.query_gap_score
         self.assertEqual(gap_function, gap_function3)
+
         def gap_function4(x, y):
             return x / y - 9
         with self.assertWarns(BiopythonDeprecationWarning):
@@ -784,22 +788,26 @@ Pairwise sequence aligner with parameters
         with self.assertWarns(BiopythonDeprecationWarning):
             gap_function = aligner.query_gap_score
         self.assertEqual(gap_function, gap_function4)
+
         def gap_function5(x, y):
             return x + 2 * y
         with self.assertWarns(BiopythonDeprecationWarning):
             aligner.target_gap_score = gap_function5
         gap_function = aligner.insertion_score
         self.assertEqual(gap_function, gap_function5)
+
         def gap_function6(x, y):
             return x * y + 2
         aligner.insertion_score = gap_function6
         self.assertEqual(aligner.insertion_score, gap_function6)
+
         def gap_function7(x, y):
             return x / y - 2
         aligner.insertion_score = gap_function7
         with self.assertWarns(BiopythonDeprecationWarning):
             gap_function = aligner.target_gap_score
         self.assertEqual(gap_function, gap_function7)
+
         def gap_function8(x, y):
             return x / y * 2
         with self.assertWarns(BiopythonDeprecationWarning):
@@ -807,6 +815,7 @@ Pairwise sequence aligner with parameters
         with self.assertWarns(BiopythonDeprecationWarning):
             gap_function = aligner.target_gap_score
         self.assertEqual(gap_function, gap_function8)
+
         def gap_function9(x, y):
             return x + 9 * y
         aligner.gap_score = gap_function9

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -18,6 +18,7 @@ except ImportError:
         "Install numpy if you want to use Bio.Align."
     ) from None
 
+from Bio import BiopythonDeprecationWarning
 from Bio import BiopythonWarning
 from Bio import Align
 from Bio import SeqIO
@@ -190,110 +191,627 @@ Pairwise sequence aligner with parameters
 
     def test_aligner_property_gapscores_deprecated(self):
         aligner = Align.PairwiseAligner()
-        open_score, extend_score = (-5, -1)
-        aligner.target_open_gap_score = open_score
-        aligner.target_extend_gap_score = extend_score
-        self.assertAlmostEqual(aligner.target_open_gap_score, open_score)
-        self.assertAlmostEqual(aligner.target_extend_gap_score, extend_score)
-        open_score, extend_score = (-6, -7)
-        aligner.query_open_gap_score = open_score
-        aligner.query_extend_gap_score = extend_score
-        self.assertAlmostEqual(aligner.query_open_gap_score, open_score)
-        self.assertAlmostEqual(aligner.query_extend_gap_score, extend_score)
-        open_score, extend_score = (-3, -9)
-        aligner.target_end_open_gap_score = open_score
-        aligner.target_end_extend_gap_score = extend_score
-        self.assertAlmostEqual(aligner.target_end_open_gap_score, open_score)
-        self.assertAlmostEqual(aligner.target_end_extend_gap_score, extend_score)
-        open_score, extend_score = (-1, -2)
-        aligner.query_end_open_gap_score = open_score
-        aligner.query_end_extend_gap_score = extend_score
-        self.assertEqual(
-            str(aligner),
-            """\
-Pairwise sequence aligner with parameters
-  wildcard: None
-  match_score: 1.000000
-  mismatch_score: 0.000000
-  open_internal_insertion_score: -5.000000
-  extend_internal_insertion_score: -1.000000
-  open_left_insertion_score: -3.000000
-  extend_left_insertion_score: -9.000000
-  open_right_insertion_score: -3.000000
-  extend_right_insertion_score: -9.000000
-  open_internal_deletion_score: -6.000000
-  extend_internal_deletion_score: -7.000000
-  open_left_deletion_score: -1.000000
-  extend_left_deletion_score: -2.000000
-  open_right_deletion_score: -1.000000
-  extend_right_deletion_score: -2.000000
-  mode: global
-""",
-        )
-        self.assertAlmostEqual(aligner.query_end_open_gap_score, open_score)
-        self.assertAlmostEqual(aligner.query_end_extend_gap_score, extend_score)
-        score = -3
-        aligner.target_gap_score = score
-        self.assertAlmostEqual(aligner.target_gap_score, score)
-        self.assertAlmostEqual(aligner.target_open_gap_score, score)
-        self.assertAlmostEqual(aligner.target_extend_gap_score, score)
-        score = -2
-        aligner.query_gap_score = score
-        self.assertAlmostEqual(aligner.query_gap_score, score)
-        self.assertAlmostEqual(aligner.query_open_gap_score, score)
-        self.assertAlmostEqual(aligner.query_extend_gap_score, score)
-        score = -4
-        aligner.target_end_gap_score = score
-        self.assertAlmostEqual(aligner.target_end_gap_score, score)
-        self.assertAlmostEqual(aligner.target_end_open_gap_score, score)
-        self.assertAlmostEqual(aligner.target_end_extend_gap_score, score)
-        self.assertAlmostEqual(aligner.target_left_gap_score, score)
-        self.assertAlmostEqual(aligner.open_left_insertion_score, score)
-        self.assertAlmostEqual(aligner.extend_left_insertion_score, score)
-        self.assertAlmostEqual(aligner.target_right_gap_score, score)
-        self.assertAlmostEqual(aligner.target_right_open_gap_score, score)
-        self.assertAlmostEqual(aligner.target_right_extend_gap_score, score)
-        score = -5
-        aligner.query_end_gap_score = score
-        self.assertAlmostEqual(aligner.query_end_gap_score, score)
-        self.assertAlmostEqual(aligner.query_end_open_gap_score, score)
-        self.assertAlmostEqual(aligner.query_end_extend_gap_score, score)
-        self.assertAlmostEqual(aligner.query_left_gap_score, score)
-        self.assertAlmostEqual(aligner.query_left_open_gap_score, score)
-        self.assertAlmostEqual(aligner.query_left_extend_gap_score, score)
-        self.assertAlmostEqual(aligner.query_right_gap_score, score)
-        self.assertAlmostEqual(aligner.query_right_open_gap_score, score)
-        self.assertAlmostEqual(aligner.query_right_extend_gap_score, score)
-        self.assertEqual(
-            str(aligner),
-            """\
-Pairwise sequence aligner with parameters
-  wildcard: None
-  match_score: 1.000000
-  mismatch_score: 0.000000
-  open_internal_insertion_score: -3.000000
-  extend_internal_insertion_score: -3.000000
-  open_left_insertion_score: -4.000000
-  extend_left_insertion_score: -4.000000
-  open_right_insertion_score: -4.000000
-  extend_right_insertion_score: -4.000000
-  open_internal_deletion_score: -2.000000
-  extend_internal_deletion_score: -2.000000
-  open_left_deletion_score: -5.000000
-  extend_left_deletion_score: -5.000000
-  open_right_deletion_score: -5.000000
-  extend_right_deletion_score: -5.000000
-  mode: global
-""",
-        )
-        with self.assertRaises(ValueError):
-            aligner.target_gap_score = "wrong"
-        with self.assertRaises(ValueError):
-            aligner.query_gap_score = "wrong"
-        with self.assertRaises(TypeError):
-            aligner.target_end_gap_score = "wrong"
-        with self.assertRaises(TypeError):
-            aligner.query_end_gap_score = "wrong"
+        value = 1
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_left_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_left_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 2
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_left_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_left_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 3
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.left_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.left_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 4
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_internal_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_internal_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 5
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_internal_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_internal_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 6
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.internal_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.internal_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 7
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_right_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_right_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 8
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_right_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_right_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 9
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.right_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.right_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 10
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_end_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_end_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 11
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_end_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_end_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 12
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.end_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.end_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 13
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 14
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_open_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 15
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_left_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_left_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 16
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_left_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_left_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 17
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.left_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.left_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 18
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_internal_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_internal_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 19
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_internal_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_internal_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 20
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.internal_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.internal_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 21
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_right_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_right_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 22
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_right_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_right_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 23
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.right_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.right_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 24
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_end_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_end_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 25
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_end_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_end_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 26
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.end_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.end_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 27
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 28
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_extend_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 29
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_left_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_left_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 30
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_left_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_left_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 31
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_internal_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_internal_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 32
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_internal_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_internal_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 33
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_right_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_right_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 34
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_right_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_right_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 35
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_end_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_end_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 36
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_end_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_end_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 37
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 38
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 39
+        aligner.open_left_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_left_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 40
+        aligner.open_left_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_left_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 41
+        aligner.open_left_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.left_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 42
+        aligner.open_internal_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_internal_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 43
+        aligner.open_internal_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_internal_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 44
+        aligner.open_internal_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.internal_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 45
+        aligner.open_right_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_right_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 46
+        aligner.open_right_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_right_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 47
+        aligner.open_right_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.right_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 48
+        aligner.open_end_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_end_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 49
+        aligner.open_end_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_end_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 50
+        aligner.open_end_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.end_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 51
+        aligner.open_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 52
+        aligner.open_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_open_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 53
+        aligner.extend_left_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_left_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 54
+        aligner.extend_left_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_left_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 55
+        aligner.extend_left_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.left_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 56
+        aligner.extend_internal_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_internal_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 57
+        aligner.extend_internal_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_internal_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 58
+        aligner.extend_internal_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.internal_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 59
+        aligner.extend_right_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_right_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 60
+        aligner.extend_right_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_right_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 61
+        aligner.extend_right_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.right_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 62
+        aligner.extend_end_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_end_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 63
+        aligner.extend_end_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_end_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 64
+        aligner.extend_end_gap_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.end_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 65
+        aligner.extend_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 66
+        aligner.extend_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_extend_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 67
+        aligner.left_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_left_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 68
+        aligner.left_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_left_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 69
+        aligner.internal_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_internal_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 70
+        aligner.internal_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_internal_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 71
+        aligner.right_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_right_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 72
+        aligner.right_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_right_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 73
+        aligner.end_insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_end_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 74
+        aligner.end_deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_end_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 75
+        aligner.insertion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.target_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 76
+        aligner.deletion_score = value
+        with self.assertWarns(BiopythonDeprecationWarning):
+            stored_value = aligner.query_gap_score
+        self.assertAlmostEqual(stored_value, value)
+        value = 77
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_left_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_left_insertion_score, value)
+        value = 78
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_left_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_left_deletion_score, value)
+        value = 79
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.left_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_left_gap_score, value)
+        value = 80
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_internal_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_internal_insertion_score, value)
+        value = 81
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_internal_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_internal_deletion_score, value)
+        value = 82
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.internal_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_internal_gap_score, value)
+        value = 83
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_right_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_right_insertion_score, value)
+        value = 84
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_right_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_right_deletion_score, value)
+        value = 85
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.right_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_right_gap_score, value)
+        value = 86
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_end_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_end_insertion_score, value)
+        value = 87
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_end_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_end_deletion_score, value)
+        value = 88
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.end_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_end_gap_score, value)
+        value = 89
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_insertion_score, value)
+        value = 90
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_open_gap_score = value
+        self.assertAlmostEqual(aligner.open_deletion_score, value)
+        value = 91
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_left_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_left_insertion_score, value)
+        value = 92
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_left_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_left_deletion_score, value)
+        value = 93
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.left_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_left_gap_score, value)
+        value = 94
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_internal_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_internal_insertion_score, value)
+        value = 95
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_internal_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_internal_deletion_score, value)
+        value = 96
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.internal_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_internal_gap_score, value)
+        value = 97
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_right_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_right_insertion_score, value)
+        value = 98
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_right_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_right_deletion_score, value)
+        value = 99
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.right_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_right_gap_score, value)
+        value = 100
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_end_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_end_insertion_score, value)
+        value = 101
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_end_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_end_deletion_score, value)
+        value = 102
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.end_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_end_gap_score, value)
+        value = 103
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_insertion_score, value)
+        value = 104
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_extend_gap_score = value
+        self.assertAlmostEqual(aligner.extend_deletion_score, value)
+        value = 105
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_left_gap_score = value
+        self.assertAlmostEqual(aligner.left_insertion_score, value)
+        value = 106
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_left_gap_score = value
+        self.assertAlmostEqual(aligner.left_deletion_score, value)
+        value = 107
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_internal_gap_score = value
+        self.assertAlmostEqual(aligner.internal_insertion_score, value)
+        value = 108
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_internal_gap_score = value
+        self.assertAlmostEqual(aligner.internal_deletion_score, value)
+        value = 109
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_right_gap_score = value
+        self.assertAlmostEqual(aligner.right_insertion_score, value)
+        value = 110
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_right_gap_score = value
+        self.assertAlmostEqual(aligner.right_deletion_score, value)
+        value = 111
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_end_gap_score = value
+        self.assertAlmostEqual(aligner.end_insertion_score, value)
+        value = 112
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_end_gap_score = value
+        self.assertAlmostEqual(aligner.end_deletion_score, value)
+        value = 113
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_gap_score = value
+        self.assertAlmostEqual(aligner.insertion_score, value)
+        value = 114
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_gap_score = value
+        self.assertAlmostEqual(aligner.deletion_score, value)
+        def gap_function1(x, y):
+            return x + y
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_gap_score = gap_function1
+        gap_function = aligner.deletion_score
+        self.assertEqual(gap_function, gap_function1)
+        def gap_function2(x, y):
+            return x * y
+        aligner.deletion_score = gap_function2
+        self.assertEqual(aligner.deletion_score, gap_function2)
+        def gap_function3(x, y):
+            return x / y
+        aligner.deletion_score = gap_function3
+        with self.assertWarns(BiopythonDeprecationWarning):
+            gap_function = aligner.query_gap_score
+        self.assertEqual(gap_function, gap_function3)
+        def gap_function4(x, y):
+            return x / y - 9
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.query_gap_score = gap_function4
+        with self.assertWarns(BiopythonDeprecationWarning):
+            gap_function = aligner.query_gap_score
+        self.assertEqual(gap_function, gap_function4)
+        def gap_function5(x, y):
+            return x + 2 * y
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_gap_score = gap_function5
+        gap_function = aligner.insertion_score
+        self.assertEqual(gap_function, gap_function5)
+        def gap_function6(x, y):
+            return x * y + 2
+        aligner.insertion_score = gap_function6
+        self.assertEqual(aligner.insertion_score, gap_function6)
+        def gap_function7(x, y):
+            return x / y - 2
+        aligner.insertion_score = gap_function7
+        with self.assertWarns(BiopythonDeprecationWarning):
+            gap_function = aligner.target_gap_score
+        self.assertEqual(gap_function, gap_function7)
+        def gap_function8(x, y):
+            return x / y * 2
+        with self.assertWarns(BiopythonDeprecationWarning):
+            aligner.target_gap_score = gap_function8
+        with self.assertWarns(BiopythonDeprecationWarning):
+            gap_function = aligner.target_gap_score
+        self.assertEqual(gap_function, gap_function8)
+        def gap_function9(x, y):
+            return x + 9 * y
+        aligner.gap_score = gap_function9
+        gap_function = aligner.gap_score
+        self.assertEqual(gap_function, gap_function9)
 
     def test_aligner_nonexisting_property(self):
         aligner = Align.PairwiseAligner()

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -68,7 +68,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: 0.000000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: 0.000000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: 0.000000
@@ -111,7 +111,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -5.000000
   extend_internal_insertion_score: -1.000000
   open_left_insertion_score: -3.000000
-  target_left_extend_gap_score: -9.000000
+  extend_left_insertion_score: -9.000000
   target_right_open_gap_score: -3.000000
   target_right_extend_gap_score: -9.000000
   query_internal_open_gap_score: -6.000000
@@ -142,7 +142,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(aligner.target_end_extend_gap_score, score)
         self.assertAlmostEqual(aligner.target_left_gap_score, score)
         self.assertAlmostEqual(aligner.open_left_insertion_score, score)
-        self.assertAlmostEqual(aligner.target_left_extend_gap_score, score)
+        self.assertAlmostEqual(aligner.extend_left_insertion_score, score)
         self.assertAlmostEqual(aligner.target_right_gap_score, score)
         self.assertAlmostEqual(aligner.target_right_open_gap_score, score)
         self.assertAlmostEqual(aligner.target_right_extend_gap_score, score)
@@ -167,7 +167,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -3.000000
   extend_internal_insertion_score: -3.000000
   open_left_insertion_score: -4.000000
-  target_left_extend_gap_score: -4.000000
+  extend_left_insertion_score: -4.000000
   target_right_open_gap_score: -4.000000
   target_right_extend_gap_score: -4.000000
   query_internal_open_gap_score: -2.000000
@@ -220,7 +220,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: 0.000000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: 0.000000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: 0.000000
@@ -328,7 +328,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -5.000000
   extend_internal_insertion_score: -1.000000
   open_left_insertion_score: -5.000000
-  target_left_extend_gap_score: -1.000000
+  extend_left_insertion_score: -1.000000
   target_right_open_gap_score: -5.000000
   target_right_extend_gap_score: -1.000000
   query_internal_open_gap_score: -5.000000
@@ -460,7 +460,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.100000
-  target_left_extend_gap_score: -0.100000
+  extend_left_insertion_score: -0.100000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.100000
@@ -509,7 +509,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.100000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
@@ -872,7 +872,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.100000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
@@ -969,7 +969,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.100000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
@@ -1068,7 +1068,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: 0.000000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: 0.000000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
@@ -1141,7 +1141,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: 0.000000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: 0.000000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
@@ -1213,7 +1213,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.100000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
@@ -1318,7 +1318,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -0.500000
   open_left_insertion_score: -0.200000
-  target_left_extend_gap_score: -0.500000
+  extend_left_insertion_score: -0.500000
   target_right_open_gap_score: -0.200000
   target_right_extend_gap_score: -0.500000
   query_internal_open_gap_score: -0.200000
@@ -1389,7 +1389,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -1.500000
   open_left_insertion_score: -0.200000
-  target_left_extend_gap_score: -1.500000
+  extend_left_insertion_score: -1.500000
   target_right_open_gap_score: -0.200000
   target_right_extend_gap_score: -1.500000
   query_internal_open_gap_score: -0.200000
@@ -1494,7 +1494,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -1.500000
   open_left_insertion_score: -0.200000
-  target_left_extend_gap_score: -1.500000
+  extend_left_insertion_score: -1.500000
   target_right_open_gap_score: -0.200000
   target_right_extend_gap_score: -1.500000
   query_internal_open_gap_score: -0.200000
@@ -1567,7 +1567,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -1.700000
   extend_internal_insertion_score: -1.500000
   open_left_insertion_score: -1.700000
-  target_left_extend_gap_score: -1.500000
+  extend_left_insertion_score: -1.500000
   target_right_open_gap_score: -1.700000
   target_right_extend_gap_score: -1.500000
   query_internal_open_gap_score: -1.700000
@@ -1640,7 +1640,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -1.700000
   extend_internal_insertion_score: -1.500000
   open_left_insertion_score: -1.700000
-  target_left_extend_gap_score: -1.500000
+  extend_left_insertion_score: -1.500000
   target_right_open_gap_score: -1.700000
   target_right_extend_gap_score: -1.500000
   query_internal_open_gap_score: -1.700000
@@ -1715,7 +1715,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -0.800000
   open_left_insertion_score: 0.000000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.200000
@@ -1845,7 +1845,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -0.800000
   open_left_insertion_score: 0.000000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: 0.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.200000
@@ -1929,7 +1929,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.300000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.800000
@@ -2032,7 +2032,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.300000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.200000
@@ -2113,7 +2113,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.100000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.100000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: -0.100000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.100000
@@ -2256,7 +2256,7 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
   open_internal_insertion_score: -0.500000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.500000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: -0.500000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.500000
@@ -2358,7 +2358,7 @@ query             3 AT-T 0
   open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -1.000000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: -1.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -1.000000
@@ -2428,7 +2428,7 @@ query             3 ATT 0
   open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -1.000000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: -1.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -1.000000
@@ -2501,7 +2501,7 @@ query             4 ATA 1
   open_internal_insertion_score: -0.500000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.500000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: -0.500000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -0.500000
@@ -2605,7 +2605,7 @@ query             3 AT-T 0
   open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -1.000000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: -1.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -1.000000
@@ -2677,7 +2677,7 @@ query             3 ATT 0
   open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -1.000000
-  target_left_extend_gap_score: 0.000000
+  extend_left_insertion_score: 0.000000
   target_right_open_gap_score: -1.000000
   target_right_extend_gap_score: 0.000000
   query_internal_open_gap_score: -1.000000
@@ -2744,7 +2744,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.300000
-  target_left_extend_gap_score: -0.100000
+  extend_left_insertion_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.300000
@@ -2791,7 +2791,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.300000
-  target_left_extend_gap_score: -0.100000
+  extend_left_insertion_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.300000
@@ -2852,7 +2852,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.300000
-  target_left_extend_gap_score: -0.100000
+  extend_left_insertion_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.300000
@@ -2901,7 +2901,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.300000
-  target_left_extend_gap_score: -0.100000
+  extend_left_insertion_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.300000
@@ -2934,7 +2934,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.300000
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.300000
-  target_left_extend_gap_score: -0.100000
+  extend_left_insertion_score: -0.100000
   target_right_open_gap_score: -0.300000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.300000
@@ -4462,7 +4462,7 @@ Pairwise sequence aligner with parameters
   open_internal_insertion_score: -0.200000
   extend_internal_insertion_score: -0.100000
   open_left_insertion_score: -0.200000
-  target_left_extend_gap_score: -0.100000
+  extend_left_insertion_score: -0.100000
   target_right_open_gap_score: -0.200000
   target_right_extend_gap_score: -0.100000
   query_internal_open_gap_score: -0.300000
@@ -4487,7 +4487,7 @@ class TestPredefinedScoringSchemes(unittest.TestCase):
   open_internal_insertion_score: -7.000000
   extend_internal_insertion_score: -2.000000
   open_left_insertion_score: -7.000000
-  target_left_extend_gap_score: -2.000000
+  extend_left_insertion_score: -2.000000
   target_right_open_gap_score: -7.000000
   target_right_extend_gap_score: -2.000000
   query_internal_open_gap_score: -7.000000
@@ -4531,7 +4531,7 @@ N -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0 -2.0
   open_internal_insertion_score: -2.500000
   extend_internal_insertion_score: -2.500000
   open_left_insertion_score: -2.500000
-  target_left_extend_gap_score: -2.500000
+  extend_left_insertion_score: -2.500000
   target_right_open_gap_score: -2.500000
   target_right_extend_gap_score: -2.500000
   query_internal_open_gap_score: -2.500000
@@ -4575,7 +4575,7 @@ N -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0 -1.0
   open_internal_insertion_score: -12.000000
   extend_internal_insertion_score: -1.000000
   open_left_insertion_score: -12.000000
-  target_left_extend_gap_score: -1.000000
+  extend_left_insertion_score: -1.000000
   target_right_open_gap_score: -12.000000
   target_right_extend_gap_score: -1.000000
   query_internal_open_gap_score: -12.000000


### PR DESCRIPTION
Rename `PairwiseAligner` attributes to be consistent with the `AlignmentCounts` class and terminology in the literature.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
