### PR TITLE
Issue 4940 - Loosen restriction of FormattedSeq._table in Restriction module

### DIFF
--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -119,7 +119,7 @@ DNA = Seq
 def _make_FormattedSeq_table() -> bytes:
     table = bytearray(256)
     upper_to_lower = ord("A") - ord("a")
-    for c in b"ABCDGHKMNRSTVWY":  # Only allow IUPAC letters
+    for c in b"ABCDEFGHIJKLMNOPQRSTUVWXYZ":  # Only allow alphabetic characters
         table[c] = c  # map uppercase to uppercase
         table[c - upper_to_lower] = c  # map lowercase to uppercase
     return bytes(table)


### PR DESCRIPTION

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.


Closes #4940 
