### PR TITLE
Deprecate MMTF in PDBList, add BinaryCIF support

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -21,7 +21,7 @@
 #
 # (c) 2016 Wiktoria Karwicka & Jacek Smietanski
 #   - updated and Python 3.x compatible code
-#   - new options to enable download PDBx/mmCif, PDBML and mmtf formatted
+#   - new options to enable download PDBx/mmCif and PDBML formatted
 #       files as well as large PDB bundles
 #   - unit tests for the module
 #
@@ -64,7 +64,7 @@ class PDBList:
     To use it properly, prepare a directory /pdb or the like,
     where PDB files are stored.
 
-    All available file formats (PDB, PDBx/mmCif, PDBML, mmtf) are supported.
+    All available file formats (PDB, PDBx/mmCif, PDBML) are supported.
     Please note that large structures (containing >62 chains
     and/or 99999 ATOM lines) are no longer stored as a single PDB file
     and by default (when PDB format selected) are not downloaded.
@@ -238,7 +238,6 @@ class PDBList:
             * "mmCif" (default, PDBx/mmCif file),
             * "pdb" (format PDB),
             * "xml" (PDBML/XML format),
-            * "mmtf" (highly compressed),
             * "bundle" (PDB formatted archive for large structure)
 
         :type file_format: string
@@ -249,8 +248,7 @@ class PDBList:
         :param obsolete:
             Has a meaning only for obsolete structures. If True, download the obsolete structure
             to 'obsolete' folder, otherwise download won't be performed.
-            This option doesn't work for mmtf format as obsoleted structures aren't stored in mmtf.
-            Also doesn't have meaning when parameter pdir is specified.
+            This option doesn't have meaning when parameter pdir is specified.
             Note: make sure that you are about to download the really obsolete structure.
             Trying to download non-obsolete structure into obsolete folder will not work
             and you face the "structure doesn't exists" error.
@@ -273,11 +271,15 @@ class PDBList:
             "pdb": f"pdb{pdb_code}.ent.gz",
             "mmCif": f"{pdb_code}.cif.gz",
             "xml": f"{pdb_code}.xml.gz",
-            "mmtf": f"{pdb_code}",
             "bundle": f"{pdb_code}-pdb-bundle.tar.gz",
         }
 
-        if file_format not in archive_dict:
+        if file_format == "mmtf":
+            raise ValueError(
+                f"The MMTF format is deprecated and no longer available. "
+                f"Please use one of the following: {', '.join(archive_dict)}"
+            )
+        elif file_format not in archive_dict:
             raise ValueError(
                 f"Specified file_format {file_format} does not exist or is not supported. "
                 f"Please use one of the following: {', '.join(archive_dict)}."
@@ -296,13 +298,12 @@ class PDBList:
                 self.pdb_server
                 + f"/pub/pdb/data/structures/{pdb_dir}/{file_type}/{pdb_code[1:3]}/{archive}"
             )
-        elif file_format == "bundle":
+        else:
+            assert file_format == "bundle"
             url = (
                 self.pdb_server
                 + f"/pub/pdb/compatible/pdb_bundle/{pdb_code[1:3]}/{pdb_code}/{archive}"
             )
-        else:
-            url = f"http://mmtf.rcsb.org/v1.0/full/{pdb_code}"
 
         # Where does the final PDB file get saved?
         if pdir is None:
@@ -318,7 +319,6 @@ class PDBList:
             "pdb": f"pdb{pdb_code}.ent",
             "mmCif": f"{pdb_code}.cif",
             "xml": f"{pdb_code}.xml",
-            "mmtf": f"{pdb_code}.mmtf",
             "bundle": f"{pdb_code}-pdb-bundle.tar",
         }
         final_file = os.path.join(path, final[file_format])
@@ -425,7 +425,6 @@ class PDBList:
             Has a meaning only for obsolete structures.
             If True, download the obsolete structure to 'obsolete' folder.
             Otherwise, the download won't be performed.
-            This option doesn't work for mmtf format as obsolete structures are not available as mmtf.
             (default: ``False``)
 
         :param pdir: Put the file in this directory. By default, create a PDB-style directory tree.
@@ -435,7 +434,6 @@ class PDBList:
             * "mmCif" (default, PDBx/mmCif file),
             * "pdb" (format PDB),
             * "xml" (PMDML/XML format),
