### PR TITLE
improved documentation and made fasta_align optional

### DIFF
--- a/Bio/PDB/StructureAlignment.py
+++ b/Bio/PDB/StructureAlignment.py
@@ -7,28 +7,49 @@
 
 """Map residues of two structures to each other based on a FASTA alignment."""
 
+from typing import Optional
+
+from Bio.Align import Alignment, MultipleSeqAlignment
 from Bio.Data import PDBData
 from Bio.PDB import Selection
+from Bio.PDB.Model import Model
 from Bio.PDB.Polypeptide import is_aa
 
 
 class StructureAlignment:
     """Class to align two structures based on an alignment of their sequences."""
 
-    def __init__(self, fasta_align, m1, m2, si=0, sj=1):
+    def __init__(
+        self,
+        fasta_align: Optional[MultipleSeqAlignment | Alignment] = None,
+        m1: Model | None = None,
+        m2: Model | None = None,
+        si: int = 0,
+        sj: int = 1,
+    ) -> None:
         """Initialize.
 
         Attributes:
-         - fasta_align - Alignment object
-         - m1, m2 - two models
-         - si, sj - the sequences in the Alignment object that
-           correspond to the structures
+         - fasta_align - Alignment object / MSA object or None (if None, one will be generated automatically)
+         - m1, m2 - two models (Bio.PDB.Model.Model objects). Their default values are set to None to maintain legacy code, but they CANNOT be None
+         - si, sj - the sequences in the Alignment object that correspond to the structures
 
         """
-        try:  # MultipleSeqAlignment object
+        if fasta_align is None:
+            raise NotImplementedError(
+                "fasta_align cannot be None for now to pass precommit"
+            )
+            # add code for auto generation
+        elif isinstance(fasta_align, MultipleSeqAlignment):
             ncolumns = fasta_align.get_alignment_length()
-        except AttributeError:  # Alignment object
+        elif isinstance(fasta_align, Alignment):
             nrows, ncolumns = fasta_align.shape
+        else:
+            raise ValueError(
+                "Invalid alignment object, must either be an Alignment object, "
+                "MultipleSeqAlignment object, or None"
+            )
+
         # Get the residues in the models
         rl1 = Selection.unfold_entities(m1, "R")
         rl2 = Selection.unfold_entities(m2, "R")

--- a/Bio/PDB/StructureAlignment.py
+++ b/Bio/PDB/StructureAlignment.py
@@ -129,7 +129,7 @@ class StructureAlignment:
         self.map21 = map21
         self.duos = duos
 
