### PR TITLE
Bio.Align msf, avoid next() so we can use NamedTemporaryFile

### DIFF
--- a/Bio/Align/msf.py
+++ b/Bio/Align/msf.py
@@ -28,9 +28,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
     fmt = "MSF"
 
     def _read_next_alignment(self, stream):
-        try:
-            line = next(stream)
-        except StopIteration:
+        line = stream.readline()
+        if not line:
             if stream.tell() == 0:
                 raise ValueError("Empty file.") from None
             return
@@ -165,9 +164,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         else:
             raise ValueError("End of file while looking for end of header // line.")
 
-        try:
-            line = next(stream)
-        except StopIteration:
+        line = stream.readline()
+        if not line:
             raise ValueError("End of file after // line, expected sequences.") from None
         if line.strip():
             raise ValueError("After // line, expected blank line before sequences.")


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
