### PR TITLE
altered behaviour to account for existing degenerate nucleotides

### DIFF
--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -193,8 +193,21 @@ class GenericPositionMatrix(dict):
             "CGU": "B",
             "ACGT": "N",
             "ACGU": "N",
+            "B" : "B",
+            "D" : "D",
+            "H" : "H",
+            "K" : "K",
+            "M" : "M",
+            "N" : "N",
+            "R" : "R",
+            "S" : "S",
+            "V" : "V",
+            "W" : "W",
+            "Y" : "Y",
+            "-" : "-",
         }
         sequence = ""
+        ambig_list = ["B", "D", "H", "K", "M", "N", "R", "S", "V", "W", "Y", "-"]
         for i in range(self.length):
 
             def get(nucleotide):
@@ -206,9 +219,13 @@ class GenericPositionMatrix(dict):
             if counts[0] > sum(counts[1:]) and counts[0] > 2 * counts[1]:
                 key = nucleotides[0]
             elif 4 * sum(counts[:2]) > 3 * sum(counts):
-                key = "".join(sorted(nucleotides[:2]))
+                key = "".join(sorted([nuc for nuc in nucleotides[:2] if nuc not in ambig_list]))
+                if len(key) == 0:       # multiple ambiguous nucleotides at that position
+                    key = nucleotides[0]
             elif counts[3] == 0:
-                key = "".join(sorted(nucleotides[:3]))
+                key = "".join(sorted([nuc for nuc in nucleotides[:3] if nuc not in ambig_list]))
+                if len(key) == 0:       # multiple ambiguous nucleotides at that position
+                    key = nucleotides[0]
             else:
                 key = "ACGT"
             nucleotide = degenerate_nucleotide.get(key, key)


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4988 

The changes should ensure the following behaviour when generating degenerate consensus sequences:
1) If there is a single degenerate nucleotide at an alignment position, retain it (don't replace with `V` as current behaviour)
2) If there are two or three top count degenerate nucleotides, retain the one with the highest count
3) If there is an `ACTG` and a degenerate nucleotide, only retain the `ACTG` nucleotide (similar to existing behaviour)

Importantly, none of these changes will matter if the motif is created with an alphabet that does not include the degenerate nucleotides to be accounted for. While a change to the default alphabet could be made in `motifs/__init__.py` line 36, I don't know the implications of that for other functionality. Instead, users who want to account for degenerate nucleotides in their motifs should create motifs that specify the alphabet explicitly. See the following example:
```
from Bio.Seq import Seq
from Bio import motifs

mymotif = motifs.create([Seq('ACGT-N'), Seq('ATGTTN'), Seq('ACGT-N')])
mymotif.degenerate_consensus
# Seq('AYGTTV')

mymotif = motifs.create([Seq('ACGT-N'), Seq('ATGTTN'), Seq('ACGT-N')], alphabet = 'ACGTN-')
mymotif.degenerate_consensus
# Seq('AYGTTN')
```