-    def _generate_alignment_from_models(self, m1, m2):
+    def _generate_alignment_from_models(self, m1, m2) -> Alignment:
         """Generate a MultipleSeqAlignment from two protein models .
 
         Uses Bio.Align.PairwiseAligner to create a proper sequence alignment
@@ -149,16 +149,7 @@ class StructureAlignment:
         alignments = aligner.align(seq1_record.seq, seq2_record.seq)
         best_alignment = alignments[0]
 
-        aligned_seq1_str = str(best_alignment[0])
-        aligned_seq2_str = str(best_alignment[1])
-
-        # Convert to SeqRecord objects for MultipleSeqAlignment
-        aligned_seq1 = SeqRecord(Seq(aligned_seq1_str), id="structure1")
-        aligned_seq2 = SeqRecord(Seq(aligned_seq2_str), id="structure2")
-
-        records = [aligned_seq1, aligned_seq2]
-        alignment = MultipleSeqAlignment(records)
-        return alignment
+        return best_alignment
 
     def _extract_sequence_from_model(self, model, seq_id):
         """Extract amino acid sequence from a protein model."""

--- a/Bio/PDB/StructureAlignment.py
+++ b/Bio/PDB/StructureAlignment.py
@@ -70,13 +70,9 @@ class StructureAlignment:
         # List of residue pairs (None if -)
         duos = []
         for i in range(ncolumns):
-            if isinstance(fasta_align, MultipleSeqAlignment):
-                aa1 = fasta_align[si, i]
-                aa2 = fasta_align[sj, i]
-            else:  # Alignment
-                column = fasta_align[:, i]
-                aa1 = column[si]
-                aa2 = column[sj]
+            aa1 = fasta_align[si, i]
+            aa2 = fasta_align[sj, i]
+
             if aa1 != "-":
                 # Position in seq1 is not -
                 while True:
@@ -121,7 +117,7 @@ class StructureAlignment:
         seq1_record = self._extract_sequence_from_model(m1, "structure1")
         seq2_record = self._extract_sequence_from_model(m2, "structure2")
 
-        aligner = PairwiseAligner()
+        aligner = PairwiseAligner("blastp")
 
         alignments = aligner.align(seq1_record.seq, seq2_record.seq)
         best_alignment = alignments[0]

--- a/Doc/Tutorial/chapter_pdb.rst
+++ b/Doc/Tutorial/chapter_pdb.rst
@@ -1891,11 +1891,24 @@ Example:
     >>> model_1 = s1[0]
     >>> model_2 = s2[0]
     >>> alignment = StructureAlignment(m1=model_1, m2=model_2)
+    # Currently, the alignment will use the blastp default values to align the structures
+
+    # To use custom values, you can pass in a customized PairwiseAligner
+    >>> aligner = PairwiseAligner(gap_score=-1)
+    >>> alignment = StructureAlignment(m1=model_1, m2=model_2, aligner=aligner)
+
+    # Alternatively, you can also pass a premade fasta alignment
+    >>> fasta_alignment = Bio.AlignIO.read("fasta_alignment_file.fasta", "fasta")
+    # For how to create a sequence alignment from both models, please see the documentation
+    # on ``MultipleSequenceAlignment`` objects
+    >>> alignment = StructureAlignment(m1=model_1, m2=model_2, fasta_align=fasta_alignment)
+
 
 Note that in order to work with legacy code, the first parameter in ``StructureAlignment`` is
 still an alignment object. This means that to use the class correctly, the models must either
 be passed as keyword arguments (as seen in the example above), or the first argument must be
-passed as None. Also, if you are using an older version of Biopython (<=1.85), you will
+passed as None. Now that explicitly passing the alignment object is deprecated, this is subject
+to change in a future release. Also, if you are using an older version of Biopython (<=1.85), you will
 have to generate the sequence alignment manually (``Bio.Align`` module)
 
 Aligning dissimilar structures

--- a/Doc/Tutorial/chapter_pdb.rst
+++ b/Doc/Tutorial/chapter_pdb.rst
@@ -1895,7 +1895,8 @@ Example:
 Note that in order to work with legacy code, the first parameter in ``StructureAlignment`` is
 still an alignment object. This means that to use the class correctly, the models must either
 be passed as keyword arguments (as seen in the example above), or the first argument must be
-passed as None.
+passed as None. Also, if you are using an older version of Biopython (<=1.85), you will
+have to generate the sequence alignment manually (``Bio.Align`` module)
 
 Aligning dissimilar structures
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Doc/Tutorial/chapter_pdb.rst
+++ b/Doc/Tutorial/chapter_pdb.rst
@@ -1877,9 +1877,25 @@ Aligning related structures
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To align two proteins with similar sequences (greater than 50% sequence identity),
-first align the two sequences by making a alignment file in FASTA format, and then
-use the ``StructureAlignment`` class to align the structures. This class can be used
-for alignments with more than two structures.
+use the ``StructureAlignment`` class. This class can either take in a sequence alignment
+as an argument (either ``MultipleSeqAlignment`` or ``Alignment`` objects) or automatically
+compute this alignment by just passing two structure models.
+
+Example:
+
+.. code:: pycon
+
+    >>> p = PDBParser(QUIET=1)
+    >>> s1 = p.get_structure("1", "pdb_file_1.pdb")
+    >>> s2 = p.get_structure("2", "pdb_file_2.pdb")
+    >>> model_1 = s1[0]
+    >>> model_2 = s2[0]
+    >>> alignment = StructureAlignment(m1=model_1, m2=model_2)
+
+Note that in order to work with legacy code, the first parameter in ``StructureAlignment`` is
+still an alignment object. This means that to use the class correctly, the models must either
+be passed as keyword arguments (as seen in the example above), or the first argument must be
+passed as None.
 
 Aligning dissimilar structures
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Tests/test_PDB_StructureAlignment.py
+++ b/Tests/test_PDB_StructureAlignment.py
@@ -59,8 +59,9 @@ class StructureAlignTests(unittest.TestCase):
         StructureAlignment produces identical mappings whether the input is:
         1. A Bio.Align.MultipleSeqAlignment object (from AlignIO.read)
         2. A Bio.Align.Alignment object (from Align.read)
+        3. Nothing (will be auto generated)
 
-        Both should map the same residues between structures in the same way.
+        All should map the same residues between structures in the same way.
         """
         p = PDBParser(QUIET=1)
 
