### PR TITLE
Document removal of deprecated 1to3 and 3to1 functions

### DIFF
--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -188,10 +188,16 @@ The `Bio.HMM.DynamicProgramming`, `Bio.HMM.Trainer`, `Bio.HMM.MarkovModel`, and
 `Bio.HMM.Utilities` modules were deprecated in release 1.82. Consider using
 hmmlearn (https://pypi.org/project/hmmlearn/) instead.
 
+Bio.PDB.Polypeptide
+-------------------
+Functions ``three_to_one`` and ``one_to_three`` were deprecated in Release 1.80
+and removed in Release 1.82. Please use the dictionary ``nucleic_letters_3to1``
+instead, available from this module but defined in ``Bio.Data.PDBData``.
+
 Bio.Data.SCOPData
 -----------------
 Deprecated in release 1.80, and removed in release 1.82. Please use
-Bio.Data.PDBData instead.
+``Bio.Data.PDBData`` instead.
 
 Bio.Application and the command line wrappers using it
 ------------------------------------------------------


### PR DESCRIPTION
Deprecated in #3985 and removed in #4508.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
