### PR TITLE
Update SeqRecord.py so that letter_annotations remain None in copies made using upper or lower methods.

### DIFF
--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -1127,7 +1127,7 @@ class SeqRecord:
             dbxrefs=self.dbxrefs[:],
             features=self.features[:],
             annotations=self.annotations.copy(),
-            letter_annotations=self.letter_annotations.copy(),
+            letter_annotations=self.letter_annotations.copy() or None,
         )
 
     def lower(self) -> "SeqRecord":
@@ -1174,7 +1174,7 @@ class SeqRecord:
             dbxrefs=self.dbxrefs[:],
             features=self.features[:],
             annotations=self.annotations.copy(),
-            letter_annotations=self.letter_annotations.copy(),
+            letter_annotations=self.letter_annotations.copy() or None,
         )
 
     def isupper(self):

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -1127,7 +1127,7 @@ class SeqRecord:
             dbxrefs=self.dbxrefs[:],
             features=self.features[:],
             annotations=self.annotations.copy(),
-            letter_annotations=self.letter_annotations.copy() or None,
+            letter_annotations==None if self.letter_annotations is None else self.letter_annotations.copy(),
         )
 
     def lower(self) -> "SeqRecord":
@@ -1174,7 +1174,7 @@ class SeqRecord:
             dbxrefs=self.dbxrefs[:],
             features=self.features[:],
             annotations=self.annotations.copy(),
-            letter_annotations=self.letter_annotations.copy() or None,
+            letter_annotations=None if self.letter_annotations is None else self.letter_annotations.copy(),
         )
 
     def isupper(self):

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -66,6 +66,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Bertrand Frottier <bertrand.frottier at domain free.fr>
 - Bertrand Néron <https://github.com/bneron>
 - Bill Barnard <bill at domain barnard-engineering.com>
+- Björn F. Johansson <bjorn_johansson@bio.uminho.pt>
 - Blaise Li <https://github.com/blaiseli>
 - Bob Bussell <rgb2003 at domain med.cornell.edu>
 - Bogdan T. <bogdan at pearlgen dot com>


### PR DESCRIPTION
Calling .upper() or .lower() sets the letter_annotations as a side effect.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [ X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
