### PR TITLE
Alignments repr

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -4057,7 +4057,7 @@ class PairwiseAlignments(AlignmentsAbstractBaseClass):
         try:
             length = len(self._paths)
         except OverflowError:
-            length = ">" + str(sys.maxsize)
+            length = f">{sys.maxsize} alignments"
         else:
             if length == 1:
                 length = "1 alignment"

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -4053,6 +4053,20 @@ class PairwiseAlignments(AlignmentsAbstractBaseClass):
     def __len__(self):
         return len(self._paths)
 
+    def __repr__(self):
+        try:
+            length = len(self._paths)
+        except OverflowError:
+            length = ">" + str(sys.maxsize)
+        else:
+            if length == 1:
+                length = "1 alignment"
+            else:
+                length = f"{length} alignments"
+        pointer = hex(id(self))
+        score = format(self.score, "g")
+        return f"<PairwiseAlignments object ({length}; score={score}) at {pointer}>"
+
     def __getitem__(self, index):
         if not isinstance(index, int):
             raise TypeError(f"index must be an integer, not {index.__class__.__name__}")

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -343,12 +343,12 @@ alignments if segments with a score 0 can be added to the alignment. We
 follow the suggestion by Waterman & Eggert
 [Waterman1987]_ and disallow such extensions.
 
-If `aligner.mode` is set to `"fogsaa"`, then the Fast Optimal Global Alignment
-Algorithm [Chakraborty2013]_ with some modifications is used. This mode
-calculates a global alignment, but it is not like the regular `"global"` mode.
-It is best suited for long alignments between similar sequences. Rather than
-calculating all possible alignments like other algorithms do, FOGSAA uses a
-heuristic to detect steps in an alignment that cannot lead to an optimal
+If ``aligner.mode`` is set to ``"fogsaa"``, then the Fast Optimal Global
+Alignment Algorithm [Chakraborty2013]_ with some modifications is used. This
+mode calculates a global alignment, but it is not like the regular `"global"`
+mode.  It is best suited for long alignments between similar sequences. Rather
+than calculating all possible alignments like other algorithms do, FOGSAA uses
+a heuristic to detect steps in an alignment that cannot lead to an optimal
 alignment. This can speed up alignment, however, the heuristic makes
 assumptions about your match, mismatch, and gap scores. If the match score is
 less than the mismatch score or any gap score, or if any gap score is greater

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -60,17 +60,29 @@ between two sequences:
    >>> score
    3.0
 
-The ``aligner.align`` method returns ``Alignment`` objects, each
-representing one alignment between the two sequences:
+The ``aligner.align`` method returns a ``PairwiseAlignments`` object, which is
+an iterator over the alignments found. The ``PairwiseAlignments`` object will
+tell you how many alignments were found, and what their score is:
 
 .. cont-doctest
 
 .. code:: pycon
 
    >>> alignments = aligner.align(target, query)
+   >>> alignments  # doctest: +ELLIPSIS
+   <PairwiseAlignments object (2 alignments; score=3) at 0x...>
+
+Each alignment between the two sequences is stored in an ``Alignment`` object.
+``Alignment`` objects can be obtained by iterating over the alignments or by
+indexing:
+
+.. cont-doctest
+
+.. code:: pycon
+
    >>> alignment = alignments[0]
    >>> alignment  # doctest: +ELLIPSIS
-   <Alignment object (2 rows x 5 columns) at ...>
+   <Alignment object (2 rows x 5 columns) at 0x...>
 
 Iterate over the ``Alignment`` objects and print them to see the
 alignments:
@@ -122,8 +134,7 @@ as well as pointers to the sequences that were aligned:
    >>> alignment.query
    'GAT'
 
