### PR TITLE
PairwiseAligner: convert bytes to ints in Python instead of C

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -4408,6 +4408,7 @@ AlignmentCounts object returned by the .counts method of an Alignment object."""
         """Return the alignment score of two sequences using PairwiseAligner."""
         if isinstance(seqA, (Seq, MutableSeq, SeqRecord)):
             seqA = bytes(seqA)
+            seqA = np.frombuffer(seqA, dtype=np.uint8).astype(np.int32)
         elif isinstance(seqA, str):
             seqA = np.frombuffer(bytearray(seqA, self.codec), dtype="i")
         else:
@@ -4420,6 +4421,7 @@ AlignmentCounts object returned by the .counts method of an Alignment object."""
             seqB = reverse_complement(seqB)
         if isinstance(seqB, (Seq, MutableSeq, SeqRecord)):
             seqB = bytes(seqB)
+            seqB = np.frombuffer(seqB, dtype=np.uint8).astype(np.int32)
         elif isinstance(seqB, str):
             seqB = np.frombuffer(bytearray(seqB, self.codec), dtype="i")
         else:

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -4376,8 +4376,9 @@ AlignmentCounts object returned by the .counts method of an Alignment object."""
         """Return the alignments of two sequences using PairwiseAligner."""
         if isinstance(seqA, (Seq, MutableSeq, SeqRecord)):
             sA = bytes(seqA)
+            sA = np.frombuffer(sA, dtype=np.uint8).astype(np.int32)
         elif isinstance(seqA, str):
-            sA = np.frombuffer(bytearray(seqA, self.codec), dtype="i")
+            sA = np.frombuffer(bytearray(seqA, self.codec), dtype=np.int32)
         else:
             alphabet = self.alphabet
             if alphabet is None:
@@ -4392,8 +4393,9 @@ AlignmentCounts object returned by the .counts method of an Alignment object."""
             sB = reverse_complement(seqB)
         if isinstance(seqB, (Seq, MutableSeq, SeqRecord)):
             sB = bytes(sB)
+            sB = np.frombuffer(sB, dtype=np.uint8).astype(np.int32)
         elif isinstance(seqB, str):
-            sB = np.frombuffer(bytearray(sB, self.codec), dtype="i")
+            sB = np.frombuffer(bytearray(sB, self.codec), dtype=np.int32)
         else:
             alphabet = self.alphabet
             if alphabet is not None:


### PR DESCRIPTION
to be strictly compliant with the.buffer protocol.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
