### PR TITLE
Add option to ignore N-/C-terminus effects in isoelectric point calculation

### DIFF
--- a/Bio/SeqUtils/IsoelectricPoint.py
+++ b/Bio/SeqUtils/IsoelectricPoint.py
@@ -79,16 +79,32 @@ class IsoelectricPoint:
 
     """
 
-    def __init__(self, protein_sequence, aa_content=None):
+    def __init__(self, protein_sequence, aa_content=None, ignore_termini=None):
         """Initialize the class."""
         self.sequence = protein_sequence.upper()
+
         if not aa_content:
             from Bio.SeqUtils.ProtParam import ProteinAnalysis as _PA
-
             aa_content = _PA(self.sequence).count_amino_acids()
+           
         self.charged_aas_content = self._select_charged(aa_content)
 
         self.pos_pKs, self.neg_pKs = self._update_pKs_tables()
+
+        if ignore_termini is not None:
+            if ignore_termini == "Nterm":
+                del self.charged_aas_content["Nterm"]
+                del self.pos_pKs["Nterm"]
+
+            if ignore_termini == "Cterm":
+                del self.charged_aas_content["Cterm"]
+                del self.neg_pKs["Cterm"]
+
+            if ignore_termini == "both":
+                del self.charged_aas_content["Nterm"]
+                del self.pos_pKs["Nterm"]
+                del self.charged_aas_content["Cterm"]
+                del self.neg_pKs["Cterm"]
 
     # This function creates a dictionary with the contents of each charged aa,
     # plus Cterm and Nterm.
@@ -134,7 +150,7 @@ class IsoelectricPoint:
 
     # This is the action function, it tries different pH until the charge of
     # the protein is 0 (or close).
-    def pi(self, pH=7.775, min_=4.05, max_=12):
+    def pi(self, pH=7.775, min_=4.05, max_=12.0):
         r"""Calculate and return the isoelectric point as float.
 
         This is a recursive function that uses bisection method.


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [ X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This update introduces a new ignore_termini parameter to the IsoelectricPoint class, allowing users to exclude the N-terminus, C-terminus, or both from isoelectric point (pI) and charge calculations.

Key Changes:
Added ignore_termini argument to IsoelectricPoint.__init__, which accepts:

"Nterm" – excludes N-terminal charge and pK contribution

"Cterm" – excludes C-terminal charge and pK contribution

"both" – excludes both N- and C-terminal contributions

Purpose:
In many use cases (e.g., peptide segments derived from a larger protein), the termini of a fragment may not be chemically exposed and therefore do not contribute to the molecule’s charge in physiological contexts. This enhancement enables more biologically realistic pI calculations for internal peptide fragments by omitting artificial terminal effects.

Additionally, it allows for flexible modeling of peptides with only one exposed terminus, such as C-terminal peptides (ignore Nterm) or N-terminal peptides (ignore Cterm), which is useful in proteomics applications and fragment-based analyses.