-Internally, the alignment is stored in terms of the sequence
-coordinates:
+Internally, the alignment is stored in terms of the sequence coordinates:
 
 .. cont-doctest
 

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -882,8 +882,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), "-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -919,8 +922,11 @@ query             0 G-A-T 3
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1005,8 +1011,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), "-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1026,8 +1035,11 @@ query             0 GA--T 3
         )
 
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1127,8 +1139,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score("AwBw", "zABz")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align("AwBw", "zABz")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=1.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=1.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -1178,8 +1193,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score("AwBw", "zABz")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align("AwBw", "zABz")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=1.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=1.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -1213,8 +1231,11 @@ class TestUnknownCharacter(unittest.TestCase):
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1239,8 +1260,11 @@ query             0 GA?T 4
         self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1271,8 +1295,11 @@ query             4 GA?T 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1297,8 +1324,11 @@ query             0 GAXT 4
         self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1328,8 +1358,11 @@ query             4 GAXT 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -1346,8 +1379,11 @@ query             0 GAXT 4
             np.array_equal(alignment.aligned, np.array([[[0, 4]], [[0, 4]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -1375,8 +1411,11 @@ query             4 GAXT 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1404,8 +1443,11 @@ query             0 GA-A?T 5
         self.assertEqual(counts.identities, 4)
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1440,8 +1482,11 @@ query             5 GA-A?T 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1469,8 +1514,11 @@ query             0 GA-AXT 5
         self.assertEqual(counts.identities, 4)
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1509,8 +1557,11 @@ query             5 GA-AXT 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1538,8 +1589,11 @@ query             0 GA-A?T 5
         self.assertEqual(counts.identities, 4)
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1574,8 +1628,11 @@ query             5 GA-A?T 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1603,8 +1660,11 @@ query             0 GA-AXT 5
         self.assertEqual(counts.identities, 4)
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1671,8 +1731,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=1.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=1.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -1703,8 +1766,11 @@ query             0 A- 1
             np.array_equal(alignment.aligned, np.array([[[0, 1]], [[0, 1]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=1.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=1.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -1772,8 +1838,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.9)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=2.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=2.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1806,8 +1875,11 @@ query             0 GA- 2
             np.array_equal(alignment.aligned, np.array([[[0, 2]], [[0, 2]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=2.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=2.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1875,8 +1947,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.9)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=2.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=2.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1895,8 +1970,11 @@ query             0 GA--T 3
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=2.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=2.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1952,8 +2030,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.9)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=2.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=2.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1972,8 +2053,11 @@ query             0 GA--T 3
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=2.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=2.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -2028,8 +2112,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.7)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=1.7) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=1.7) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.7)
@@ -2064,8 +2151,11 @@ query             0 G-ATA 4
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=1.7) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=1.7) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.7)
@@ -2137,8 +2227,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.3)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=1.3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=1.3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.3)
@@ -2157,8 +2250,11 @@ query             0 G--T 2
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=1.3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=1.3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.3)
@@ -2212,8 +2308,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 0.6)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=0.6) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=0.6) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.6)
@@ -2248,8 +2347,11 @@ query             0 G-T- 2
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=0.6) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=0.6) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.6)
@@ -2321,8 +2423,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 0.6)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=0.6) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=0.6) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.6)
@@ -2341,8 +2446,11 @@ query             0 -G-T 2
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=0.6) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=0.6) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.6)
@@ -2398,8 +2506,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, -1.2)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=-1.2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=-1.2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -1.2)
@@ -2418,8 +2529,11 @@ query             0 G--T 2
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=-1.2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=-1.2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -1.2)
@@ -2475,8 +2589,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, -1.2)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=-1.2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=-1.2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -1.2)
@@ -2495,8 +2612,11 @@ query             0 G--T 2
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=-1.2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=-1.2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -1.2)
@@ -2553,8 +2673,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (3 alignments; score=1) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (3 alignments; score=1) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -2601,8 +2724,11 @@ query             0 GT-- 2
             np.array_equal(alignment.aligned, np.array([[[0, 2]], [[0, 2]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (3 alignments; score=1) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (3 alignments; score=1) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -2688,8 +2814,11 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 1.0)
 
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -2707,8 +2836,11 @@ query             0 GT-- 2
         )
 
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -2766,8 +2898,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.7)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=1.7) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=1.7) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.7)
@@ -2802,8 +2937,11 @@ query             0 GTCT 4
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=1.7) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=1.7) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.7)
@@ -2875,8 +3013,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.8)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=1.8) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=1.8) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.8)
@@ -2895,8 +3036,11 @@ query             0 G-T 2
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=1.8) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=1.8) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.8)
@@ -2955,8 +3099,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (3 alignments; score=1.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (3 alignments; score=1.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -3007,8 +3154,11 @@ query             0 GTCCT 5
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (3 alignments; score=1.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (3 alignments; score=1.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -3102,8 +3252,11 @@ $""",
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3136,8 +3289,11 @@ query             0 AT-T 3
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3208,8 +3364,11 @@ $""",
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3226,8 +3385,11 @@ query             0 ATT 3
             np.array_equal(alignment.aligned, np.array([[[0, 3]], [[0, 3]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3282,8 +3444,11 @@ $""",
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3300,8 +3465,11 @@ query             0 ATA 3
             np.array_equal(alignment.aligned, np.array([[[0, 3]], [[0, 3]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3359,8 +3527,11 @@ $""",
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3393,8 +3564,11 @@ query             0 AT-T 3
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3467,8 +3641,11 @@ $""",
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3485,8 +3662,11 @@ query             0 ATT 3
             np.array_equal(alignment.aligned, np.array([[[0, 3]], [[0, 3]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3543,8 +3723,11 @@ $""",
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3561,8 +3744,11 @@ query             0 ATA 3
             np.array_equal(alignment.aligned, np.array([[[0, 3]], [[0, 3]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3612,8 +3798,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score("abcde", "c")
         self.assertAlmostEqual(score, 1)
         alignments = aligner.align("abcde", "c")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1)
@@ -3661,8 +3850,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score("abcce", "c")
         self.assertAlmostEqual(score, 1)
         alignments = aligner.align("abcce", "c")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=1) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=1) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1)
@@ -3726,8 +3918,11 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 0.2)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=0.2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=0.2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.2)
@@ -3857,8 +4052,11 @@ class TestPerSiteGapPenalties(unittest.TestCase):
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2)
@@ -3878,8 +4076,11 @@ query             0 --AABBBAAAACC----------CCAAAABBBAA-- 22
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2)
@@ -3945,8 +4146,11 @@ query            22 --AABBBAAAACC----------CCAAAABBBAA--  0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, -10)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=-10) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=-10) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -10)
@@ -3981,8 +4185,11 @@ query             0 AAB------------BBAAAACCCCAAAABBBAA-- 22
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=-10) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=-10) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -10)
@@ -4058,8 +4265,11 @@ query            22 --AABBBAAAACCCCAAAABB----------BAA--  0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4078,8 +4288,11 @@ query             0 TTG--GAA 6
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4114,8 +4327,11 @@ query             6 TTG--GAA 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, -8.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (4 alignments; score=-8) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (4 alignments; score=-8) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 4)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -8.0)
@@ -4184,8 +4400,11 @@ query             0 TTG--GAA 6
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (4 alignments; score=-8) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (4 alignments; score=-8) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 4)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -8.0)
@@ -4295,8 +4514,11 @@ query             6 TTG--GAA 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 13)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13)
@@ -4327,8 +4549,11 @@ query             9 CCCCAAAABBBAA 22
             np.array_equal(alignment.aligned, np.array([[[21, 34]], [[9, 22]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13)
@@ -4405,8 +4630,11 @@ query            13 CCCCAAAABBBAA  0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 13)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13)
@@ -4437,8 +4665,11 @@ query             9 CCCCAAAABBBAA 22
             np.array_equal(alignment.aligned, np.array([[[21, 34]], [[9, 22]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13)
@@ -4510,8 +4741,11 @@ query            13 CCCCAAAABBBAA  0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4542,8 +4776,11 @@ query             4 AA 6
             np.array_equal(alignment.aligned, np.array([[[4, 6]], [[4, 6]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4590,8 +4827,11 @@ query             2 AA 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4622,8 +4862,11 @@ query             4 AA 6
             np.array_equal(alignment.aligned, np.array([[[4, 6]], [[4, 6]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=2) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=2) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4731,8 +4974,11 @@ class TestAlignerInput(unittest.TestCase):
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         self.assertEqual(
             str(alignments[0]),
@@ -4758,8 +5004,11 @@ Gly Ala Ala Cys Thr
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertEqual(
@@ -4838,8 +5087,11 @@ Pro Pro Gly --- Ala --- Thr --- ---
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertEqual(
@@ -4892,8 +5144,11 @@ Gly Ala Ala Cys Thr
         r1 = SeqRecord(s1, id="first", description="1st sequence")
         r2 = SeqRecord(s2, id="second", description="2nd sequence")
         alignments = aligner.align(t1, t2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=-7) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=-7) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -4914,8 +5169,11 @@ CGTT
 """,
         )
         alignments = aligner.align(s1, s2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=-7) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=-7) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -4936,8 +5194,11 @@ CGTT
 """,
         )
         alignments = aligner.align(r1, r2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=-7) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=-7) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -5066,8 +5327,11 @@ class TestOverflowError(unittest.TestCase):
         record = SeqIO.read(path, "fasta")
         seq2 = record.seq
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (>{sys.maxsize} alignments; score=1286) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (>{sys.maxsize} alignments; score=1286) at {hex(id(alignments))}>""",
+        )
         self.assertAlmostEqual(alignments.score, 1286.0)
         message = "^number of optimal alignments is larger than (%d|%d)$" % (
             2147483647,  # on 32-bit systems
@@ -5208,8 +5472,11 @@ query          1534 CCTCCTT---A 1542
         self.assertEqual(alignment.shape, (2, 1811))
         self.assertAlmostEqual(alignment.score, 1286.0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (>{sys.maxsize} alignments; score=1286) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (>{sys.maxsize} alignments; score=1286) at {hex(id(alignments))}>""",
+        )
         self.assertAlmostEqual(alignments.score, 1286.0)
         message = "^number of optimal alignments is larger than (%d|%d)$" % (
             2147483647,  # on 32-bit systems
@@ -5540,8 +5807,11 @@ class TestUnicodeStrings(unittest.TestCase):
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -5589,8 +5859,11 @@ class TestUnicodeStrings(unittest.TestCase):
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -5644,8 +5917,11 @@ class TestUnicodeStrings(unittest.TestCase):
         score = aligner.score("ℵℷℶℷ", "ℸℵℶℸ")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align("ℵℷℶℷ", "ℸℵℶℸ")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=1.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=1.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -5674,8 +5950,11 @@ class TestUnicodeStrings(unittest.TestCase):
         score = aligner.score("生物科物", "学生科学")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align("生物科物", "学生科学")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=1.9) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=1.9) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -5867,8 +6146,11 @@ class TestAlignmentFormat(unittest.TestCase):
         aligner.end_gap_score = 0
         aligner.mismatch = -1
         alignments = aligner.align(chromosome, transcript)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=19) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=19) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 19.0)
@@ -5906,8 +6188,11 @@ query	0	target	1	255	10D10M1I3M11D12M14D7M1D5M6D	*	0	0	AGCATCGAGCGACTTGAGTACTATT
         alignments = aligner.align(
             chromosome, reverse_complement(transcript), strand="-"
         )
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=19) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=19) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 19.0)
@@ -5949,8 +6234,11 @@ query	16	target	1	255	10D10M1I3M11D12M14D7M1D5M6D	*	0	0	AGCATCGAGCGACTTGAGTACTAT
         aligner.end_gap_score = 0
         aligner.mismatch = -10
         alignments = aligner.align("ACGTAGCATCAGC", "CCCCACGTAGCATCAGC")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         self.assertAlmostEqual(alignments.score, 13.0)
         alignment = alignments[0]
@@ -5984,8 +6272,11 @@ query	0	target	1	255	4I13M	*	0	0	CCCCACGTAGCATCAGC	*	AS:i:13
         alignments = aligner.align(
             "ACGTAGCATCAGC", reverse_complement("CCCCACGTAGCATCAGC"), strand="-"
         )
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         self.assertAlmostEqual(alignments.score, 13.0)
         alignment = alignments[0]
@@ -6017,8 +6308,11 @@ query	16	target	1	255	4I13M	*	0	0	CCCCACGTAGCATCAGC	*	AS:i:13
 """,
         )
         alignments = aligner.align("CCCCACGTAGCATCAGC", "ACGTAGCATCAGC")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13.0)
@@ -6052,8 +6346,11 @@ query	0	target	1	255	4D13M	*	0	0	ACGTAGCATCAGC	*	AS:i:13
         alignments = aligner.align(
             "CCCCACGTAGCATCAGC", reverse_complement("ACGTAGCATCAGC"), strand="-"
         )
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13.0)
@@ -6085,8 +6382,11 @@ query	16	target	1	255	4D13M	*	0	0	ACGTAGCATCAGC	*	AS:i:13
 """,
         )
         alignments = aligner.align("ACGTAGCATCAGC", "ACGTAGCATCAGCGGGG")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6119,8 +6419,11 @@ query	0	target	1	255	13M4I	*	0	0	ACGTAGCATCAGCGGGG	*	AS:i:13
         alignments = aligner.align(
             "ACGTAGCATCAGC", reverse_complement("ACGTAGCATCAGCGGGG"), strand="-"
         )
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6151,8 +6454,11 @@ query	16	target	1	255	13M4I	*	0	0	ACGTAGCATCAGCGGGG	*	AS:i:13
 """,
         )
         alignments = aligner.align("ACGTAGCATCAGCGGGG", "ACGTAGCATCAGC")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13.0)
@@ -6186,8 +6492,11 @@ query	0	target	1	255	13M4D	*	0	0	ACGTAGCATCAGC	*	AS:i:13
         alignments = aligner.align(
             "ACGTAGCATCAGCGGGG", reverse_complement("ACGTAGCATCAGC"), strand="-"
         )
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13.0)
@@ -6231,8 +6540,11 @@ query	16	target	1	255	13M4D	*	0	0	ACGTAGCATCAGC	*	AS:i:13
         # use strings for target and query
         alignments = aligner.align(target, query)
         self.assertEqual(len(alignments), 1)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         alignment = alignments[0]
         self.assertEqual(
             str(alignment),
@@ -6270,8 +6582,11 @@ query	0	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
 """,
         )
         alignments = aligner.align(target, reverse_complement(query), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6311,8 +6626,11 @@ query	16	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         )
         # use Seq objects for target and query
         alignments = aligner.align(Seq(target), Seq(query))
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6353,8 +6671,11 @@ query	0	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         alignments = aligner.align(
             Seq(target), Seq(query).reverse_complement(), strand="-"
         )
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6397,8 +6718,11 @@ query	16	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         aligner.end_gap_score = 0
         # use strings for target and query
         alignments = aligner.align(target, query)
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6437,8 +6761,11 @@ query	0	target	1	255	6D17M5I	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
 """,
         )
         alignments = aligner.align(target, reverse_complement(query), strand="-")
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6478,8 +6805,11 @@ query	16	target	1	255	6D17M5I	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         )
         # use Seq objects for target and query
         alignments = aligner.align(Seq(target), Seq(query))
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6520,8 +6850,11 @@ query	0	target	1	255	6D17M5I	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         alignments = aligner.align(
             Seq(target), Seq(query).reverse_complement(), strand="-"
         )
-        self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
+        self.assertEqual(
+            repr(alignments),
+            f"""\
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""",
+        )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -883,7 +883,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -920,7 +920,7 @@ query             0 G-A-T 3
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1006,7 +1006,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1027,7 +1027,7 @@ query             0 GA--T 3
 
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1128,7 +1128,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align("AwBw", "zABz")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.9)>""")
+<PairwiseAlignments object (1 alignment; score=1.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -1179,7 +1179,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align("AwBw", "zABz")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.9)>""")
+<PairwiseAlignments object (1 alignment; score=1.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -1214,7 +1214,7 @@ class TestUnknownCharacter(unittest.TestCase):
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1240,7 +1240,7 @@ query             0 GA?T 4
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1272,7 +1272,7 @@ query             4 GA?T 0
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1298,7 +1298,7 @@ query             0 GAXT 4
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1329,7 +1329,7 @@ query             4 GAXT 0
         self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2)>""")
