### PR TITLE
Use default gap='-' in translate function to match Seq method

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -2734,7 +2734,7 @@ def back_transcribe(rna):
 
 
 def _translate_str(
-    sequence, table, stop_symbol="*", to_stop=False, cds=False, pos_stop="X", gap=None
+    sequence, table, stop_symbol="*", to_stop=False, cds=False, pos_stop="X", gap="-"
 ):
     """Translate nucleotide string into a protein string (PRIVATE).
 
@@ -2913,7 +2913,7 @@ def _translate_str(
 
 
 def translate(
-    sequence, table="Standard", stop_symbol="*", to_stop=False, cds=False, gap=None
+    sequence, table="Standard", stop_symbol="*", to_stop=False, cds=False, gap="-"
 ):
     """Translate a nucleotide sequence into amino acids.
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -20,9 +20,15 @@ has also been tested on PyPy3.10 v7.3.17.
 `Infernal <http://eddylab.org/infernal/>` (v1.0.0+) RNA search tool. The 
 format are ``infernal-tab`` and ``infernal-text``.
 
+The ``Bio.Seq.translate()`` function now defaults to ``gap="-"`` to match the
+``Seq`` object method, meaning the gap codon "---" is translated as "-" rather
+than raising an exception.
+
 Many thanks to the Biopython developers and community for making this release
 possible, especially the following contributors:
 
+- Michiel de Hoon
+- Peter Cock
 - Samuel Prince (first contribution)
 
 15 January 2025: Biopython 1.85
@@ -62,8 +68,8 @@ possible, especially the following contributors:
 - Alan Medlar
 - Carlos Peña
 - Gert Hulselmans
-- Peter Cock
 - Michiel de Hoon
+- Peter Cock
 
 28 June 2024: Biopython 1.84
 ============================

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -1090,16 +1090,14 @@ class TestTranslating(unittest.TestCase):
         seq = "GTGGCCATTGTAATGGGCCGC"
         self.assertEqual("VAIVMGR", Seq.translate(seq))
 
-    def test_translation_of_gapped_string_with_gap_char_given(self):
+    def test_translation_of_gapped_string(self):
         seq = "GTG---GCCATTGTAATGGGCCGC"
         expected = "V-AIVMGR"
         self.assertEqual(expected, Seq.translate(seq, gap="-"))
+        self.assertEqual(expected, Seq.translate(seq))
         self.assertRaises(TypeError, Seq.translate, seq, gap=[])
         self.assertRaises(ValueError, Seq.translate, seq, gap="-*")
-
-    def test_translation_of_gapped_string_no_gap_char_given(self):
-        seq = "GTG---GCCATTGTAATGGGCCGC"
-        self.assertRaises(TranslationError, Seq.translate, seq)
+        self.assertRaises(TranslationError, Seq.translate, seq, gap=None)
 
     def test_translation_to_stop(self):
         for nucleotide_seq in self.test_seqs:


### PR DESCRIPTION
This fixes an inconsistency noted on #4992.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
