### PR TITLE
types - add a script that tracks the progress of typed API surface

### DIFF
--- a/Scripts/hacked_parse_mypy.py
+++ b/Scripts/hacked_parse_mypy.py
@@ -1,0 +1,53 @@
+import os
+from pathlib import Path
+import re
+import subprocess
+from datetime import datetime
+
+script_path = Path(__file__).absolute()
+root_path = script_path.parent.parent
+os.chdir(root_path)
+
+# Get the current timestamp
+timestamp = datetime.now().strftime("%d%m%y%H%M%S")
+
+# Get the latest Git hash
+git_hash = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()[:7]
+
+
+# Run the mypy command and capture its output
+process = subprocess.Popen(
+    ["mypy", "--disallow-untyped-defs", "Bio"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True
+)
+
+# Process the log
+merged_lines = []
+merged_lines2 = []
+last_line = None
+
+for line in process.stdout:
+    line = line.strip()
+    if last_line:
+        match = re.match(r'(.*): note: (.*)', last_line)
+        if match and re.match(r'.*:\d+:\d+:', line):
+            method = match.group(2)
+            out_line = f"{line.split(': error:')[0]}: {method}"
+            if re.findall(r'In (member|function) "_[^\W_]', last_line):
+                merged_lines2.append(out_line)
+            else:
+                merged_lines.append(out_line)
+    last_line = line
+
+
+for line in process.stderr:
+    line = line.strip()
+    print(line)
+
+
+# Output the merged lines
+output_dir = Path(".")
+output_dir.joinpath(f'todo_{timestamp}_{git_hash}.txt').write_text('\n'.join(merged_lines))
+output_dir.joinpath(f'todo_extra_{timestamp}_{git_hash}.txt').write_text('\n'.join(merged_lines2))


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

References #2236

Is there any interest in tracking the progress of type hinting the API surface ?
IMHO tracking and portioning the task will turn it into a tractable one.

see current outputs:
[todo_030625192901_1172869.txt](https://github.com/user-attachments/files/20581957/todo_030625192901_1172869.txt)
and methods and function named as private (_[A-Za-z]+) 
[todo_extra_030625192901_1172869.txt](https://github.com/user-attachments/files/20581958/todo_extra_030625192901_1172869.txt)