+<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -1347,7 +1347,7 @@ query             0 GAXT 4
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2)>""")
+<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -1376,7 +1376,7 @@ query             4 GAXT 0
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1405,7 +1405,7 @@ query             0 GA-A?T 5
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1441,7 +1441,7 @@ query             5 GA-A?T 0
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1470,7 +1470,7 @@ query             0 GA-AXT 5
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1510,7 +1510,7 @@ query             5 GA-AXT 0
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1539,7 +1539,7 @@ query             0 GA-A?T 5
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1575,7 +1575,7 @@ query             5 GA-A?T 0
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1604,7 +1604,7 @@ query             0 GA-AXT 5
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
+<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1672,7 +1672,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1.9)>""")
+<PairwiseAlignments object (2 alignments; score=1.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -1704,7 +1704,7 @@ query             0 A- 1
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1.9)>""")
+<PairwiseAlignments object (2 alignments; score=1.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -1773,7 +1773,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 2.9)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=2.9)>""")
+<PairwiseAlignments object (2 alignments; score=2.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1807,7 +1807,7 @@ query             0 GA- 2
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=2.9)>""")
+<PairwiseAlignments object (2 alignments; score=2.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1876,7 +1876,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 2.9)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2.9)>""")
+<PairwiseAlignments object (1 alignment; score=2.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1896,7 +1896,7 @@ query             0 GA--T 3
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2.9)>""")
+<PairwiseAlignments object (1 alignment; score=2.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1953,7 +1953,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 2.9)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2.9)>""")
+<PairwiseAlignments object (1 alignment; score=2.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1973,7 +1973,7 @@ query             0 GA--T 3
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2.9)>""")
+<PairwiseAlignments object (1 alignment; score=2.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -2029,7 +2029,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 1.7)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1.7)>""")
+<PairwiseAlignments object (2 alignments; score=1.7) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.7)
@@ -2065,7 +2065,7 @@ query             0 G-ATA 4
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1.7)>""")
+<PairwiseAlignments object (2 alignments; score=1.7) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.7)
@@ -2138,7 +2138,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 1.3)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.3)>""")
+<PairwiseAlignments object (1 alignment; score=1.3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.3)
@@ -2158,7 +2158,7 @@ query             0 G--T 2
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.3)>""")
+<PairwiseAlignments object (1 alignment; score=1.3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.3)
@@ -2213,7 +2213,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 0.6)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=0.6)>""")
+<PairwiseAlignments object (2 alignments; score=0.6) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.6)
@@ -2249,7 +2249,7 @@ query             0 G-T- 2
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=0.6)>""")
+<PairwiseAlignments object (2 alignments; score=0.6) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.6)
@@ -2322,7 +2322,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 0.6)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=0.6)>""")
+<PairwiseAlignments object (1 alignment; score=0.6) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.6)
@@ -2342,7 +2342,7 @@ query             0 -G-T 2
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=0.6)>""")
+<PairwiseAlignments object (1 alignment; score=0.6) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.6)
@@ -2399,7 +2399,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, -1.2)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-1.2)>""")
+<PairwiseAlignments object (1 alignment; score=-1.2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -1.2)
@@ -2419,7 +2419,7 @@ query             0 G--T 2
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-1.2)>""")
+<PairwiseAlignments object (1 alignment; score=-1.2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -1.2)
@@ -2476,7 +2476,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, -1.2)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-1.2)>""")
+<PairwiseAlignments object (1 alignment; score=-1.2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -1.2)
@@ -2496,7 +2496,7 @@ query             0 G--T 2
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-1.2)>""")
+<PairwiseAlignments object (1 alignment; score=-1.2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -1.2)
@@ -2554,7 +2554,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 1.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (3 alignments; score=1)>""")
+<PairwiseAlignments object (3 alignments; score=1) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -2602,7 +2602,7 @@ query             0 GT-- 2
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (3 alignments; score=1)>""")
+<PairwiseAlignments object (3 alignments; score=1) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -2689,7 +2689,7 @@ Pairwise sequence aligner with parameters
 
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1)>""")
+<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -2708,7 +2708,7 @@ query             0 GT-- 2
 
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1)>""")
+<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -2767,7 +2767,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 1.7)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1.7)>""")
+<PairwiseAlignments object (2 alignments; score=1.7) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.7)
@@ -2803,7 +2803,7 @@ query             0 GTCT 4
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1.7)>""")
+<PairwiseAlignments object (2 alignments; score=1.7) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.7)
@@ -2876,7 +2876,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 1.8)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.8)>""")
+<PairwiseAlignments object (1 alignment; score=1.8) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.8)
@@ -2896,7 +2896,7 @@ query             0 G-T 2
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.8)>""")
+<PairwiseAlignments object (1 alignment; score=1.8) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.8)
@@ -2956,7 +2956,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (3 alignments; score=1.9)>""")
+<PairwiseAlignments object (3 alignments; score=1.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -3008,7 +3008,7 @@ query             0 GTCCT 5
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (3 alignments; score=1.9)>""")
+<PairwiseAlignments object (3 alignments; score=1.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -3103,7 +3103,7 @@ $""",
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3137,7 +3137,7 @@ query             0 AT-T 3
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3209,7 +3209,7 @@ $""",
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3227,7 +3227,7 @@ query             0 ATT 3
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3283,7 +3283,7 @@ $""",
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3301,7 +3301,7 @@ query             0 ATA 3
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3360,7 +3360,7 @@ $""",
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3394,7 +3394,7 @@ query             0 AT-T 3
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3468,7 +3468,7 @@ $""",
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3486,7 +3486,7 @@ query             0 ATT 3
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3544,7 +3544,7 @@ $""",
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3562,7 +3562,7 @@ query             0 ATA 3
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3613,7 +3613,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 1)
         alignments = aligner.align("abcde", "c")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1)>""")
