### PR TITLE
Pre-commit hook update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     -   id: end-of-file-fixer
         files: \.py$
     -   id: mixed-line-ending
+        exclude: \.bb$
 -   repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.7
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         files: \.py$
     -   id: mixed-line-ending
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.9.7
     hooks:
     # Run the Ruff linter.
     -   id: ruff
@@ -34,14 +34,14 @@ repos:
     -   id: black
         args: [--check,--target-version,py310]
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.1.2
     hooks:
     -   id: flake8
         additional_dependencies: [
             'flake8-rst-docstrings>=0.2.3',
         ]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.15.0
     hooks:
     -   id: mypy
         # equivalent to "files" in .mypy.ini
@@ -50,7 +50,7 @@ repos:
     rev: 1.19.1
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==24.2.0]
+        additional_dependencies: [black==24.10.0]
         exclude: ^.github/
 -   repo: https://github.com/rstcheck/rstcheck
     rev: v6.2.4
@@ -74,7 +74,7 @@ repos:
         '--ignore=D000,D001,D002,D004'
     ]
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
     -   id: codespell
         files: \.(rst|md)$

--- a/Doc/doc.rst
+++ b/Doc/doc.rst
@@ -200,7 +200,7 @@ X.3 Build a Codon Alignment
 ---------------------------
 
 Building a codon alignment is the first step of many evolutionary
-anaysis. But how to do that? ``Bio.codonalign`` provides you an easy
+analysis. But how to do that? ``Bio.codonalign`` provides you an easy
 function ``build()`` to achieve all. The data you need to prepare in
 advance is a protein alignment and a set of DNA sequences that can be
 translated into the protein sequences in the alignment.


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This updates the version of all the hooks except black (due to a trailing whitespace regression in docstrings).

This also fixes the mixed-line-endings hook trying to change the binary ``*.bb`` files, and a typo spotted in the updated spelling checking.