### PR TITLE
Locale independent date serialization

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -647,7 +647,7 @@ class GenBankWriter(_InsdcWriter):
             "NOV",
             "DEC",
         ]
-        if isinstance(date, datetime) or isinstance(date, datetime_date):
+        if isinstance(date, datetime_date):
             date = f"{date.day:02d}-{months[date.month - 1]}-{date.year}"
         if not isinstance(date, str) or len(date) != 11:
             warnings.warn(

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -651,7 +651,7 @@ class GenBankWriter(_InsdcWriter):
             date = f"{date.day:02d}-{months[date.month - 1]}-{date.year}"
         if not isinstance(date, str) or len(date) != 11:
             warnings.warn(
-                f"Invalide date format provided {record.annotations['date']!r}, using default {default!r}",
+                f"Invalid date format provided {record.annotations['date']!r}, using default {default!r}",
                 BiopythonWarning,
             )
             return default
@@ -659,7 +659,7 @@ class GenBankWriter(_InsdcWriter):
             datetime(int(date[-4:]), months.index(date[3:6]) + 1, int(date[0:2]))
         except ValueError:
             warnings.warn(
-                f"Invalide date provided {record.annotations['date']!r}, using default {default!r}",
+                f"Invalid date provided {record.annotations['date']!r}, using default {default!r}",
                 BiopythonWarning,
             )
             date = default

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -650,10 +650,18 @@ class GenBankWriter(_InsdcWriter):
         if isinstance(date, datetime) or isinstance(date, datetime_date):
             date = f"{date.day:02d}-{months[date.month - 1]}-{date.year}"
         if not isinstance(date, str) or len(date) != 11:
+            warnings.warn(
+                f"Invalide date format provided {record.annotations['date']!r}, using default {default!r}",
+                BiopythonWarning,
+            )
             return default
         try:
             datetime(int(date[-4:]), months.index(date[3:6]) + 1, int(date[0:2]))
         except ValueError:
+            warnings.warn(
+                f"Invalide date provided {record.annotations['date']!r}, using default {default!r}",
+                BiopythonWarning,
+            )
             date = default
         return date
 

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -31,7 +31,7 @@ http://www.ebi.ac.uk/imgt/hla/docs/manual.html
 """
 
 import warnings
-from datetime import datetime
+from datetime import datetime, date as datetime_date
 from string import ascii_letters
 from string import digits
 
@@ -633,9 +633,6 @@ class GenBankWriter(_InsdcWriter):
         # Cope with a list of one string:
         if isinstance(date, list) and len(date) == 1:
             date = date[0]
-        if isinstance(date, datetime):
-            date = date.strftime("%d-%b-%Y").upper()
-
         months = [
             "JAN",
             "FEB",
@@ -650,6 +647,8 @@ class GenBankWriter(_InsdcWriter):
             "NOV",
             "DEC",
         ]
+        if isinstance(date, datetime) or isinstance(date, datetime_date):
+            date = f"{date.day:02d}-{months[date.month - 1]}-{date.year}"
         if not isinstance(date, str) or len(date) != 11:
             return default
         try:

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -74,6 +74,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Brandon Carter  <https://github.com/b-carter>
 - Brandon Invergo <https://github.com/brandoninvergo>
 - Brian Osborne <https://github.com/bosborne>
+- Bryan Brancotte <https://github.com/bryan-brancotte>
 - Bryan Lunt <https://github.com/bryan-lunt>
 - Caio Fontes <https://github.com/Caiofcas>
 - Cam McMenamie <https://github.com/kamurani>

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -1112,6 +1112,30 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
             ).date()
             self.write_read_check("gb")
 
+    def test_invalide_date_format(self):
+        # Using a date in the wrong format
+        self.record.annotations["date"] = "04-04-1970"
+        stream = StringIO()
+        with warnings.catch_warnings(record=True) as w:
+            SeqIO.write([self.record], stream, "gb")
+            self.assertEqual(len(w), 1, "a warning should be raised")
+            self.assertIn("Invalide date format", str(w[0].message))
+        stream.seek(0)
+        self.assertIn("1980", stream.getvalue())
+        self.assertNotIn(self.record.annotations["date"], stream.getvalue())
+
+    def test_invalide_date_locale(self):
+        # Using a date not in english which is not accepted by the writer
+        self.record.annotations["date"] = "04-OKT-1970"
+        stream = StringIO()
+        with warnings.catch_warnings(record=True) as w:
+            SeqIO.write([self.record], stream, "gb")
+            self.assertEqual(len(w), 1, "a warning should be raised")
+            self.assertIn("Invalide date", str(w[0].message))
+        stream.seek(0)
+        self.assertIn("1980", stream.getvalue())
+        self.assertNotIn(self.record.annotations["date"], stream.getvalue())
+
 
 class NC_000932(SeqIOFeatureTestBaseClass):
     # This includes an evil dual strand gene

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -1112,26 +1112,26 @@ class FeatureWriting(SeqIOFeatureTestBaseClass):
             ).date()
             self.write_read_check("gb")
 
-    def test_invalide_date_format(self):
+    def test_invalid_date_format(self):
         # Using a date in the wrong format
         self.record.annotations["date"] = "04-04-1970"
         stream = StringIO()
         with warnings.catch_warnings(record=True) as w:
             SeqIO.write([self.record], stream, "gb")
             self.assertEqual(len(w), 1, "a warning should be raised")
-            self.assertIn("Invalide date format", str(w[0].message))
+            self.assertIn("Invalid date format", str(w[0].message))
         stream.seek(0)
         self.assertIn("1980", stream.getvalue())
         self.assertNotIn(self.record.annotations["date"], stream.getvalue())
 
-    def test_invalide_date_locale(self):
+    def test_invalid_date_locale(self):
         # Using a date not in english which is not accepted by the writer
         self.record.annotations["date"] = "04-OKT-1970"
         stream = StringIO()
         with warnings.catch_warnings(record=True) as w:
             SeqIO.write([self.record], stream, "gb")
             self.assertEqual(len(w), 1, "a warning should be raised")
-            self.assertIn("Invalide date", str(w[0].message))
+            self.assertIn("Invalid date", str(w[0].message))
         stream.seek(0)
         self.assertIn("1980", stream.getvalue())
         self.assertNotIn(self.record.annotations["date"], stream.getvalue())


### PR DESCRIPTION
- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Locale independent date serialization when writing GenBank file. Also added support for datetime.date.
Added test with various local known to make the former serialization fail (when available).

Show a warning when writing a file with an invalide date format

Closes #4972 