+<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1)
@@ -3662,7 +3662,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 1)
         alignments = aligner.align("abcce", "c")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1)>""")
+<PairwiseAlignments object (2 alignments; score=1) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1)
@@ -3727,7 +3727,7 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 0.2)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=0.2)>""")
+<PairwiseAlignments object (1 alignment; score=0.2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.2)
@@ -3858,7 +3858,7 @@ class TestPerSiteGapPenalties(unittest.TestCase):
         self.assertAlmostEqual(score, 2)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2)>""")
+<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2)
@@ -3879,7 +3879,7 @@ query             0 --AABBBAAAACC----------CCAAAABBBAA-- 22
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2)>""")
+<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2)
@@ -3946,7 +3946,7 @@ query            22 --AABBBAAAACC----------CCAAAABBBAA--  0
         self.assertAlmostEqual(score, -10)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=-10)>""")
+<PairwiseAlignments object (2 alignments; score=-10) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -10)
@@ -3982,7 +3982,7 @@ query             0 AAB------------BBAAAACCCCAAAABBBAA-- 22
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=-10)>""")
+<PairwiseAlignments object (2 alignments; score=-10) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -10)
@@ -4059,7 +4059,7 @@ query            22 --AABBBAAAACCCCAAAABB----------BAA--  0
         self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2)>""")
+<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4079,7 +4079,7 @@ query             0 TTG--GAA 6
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2)>""")
+<PairwiseAlignments object (1 alignment; score=2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4115,7 +4115,7 @@ query             6 TTG--GAA 0
         self.assertAlmostEqual(score, -8.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (4 alignments; score=-8)>""")
+<PairwiseAlignments object (4 alignments; score=-8) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 4)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -8.0)
@@ -4185,7 +4185,7 @@ query             0 TTG--GAA 6
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (4 alignments; score=-8)>""")
+<PairwiseAlignments object (4 alignments; score=-8) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 4)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -8.0)
@@ -4296,7 +4296,7 @@ query             6 TTG--GAA 0
         self.assertAlmostEqual(score, 13)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=13)>""")
+<PairwiseAlignments object (2 alignments; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13)
@@ -4328,7 +4328,7 @@ query             9 CCCCAAAABBBAA 22
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=13)>""")
+<PairwiseAlignments object (2 alignments; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13)
@@ -4406,7 +4406,7 @@ query            13 CCCCAAAABBBAA  0
         self.assertAlmostEqual(score, 13)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=13)>""")
+<PairwiseAlignments object (2 alignments; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13)
@@ -4438,7 +4438,7 @@ query             9 CCCCAAAABBBAA 22
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=13)>""")
+<PairwiseAlignments object (2 alignments; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13)
@@ -4511,7 +4511,7 @@ query            13 CCCCAAAABBBAA  0
         self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=2)>""")
+<PairwiseAlignments object (2 alignments; score=2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4543,7 +4543,7 @@ query             4 AA 6
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=2)>""")
+<PairwiseAlignments object (2 alignments; score=2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4591,7 +4591,7 @@ query             2 AA 0
         self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=2)>""")
+<PairwiseAlignments object (2 alignments; score=2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4623,7 +4623,7 @@ query             4 AA 6
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=2)>""")
+<PairwiseAlignments object (2 alignments; score=2) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4732,7 +4732,7 @@ class TestAlignerInput(unittest.TestCase):
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         self.assertEqual(
             str(alignments[0]),
@@ -4759,7 +4759,7 @@ Gly Ala Ala Cys Thr
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertEqual(
@@ -4839,7 +4839,7 @@ Pro Pro Gly --- Ala --- Thr --- ---
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertEqual(
@@ -4893,7 +4893,7 @@ Gly Ala Ala Cys Thr
         r2 = SeqRecord(s2, id="second", description="2nd sequence")
         alignments = aligner.align(t1, t2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-7)>""")
+<PairwiseAlignments object (1 alignment; score=-7) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -4915,7 +4915,7 @@ CGTT
         )
         alignments = aligner.align(s1, s2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-7)>""")
+<PairwiseAlignments object (1 alignment; score=-7) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -4937,7 +4937,7 @@ CGTT
         )
         alignments = aligner.align(r1, r2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-7)>""")
+<PairwiseAlignments object (1 alignment; score=-7) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -5067,7 +5067,7 @@ class TestOverflowError(unittest.TestCase):
         seq2 = record.seq
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (>{sys.maxsize} alignments; score=1286)>""")
+<PairwiseAlignments object (>{sys.maxsize} alignments; score=1286) at {hex(id(alignments))}>""")
         self.assertAlmostEqual(alignments.score, 1286.0)
         message = "^number of optimal alignments is larger than (%d|%d)$" % (
             2147483647,  # on 32-bit systems
@@ -5209,7 +5209,7 @@ query          1534 CCTCCTT---A 1542
         self.assertAlmostEqual(alignment.score, 1286.0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (>9223372036854775807 alignments; score=1286)>""")
