### PR TITLE
Bio.Align maf, avoid next() so we can use NamedTemporaryFile

### DIFF
--- a/Bio/Align/maf.py
+++ b/Bio/Align/maf.py
@@ -276,7 +276,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
 
     def _read_header(self, stream):
         metadata = {}
-        line = next(stream)
+        line = stream.readline()
         if line.startswith("track "):
             words = shlex.split(line)
             for word in words[1:]:
@@ -300,7 +300,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 else:
                     raise ValueError("Unexpected variable '%s' in track line" % key)
                 metadata[key] = value
-            line = next(stream)
+            line = stream.readline()
         words = line.split()
         if words[0] != "##maf":
             raise ValueError("header line does not start with ##maf")

--- a/Tests/test_Align_maf.py
+++ b/Tests/test_Align_maf.py
@@ -5,6 +5,7 @@
 """Tests for Align.maf module."""
 import unittest
 from io import StringIO
+from tempfile import NamedTemporaryFile
 
 from Bio import Align
 
@@ -11643,6 +11644,13 @@ np.array([['T', 'G', 'T', 'T', 'T', 'A', 'G', 'T', 'A', 'C', 'C', '-', '-',
         self.check_reading_ucsc_mm9_chr10(alignments)
         self.assertRaises(StopIteration, next, alignments)
         alignments = alignments[:]
+        self.check_reading_ucsc_mm9_chr10(alignments)
+        with open(path) as stream:
+            data = stream.read()
+        stream = NamedTemporaryFile("w+t")
+        stream.write(data)
+        stream.seek(0)
+        alignments = Align.parse(stream, "maf")
         self.check_reading_ucsc_mm9_chr10(alignments)
 
     def test_reading_missing_signature(self):


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
