### PR TITLE
Fix QCPSuperimposer bug

### DIFF
--- a/Bio/PDB/qcprot.py
+++ b/Bio/PDB/qcprot.py
@@ -117,7 +117,7 @@ def qcp(coords1, coords2, natoms):
 
         delta = f / (f_prime + evalprec)  # avoid division by zero
         mxEigenV = abs(mxEigenV - delta)
-        if (mxEigenV - oldg) < (evalprec * mxEigenV):
+        if abs(mxEigenV - oldg) < (evalprec * mxEigenV):
             break  # convergence
     else:
         print(f"Newton-Rhapson did not converge after {nr_it} iterations")

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -299,6 +299,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Sacha Laurent <https://github.com/Cashalow>
 - Saket Choudhary <https://github.com/saketkc>
 - Samuel Prince <https://github.com/drs>
+- Santeri Paajanen <https://github.com/paajasan>
 - Sean Aubin <https://github.com/seanny123>
 - Sean Davis <https://github.com/seandavi>
 - Sean Johnson <https://github.com/seanrjohnson>

--- a/Tests/test_PDB_CEAligner.py
+++ b/Tests/test_PDB_CEAligner.py
@@ -43,7 +43,7 @@ class CEAlignerTests(unittest.TestCase):
         aligner.set_reference(s1)
         aligner.align(s2, final_optimization=False)
 
-        self.assertAlmostEqual(aligner.rms, 3.74, places=2)
+        self.assertAlmostEqual(aligner.rms, 3.83, places=2)
 
         # Assert the transformation was done right by comparing
         # the moved coordinates to a 'ground truth' reference.
@@ -54,7 +54,7 @@ class CEAlignerTests(unittest.TestCase):
 
         diff = refe_coords - s2_f_coords
         rmsd = np.sqrt((diff * diff).sum() / len(refe_coords))
-        self.assertTrue(rmsd < 0.5)
+        self.assertAlmostEqual(rmsd, 0.0, places=2)
 
     def test_cealigner_no_transform(self):
         """Test aligning 7CFN on 6WQA without transforming 7CFN."""
@@ -72,7 +72,7 @@ class CEAlignerTests(unittest.TestCase):
         aligner.align(s2, transform=False, final_optimization=False)
         s2_coords_final = [list(a.coord) for a in s2.get_atoms()]
 
-        self.assertAlmostEqual(aligner.rms, 3.74, places=2)
+        self.assertAlmostEqual(aligner.rms, 3.83, places=2)
         self.assertEqual(s2_original_coords, s2_coords_final)
 
     def test_ce_aligner_final_optimization(self):
@@ -88,7 +88,7 @@ class CEAlignerTests(unittest.TestCase):
         aligner.set_reference(s1)
         aligner.align(s2)
 
-        self.assertAlmostEqual(aligner.rms, 3.66, places=2)
+        self.assertAlmostEqual(aligner.rms, 3.75, places=2)
 
     def test_cealigner_nucleic(self):
         """Test aligning 1LCD on 1LCD."""

--- a/Tests/test_PDB_QCPSuperimposer.py
+++ b/Tests/test_PDB_QCPSuperimposer.py
@@ -99,6 +99,24 @@ class QCPSuperimposerTest(unittest.TestCase):
             np.allclose(svd_sup.get_transformed(), sup.get_transformed(), atol=1e-3)
         )
 
+    def test_compare_to_svd_lines(self):
+        """Compare results of QCP to SVD using simple lines."""
+        ref = np.linspace([0, 0, 0], [10, 10, 10], 5)
+        mob = np.linspace([20, 10, 30], [20, 20, 30], 5)
+
+        sup = QCPSuperimposer()
+        sup.set(ref, mob)
+        sup.run()
+
+        svd_sup = SVDSuperimposer()
+        svd_sup.set(ref, mob)
+        svd_sup.run()
+
+        self.assertAlmostEqual(svd_sup.get_rms(), sup.rms, places=3)
+        self.assertTrue(
+            np.allclose(svd_sup.get_transformed(), sup.get_transformed(), atol=1e-3)
+        )
+
     def test_get_transformed(self):
         """Test transformation of coordinates after QCP."""
         sup = QCPSuperimposer()
@@ -147,6 +165,19 @@ class QCPSuperimposerTest(unittest.TestCase):
         self.assertTrue(np.allclose(sup.rotran[0], rot, atol=1e-3))
         self.assertTrue(np.allclose(sup.rotran[1], -tran, atol=1e-3))
         self.assertAlmostEqual(sup.rms, 0.0, places=6)
+
+    def test_compare_rmsd_to_transformed(self):
+        """Compare RMSD from QCP algorithm to that from transformed"""
+        ref = np.linspace([0, 0, 0], [10, 10, 10], 5)
+        mob = np.linspace([20, 10, 30], [20, 20, 30], 5)
+
+        sup = QCPSuperimposer()
+        sup.set(ref, mob)
+        sup.run()
+        rms = sup.get_rms()
+        mob_fitted = sup.get_transformed()
+        rms_fitted = np.sqrt(((ref - mob_fitted) ** 2).sum() / ref.shape[0])
+        self.assertAlmostEqual(rms, rms_fitted, places=6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #5004 

- The Newton-Raphson method within the QCP algorithm stopped early if value of `mxEigenV` was at any point smaller than the old value. Added absolute value between the difference to fix this.
- Added two new test cases for QCPSuperimposer with points along two lines of slightly different lengths and oriented differently. One test checks that the results is the same between QCPSuperimposer and SVDSuperimposer and other checks the RMSD value from the QCP algorithm and compares it to the value calculated from the transformed coordinates. The old code fails both tests and new passes them.
- Modified the CEAligner tests since the hardcoded RMS values were now wrong. Mostly this reverted and old change, so these new ones seem to be correct. Also double checked by substituting the SVDSuperimposer into CEAligner and got the same answer.