+<PairwiseAlignments object (>9223372036854775807 alignments; score=1286) at {hex(id(alignments))}>""")
         self.assertAlmostEqual(alignments.score, 1286.0)
         message = "^number of optimal alignments is larger than (%d|%d)$" % (
             2147483647,  # on 32-bit systems
@@ -5541,7 +5541,7 @@ class TestUnicodeStrings(unittest.TestCase):
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
+<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -5590,7 +5590,7 @@ class TestUnicodeStrings(unittest.TestCase):
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -5645,7 +5645,7 @@ class TestUnicodeStrings(unittest.TestCase):
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align("ℵℷℶℷ", "ℸℵℶℸ")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.9)>""")
+<PairwiseAlignments object (1 alignment; score=1.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -5675,7 +5675,7 @@ class TestUnicodeStrings(unittest.TestCase):
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align("生物科物", "学生科学")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.9)>""")
+<PairwiseAlignments object (1 alignment; score=1.9) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -5868,7 +5868,7 @@ class TestAlignmentFormat(unittest.TestCase):
         aligner.mismatch = -1
         alignments = aligner.align(chromosome, transcript)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=19)>""")
+<PairwiseAlignments object (1 alignment; score=19) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 19.0)
@@ -5907,7 +5907,7 @@ query	0	target	1	255	10D10M1I3M11D12M14D7M1D5M6D	*	0	0	AGCATCGAGCGACTTGAGTACTATT
             chromosome, reverse_complement(transcript), strand="-"
         )
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=19)>""")
+<PairwiseAlignments object (1 alignment; score=19) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 19.0)
@@ -5950,7 +5950,7 @@ query	16	target	1	255	10D10M1I3M11D12M14D7M1D5M6D	*	0	0	AGCATCGAGCGACTTGAGTACTAT
         aligner.mismatch = -10
         alignments = aligner.align("ACGTAGCATCAGC", "CCCCACGTAGCATCAGC")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         self.assertAlmostEqual(alignments.score, 13.0)
         alignment = alignments[0]
@@ -5985,7 +5985,7 @@ query	0	target	1	255	4I13M	*	0	0	CCCCACGTAGCATCAGC	*	AS:i:13
             "ACGTAGCATCAGC", reverse_complement("CCCCACGTAGCATCAGC"), strand="-"
         )
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         self.assertAlmostEqual(alignments.score, 13.0)
         alignment = alignments[0]
@@ -6018,7 +6018,7 @@ query	16	target	1	255	4I13M	*	0	0	CCCCACGTAGCATCAGC	*	AS:i:13
         )
         alignments = aligner.align("CCCCACGTAGCATCAGC", "ACGTAGCATCAGC")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13.0)
@@ -6053,7 +6053,7 @@ query	0	target	1	255	4D13M	*	0	0	ACGTAGCATCAGC	*	AS:i:13
             "CCCCACGTAGCATCAGC", reverse_complement("ACGTAGCATCAGC"), strand="-"
         )
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13.0)
@@ -6086,7 +6086,7 @@ query	16	target	1	255	4D13M	*	0	0	ACGTAGCATCAGC	*	AS:i:13
         )
         alignments = aligner.align("ACGTAGCATCAGC", "ACGTAGCATCAGCGGGG")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6120,7 +6120,7 @@ query	0	target	1	255	13M4I	*	0	0	ACGTAGCATCAGCGGGG	*	AS:i:13
             "ACGTAGCATCAGC", reverse_complement("ACGTAGCATCAGCGGGG"), strand="-"
         )
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6152,7 +6152,7 @@ query	16	target	1	255	13M4I	*	0	0	ACGTAGCATCAGCGGGG	*	AS:i:13
         )
         alignments = aligner.align("ACGTAGCATCAGCGGGG", "ACGTAGCATCAGC")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13.0)
@@ -6187,7 +6187,7 @@ query	0	target	1	255	13M4D	*	0	0	ACGTAGCATCAGC	*	AS:i:13
             "ACGTAGCATCAGCGGGG", reverse_complement("ACGTAGCATCAGC"), strand="-"
         )
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13.0)
@@ -6232,7 +6232,7 @@ query	16	target	1	255	13M4D	*	0	0	ACGTAGCATCAGC	*	AS:i:13
         alignments = aligner.align(target, query)
         self.assertEqual(len(alignments), 1)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         alignment = alignments[0]
         self.assertEqual(
             str(alignment),
@@ -6271,7 +6271,7 @@ query	0	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         )
         alignments = aligner.align(target, reverse_complement(query), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6312,7 +6312,7 @@ query	16	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         # use Seq objects for target and query
         alignments = aligner.align(Seq(target), Seq(query))
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6354,7 +6354,7 @@ query	0	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
             Seq(target), Seq(query).reverse_complement(), strand="-"
         )
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6398,7 +6398,7 @@ query	16	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         # use strings for target and query
         alignments = aligner.align(target, query)
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6438,7 +6438,7 @@ query	0	target	1	255	6D17M5I	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         )
         alignments = aligner.align(target, reverse_complement(query), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6479,7 +6479,7 @@ query	16	target	1	255	6D17M5I	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         # use Seq objects for target and query
         alignments = aligner.align(Seq(target), Seq(query))
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6521,7 +6521,7 @@ query	0	target	1	255	6D17M5I	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
             Seq(target), Seq(query).reverse_complement(), strand="-"
         )
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
+<PairwiseAlignments object (1 alignment; score=13) at {hex(id(alignments))}>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -5209,7 +5209,7 @@ query          1534 CCTCCTT---A 1542
         self.assertAlmostEqual(alignment.score, 1286.0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(repr(alignments), f"""\
