### PR TITLE
Add more ways to translate nucleotide sequence with dashes

### DIFF
--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -237,6 +237,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Mark Amery <https://github.com/ExplodingCabbage>
 - Markus Piotrowski <https://github.com/MarkusPiotrowski>
 - Martin Thoma <https://martin-thoma.com/author/martin-thoma/>
+- Martin Mokrejš <https://github.com/mmokrejs>
 - Marton Langa <https://github.com/martonlanga>
 - Mateusz Korycinski <https://github.com/mkorycinski>
 - Matt Ruffalo <https://github.com/mruffalo>


### PR DESCRIPTION
Currently one cannot translate sequences aligned (padded) with dashes into a protein sequence as the in-built tests are way too strict. Add a couple of arguments to the translate() functions to overcome the road blocks.

Typically padding symbols for gaps are '-' but this default can be changed on the fly if necessary.

With this change one can with respect_alignment=True translate a padded alignment file in FASTA format so that '---' translates to '-', 'AT-' translates to 'X'.

In an alternative mode with ignore_gaps=True it is possible to ignore the padding dashes so that 'AT-GATG' translates to 'MM'.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
