### PR TITLE
Bio.Align nexus, avoid next() so we can use NamedTemporaryFile

### DIFF
--- a/Bio/Align/nexus.py
+++ b/Bio/Align/nexus.py
@@ -153,9 +153,8 @@ class AlignmentIterator(interfaces.AlignmentIterator):
     fmt = "Nexus"
 
     def _read_header(self, stream):
-        try:
-            line = next(stream)
-        except StopIteration:
+        line = stream.readline()
+        if not line:
             raise ValueError("Empty file.") from None
 
         if line.strip() != "#NEXUS":

--- a/Tests/test_Align_nexus.py
+++ b/Tests/test_Align_nexus.py
@@ -6,6 +6,7 @@
 """Tests for Bio.Align.nexus module."""
 import unittest
 from io import StringIO
+from tempfile import NamedTemporaryFile
 
 from Bio import Align
 
@@ -59,6 +60,13 @@ class TestNexusReading(unittest.TestCase):
         with self.assertRaises(AttributeError):
             alignments._stream
         self.check_reading_writing(path)
+        with open(path) as stream:
+            data = stream.read()
+        stream = NamedTemporaryFile("w+t")
+        stream.write(data)
+        stream.seek(0)
+        alignments = Align.parse(stream, "nexus")
+        self.check_nexus1(alignments)
 
     def check_nexus1(self, alignments):
         alignment = next(alignments)


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