-<PairwiseAlignments object (>9223372036854775807 alignments; score=1286) at {hex(id(alignments))}>""")
+<PairwiseAlignments object (>{sys.maxsize} alignments; score=1286) at {hex(id(alignments))}>""")
         self.assertAlmostEqual(alignments.score, 1286.0)
         message = "^number of optimal alignments is larger than (%d|%d)$" % (
             2147483647,  # on 32-bit systems

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -7,6 +7,7 @@
 
 import array
 import os
+import sys
 import unittest
 
 try:
@@ -881,6 +882,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), "-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -916,6 +919,8 @@ query             0 G-A-T 3
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1000,6 +1005,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), "-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1019,6 +1026,8 @@ query             0 GA--T 3
         )
 
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1118,6 +1127,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score("AwBw", "zABz")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align("AwBw", "zABz")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.9)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -1167,6 +1178,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score("AwBw", "zABz")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align("AwBw", "zABz")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.9)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -1200,6 +1213,8 @@ class TestUnknownCharacter(unittest.TestCase):
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1224,6 +1239,8 @@ query             0 GA?T 4
         self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1254,6 +1271,8 @@ query             4 GA?T 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1278,6 +1297,8 @@ query             0 GAXT 4
         self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -1307,6 +1328,8 @@ query             4 GAXT 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -1323,6 +1346,8 @@ query             0 GAXT 4
             np.array_equal(alignment.aligned, np.array([[[0, 4]], [[0, 4]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -1350,6 +1375,8 @@ query             4 GAXT 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1377,6 +1404,8 @@ query             0 GA-A?T 5
         self.assertEqual(counts.identities, 4)
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1411,6 +1440,8 @@ query             5 GA-A?T 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1438,6 +1469,8 @@ query             0 GA-AXT 5
         self.assertEqual(counts.identities, 4)
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1476,6 +1509,8 @@ query             5 GA-AXT 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1503,6 +1538,8 @@ query             0 GA-A?T 5
         self.assertEqual(counts.identities, 4)
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1537,6 +1574,8 @@ query             5 GA-A?T 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 4.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1564,6 +1603,8 @@ query             0 GA-AXT 5
         self.assertEqual(counts.identities, 4)
         self.assertEqual(counts.mismatches, 0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=4)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 4.0)
@@ -1630,6 +1671,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1.9)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -1660,6 +1703,8 @@ query             0 A- 1
             np.array_equal(alignment.aligned, np.array([[[0, 1]], [[0, 1]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1.9)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -1727,6 +1772,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.9)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=2.9)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1759,6 +1806,8 @@ query             0 GA- 2
             np.array_equal(alignment.aligned, np.array([[[0, 2]], [[0, 2]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=2.9)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1826,6 +1875,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.9)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2.9)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1844,6 +1895,8 @@ query             0 GA--T 3
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2.9)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1899,6 +1952,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.9)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2.9)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1917,6 +1972,8 @@ query             0 GA--T 3
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2.9)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.9)
@@ -1971,6 +2028,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.7)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1.7)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.7)
@@ -2005,6 +2064,8 @@ query             0 G-ATA 4
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1.7)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.7)
@@ -2076,6 +2137,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.3)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.3)
@@ -2094,6 +2157,8 @@ query             0 G--T 2
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.3)
@@ -2147,6 +2212,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 0.6)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=0.6)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.6)
@@ -2181,6 +2248,8 @@ query             0 G-T- 2
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=0.6)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.6)
@@ -2252,6 +2321,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 0.6)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=0.6)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.6)
@@ -2270,6 +2341,8 @@ query             0 -G-T 2
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=0.6)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.6)
@@ -2325,6 +2398,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, -1.2)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-1.2)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -1.2)
@@ -2343,6 +2418,8 @@ query             0 G--T 2
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-1.2)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -1.2)
@@ -2398,6 +2475,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, -1.2)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-1.2)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -1.2)
@@ -2416,6 +2495,8 @@ query             0 G--T 2
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-1.2)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -1.2)
@@ -2472,6 +2553,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (3 alignments; score=1)>""")
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -2518,6 +2601,8 @@ query             0 GT-- 2
             np.array_equal(alignment.aligned, np.array([[[0, 2]], [[0, 2]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (3 alignments; score=1)>""")
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -2603,6 +2688,8 @@ Pairwise sequence aligner with parameters
         self.assertAlmostEqual(score, 1.0)
 
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -2620,6 +2707,8 @@ query             0 GT-- 2
         )
 
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.0)
@@ -2677,6 +2766,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.7)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1.7)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.7)
@@ -2711,6 +2802,8 @@ query             0 GTCT 4
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1.7)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.7)
@@ -2782,6 +2875,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.8)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.8)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.8)
@@ -2800,6 +2895,8 @@ query             0 G-T 2
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.8)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.8)
@@ -2858,6 +2955,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (3 alignments; score=1.9)>""")
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -2908,6 +3007,8 @@ query             0 GTCCT 5
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (3 alignments; score=1.9)>""")
         self.assertEqual(len(alignments), 3)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -3001,6 +3102,8 @@ $""",
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3033,6 +3136,8 @@ query             0 AT-T 3
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3103,6 +3208,8 @@ $""",
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3119,6 +3226,8 @@ query             0 ATT 3
             np.array_equal(alignment.aligned, np.array([[[0, 3]], [[0, 3]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3173,6 +3282,8 @@ $""",
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3189,6 +3300,8 @@ query             0 ATA 3
             np.array_equal(alignment.aligned, np.array([[[0, 3]], [[0, 3]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3246,6 +3359,8 @@ $""",
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3278,6 +3393,8 @@ query             0 AT-T 3
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3350,6 +3467,8 @@ $""",
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3366,6 +3485,8 @@ query             0 ATT 3
             np.array_equal(alignment.aligned, np.array([[[0, 3]], [[0, 3]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3422,6 +3543,8 @@ $""",
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3438,6 +3561,8 @@ query             0 ATA 3
             np.array_equal(alignment.aligned, np.array([[[0, 3]], [[0, 3]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -3487,6 +3612,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score("abcde", "c")
         self.assertAlmostEqual(score, 1)
         alignments = aligner.align("abcde", "c")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1)
@@ -3534,6 +3661,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score("abcce", "c")
         self.assertAlmostEqual(score, 1)
         alignments = aligner.align("abcce", "c")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=1)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1)
@@ -3597,6 +3726,8 @@ Pairwise sequence aligner with parameters
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 0.2)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=0.2)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 0.2)
@@ -3726,6 +3857,8 @@ class TestPerSiteGapPenalties(unittest.TestCase):
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2)
@@ -3745,6 +3878,8 @@ query             0 --AABBBAAAACC----------CCAAAABBBAA-- 22
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2)
@@ -3810,6 +3945,8 @@ query            22 --AABBBAAAACC----------CCAAAABBBAA--  0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, -10)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=-10)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -10)
@@ -3844,6 +3981,8 @@ query             0 AAB------------BBAAAACCCCAAAABBBAA-- 22
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=-10)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -10)
@@ -3919,6 +4058,8 @@ query            22 --AABBBAAAACCCCAAAABB----------BAA--  0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -3937,6 +4078,8 @@ query             0 TTG--GAA 6
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=2)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -3971,6 +4114,8 @@ query             6 TTG--GAA 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, -8.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (4 alignments; score=-8)>""")
         self.assertEqual(len(alignments), 4)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -8.0)
@@ -4039,6 +4184,8 @@ query             0 TTG--GAA 6
             )
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (4 alignments; score=-8)>""")
         self.assertEqual(len(alignments), 4)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, -8.0)
