### PR TITLE
Bio.Align clustal avoid next() so we can use NamedTemporaryFile

### DIFF
--- a/Bio/Align/clustal.py
+++ b/Bio/Align/clustal.py
@@ -98,10 +98,9 @@ class AlignmentIterator(interfaces.AlignmentIterator):
     fmt = "Clustal"
 
     def _read_header(self, stream):
-        try:
-            line = next(stream)
-        except StopIteration:
-            raise ValueError("Empty file.") from None
+        line = stream.readline()
+        if line == "":
+            raise ValueError("Empty file.")
 
         self.metadata = {}
         # Whitelisted programs we know about

--- a/Tests/test_Align_clustal.py
+++ b/Tests/test_Align_clustal.py
@@ -5,6 +5,7 @@
 """Tests for Bio.Align.clustal module."""
 import unittest
 from io import StringIO
+from tempfile import NamedTemporaryFile
 
 import numpy as np
 
@@ -53,6 +54,13 @@ class TestClustalReadingWriting(unittest.TestCase):
         with self.assertRaises(AttributeError):
             alignments._stream
         self.check_reading_writing(path)
+        with open(path) as stream:
+            data = stream.read()
+        stream = NamedTemporaryFile("w+t")
+        stream.write(data)
+        stream.seek(0)
+        alignments = Align.parse(stream, "clustal")
+        self.check_clustalw(alignments)
 
     def check_clustalw(self, alignments):
         self.assertEqual(alignments.metadata["Program"], "CLUSTAL")


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