-            * "mmtf" (highly compressed),
             * "bundle" (PDB formatted archive for large structure).
 
         :param overwrite: If set to true, existing structure files will be overwritten. (default: ``False``)
@@ -623,7 +621,6 @@ class PDBList:
             * "mmCif" (default, PDBx/mmCif file),
             * "pdb" (format PDB),
             * "xml" (PMDML/XML format),
-            * "mmtf" (highly compressed),
             * "bundle" (PDB formatted archive for large structure)
 
         :param max_num_threads: The maximum number of threads to use while downloading PDB entries
@@ -708,7 +705,6 @@ if __name__ == "__main__":
      -o       Overwrite existing structure files.
      -pdb     Downloads structures in PDB format
      -xml     Downloads structures in PDBML (XML) format
-     -mmtf    Downloads structures in mmtf format
      -with-assemblies    Downloads assemblies along with regular entries.
 
     Maximum one format can be specified simultaneously (if more selected, only
@@ -730,7 +726,7 @@ if __name__ == "__main__":
                     pl.flat_tree = True
                 elif option == "-o":
                     overwrite = True
-                elif option in ("-pdb", "-xml", "-mmtf"):
+                elif option in ("-pdb", "-xml"):
                     file_format = option[1:]
                 # Allow for download of assemblies alongside ASU
                 elif option == "-with-assemblies":

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -236,6 +236,7 @@ class PDBList:
             File format. Available options:
 
             * "mmCif" (default, PDBx/mmCif file),
+            * "bcif" (BinaryCIF format),
             * "pdb" (format PDB),
             * "xml" (PDBML/XML format),
             * "bundle" (PDB formatted archive for large structure)
@@ -270,6 +271,7 @@ class PDBList:
         archive_dict = {
             "pdb": f"pdb{pdb_code}.ent.gz",
             "mmCif": f"{pdb_code}.cif.gz",
+            "bcif": f"{pdb_code}.bcif.gz",
             "xml": f"{pdb_code}.xml.gz",
             "bundle": f"{pdb_code}-pdb-bundle.tar.gz",
         }
@@ -298,12 +300,17 @@ class PDBList:
                 self.pdb_server
                 + f"/pub/pdb/data/structures/{pdb_dir}/{file_type}/{pdb_code[1:3]}/{archive}"
             )
-        else:
-            assert file_format == "bundle"
+        elif file_format == "bundle":
             url = (
                 self.pdb_server
                 + f"/pub/pdb/compatible/pdb_bundle/{pdb_code[1:3]}/{pdb_code}/{archive}"
             )
+        else:
+            assert file_format == "bcif"
+            assert (
+                not obsolete
+            ), "PDBList cannot retrieve obsolete structures in BinaryCIF format."
+            url = f"https://models.rcsb.org/{archive}"
 
         # Where does the final PDB file get saved?
         if pdir is None:
@@ -318,6 +325,7 @@ class PDBList:
         final = {
             "pdb": f"pdb{pdb_code}.ent",
             "mmCif": f"{pdb_code}.cif",
+            "bcif": f"{pdb_code}.bcif",
             "xml": f"{pdb_code}.xml",
             "bundle": f"{pdb_code}-pdb-bundle.tar",
         }
@@ -432,6 +440,7 @@ class PDBList:
         :param file_format: File format. Available options:
 
             * "mmCif" (default, PDBx/mmCif file),
+            * "bcif" (BinaryCIF format),
             * "pdb" (format PDB),
             * "xml" (PMDML/XML format),
             * "bundle" (PDB formatted archive for large structure).

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -16,6 +16,11 @@ The latest news is at the top of this file.
 This release of Biopython supports Python 3.10, 3.11, 3.12 and 3.13.  It
 has also been tested on PyPy3.10 v7.3.17.
 
+The RCSB PDB deprecated the MMTF format and encouraged users to use BinaryCIF
+instead (`see announcement <https://www.rcsb.org/news/feature/65a1af31c76ca3abcc925d0c>`_).
+Biopython already includes a BinaryCIF parser, so we updated PDBList to support
+retrieving PDB structures in the BinaryCIF format and deprecate the MMTF format.
+
 15 January 2025: Biopython 1.85
 ===============================
 

