### PR TITLE
Bio.Align exonerate, avoid next() so we can use NamedTemporaryFile

### DIFF
--- a/Bio/Align/exonerate.py
+++ b/Bio/Align/exonerate.py
@@ -430,14 +430,14 @@ class AlignmentIterator(interfaces.AlignmentIterator):
     def _read_header(self, stream):
         self.metadata = {}
         self.metadata["Program"] = "exonerate"
-        line = next(stream)
+        line = stream.readline()
         prefix = "Command line: "
         assert line.startswith(prefix)
         commandline = line[len(prefix) :].strip()
         assert commandline.startswith("[")
         assert commandline.endswith("]")
         self.metadata["Command line"] = commandline[1:-1]
-        line = next(stream)
+        line = stream.readline()
         prefix = "Hostname: "
         assert line.startswith(prefix)
         hostname = line[len(prefix) :].strip()
@@ -637,13 +637,12 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         for line in stream:
             line = line.strip()
             if line == "-- completed exonerate analysis":
-                try:
-                    next(stream)
-                except StopIteration:
-                    return
-                raise ValueError(
-                    "Found additional data after 'completed exonerate analysis'; corrupt file?"
-                )
+                line = stream.readline()
+                if line:
+                    raise ValueError(
+                        "Found additional data after 'completed exonerate analysis'; corrupt file?"
+                    )
+                return
             if line.startswith("vulgar: "):
                 words = line[8:].split()
                 alignment = self._parse_vulgar(words)


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
