### PR TITLE
Bio.Align emboss, avoid next() so we can use NamedTemporaryFile

### DIFF
--- a/Bio/Align/chain.py
+++ b/Bio/Align/chain.py
@@ -175,7 +175,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         self._line = stream.readline()
 
     def _read_next_alignment(self, stream):
-        if self._line == "":
+        if not self._line:
             return
         line = self._line
         self._line = ""
@@ -257,7 +257,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         # tools (e.g. pslToChain) do not include such a blank line in their
         # output.
         line = stream.readline()
-        if line != "" and line.strip() == "":
+        if not line.strip():
             line = stream.readline()
         self._line = line
         return alignment

--- a/Bio/Align/clustal.py
+++ b/Bio/Align/clustal.py
@@ -99,7 +99,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
     def _read_header(self, stream):
         line = stream.readline()
-        if line == "":
+        if not line:
             raise ValueError("Empty file.")
 
         self.metadata = {}

--- a/Bio/Align/emboss.py
+++ b/Bio/Align/emboss.py
@@ -26,10 +26,9 @@ class AlignmentIterator(interfaces.AlignmentIterator):
     fmt = "EMBOSS"
 
     def _read_header(self, stream):
-        try:
-            line = next(stream)
-        except StopIteration:
-            raise ValueError("Empty file.") from None
+        line = stream.readline()
+        if not line:
+            raise ValueError("Empty file.")
         if line.rstrip() != "########################################":
             raise ValueError("Unexpected line: %s") % line
 

--- a/Tests/test_Align_emboss.py
+++ b/Tests/test_Align_emboss.py
@@ -6,6 +6,7 @@
 """Tests for Bio.Align.emboss module."""
 import unittest
 from io import StringIO
+from tempfile import NamedTemporaryFile
 
 from Bio import Align
 from Bio.Align import substitution_matrices
@@ -304,6 +305,13 @@ np.array([['G', 'P', 'P', 'P', 'Q', 'S', 'P', 'D', 'E', 'N', 'R', 'A', 'G',
             pass
         with self.assertRaises(AttributeError):
             alignments._stream
+        with open(path) as stream:
+            data = stream.read()
+        stream = NamedTemporaryFile("w+t")
+        stream.write(data)
+        stream.seek(0)
+        alignments = Align.parse(stream, "emboss")
+        self.check_matcher_pair(alignments)
 
     def check_matcher_pair(self, alignments):
         self.assertEqual(alignments.metadata["Program"], "matcher")


### PR DESCRIPTION

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
