### PR TITLE
BlastXML2 output

### DIFF
--- a/Bio/Blast/_parser.py
+++ b/Bio/Blast/_parser.py
@@ -205,8 +205,10 @@ class XMLHandler:
 
     def _start_blastxml2(self, name, attributes):
         """Process the XML schema (before processing the element)."""
+        uri, localname = name.split(" ")
+        assert uri == "http://www.ncbi.nlm.nih.gov"
+        assert localname in ("BlastXML2", "BlastOutput2")
         key = "%s schemaLocation" % XMLHandler.schema_namespace
-        assert name == "http://www.ncbi.nlm.nih.gov BlastXML2"
         domain, url = attributes[key].split()
         assert domain == "http://www.ncbi.nlm.nih.gov"
         if XMLHandler._schema_methods is None:


### PR DESCRIPTION
NCBI renamed the first tag in Blast XML2 output from BlastXML2 to BlastOutput2.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #4974
