### PR TITLE
Bio.Align chain avoid next() so we can use NamedTemporaryFile

### DIFF
--- a/Bio/Align/chain.py
+++ b/Bio/Align/chain.py
@@ -172,16 +172,13 @@ class AlignmentIterator(interfaces.AlignmentIterator):
     fmt = "chain"
 
     def _read_header(self, stream):
-        try:
-            self._line = next(stream)
-        except StopIteration:
-            self._line = None
+        self._line = stream.readline()
 
     def _read_next_alignment(self, stream):
-        if self._line is None:
+        if self._line == "":
             return
         line = self._line
-        self._line = None
+        self._line = ""
         words = line.split()
         if len(words) == 12:
             chainID = None
@@ -259,11 +256,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         # There is supposed to be a blank line between chain blocks, but some
         # tools (e.g. pslToChain) do not include such a blank line in their
         # output.
-        try:
-            line = next(stream)
-            if line.strip() == "":
-                line = next(stream)
-            self._line = line
-        except StopIteration:
-            self._line = None
+        line = stream.readline()
+        if line != "" and line.strip() == "":
+            line = stream.readline()
+        self._line = line
         return alignment

--- a/Tests/test_Align_chain.py
+++ b/Tests/test_Align_chain.py
@@ -5,6 +5,7 @@
 """Tests for Align.chain module."""
 import unittest
 from io import StringIO
+from tempfile import NamedTemporaryFile
 
 from Bio import Align
 from Bio import SeqIO
@@ -45,22 +46,6 @@ class TestAlign_dna_rna(unittest.TestCase):
         self.dna = data
         records = SeqIO.parse("Blat/rna.fa", "fasta")
         self.rna = {record.id: record.seq for record in records}
-
-    def test_reading(self):
-        """Test parsing dna_rna.chain."""
-        path = "Blat/dna_rna.chain"
-        alignments = Align.parse(path, "chain")
-        self.check_alignments(alignments)
-        alignments = iter(alignments)
-        self.check_alignments(alignments)
-        with Align.parse(path, "chain") as alignments:
-            self.check_alignments(alignments)
-        with self.assertRaises(AttributeError):
-            alignments._stream
-        with Align.parse(path, "chain") as alignments:
-            pass
-        with self.assertRaises(AttributeError):
-            alignments._stream
 
     def check_alignments(self, alignments):
         alignment = next(alignments)
@@ -1307,6 +1292,29 @@ chain 175 chr3 198295559 + 48663767 48669174 NR_111921.1_modified 220 + 3 208 4
         self.assertEqual(counts.identities, 162)
         self.assertEqual(counts.mismatches, 41)
         self.assertRaises(StopIteration, next, alignments)
+
+    def test_reading(self):
+        """Test parsing dna_rna.chain."""
+        path = "Blat/dna_rna.chain"
+        alignments = Align.parse(path, "chain")
+        self.check_alignments(alignments)
+        alignments = iter(alignments)
+        self.check_alignments(alignments)
+        with Align.parse(path, "chain") as alignments:
+            self.check_alignments(alignments)
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with Align.parse(path, "chain") as alignments:
+            pass
+        with self.assertRaises(AttributeError):
+            alignments._stream
+        with open(path) as stream:
+            data = stream.read()
+        stream = NamedTemporaryFile("w+t")
+        stream.write(data)
+        stream.seek(0)
+        alignments = Align.parse(stream, "chain")
+        self.check_alignments(alignments)
 
     def test_writing(self):
         """Test writing the alignments in dna_rna.chain."""


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