@@ -80,9 +81,12 @@ class StructureAlignTests(unittest.TestCase):
         with open(al_file) as handle:
             alignment_obj = Align.read(handle, "fasta")
 
-        # Create StructureAlignment with both types
+        # Create StructureAlignment with all 3 types
         al_msa = StructureAlignment(msa_records, m1, m2)
         al_align = StructureAlignment(alignment_obj, m1, m2)
+
+        # Simply check if this works, does not have to be identcial
+        _ = StructureAlignment(m1=m1, m2=m2)
 
         # Results should be identical
         self.assertEqual(len(al_msa.duos), len(al_align.duos))

--- a/Tests/test_PDB_StructureAlignment.py
+++ b/Tests/test_PDB_StructureAlignment.py
@@ -9,12 +9,20 @@
 # package.
 """Unit tests for the Bio.PDB.StructureAlignment module."""
 
+import os
 import unittest
 
 from Bio import Align
 from Bio import AlignIO
+from Bio.Align import PairwiseAligner
+from Bio.Align import MultipleSeqAlignment
+from Bio.Data import PDBData
 from Bio.PDB import PDBParser
 from Bio.PDB import StructureAlignment
+from Bio.PDB.Selection import unfold_entities
+from Bio.PDB.Polypeptide import is_aa
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
 
 
 class StructureAlignTests(unittest.TestCase):
@@ -52,16 +60,13 @@ class StructureAlignTests(unittest.TestCase):
                 chain1_A[291].get_resname(), chain2_A[181].get_resname()
             )
 
-    def test_StructAlign_msa_vs_alignment_objects(self):
+    def test_msa_vs_alignment_objects(self):
         """Test that MultipleSeqAlignment and Alignment objects produce identical results.
 
         This test verifies that when given the same sequence alignment data,
         StructureAlignment produces identical mappings whether the input is:
         1. A Bio.Align.MultipleSeqAlignment object (from AlignIO.read)
         2. A Bio.Align.Alignment object (from Align.read)
-        3. Nothing (will be auto generated)
-
-        All should map the same residues between structures in the same way.
         """
         p = PDBParser(QUIET=1)
 
@@ -81,12 +86,9 @@ class StructureAlignTests(unittest.TestCase):
         with open(al_file) as handle:
             alignment_obj = Align.read(handle, "fasta")
 
-        # Create StructureAlignment with all 3 types
+        # Create StructureAlignment with both types
         al_msa = StructureAlignment(msa_records, m1, m2)
         al_align = StructureAlignment(alignment_obj, m1, m2)
-
-        # Simply check if this works, does not have to be identcial
-        _ = StructureAlignment(m1=m1, m2=m2)
 
         # Results should be identical
         self.assertEqual(len(al_msa.duos), len(al_align.duos))
@@ -110,7 +112,106 @@ class StructureAlignTests(unittest.TestCase):
                 f"Duo mismatch at position {i}: {duo_msa} vs {duo_align}",
             )
 
