### PR TITLE
Bio.Align psl, avoid next() so we can use NamedTemporaryFile

### DIFF
--- a/Bio/Align/psl.py
+++ b/Bio/Align/psl.py
@@ -318,16 +318,16 @@ class AlignmentIterator(interfaces.AlignmentIterator):
     fmt = "PSL"
 
     def _read_header(self, stream):
-        line = next(stream)
+        line = stream.readline()
         if line.startswith("psLayout "):
             words = line.split()
             if words[1] != "version":
                 raise ValueError("Unexpected word '%s' in header line" % words[1])
             self.metadata = {"psLayout version": words[2]}
-            line = next(stream)
-            line = next(stream)
-            line = next(stream)
-            line = next(stream)
+            line = stream.readline()
+            line = stream.readline()
+            line = stream.readline()
+            line = stream.readline()
             if line.lstrip("-").strip() != "":
                 raise ValueError("End of header not found")
         else:

--- a/Tests/test_Align_psl.py
+++ b/Tests/test_Align_psl.py
@@ -5,6 +5,7 @@
 """Tests for Align.psl module."""
 import unittest
 from io import StringIO
+from tempfile import NamedTemporaryFile
 
 from Bio import Align
 from Bio.Align import substitution_matrices
@@ -65,6 +66,13 @@ class TestAlign_dna_rna(unittest.TestCase):
             pass
         with self.assertRaises(AttributeError):
             alignments._stream
+        with open(path) as stream:
+            data = stream.read()
+        stream = NamedTemporaryFile("w+t")
+        stream.write(data)
+        stream.seek(0)
+        alignments = Align.parse(stream, "psl")
+        self.check_alignments(alignments)
 
     def check_alignments(self, alignments):
         self.assertEqual(alignments.metadata["psLayout version"], "3")


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
