### PR TITLE
Bio.Align hhr, avoid next() so we can use NamedTemporaryFile

### DIFF
--- a/Bio/Align/hhr.py
+++ b/Bio/Align/hhr.py
@@ -50,10 +50,9 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             else:
                 raise ValueError("Unknown key '%s'" % key)
         self.metadata = metadata
-        try:
-            line = next(stream)
-        except StopIteration:
-            raise ValueError("Truncated file.") from None
+        line = stream.readline()
+        if not line:
+            raise ValueError("Truncated file.")
         assert line.split() == [
             "No",
             "Hit",
@@ -141,7 +140,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 pass
             elif line.startswith(">"):
                 hmm_name, hmm_description = line[1:].split(None, 1)
-                line = next(stream)
+                line = stream.readline()
                 words = line.split()
                 alignment_annotations = {}
                 for word in words:
@@ -153,11 +152,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                     value = float(value)
                     alignment_annotations[key] = value
             elif line == "Done!":
-                try:
-                    next(stream)
-                except StopIteration:
-                    pass
-                else:
+                line = stream.readline()
+                if line:
                     raise ValueError(
                         "Found additional data after 'Done!'; corrupt file?"
                     )

--- a/Tests/test_Align_exonerate.py
+++ b/Tests/test_Align_exonerate.py
@@ -8,6 +8,7 @@
 import io
 import os
 import unittest
+from tempfile import NamedTemporaryFile
 
 from Bio import Align
 
@@ -51,6 +52,13 @@ class Exonerate_est2genome(unittest.TestCase):
             pass
         with self.assertRaises(AttributeError):
             alignments._stream
+        with open(exn_file) as stream:
+            data = stream.read()
+        stream = NamedTemporaryFile("w+t")
+        stream.write(data)
+        stream.seek(0)
+        alignments = Align.parse(stream, "exonerate")
+        self.check_cigar(alignments)
 
     def check_cigar(self, alignments):
         self.assertEqual(alignments.metadata["Program"], "exonerate")

--- a/Tests/test_Align_hhr.py
+++ b/Tests/test_Align_hhr.py
@@ -5,6 +5,7 @@
 """Tests for Bio.Align.hhr module."""
 import os
 import unittest
+from tempfile import NamedTemporaryFile
 
 import numpy as np
 
@@ -30,6 +31,13 @@ class Align_hhr_2uvo_hhblits(unittest.TestCase):
             pass
         with self.assertRaises(AttributeError):
             alignments._stream
+        with open(self.path) as stream:
+            data = stream.read()
+        stream = NamedTemporaryFile("w+t")
+        stream.write(data)
+        stream.seek(0)
+        alignments = Align.parse(stream, "hhr")
+        self.check_alignments(alignments)
 
     def check_alignments(self, alignments):
         self.assertEqual(alignments.metadata["No_of_seqs"], (1560, 4005))


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
