### PR TITLE
Fix/seq feature fromstring

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -625,6 +625,7 @@ class Location(ABC):
         """Represent the Location object as a string for debugging."""
         return f"{self.__class__.__name__}(...)"
 
+    @staticmethod
     def fromstring(text, length=None, circular=False, stranded=True):
         """Create a Location object from a string.
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -138,6 +138,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Frederic Sohm <fsms at domain users.sourceforge.net>
 - Frederik Gwinner
 - Fredric Johansson <https://github.com/fredricj>
+- Fynn Freyer <https://github.com/FynnFreyer>
 - Fábio Madeira <https://github.com/biomadeira>
 - Gaetan Lehman <gaetan.lehmann at domain jouy.inra.fr>
 - Gavin E Crooks <https://github.com/gecrooks>

--- a/Tests/test_SeqFeature.py
+++ b/Tests/test_SeqFeature.py
@@ -16,7 +16,7 @@ from Bio import Seq
 from Bio import SeqIO
 from Bio import SeqRecord
 from Bio.Data.CodonTable import TranslationError
-from Bio.SeqFeature import AfterPosition
+from Bio.SeqFeature import AfterPosition, Location
 from Bio.SeqFeature import BeforePosition
 from Bio.SeqFeature import BetweenPosition
 from Bio.SeqFeature import CompoundLocation
@@ -242,6 +242,21 @@ class TestLocations(unittest.TestCase):
         self.assertEqual(int(location2.end), 24)
         self.assertEqual(int(location3.start), 10)
         self.assertEqual(int(location3.end), 40)
+
+    def test_fromstring_is_static(self):
+        """Test whether Location.fromstring is static.
+        See `#4984 <https://github.com/biopython/biopython/pull/4984#issuecomment-2758280951>`_.
+        """
+        is_static = isinstance(Location.__dict__["fromstring"], staticmethod)
+        self.assertTrue(is_static)
+        # with old implementation
+        # behaviour of CompoundLocation.fromstring would change
+        # depending on whether we call from instance or class
+        f1 = SimpleLocation(10, 40)
+        f2 = SimpleLocation(50, 59)
+        instance = CompoundLocation([f1, f2])
+        spec = "10..40"
+        self.assertEqual(Location.fromstring(spec), instance.fromstring(spec))
 
 
 class TestPositions(unittest.TestCase):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4983

The fromstring method of the abstract Location class is missing a method decorator, which causes the first argument to be interpreted as self. This doesn't lead to any problems when calling it from the class, but confuses tooling.

Note that the commit that added this (908ee298) speaks of a "fromstring class method", so taking this method in the instance context should be fine.

I agree to my contributions being dual licensed under the BSD 3-Clause and Biopython License
Signed-off-by: Fynn Freyer <fynn.freyer@googlemail.com>