@@ -4148,6 +4295,8 @@ query             6 TTG--GAA 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 13)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=13)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13)
@@ -4178,6 +4327,8 @@ query             9 CCCCAAAABBBAA 22
             np.array_equal(alignment.aligned, np.array([[[21, 34]], [[9, 22]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=13)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13)
@@ -4254,6 +4405,8 @@ query            13 CCCCAAAABBBAA  0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 13)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=13)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13)
@@ -4284,6 +4437,8 @@ query             9 CCCCAAAABBBAA 22
             np.array_equal(alignment.aligned, np.array([[[21, 34]], [[9, 22]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=13)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13)
@@ -4355,6 +4510,8 @@ query            13 CCCCAAAABBBAA  0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=2)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4385,6 +4542,8 @@ query             4 AA 6
             np.array_equal(alignment.aligned, np.array([[[4, 6]], [[4, 6]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=2)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4431,6 +4590,8 @@ query             2 AA 0
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
         self.assertAlmostEqual(score, 2.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=2)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4461,6 +4622,8 @@ query             4 AA 6
             np.array_equal(alignment.aligned, np.array([[[4, 6]], [[4, 6]]]))
         )
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=2)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 2.0)
@@ -4568,6 +4731,8 @@ class TestAlignerInput(unittest.TestCase):
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
         self.assertEqual(len(alignments), 2)
         self.assertEqual(
             str(alignments[0]),
@@ -4593,6 +4758,8 @@ Gly Ala Ala Cys Thr
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertEqual(
@@ -4671,6 +4838,8 @@ Pro Pro Gly --- Ala --- Thr --- ---
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertEqual(
@@ -4723,6 +4892,8 @@ Gly Ala Ala Cys Thr
         r1 = SeqRecord(s1, id="first", description="1st sequence")
         r2 = SeqRecord(s2, id="second", description="2nd sequence")
         alignments = aligner.align(t1, t2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-7)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -4743,6 +4914,8 @@ CGTT
 """,
         )
         alignments = aligner.align(s1, s2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-7)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -4763,6 +4936,8 @@ CGTT
 """,
         )
         alignments = aligner.align(r1, r2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=-7)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -4891,6 +5066,8 @@ class TestOverflowError(unittest.TestCase):
         record = SeqIO.read(path, "fasta")
         seq2 = record.seq
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (>{sys.maxsize} alignments; score=1286)>""")
         self.assertAlmostEqual(alignments.score, 1286.0)
         message = "^number of optimal alignments is larger than (%d|%d)$" % (
             2147483647,  # on 32-bit systems
@@ -5031,6 +5208,8 @@ query          1534 CCTCCTT---A 1542
         self.assertEqual(alignment.shape, (2, 1811))
         self.assertAlmostEqual(alignment.score, 1286.0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (>9223372036854775807 alignments; score=1286)>""")
         self.assertAlmostEqual(alignments.score, 1286.0)
         message = "^number of optimal alignments is larger than (%d|%d)$" % (
             2147483647,  # on 32-bit systems
@@ -5361,6 +5540,8 @@ class TestUnicodeStrings(unittest.TestCase):
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (2 alignments; score=3)>""")
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -5408,6 +5589,8 @@ class TestUnicodeStrings(unittest.TestCase):
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=3)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 3.0)
@@ -5461,6 +5644,8 @@ class TestUnicodeStrings(unittest.TestCase):
         score = aligner.score("ℵℷℶℷ", "ℸℵℶℸ")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align("ℵℷℶℷ", "ℸℵℶℸ")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.9)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -5489,6 +5674,8 @@ class TestUnicodeStrings(unittest.TestCase):
         score = aligner.score("生物科物", "学生科学")
         self.assertAlmostEqual(score, 1.9)
         alignments = aligner.align("生物科物", "学生科学")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=1.9)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 1.9)
@@ -5680,6 +5867,8 @@ class TestAlignmentFormat(unittest.TestCase):
         aligner.end_gap_score = 0
         aligner.mismatch = -1
         alignments = aligner.align(chromosome, transcript)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=19)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 19.0)
@@ -5717,6 +5906,8 @@ query	0	target	1	255	10D10M1I3M11D12M14D7M1D5M6D	*	0	0	AGCATCGAGCGACTTGAGTACTATT
         alignments = aligner.align(
             chromosome, reverse_complement(transcript), strand="-"
         )
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=19)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 19.0)
@@ -5758,6 +5949,8 @@ query	16	target	1	255	10D10M1I3M11D12M14D7M1D5M6D	*	0	0	AGCATCGAGCGACTTGAGTACTAT
         aligner.end_gap_score = 0
         aligner.mismatch = -10
         alignments = aligner.align("ACGTAGCATCAGC", "CCCCACGTAGCATCAGC")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         self.assertAlmostEqual(alignments.score, 13.0)
         alignment = alignments[0]
@@ -5791,6 +5984,8 @@ query	0	target	1	255	4I13M	*	0	0	CCCCACGTAGCATCAGC	*	AS:i:13
         alignments = aligner.align(
             "ACGTAGCATCAGC", reverse_complement("CCCCACGTAGCATCAGC"), strand="-"
         )
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         self.assertAlmostEqual(alignments.score, 13.0)
         alignment = alignments[0]
@@ -5822,6 +6017,8 @@ query	16	target	1	255	4I13M	*	0	0	CCCCACGTAGCATCAGC	*	AS:i:13
 """,
         )
         alignments = aligner.align("CCCCACGTAGCATCAGC", "ACGTAGCATCAGC")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13.0)
@@ -5855,6 +6052,8 @@ query	0	target	1	255	4D13M	*	0	0	ACGTAGCATCAGC	*	AS:i:13
         alignments = aligner.align(
             "CCCCACGTAGCATCAGC", reverse_complement("ACGTAGCATCAGC"), strand="-"
         )
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13.0)
@@ -5886,6 +6085,8 @@ query	16	target	1	255	4D13M	*	0	0	ACGTAGCATCAGC	*	AS:i:13
 """,
         )
         alignments = aligner.align("ACGTAGCATCAGC", "ACGTAGCATCAGCGGGG")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -5918,6 +6119,8 @@ query	0	target	1	255	13M4I	*	0	0	ACGTAGCATCAGCGGGG	*	AS:i:13
         alignments = aligner.align(
             "ACGTAGCATCAGC", reverse_complement("ACGTAGCATCAGCGGGG"), strand="-"
         )
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -5948,6 +6151,8 @@ query	16	target	1	255	13M4I	*	0	0	ACGTAGCATCAGCGGGG	*	AS:i:13
 """,
         )
         alignments = aligner.align("ACGTAGCATCAGCGGGG", "ACGTAGCATCAGC")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13.0)
