### PR TITLE
fix model_n

### DIFF
--- a/Bio/PDB/mmcifio.py
+++ b/Bio/PDB/mmcifio.py
@@ -281,10 +281,7 @@ class MMCIFIO(StructureIO):
             if not select.accept_model(model):
                 continue
             # mmCIF files with a single model have it specified as model 1
-            if model.serial_num == 0:
-                model_n = "1"
-            else:
-                model_n = str(model.serial_num)
+            model_n = str(model.serial_num + 1)
             # This is used to write label_entity_id and label_asym_id and
             # increments from 1, changing with each molecule
             entity_id = 0

--- a/Bio/PDB/mmcifio.py
+++ b/Bio/PDB/mmcifio.py
@@ -281,7 +281,7 @@ class MMCIFIO(StructureIO):
             if not select.accept_model(model):
                 continue
             # mmCIF files with a single model have it specified as model 1
-            model_n = str(model.serial_num + 1)
+            model_n = str(model.serial_num)
             # This is used to write label_entity_id and label_asym_id and
             # increments from 1, changing with each molecule
             entity_id = 0

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -445,6 +445,7 @@ possible, especially the following contributors:
 - Hussein Faara (first contribution)
 - Manuel Lera Ramirez
 - Jacob Beal (first contribution)
+- James Krieger
 - Jarrod Millman
 - João Rodrigues
 - Josha Inglis


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Solves the issue reported in https://github.com/prody/ProDy/issues/2111, where biopython MMCIFIO _save_structure was writing model serial num 1 twice so there was one model too few and the number of atoms was wrong too.
