### PR TITLE
Bio.Align tabular, avoid next() so we can use NamedTemporaryFile

### DIFF
--- a/Bio/Align/tabular.py
+++ b/Bio/Align/tabular.py
@@ -43,10 +43,9 @@ class AlignmentIterator(interfaces.AlignmentIterator):
     fmt = "Tabular"
 
     def _read_header(self, stream):
-        try:
-            line = next(stream)
-        except StopIteration:
-            raise ValueError("Empty file.") from None
+        line = stream.readline()
+        if not line:
+            raise ValueError("Empty file.")
         if not line.startswith("# "):
             raise ValueError("Missing header.")
         line = line.rstrip()
@@ -72,7 +71,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         except ValueError:
             # FASTA
             metadata["Command line"] = line[2:]
-            line = next(stream)
+            line = stream.readline()
             assert line.startswith("# ")
             metadata["Program"], metadata["Version"] = line[2:].rstrip().split(None, 1)
             self._final_prefix = "# FASTA processed "

--- a/Tests/test_Align_tabular.py
+++ b/Tests/test_Align_tabular.py
@@ -6,6 +6,7 @@
 """Tests for Bio.Align.tabular module."""
 import os
 import unittest
+from tempfile import NamedTemporaryFile
 
 from Bio import Align
 from Bio.Align import substitution_matrices
@@ -50,6 +51,13 @@ class TestFastaProtein(unittest.TestCase):
             pass
         with self.assertRaises(AttributeError):
             alignments._stream
+        with open(path) as stream:
+            data = stream.read()
+        stream = NamedTemporaryFile("w+t")
+        stream.write(data)
+        stream.seek(0)
+        alignments = Align.parse(stream, "tabular")
+        self.check_m8CB(alignments)
 
     def check_m8CB(self, alignments):
         self.assertEqual(


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