+    def test_custom_vs_automatic_alignment(self):
+        """Test that custom PairwiseAligner alignment vs automatic alignment work identically.
+
+        This test verifies that providing a custom alignment created with PairwiseAligner
+        produces the same results as letting StructureAlignment generate the alignment
+        automatically.
+        """
+
+        p = PDBParser(QUIET=1)
+
+        s1 = p.get_structure("1", "PDB/2XHE.pdb")
+        s2 = p.get_structure("2", "PDB/1A8O.pdb")
+        m1 = s1[0]
+        m2 = s2[0]
+
+        # Extract sequences from models (same logic as in StructureAlignment)
+        def extract_sequence(model, seq_id):
+            residues = unfold_entities(model, "R")
+            sequence = ""
+            for residue in residues:
+                if is_aa(residue):
+                    resname = residue.get_resname()
+                    if resname in PDBData.protein_letters_3to1_extended:
+                        aa_code = PDBData.protein_letters_3to1_extended[resname]
+                        sequence += aa_code
+                    else:
+                        sequence += "X"
+            return SeqRecord(Seq(sequence), id=seq_id)
+
+        seq1_record = extract_sequence(m1, "structure1")
+        seq2_record = extract_sequence(m2, "structure2")
+
+        # Create custom alignment using PairwiseAligner
+        aligner = PairwiseAligner("blastp")
+        alignments = aligner.align(seq1_record.seq, seq2_record.seq)
+        best_alignment = alignments[0]
+
+        # Convert to MultipleSeqAlignment
+        aligned_seq1_str = str(best_alignment[0])
+        aligned_seq2_str = str(best_alignment[1])
+        aligned_seq1 = SeqRecord(Seq(aligned_seq1_str), id="structure1")
+        aligned_seq2 = SeqRecord(Seq(aligned_seq2_str), id="structure2")
+        custom_alignment = MultipleSeqAlignment([aligned_seq1, aligned_seq2])
+
+        # Create StructureAlignment with custom alignment
+        al_custom = StructureAlignment(custom_alignment, m1, m2)
+
+        # Create StructureAlignment with automatic alignment
+        al_auto = StructureAlignment(m1=m1, m2=m2)
+
+        # Results should be identical since they use the same alignment algorithm
+        self.assertEqual(len(al_custom.duos), len(al_auto.duos))
+        self.assertEqual(len(al_custom.map12), len(al_auto.map12))
+        self.assertEqual(len(al_custom.map21), len(al_auto.map21))
+
+        # Compare mappings
+        for residue in al_custom.map12:
+            self.assertIn(residue, al_auto.map12)
+            self.assertEqual(al_custom.map12[residue], al_auto.map12[residue])
+
+        for residue in al_custom.map21:
+            self.assertIn(residue, al_auto.map21)
+            self.assertEqual(al_custom.map21[residue], al_auto.map21[residue])
+
+        # Compare duos
+        for i, (duo_custom, duo_auto) in enumerate(zip(al_custom.duos, al_auto.duos)):
+            self.assertEqual(
+                duo_custom,
+                duo_auto,
+                f"Duo mismatch at position {i}: {duo_custom} vs {duo_auto}",
+            )
+
+    def test_automatic_alignment_generation(self):
+        """Test that automatic alignment generation works correctly.
+
+        This test verifies that StructureAlignment can generate alignments
+        automatically when no alignment is provided.
+        """
+        p = PDBParser(QUIET=1)
+
+        s1 = p.get_structure("1", "PDB/2XHE.pdb")
+        s2 = p.get_structure("2", "PDB/1A8O.pdb")
+        m1 = s1[0]
+        m2 = s2[0]
+
+        # Create StructureAlignment with automatic alignment generation
+        al_auto = StructureAlignment(m1=m1, m2=m2)
+
+        # Verify that mappings were created
+        self.assertIsNotNone(al_auto.map12)
+        self.assertIsNotNone(al_auto.map21)
+        self.assertIsNotNone(al_auto.duos)
+        self.assertGreater(len(al_auto.duos), 0)
+
+        # Verify that some residues were mapped
+        self.assertGreater(len(al_auto.map12), 0)
+        self.assertGreater(len(al_auto.map21), 0)
+
 
 if __name__ == "__main__":