@@ -5981,6 +6186,8 @@ query	0	target	1	255	13M4D	*	0	0	ACGTAGCATCAGC	*	AS:i:13
         alignments = aligner.align(
             "ACGTAGCATCAGCGGGG", reverse_complement("ACGTAGCATCAGC"), strand="-"
         )
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertAlmostEqual(alignment.score, 13.0)
@@ -6024,6 +6231,8 @@ query	16	target	1	255	13M4D	*	0	0	ACGTAGCATCAGC	*	AS:i:13
         # use strings for target and query
         alignments = aligner.align(target, query)
         self.assertEqual(len(alignments), 1)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         alignment = alignments[0]
         self.assertEqual(
             str(alignment),
@@ -6061,6 +6270,8 @@ query	0	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
 """,
         )
         alignments = aligner.align(target, reverse_complement(query), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6100,6 +6311,8 @@ query	16	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         )
         # use Seq objects for target and query
         alignments = aligner.align(Seq(target), Seq(query))
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6140,6 +6353,8 @@ query	0	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         alignments = aligner.align(
             Seq(target), Seq(query).reverse_complement(), strand="-"
         )
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6182,6 +6397,8 @@ query	16	target	7	255	17M5S	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         aligner.end_gap_score = 0
         # use strings for target and query
         alignments = aligner.align(target, query)
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6220,6 +6437,8 @@ query	0	target	1	255	6D17M5I	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
 """,
         )
         alignments = aligner.align(target, reverse_complement(query), strand="-")
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6259,6 +6478,8 @@ query	16	target	1	255	6D17M5I	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         )
         # use Seq objects for target and query
         alignments = aligner.align(Seq(target), Seq(query))
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(
@@ -6299,6 +6520,8 @@ query	0	target	1	255	6D17M5I	*	0	0	ACGATCGAGCNGCTACGCCCNC	*	AS:i:13
         alignments = aligner.align(
             Seq(target), Seq(query).reverse_complement(), strand="-"
         )
+        self.assertEqual(repr(alignments), f"""\
+<PairwiseAlignments object at {hex(id(alignments))} (1 alignment; score=13)>""")
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
         self.assertEqual(


### PR DESCRIPTION
Make `repr(alignments)` (where `alignments` are pairwise alignments returned by `PairwiseAligner`) more informative.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