--- a/Tests/test_PDB_PDBList.py
+++ b/Tests/test_PDB_PDBList.py
@@ -137,11 +137,6 @@ class TestPDBListGetStructure(unittest.TestCase):
         structure = "127d"
         self.check(structure, os.path.join(structure[1:3], f"{structure}.xml"), "xml")
 
-    def test_retrieve_pdb_file_mmtf(self):
-        """Tests retrieving the molecule in mmtf format."""
-        structure = "127d"
-        self.check(structure, os.path.join(structure[1:3], f"{structure}.mmtf"), "mmtf")
-
     def test_double_retrieve_structure(self):
         """Tests retrieving the same file to different directories."""
         structure = "127d"
@@ -153,11 +148,22 @@ class TestPDBListGetStructure(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             pdb_list.retrieve_pdb_file("127d", file_format="invalid")
 
-        self.assertEqual(
-            "Specified file_format invalid does not exist or is not supported. Please use one of the "
-            "following: pdb, mmCif, xml, mmtf, bundle.",
-            str(context.exception),
-        )
+            self.assertEqual(
+                "Specified file_format invalid does not exist or is not supported. Please use one of the "
+                "following: pdb, mmCif, xml, bundle.",
+                str(context.exception),
+            )
+
+    def test_deprecated_mmtf_format(self):
+        pdb_list = PDBList()
+        with self.assertRaises(ValueError) as context:
+            pdb_list.retrieve_pdb_file("127d", file_format="mmtf")
+
+            self.assertEqual(
+                "The MMTF format is deprecated and no longer available. Please use one of the "
+                "following: pdb, mmCif, xml, bundle.",
+                str(context.exception),
+            )
 
 
 class TestPDBListGetAssembly(unittest.TestCase):

--- a/Tests/test_PDB_PDBList.py
+++ b/Tests/test_PDB_PDBList.py
@@ -117,10 +117,24 @@ class TestPDBListGetStructure(unittest.TestCase):
             obsolete=True,
         )
 
+    def test_retrieve_pdb_file_obsolete_bcif(self):
+        """Tests retrieving the obsolete molecule in bcif format."""
+        pdb_list = PDBList()
+        with self.assertRaises(
+            AssertionError,
+            msg="PDBList cannot retrieve obsolete structures in BinaryCIF format.",
+        ):
+            pdb_list.retrieve_pdb_file("347d", file_format="bcif", obsolete=True)
+
     def test_retrieve_pdb_file_mmcif(self):
         """Tests retrieving the (non-obsolete) molecule in mmcif format."""
         structure = "127d"
         self.check(structure, os.path.join(structure[1:3], f"{structure}.cif"), "mmCif")
+
+    def test_retrieve_pdb_file_bcif(self):
+        """Tests retrieving the (non-obsolete) molecule in BinaryCIF format."""
+        structure = "127d"
+        self.check(structure, os.path.join(structure[1:3], f"{structure}.bcif"), "bcif")
 
     def test_retrieve_pdb_file_obsolete_xml(self):
         """Tests retrieving the obsolete molecule in mmcif format."""


### PR DESCRIPTION
### Acknowledgements

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

### Description

The RCSB PDB deprecated the MMTF format and encouraged users to use BinaryCIF instead ([see announcement](https://www.rcsb.org/news/feature/65a1af31c76ca3abcc925d0c)). This pull request updates the PDB list class accordingly by deprecating the MMTF format and adding support for the BinaryCIF format.

This pull request fixes a test case failure described in #4920.

This pull request uses the RCSB server to download BinaryCIF files. See [here](https://www.rcsb.org/docs/programmatic-access/file-download-services) for a description of the available file download services.

### Testing

I update the unit tests. I also manually tested using the BinaryCIF parser to read a retrieved BinaryCIF file.

```
>>> from Bio.PDB import PDBList
>>> pdblist = PDBList()
>>> pdblist.retrieve_pdb_file('127d', file_format='bcif')
Downloading PDB structure '127d'...
'/Users/willtyler/Desktop/biopython/27/127d.bcif'
>>> from Bio.PDB.binary_cif import BinaryCIFParser
>>> parser = BinaryCIFParser()
>>> parser.get_structure('127d', '27/127d.bcif')
<Structure id=127d>
>>> structure = parser.get_structure('127d', '27/127d.bcif')
>>> list(structure.get_atoms())
[<Atom O5'>, <Atom C5'>, <Atom C4'>, <Atom O4'>, <Atom C3'>, <Atom O3'>, ...]
```