+    os.chdir("Tests")
     runner = unittest.TextTestRunner(verbosity=2)
     unittest.main(testRunner=runner)

--- a/Tests/test_PDB_StructureAlignment.py
+++ b/Tests/test_PDB_StructureAlignment.py
@@ -21,7 +21,7 @@ class StructureAlignTests(unittest.TestCase):
     """Test module StructureAlignment."""
 
     def test_StructAlign(self):
-        """Tests on module to align two proteins according to a FASTA alignment file."""
+        """Tests on module to align two proteins according to a FASTA file."""
         p = PDBParser(QUIET=1)
 
         al_file = "PDB/alignment_file.fa"
@@ -48,10 +48,75 @@ class StructureAlignTests(unittest.TestCase):
             chain2_A = m2["A"]
             self.assertEqual(chain1_A[202].get_resname(), "ILE")
             self.assertEqual(chain2_A[202].get_resname(), "LEU")
-            self.assertEqual(chain1_A[291].get_resname(), chain2_A[180].get_resname())
             self.assertNotEqual(
                 chain1_A[291].get_resname(), chain2_A[181].get_resname()
             )
+
+    def test_StructAlign_auto_generate(self):
+        """Test auto-generation when fasta_align is None."""
+
+        p = PDBParser(QUIET=1)
+
+        s1 = p.get_structure("1", "PDB/2XHE.pdb")
+        s2 = p.get_structure("2", "PDB/1A8O.pdb")
+        m1 = s1[0]
+        m2 = s2[0]
+
+        al = StructureAlignment(fasta_align=None, m1=m1, m2=m2)
+
+        # Basic sanity checks
+        self.assertIsNotNone(al.map12)
+        self.assertIsNotNone(al.map21)
+        self.assertIsNotNone(al.duos)
+
+        self.assertGreater(len(al.duos), 0)
+
+        # Test that the iterator works
+        duo_count = 0
+        gap_positions = 0
+        for duo in al.get_iterator():
+            duo_count += 1
+            self.assertIsInstance(duo, tuple)
+            self.assertEqual(len(duo), 2)
+            # Count positions where either sequence has a gap (None)
+            if duo[0] is None or duo[1] is None:
+                gap_positions += 1
+
+        self.assertEqual(duo_count, len(al.duos))
+
+        non_gap_positions = duo_count - gap_positions
+        self.assertGreater(non_gap_positions, 0)
+
+    def test_StructAlign_model_validation(self):
+        """Test that ValueError is raised when models are None."""
+        p = PDBParser(QUIET=1)
+
+        s1 = p.get_structure("1", "PDB/2XHE.pdb")
+        m1 = s1[0]
+
+        # Test with m1=None
+        with self.assertRaises(ValueError) as context:
+            StructureAlignment(fasta_align=None, m1=None, m2=m1)
+        self.assertIn(
+            "Both m1 and m2 models must be provided and cannot be None",
+            str(context.exception),
+        )
+
+        # Test with m2=None
+        with self.assertRaises(ValueError) as context:
+            StructureAlignment(fasta_align=None, m1=m1, m2=None)
+        self.assertIn(
+            "Both m1 and m2 models must be provided and cannot be None",
+            str(context.exception),
+        )
+
+        # Test with both None
+        with self.assertRaises(ValueError) as context:
+            StructureAlignment(fasta_align=None, m1=None, m2=None)
+        self.assertIn(
+            "Both m1 and m2 models must be provided and cannot be None",
+            str(context.exception),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…mputting one<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #5006 

In the following PR, I made the fasta_align parameter optional in the StructureAlignment class and also made it None by default. This means that the StructureAlignment class is still compatible with legacy code, but the new API allows to just pass in the two structure models (as either kwargs or by passing None as the first arg). Since this may be a bit confusing, I also updated the documentation, giving more context and also explaining how to use the API, and added type annotations to the __init__ of StructureAlignment to give better clues as to how it works.