### PR TITLE
Aligner default arguments

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -57,6 +57,9 @@ from Bio.SeqRecord import SeqRecord
 # https://github.com/biopython/biopython/pull/2007
 
 
+from Bio import BiopythonWarning
+
+
 class MultipleSeqAlignment:
     """Represents a classical multiple sequence alignment (MSA).
 
@@ -4243,6 +4246,7 @@ AlignmentCounts object returned by the .counts method of an Alignment object."""
 
     def align(self, seqA, seqB, strand="+"):
         """Return the alignments of two sequences using PairwiseAligner."""
+        self.warn_defaults_changed()  # FIXME remove this after 1.87 is out
         if isinstance(seqA, (bytes, Seq, MutableSeq, SeqRecord)):
             sA = bytes(seqA)
             sA = np.frombuffer(sA, dtype=np.uint8).astype(np.int32)
@@ -4300,6 +4304,7 @@ AlignmentCounts object returned by the .counts method of an Alignment object."""
 
     def score(self, seqA, seqB, strand="+"):
         """Return the alignment score of two sequences using PairwiseAligner."""
+        self.warn_defaults_changed()  # FIXME remove this after 1.87 is out
         if isinstance(seqA, (bytes, Seq, MutableSeq, SeqRecord)):
             seqA = bytes(seqA)
             seqA = np.frombuffer(seqA, dtype=np.uint8).astype(np.int32)

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1330,22 +1330,22 @@ class Alignment:
         >>> alignments = aligner.align("GACCTG", "CGATCG")
         >>> alignment = alignments[0]
         >>> print(alignment)
-        target            0 -GACCT-G 6
-                          0 -||--|-| 8
-        query             0 CGA--TCG 6
+        target            0 -GACCTG 6
+                          0 -||.|-| 7
+        query             0 CGATC-G 6
         <BLANKLINE>
         >>> alignment.frequencies
-        {'-': array([1., 0., 0., 1., 1., 0., 1., 0.]), 'G': array([0., 2., 0., 0., 0., 0., 0., 2.]), 'A': array([0., 0., 2., 0., 0., 0., 0., 0.]), 'C': array([1., 0., 0., 1., 1., 0., 1., 0.]), 'T': array([0., 0., 0., 0., 0., 2., 0., 0.])}
+        {'-': array([1., 0., 0., 0., 0., 1., 0.]), 'G': array([0., 2., 0., 0., 0., 0., 2.]), 'A': array([0., 0., 2., 0., 0., 0., 0.]), 'C': array([1., 0., 0., 1., 2., 0., 0.]), 'T': array([0., 0., 0., 1., 0., 1., 0.])}
         >>> aligner.mode = "local"
         >>> alignments = aligner.align("GACCTG", "CGATCG")
         >>> alignment = alignments[0]
         >>> print(alignment)
-        target            0 GACCT-G 6
-                          0 ||--|-| 7
-        query             1 GA--TCG 6
+        target            0 GACC 4
+                          0 ||.| 4
+        query             1 GATC 5
         <BLANKLINE>
         >>> alignment.frequencies
-        {'G': array([2., 0., 0., 0., 0., 0., 2.]), 'A': array([0., 2., 0., 0., 0., 0., 0.]), 'C': array([0., 0., 1., 1., 0., 1., 0.]), 'T': array([0., 0., 0., 0., 2., 0., 0.]), '-': array([0., 0., 1., 1., 0., 1., 0.])}
+        {'G': array([2., 0., 0., 0.]), 'A': array([0., 2., 0., 0.]), 'C': array([0., 0., 1., 2.]), 'T': array([0., 0., 1., 0.])}
         """
         coordinates = self.coordinates.copy()
         sequences = list(self.sequences)
@@ -1709,7 +1709,9 @@ class Alignment:
                 if steps[i] == 0:
                     line = "-" * length
                 else:
-                    start = coordinate[i] + start_index - indices[i - 1]
+                    start = coordinate[i] + start_index
+                    if i > 0:
+                        start -= indices[i - 1]
                     stop = start + length
                     line = str(sequence[start:stop])
             else:
@@ -1744,7 +1746,9 @@ class Alignment:
                 if steps[i] == 0:
                     line = [None] * length
                 else:
-                    start = coordinate[i] + start_index - indices[i - 1]
+                    start = coordinate[i] + start_index
+                    if i > 0:
+                        start -= indices[i - 1]
                     stop = start + length
                     line = sequence[start:stop]
             else:
@@ -2000,68 +2004,68 @@ class Alignment:
         >>> alignments = aligner.align("ACCGGTTT", "ACGGGTT")
         >>> alignment = alignments[0]
         >>> print(alignment)
-        target            0 ACCGG-TTT 8
-                          0 ||-||-||- 9
-        query             0 AC-GGGTT- 7
+        target            0 ACCGGTTT 8
+                          0 ||.||||- 8
+        query             0 ACGGGTT- 7
         <BLANKLINE>
         >>> alignment[0, :]
-        'ACCGG-TTT'
+        'ACCGGTTT'
         >>> alignment[1, :]
-        'AC-GGGTT-'
+        'ACGGGTT-'
         >>> alignment[0]
-        'ACCGG-TTT'
+        'ACCGGTTT'
         >>> alignment[1]
-        'AC-GGGTT-'
+        'ACGGGTT-'
         >>> alignment[0, 1:-2]
-        'CCGG-T'
+        'CCGGT'
         >>> alignment[1, 1:-2]
-        'C-GGGT'
-        >>> alignment[0, (1, 5, 2)]
-        'C-C'
+        'CGGGT'
+        >>> alignment[1, (1, 7, 2)]
+        'C-G'
         >>> alignment[1, ::2]
-        'A-GT-'
-        >>> alignment[1, range(0, 9, 2)]
-        'A-GT-'
+        'AGGT'
+        >>> alignment[1, range(0, 8, 2)]
+        'AGGT'
         >>> alignment[:, 0]
         'AA'
         >>> alignment[:, 5]
-        '-G'
+        'TT'
         >>> alignment[:, 1:]  # doctest:+ELLIPSIS
-        <Alignment object (2 rows x 8 columns) at 0x...>
+        <Alignment object (2 rows x 7 columns) at 0x...>
         >>> print(alignment[:, 1:])
-        target            1 CCGG-TTT 8
-                          0 |-||-||- 8
-        query             1 C-GGGTT- 7
+        target            1 CCGGTTT 8
+                          0 |.||||- 7
+        query             1 CGGGTT- 7
         <BLANKLINE>
         >>> print(alignment[:, 2:])
-        target            2 CGG-TTT 8
-                          0 -||-||- 7
-        query             2 -GGGTT- 7
-        <BLANKLINE>
-        >>> print(alignment[:, 3:])
-        target            3 GG-TTT 8
-                          0 ||-||- 6
+        target            2 CGGTTT 8
+                          0 .||||- 6
         query             2 GGGTT- 7
         <BLANKLINE>
+        >>> print(alignment[:, 3:])
+        target            3 GGTTT 8
+                          0 ||||- 5
+        query             3 GGTT- 7
+        <BLANKLINE>
         >>> print(alignment[:, 3:-1])
-        target            3 GG-TT 7
-                          0 ||-|| 5
-        query             2 GGGTT 7
+        target            3 GGTT 7
+                          0 |||| 4
+        query             3 GGTT 7
         <BLANKLINE>
         >>> print(alignment[:, ::2])
-        target            0 ACGTT 5
-                          0 |-||- 5
-        query             0 A-GT- 3
+        target            0 ACGT 4
+                          0 |.|| 4
+        query             0 AGGT 4
         <BLANKLINE>
-        >>> print(alignment[:, range(1, 9, 2)])
-        target            0 CG-T 3
-                          0 ||-| 4
-        query             0 CGGT 4
+        >>> print(alignment[:, range(1, 8, 2)])
+        target            0 CGTT 4
+                          0 |||- 4
+        query             0 CGT- 3
         <BLANKLINE>
         >>> print(alignment[:, (2, 7, 3)])
         target            0 CTG 3
-                          0 -|| 3
-        query             0 -TG 2
+                          0 .-| 3
+        query             0 G-G 2
         <BLANKLINE>
         """
         if isinstance(key, numbers.Integral):
@@ -2590,12 +2594,24 @@ class Alignment:
 
         >>> alignments = aligner.align(seqA, seqB)
         >>> len(alignments)
-        1
+        3
         >>> alignment = alignments[0]
         >>> print(alignment)
-        target            0 TTAA-CCCCATTTG 13
-                          0 --||-||||-|||- 14
-        query             0 --AAGCCCC-TTT- 10
+        target            0 TTAACCCCATTTG 13
+                          0 .-|.||||-|||- 13
+        query             0 A-AGCCCC-TTT- 10
+        <BLANKLINE>
+        >>> alignment = alignments[1]
+        >>> print(alignment)
+        target            0 TTAACCCCATTTG 13
+                          0 -.|.||||-|||- 13
+        query             0 -AAGCCCC-TTT- 10
+        <BLANKLINE>
+        >>> alignment = alignments[2]
+        >>> print(alignment)
+        target            0 TTAACCCCATTTG 13
+                          0 --||.|||.|||- 13
+        query             0 --AAGCCCCTTT- 10
         <BLANKLINE>
 
         Note that seqC is the reverse complement of seqB. Aligning it to the
@@ -2604,12 +2620,24 @@ class Alignment:
 
         >>> alignments = aligner.align(seqA, seqC, strand="-")
         >>> len(alignments)
-        1
+        3
         >>> alignment = alignments[0]
         >>> print(alignment)
-        target            0 TTAA-CCCCATTTG 13
-                          0 --||-||||-|||- 14
-        query            10 --AAGCCCC-TTT-  0
+        target            0 TTAACCCCATTTG 13
+                          0 .-|.||||-|||- 13
+        query            10 A-AGCCCC-TTT-  0
+        <BLANKLINE>
+        >>> alignment = alignments[1]
+        >>> print(alignment)
+        target            0 TTAACCCCATTTG 13
+                          0 -.|.||||-|||- 13
+        query            10 -AAGCCCC-TTT-  0
+        <BLANKLINE>
+        >>> alignment = alignments[2]
+        >>> print(alignment)
+        target            0 TTAACCCCATTTG 13
+                          0 --||.|||.|||- 13
+        query            10 --AAGCCCCTTT-  0
         <BLANKLINE>
 
         """
@@ -2676,24 +2704,24 @@ class Alignment:
         >>> alignments = aligner.align("GACCTG", "CGATCG")
         >>> alignment = alignments[0]
         >>> print(alignment)
-        target            0 -GACCT-G 6
-                          0 -||--|-| 8
-        query             0 CGA--TCG 6
+        target            0 -GACCTG 6
+                          0 -||.|-| 7
+        query             0 CGATC-G 6
         <BLANKLINE>
         >>> alignment.length
-        8
+        7
         >>> aligner.mode = "local"
         >>> alignments = aligner.align("GACCTG", "CGATCG")
         >>> alignment = alignments[0]
         >>> print(alignment)
-        target            0 GACCT-G 6
-                          0 ||--|-| 7
-        query             1 GA--TCG 6
+        target            0 GACC 4
+                          0 ||.| 4
+        query             1 GATC 5
         <BLANKLINE>
         >>> len(alignment)
         2
         >>> alignment.length
-        7
+        4
         """
         n = len(self.coordinates)
         if n == 0:  # no sequences
@@ -2735,26 +2763,26 @@ class Alignment:
         >>> alignments = aligner.align("GACCTG", "CGATCG")
         >>> alignment = alignments[0]
         >>> print(alignment)
-        target            0 -GACCT-G 6
-                          0 -||--|-| 8
-        query             0 CGA--TCG 6
-        <BLANKLINE>
-        >>> len(alignment)
-        2
-        >>> alignment.shape
-        (2, 8)
-        >>> aligner.mode = "local"
-        >>> alignments = aligner.align("GACCTG", "CGATCG")
-        >>> alignment = alignments[0]
-        >>> print(alignment)
-        target            0 GACCT-G 6
-                          0 ||--|-| 7
-        query             1 GA--TCG 6
+        target            0 -GACCTG 6
+                          0 -||.|-| 7
+        query             0 CGATC-G 6
         <BLANKLINE>
         >>> len(alignment)
         2
         >>> alignment.shape
         (2, 7)
+        >>> aligner.mode = "local"
+        >>> alignments = aligner.align("GACCTG", "CGATCG")
+        >>> alignment = alignments[0]
+        >>> print(alignment)
+        target            0 GACC 4
+                          0 ||.| 4
+        query             1 GATC 5
+        <BLANKLINE>
+        >>> len(alignment)
+        2
+        >>> alignment.shape
+        (2, 4)
         """
         n = len(self.coordinates)
         m = self.length
@@ -2900,13 +2928,13 @@ class Alignment:
                [ 0,  1, -1,  2,  3]])
         >>> alignment = alignments[1]
         >>> print(alignment)
-        target            1 AACTGG 7
-                          0 ||-|-| 6
-        query             0 AA-T-G 4
+        target            2 ACTG 6
+                          0 |.|| 4
+        query             0 AATG 4
         <BLANKLINE>
         >>> alignment.indices
-        array([[ 1,  2,  3,  4,  5,  6],
-               [ 0,  1, -1,  2, -1,  3]])
+        array([[2, 3, 4, 5],
+               [0, 1, 2, 3]])
 
         >>> alignments = aligner.align("GAACTGG", "CATT", strand="-")
         >>> alignment = alignments[0]
@@ -2920,13 +2948,13 @@ class Alignment:
                [ 3,  2, -1,  1,  0]])
         >>> alignment = alignments[1]
         >>> print(alignment)
-        target            1 AACTGG 7
-                          0 ||-|-| 6
-        query             4 AA-T-G 0
+        target            2 ACTG 6
+                          0 |.|| 4
+        query             4 AATG 0
         <BLANKLINE>
         >>> alignment.indices
-        array([[ 1,  2,  3,  4,  5,  6],
-               [ 3,  2, -1,  1, -1,  0]])
+        array([[2, 3, 4, 5],
+               [3, 2, 1, 0]])
 
         """
         a = -np.ones(self.shape, int)
@@ -2987,12 +3015,12 @@ class Alignment:
         [array([-1,  0,  1,  2,  3,  4, -1]), array([0, 1, 3, 4])]
         >>> alignment = alignments[1]
         >>> print(alignment)
-        target            1 AACTGG 7
-                          0 ||-|-| 6
-        query             0 AA-T-G 4
+        target            2 ACTG 6
+                          0 |.|| 4
+        query             0 AATG 4
         <BLANKLINE>
         >>> alignment.inverse_indices
-        [array([-1,  0,  1,  2,  3,  4,  5]), array([0, 1, 3, 5])]
+        [array([-1, -1,  0,  1,  2,  3, -1]), array([0, 1, 2, 3])]
         >>> alignments = aligner.align("GAACTGG", "CATT", strand="-")
         >>> alignment = alignments[0]
         >>> print(alignment)
@@ -3004,12 +3032,12 @@ class Alignment:
         [array([-1,  0,  1,  2,  3,  4, -1]), array([4, 3, 1, 0])]
         >>> alignment = alignments[1]
         >>> print(alignment)
-        target            1 AACTGG 7
-                          0 ||-|-| 6
-        query             4 AA-T-G 0
+        target            2 ACTG 6
+                          0 |.|| 4
+        query             4 AATG 0
         <BLANKLINE>
         >>> alignment.inverse_indices
-        [array([-1,  0,  1,  2,  3,  4,  5]), array([5, 3, 1, 0])]
+        [array([-1, -1,  0,  1,  2,  3, -1]), array([3, 2, 1, 0])]
 
         """
         a = [-np.ones(len(sequence), int) for sequence in self.sequences]
@@ -3571,13 +3599,13 @@ class Alignment:
         ...     print(f"{c.gaps} gaps, {c.identities} identities, {c.mismatches} mismatches")
         ...     print(alignment)
         ...
-        Score = 6.0:
+        Score = 4.0:
         2 gaps, 3 identities, 0 mismatches
         target            0 TACCG 5
                           0 -||-| 5
         query             0 -AC-G 3
         <BLANKLINE>
-        Score = 6.0:
+        Score = 4.0:
         2 gaps, 3 identities, 0 mismatches
         target            0 TACCG 5
                           0 -|-|| 5
@@ -3965,12 +3993,12 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
     ...     print("Score = %.1f:" % alignment.score)
     ...     print(alignment)
     ...
-    Score = 3.0:
+    Score = 1.0:
     target            0 TACCG 5
                       0 -|-|| 5
     query             0 -A-CG 3
     <BLANKLINE>
-    Score = 3.0:
+    Score = 1.0:
     target            0 TACCG 5
                       0 -||-| 5
     query             0 -AC-G 3
@@ -3984,15 +4012,15 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
     ...     print("Score = %.1f:" % alignment.score)
     ...     print(alignment)
     ...
-    Score = 3.0:
-    target            1 ACCG 5
-                      0 |-|| 4
-    query             0 A-CG 3
+    Score = 2.0:
+    target            1 AC 3
+                      0 || 2
+    query             0 AC 2
     <BLANKLINE>
-    Score = 3.0:
-    target            1 ACCG 5
-                      0 ||-| 4
-    query             0 AC-G 3
+    Score = 2.0:
+    target            3 CG 5
+                      0 || 2
+    query             1 CG 3
     <BLANKLINE>
 
     Do a global alignment.  Identical characters are given 2 points,
@@ -4005,12 +4033,12 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
     ...     print("Score = %.1f:" % alignment.score)
     ...     print(alignment)
     ...
-    Score = 6.0:
+    Score = 4.0:
     target            0 TACCG 5
                       0 -||-| 5
     query             0 -AC-G 3
     <BLANKLINE>
-    Score = 6.0:
+    Score = 4.0:
     target            0 TACCG 5
                       0 -|-|| 5
     query             0 -A-CG 3
@@ -4049,7 +4077,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
     Number of alignments: 1
     >>> alignment = alignments[0]
     >>> print("Score = %.1f" % alignment.score)
-    Score = 13.0
+    Score = 11.0
     >>> print(alignment)
     target            0 KEVLA 5
                       0 -|||- 5
@@ -4064,12 +4092,12 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
     ...     print("Score = %.1f:" % alignment.score)
     ...     print(alignment)
     ...
-    Score = 6.0:
+    Score = 4.0:
     target            0 TACCG 5
                       0 -||-| 5
     query             0 -AC-G 3
     <BLANKLINE>
-    Score = 6.0:
+    Score = 4.0:
     target            0 TACCG 5
                       0 -|-|| 5
     query             0 -A-CG 3

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -4096,7 +4096,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             # use default values:
             # match = 1.0
             # mismatch = 0.0
-            # gap_score = 0.0
+            # gap_score = -1.0
             pass
         elif scoring == "blastn":
             self.substitution_matrix = substitution_matrices.load("BLASTN")

--- a/Bio/Align/_alignmentcounts.c
+++ b/Bio/Align/_alignmentcounts.c
@@ -1643,15 +1643,10 @@ static char _alignmentcounts__doc__[] =
 /* Module definition */
 
 static struct PyModuleDef moduledef = {
-        PyModuleDef_HEAD_INIT,
-        "_alignmentcounts",
-        _alignmentcounts__doc__,
-        -1,
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        NULL
+    PyModuleDef_HEAD_INIT,
+    .m_name = "_alignmentcounts",
+    .m_doc = _alignmentcounts__doc__,
+    .m_size = -1,
 };
 
 PyObject *

--- a/Bio/Align/_codonaligner.c
+++ b/Bio/Align/_codonaligner.c
@@ -1074,15 +1074,10 @@ static char _codonaligner__doc__[] =
 "C extension module implementing a dynamic programming algorithm to align a nucleotide sequence to an amino acid sequence";
 
 static struct PyModuleDef moduledef = {
-        PyModuleDef_HEAD_INIT,
-        "_codonaligner",
-        _codonaligner__doc__,
-        -1,
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        NULL
+    PyModuleDef_HEAD_INIT,
+    .m_name = "_codonaligner",
+    .m_doc = _codonaligner__doc__,
+    .m_size = -1,
 };
 
 PyObject *

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -1767,18 +1767,18 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->match = 1.0;
     self->mismatch = 0.0;
     self->epsilon = 1.e-6;
-    self->open_internal_insertion_score = 0;
-    self->extend_internal_insertion_score = 0;
-    self->open_internal_deletion_score = 0;
-    self->extend_internal_deletion_score = 0;
-    self->open_left_insertion_score = 0;
-    self->extend_left_insertion_score = 0;
-    self->open_right_insertion_score = 0;
-    self->extend_right_insertion_score = 0;
-    self->open_left_deletion_score = 0;
-    self->extend_left_deletion_score = 0;
-    self->open_right_deletion_score = 0;
-    self->extend_right_deletion_score = 0;
+    self->open_internal_insertion_score = -1.0;
+    self->extend_internal_insertion_score = -1.0;
+    self->open_internal_deletion_score = -1.0;
+    self->extend_internal_deletion_score = -1.0;
+    self->open_left_insertion_score = -1.0;
+    self->extend_left_insertion_score = -1.0;
+    self->open_right_insertion_score = -1.0;
+    self->extend_right_insertion_score = -1.0;
+    self->open_left_deletion_score = -1.0;
+    self->extend_left_deletion_score = -1.0;
+    self->open_right_deletion_score = -1.0;
+    self->extend_right_deletion_score = -1.0;
     self->insertion_score_function = NULL;
     self->deletion_score_function = NULL;
     self->substitution_matrix.obj = NULL;
@@ -7499,15 +7499,10 @@ static char _pairwisealigner__doc__[] =
 "C extension module implementing pairwise alignment algorithms";
 
 static struct PyModuleDef moduledef = {
-        PyModuleDef_HEAD_INIT,
-        "_pairwisealigner",
-        _pairwisealigner__doc__,
-        -1,
-        NULL,
-        NULL,
-        NULL,
-        NULL,
-        NULL
+    PyModuleDef_HEAD_INIT,
+    .m_name = "_pairwisealigner",
+    .m_doc = _pairwisealigner__doc__,
+    .m_size = -1,
 };
 
 PyObject *

--- a/Bio/Align/_pairwisealigner.c
+++ b/Bio/Align/_pairwisealigner.c
@@ -1779,6 +1779,18 @@ Aligner_init(Aligner *self, PyObject *args, PyObject *kwds)
     self->extend_left_deletion_score = -1.0;
     self->open_right_deletion_score = -1.0;
     self->extend_right_deletion_score = -1.0;
+    self->open_internal_insertion_score_set = false;
+    self->extend_internal_insertion_score_set = false;
+    self->open_left_insertion_score_set = false;
+    self->extend_left_insertion_score_set = false;
+    self->open_right_insertion_score_set = false;
+    self->extend_right_insertion_score_set = false;
+    self->open_internal_deletion_score_set = false;
+    self->extend_internal_deletion_score_set = false;
+    self->open_left_deletion_score_set = false;
+    self->extend_left_deletion_score_set = false;
+    self->open_right_deletion_score_set = false;
+    self->extend_right_deletion_score_set = false;
     self->insertion_score_function = NULL;
     self->deletion_score_function = NULL;
     self->substitution_matrix.obj = NULL;
@@ -2165,17 +2177,29 @@ Aligner_set_gap_score(Aligner* self, PyObject* value, void* closure)
             self->deletion_score_function = NULL;
         }
         self->open_internal_insertion_score = score;
+        self->open_internal_insertion_score_set = true;
         self->extend_internal_insertion_score = score;
+        self->extend_internal_insertion_score_set = true;
         self->open_left_insertion_score = score;
+        self->open_left_insertion_score_set = true;
         self->extend_left_insertion_score = score;
+        self->extend_left_insertion_score_set = true;
         self->open_right_insertion_score = score;
+        self->open_right_insertion_score_set = true;
         self->extend_right_insertion_score = score;
+        self->extend_right_insertion_score_set = true;
         self->open_internal_deletion_score = score;
+        self->open_internal_deletion_score_set = true;
         self->extend_internal_deletion_score = score;
+        self->extend_internal_deletion_score_set = true;
         self->open_left_deletion_score = score;
+        self->open_left_deletion_score_set = true;
         self->extend_left_deletion_score = score;
+        self->extend_left_deletion_score_set = true;
         self->open_right_deletion_score = score;
+        self->open_right_deletion_score_set = true;
         self->extend_right_deletion_score = score;
+        self->extend_right_deletion_score_set = true;
     }
     self->algorithm = Unknown;
     return 0;
@@ -2217,11 +2241,17 @@ Aligner_set_open_gap_score(Aligner* self, PyObject* value, void* closure)
         self->deletion_score_function = NULL;
     }
     self->open_internal_insertion_score = score;
+    self->open_internal_insertion_score_set = true;
     self->open_left_insertion_score = score;
+    self->open_left_insertion_score_set = true;
     self->open_right_insertion_score = score;
+    self->open_right_insertion_score_set = true;
     self->open_internal_deletion_score = score;
+    self->open_internal_deletion_score_set = true;
     self->open_left_deletion_score = score;
+    self->open_left_deletion_score_set = true;
     self->open_right_deletion_score = score;
+    self->open_right_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2262,11 +2292,17 @@ Aligner_set_extend_gap_score(Aligner* self, PyObject* value, void* closure)
         self->deletion_score_function = NULL;
     }
     self->extend_internal_insertion_score = score;
+    self->extend_internal_insertion_score_set = true;
     self->extend_left_insertion_score = score;
+    self->extend_left_insertion_score_set = true;
     self->extend_right_insertion_score = score;
+    self->extend_right_insertion_score_set = true;
     self->extend_internal_deletion_score = score;
+    self->extend_internal_deletion_score_set = true;
     self->extend_left_deletion_score = score;
+    self->extend_left_deletion_score_set = true;
     self->extend_right_deletion_score = score;
+    self->extend_right_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2304,9 +2340,13 @@ Aligner_set_internal_gap_score(Aligner* self, PyObject* value, void* closure)
         self->deletion_score_function = NULL;
     }
     self->open_internal_insertion_score = score;
+    self->open_internal_insertion_score_set = true;
     self->extend_internal_insertion_score = score;
+    self->extend_internal_insertion_score_set = true;
     self->open_internal_deletion_score = score;
+    self->open_internal_deletion_score_set = true;
     self->extend_internal_deletion_score = score;
+    self->extend_internal_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2342,7 +2382,9 @@ Aligner_set_open_internal_gap_score(Aligner* self, PyObject* value, void* closur
         self->deletion_score_function = NULL;
     }
     self->open_internal_insertion_score = score;
+    self->open_internal_insertion_score_set = true;
     self->open_internal_deletion_score = score;
+    self->open_internal_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2379,7 +2421,9 @@ Aligner_set_extend_internal_gap_score(Aligner* self, PyObject* value,
         self->deletion_score_function = NULL;
     }
     self->extend_internal_insertion_score = score;
+    self->extend_internal_insertion_score_set = true;
     self->extend_internal_deletion_score = score;
+    self->extend_internal_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2421,13 +2465,21 @@ Aligner_set_end_gap_score(Aligner* self, PyObject* value, void* closure)
         self->deletion_score_function = NULL;
     }
     self->open_left_insertion_score = score;
+    self->open_left_insertion_score_set = true;
     self->extend_left_insertion_score = score;
+    self->extend_left_insertion_score_set = true;
     self->open_right_insertion_score = score;
+    self->open_right_insertion_score_set = true;
     self->extend_right_insertion_score = score;
+    self->extend_right_insertion_score_set = true;
     self->open_left_deletion_score = score;
+    self->open_left_deletion_score_set = true;
     self->extend_left_deletion_score = score;
+    self->extend_left_deletion_score_set = true;
     self->open_right_deletion_score = score;
+    self->open_right_deletion_score_set = true;
     self->extend_right_deletion_score = score;
+    self->extend_right_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2465,9 +2517,13 @@ Aligner_set_open_end_gap_score(Aligner* self, PyObject* value, void* closure)
         self->deletion_score_function = NULL;
     }
     self->open_left_insertion_score = score;
+    self->open_left_insertion_score_set = true;
     self->open_right_insertion_score = score;
+    self->open_right_insertion_score_set = true;
     self->open_left_deletion_score = score;
+    self->open_left_deletion_score_set = true;
     self->open_right_deletion_score = score;
+    self->open_right_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2505,9 +2561,13 @@ Aligner_set_extend_end_gap_score(Aligner* self, PyObject* value, void* closure)
         self->deletion_score_function = NULL;
     }
     self->extend_left_insertion_score = score;
+    self->extend_left_insertion_score_set = true;
     self->extend_right_insertion_score = score;
+    self->extend_right_insertion_score_set = true;
     self->extend_left_deletion_score = score;
+    self->extend_left_deletion_score_set = true;
     self->extend_right_deletion_score = score;
+    self->extend_right_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2545,9 +2605,13 @@ Aligner_set_left_gap_score(Aligner* self, PyObject* value, void* closure)
         self->deletion_score_function = NULL;
     }
     self->open_left_insertion_score = score;
+    self->open_left_insertion_score_set = true;
     self->extend_left_insertion_score = score;
+    self->extend_left_insertion_score_set = true;
     self->open_left_deletion_score = score;
+    self->open_left_deletion_score_set = true;
     self->extend_left_deletion_score = score;
+    self->extend_left_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2585,9 +2649,13 @@ Aligner_set_right_gap_score(Aligner* self, PyObject* value, void* closure)
         self->deletion_score_function = NULL;
     }
     self->open_right_insertion_score = score;
+    self->open_right_insertion_score_set = true;
     self->extend_right_insertion_score = score;
+    self->extend_right_insertion_score_set = true;
     self->open_right_deletion_score = score;
+    self->open_right_deletion_score_set = true;
     self->extend_right_deletion_score = score;
+    self->extend_right_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2623,7 +2691,9 @@ Aligner_set_open_left_gap_score(Aligner* self, PyObject* value, void* closure)
         self->deletion_score_function = NULL;
     }
     self->open_left_insertion_score = score;
+    self->open_left_insertion_score_set = true;
     self->open_left_deletion_score = score;
+    self->open_left_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2659,7 +2729,9 @@ Aligner_set_extend_left_gap_score(Aligner* self, PyObject* value, void* closure)
         self->deletion_score_function = NULL;
     }
     self->extend_left_insertion_score = score;
+    self->extend_left_insertion_score_set = true;
     self->extend_left_deletion_score = score;
+    self->extend_left_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2695,7 +2767,9 @@ Aligner_set_open_right_gap_score(Aligner* self, PyObject* value, void* closure)
         self->deletion_score_function = NULL;
     }
     self->open_right_insertion_score = score;
+    self->open_right_insertion_score_set = true;
     self->open_right_deletion_score = score;
+    self->open_right_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2731,7 +2805,9 @@ Aligner_set_extend_right_gap_score(Aligner* self, PyObject* value, void* closure
         self->deletion_score_function = NULL;
     }
     self->extend_right_insertion_score = score;
+    self->extend_right_insertion_score_set = true;
     self->extend_right_deletion_score = score;
+    self->extend_right_deletion_score_set = true;
     self->algorithm = Unknown;
     return 0;
 }
@@ -2760,8 +2836,11 @@ Aligner_set_open_insertion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_internal_insertion_score = score;
+    self->open_internal_insertion_score_set = true;
     self->open_left_insertion_score = score;
+    self->open_left_insertion_score_set = true;
     self->open_right_insertion_score = score;
+    self->open_right_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -2794,8 +2873,11 @@ Aligner_set_extend_insertion_score(Aligner* self, PyObject* value, void* closure
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_internal_insertion_score = score;
+    self->extend_internal_insertion_score_set = true;
     self->extend_left_insertion_score = score;
+    self->extend_left_insertion_score_set = true;
     self->extend_right_insertion_score = score;
+    self->extend_right_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -2842,11 +2924,17 @@ Aligner_set_insertion_score(Aligner* self, PyObject* value, void* closure)
             return -1;
         }
         self->open_internal_insertion_score = score;
+        self->open_internal_insertion_score_set = true;
         self->extend_internal_insertion_score = score;
+        self->extend_internal_insertion_score_set = true;
         self->open_left_insertion_score = score;
+        self->open_left_insertion_score_set = true;
         self->extend_left_insertion_score = score;
+        self->extend_left_insertion_score_set = true;
         self->open_right_insertion_score = score;
+        self->open_right_insertion_score_set = true;
         self->extend_right_insertion_score = score;
+        self->extend_right_insertion_score_set = true;
         if (self->insertion_score_function) {
             Py_DECREF(self->insertion_score_function);
             self->insertion_score_function = NULL;
@@ -2880,8 +2968,11 @@ Aligner_set_open_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_internal_deletion_score = score;
+    self->open_internal_deletion_score_set = true;
     self->open_left_deletion_score = score;
+    self->open_left_deletion_score_set = true;
     self->open_right_deletion_score = score;
+    self->open_right_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -2914,8 +3005,11 @@ Aligner_set_extend_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_internal_deletion_score = score;
+    self->extend_internal_deletion_score_set = true;
     self->extend_left_deletion_score = score;
+    self->extend_left_deletion_score_set = true;
     self->extend_right_deletion_score = score;
+    self->extend_right_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -2961,11 +3055,17 @@ Aligner_set_deletion_score(Aligner* self, PyObject* value, void* closure)
             return -1;
         }
         self->open_internal_deletion_score = score;
+        self->open_internal_deletion_score_set = true;
         self->extend_internal_deletion_score = score;
+        self->extend_internal_deletion_score_set = true;
         self->open_left_deletion_score = score;
+        self->open_left_deletion_score_set = true;
         self->extend_left_deletion_score = score;
+        self->extend_left_deletion_score_set = true;
         self->open_right_deletion_score = score;
+        self->open_right_deletion_score_set = true;
         self->extend_right_deletion_score = score;
+        self->extend_right_deletion_score_set = true;
         if (self->deletion_score_function) {
             Py_DECREF(self->deletion_score_function);
             self->deletion_score_function = NULL;
@@ -2992,6 +3092,7 @@ Aligner_set_open_internal_insertion_score(Aligner* self,
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_internal_insertion_score = score;
+    self->open_internal_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -3017,6 +3118,7 @@ Aligner_set_extend_internal_insertion_score(Aligner* self,
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_internal_insertion_score = score;
+    self->extend_internal_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -3049,7 +3151,9 @@ Aligner_set_internal_insertion_score(Aligner* self, PyObject* value,
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_internal_insertion_score = score;
+    self->open_internal_insertion_score_set = true;
     self->extend_internal_insertion_score = score;
+    self->extend_internal_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -3083,9 +3187,13 @@ Aligner_set_end_insertion_score(Aligner* self, PyObject* value, void* closure) {
     const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_insertion_score = score;
+    self->open_left_insertion_score_set = true;
     self->extend_left_insertion_score = score;
+    self->extend_left_insertion_score_set = true;
     self->open_right_insertion_score = score;
+    self->open_right_insertion_score_set = true;
     self->extend_right_insertion_score = score;
+    self->extend_right_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -3118,7 +3226,9 @@ Aligner_set_open_end_insertion_score(Aligner* self, PyObject* value,
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_insertion_score = score;
+    self->open_left_insertion_score_set = true;
     self->open_right_insertion_score = score;
+    self->open_right_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -3150,7 +3260,9 @@ Aligner_set_extend_end_insertion_score(Aligner* self, PyObject* value, void* clo
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_left_insertion_score = score;
+    self->extend_left_insertion_score_set = true;
     self->extend_right_insertion_score = score;
+    self->extend_right_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -3175,6 +3287,7 @@ Aligner_set_open_left_insertion_score(Aligner* self, PyObject* value, void* clos
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_insertion_score = score;
+    self->open_left_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -3199,6 +3312,7 @@ Aligner_set_extend_left_insertion_score(Aligner* self, PyObject* value, void* cl
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_left_insertion_score = score;
+    self->extend_left_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -3230,7 +3344,9 @@ Aligner_set_left_insertion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_insertion_score = score;
+    self->open_left_insertion_score_set = true;
     self->extend_left_insertion_score = score;
+    self->extend_left_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -3255,6 +3371,7 @@ Aligner_set_open_right_insertion_score(Aligner* self, PyObject* value, void* clo
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_right_insertion_score = score;
+    self->open_right_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -3279,6 +3396,7 @@ Aligner_set_extend_right_insertion_score(Aligner* self, PyObject* value, void* c
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_right_insertion_score = score;
+    self->extend_right_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -3310,7 +3428,9 @@ Aligner_set_right_insertion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_right_insertion_score = score;
+    self->open_right_insertion_score_set = true;
     self->extend_right_insertion_score = score;
+    self->extend_right_insertion_score_set = true;
     if (self->insertion_score_function) {
         Py_DECREF(self->insertion_score_function);
         self->insertion_score_function = NULL;
@@ -3344,9 +3464,13 @@ Aligner_set_end_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_deletion_score = score;
+    self->open_left_deletion_score_set = true;
     self->extend_left_deletion_score = score;
+    self->extend_left_deletion_score_set = true;
     self->open_right_deletion_score = score;
+    self->open_right_deletion_score_set = true;
     self->extend_right_deletion_score = score;
+    self->extend_right_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -3378,7 +3502,9 @@ Aligner_set_open_end_deletion_score(Aligner* self, PyObject* value, void* closur
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_deletion_score = score;
+    self->open_left_deletion_score_set = true;
     self->open_right_deletion_score = score;
+    self->open_right_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -3410,7 +3536,9 @@ Aligner_set_extend_end_deletion_score(Aligner* self, PyObject* value, void* clos
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_left_deletion_score = score;
+    self->extend_left_deletion_score_set = true;
     self->extend_right_deletion_score = score;
+    self->extend_right_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -3436,6 +3564,7 @@ Aligner_set_open_internal_deletion_score(Aligner* self, PyObject* value,
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_internal_deletion_score = score;
+    self->open_internal_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -3461,6 +3590,7 @@ Aligner_set_extend_internal_deletion_score(Aligner* self, PyObject* value,
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_internal_deletion_score = score;
+    self->extend_internal_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -3493,7 +3623,9 @@ Aligner_set_internal_deletion_score(Aligner* self, PyObject* value,
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_internal_deletion_score = score;
+    self->open_internal_deletion_score_set = true;
     self->extend_internal_deletion_score = score;
+    self->extend_internal_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -3518,6 +3650,7 @@ Aligner_set_open_left_deletion_score(Aligner* self, PyObject* value, void* closu
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_deletion_score = score;
+    self->open_left_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -3542,6 +3675,7 @@ Aligner_set_extend_left_deletion_score(Aligner* self, PyObject* value, void* clo
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_left_deletion_score = score;
+    self->extend_left_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -3573,7 +3707,9 @@ Aligner_set_left_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_left_deletion_score = score;
+    self->open_left_deletion_score_set = true;
     self->extend_left_deletion_score = score;
+    self->extend_left_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -3598,6 +3734,7 @@ Aligner_set_open_right_deletion_score(Aligner* self, PyObject* value, void* clos
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_right_deletion_score = score;
+    self->open_right_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -3622,6 +3759,7 @@ Aligner_set_extend_right_deletion_score(Aligner* self, PyObject* value, void* cl
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->extend_right_deletion_score = score;
+    self->extend_right_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -3653,7 +3791,9 @@ Aligner_set_right_deletion_score(Aligner* self, PyObject* value, void* closure)
 {   const double score = PyFloat_AsDouble(value);
     if (PyErr_Occurred()) return -1;
     self->open_right_deletion_score = score;
+    self->open_right_deletion_score_set = true;
     self->extend_right_deletion_score = score;
+    self->extend_right_deletion_score_set = true;
     if (self->deletion_score_function) {
         Py_DECREF(self->deletion_score_function);
         self->deletion_score_function = NULL;
@@ -4351,7 +4491,8 @@ struct fogsaa_queue_node {
      (queue->array[a].next_upper == queue->array[b].next_upper && \
       queue->array[a].next_lower > queue->array[b].next_lower))
 
-int fogsaa_queue_insert(struct fogsaa_queue *queue, int pA, int pB,
+static int
+fogsaa_queue_insert(struct fogsaa_queue *queue, int pA, int pB,
         int type_total, int next_type, double next_lower, double next_upper) {
     // max heap implementation for the priority queue by next_upper
     struct fogsaa_queue_node temp;
@@ -4387,7 +4528,7 @@ int fogsaa_queue_insert(struct fogsaa_queue *queue, int pA, int pB,
     return 1;
 }
 
-struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
+static struct fogsaa_queue_node fogsaa_queue_pop(struct fogsaa_queue *queue) {
     // caller code must check queue is not empty
     struct fogsaa_queue_node temp, root = queue->array[0];
     int largest_child, i = 0;
@@ -7464,6 +7605,24 @@ static char Aligner_doc[] =
 "The PairwiseAligner class implements common algorithms to align two\n"
 "sequences to each other.\n";
 
+static PyObject*
+Aligner_warn_defaults_changed(Aligner* self)
+{
+    if (self->open_internal_insertion_score_set
+     && self->extend_internal_insertion_score_set
+     && self->open_left_insertion_score_set
+     && self->extend_left_insertion_score_set
+     && self->open_right_insertion_score_set
+     && self->extend_right_insertion_score_set
+     && self->open_internal_deletion_score_set
+     && self->extend_internal_deletion_score_set
+     && self->open_left_deletion_score_set
+     && self->extend_left_deletion_score_set
+     && self->open_right_deletion_score_set
+     && self->extend_right_deletion_score_set) Py_RETURN_FALSE;
+    else Py_RETURN_TRUE;
+}
+
 static PyMethodDef Aligner_methods[] = {
     {"score",
      (PyCFunction)Aligner_score,
@@ -7474,6 +7633,11 @@ static PyMethodDef Aligner_methods[] = {
      (PyCFunction)Aligner_align,
      METH_VARARGS | METH_KEYWORDS,
      Aligner_align__doc__
+    },
+    {"warn_defaults_changed",
+     (PyCFunction)Aligner_warn_defaults_changed,
+     METH_NOARGS,
+     "return False if all gap scores have been set explicitly, and True otherwise."
     },
     {NULL, NULL, 0, NULL}  /* Sentinel */
 };

--- a/Bio/Align/_pairwisealigner.h
+++ b/Bio/Align/_pairwisealigner.h
@@ -40,6 +40,18 @@ typedef struct {
     double extend_left_deletion_score;
     double open_right_deletion_score;
     double extend_right_deletion_score;
+    bool open_internal_insertion_score_set;
+    bool extend_internal_insertion_score_set;
+    bool open_left_insertion_score_set;
+    bool extend_left_insertion_score_set;
+    bool open_right_insertion_score_set;
+    bool extend_right_insertion_score_set;
+    bool open_internal_deletion_score_set;
+    bool extend_internal_deletion_score_set;
+    bool open_left_deletion_score_set;
+    bool extend_left_deletion_score_set;
+    bool open_right_deletion_score_set;
+    bool extend_right_deletion_score_set;
     PyObject* insertion_score_function;
     PyObject* deletion_score_function;
     Py_buffer substitution_matrix;

--- a/Bio/Align/substitution_matrices/_arraycore.c
+++ b/Bio/Align/substitution_matrices/_arraycore.c
@@ -171,11 +171,9 @@ static PyTypeObject Array_Type = {
 
 static struct PyModuleDef module = {
     PyModuleDef_HEAD_INIT,
-    "_arraycore",
-    "Base module defining the Array base class",
-    -1,
-    NULL,
-    NULL, NULL, NULL, NULL
+    .m_name = "_arraycore",
+    .m_doc = "Base module defining the Array base class",
+    .m_size = -1,
 };
 
 PyMODINIT_FUNC

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -644,6 +644,20 @@ Release 1.86, with the original name still available with a deprecation warning.
 These attributes were renamed to be consistent with the AlignmentCounts class
 and with the common nomenclature in the literature.
 
+The default value of the gap score of a PairwiseAligner object was changed in
+Release 1.86.  Previously, for consistency with Bio.pairwise2, the gap score
+was 0.  However, this means that a mismatch, an insertion followed by a deletion,
+and a deletion followed by an insertion all get assigned a score of 0.  The
+aligner then finds a large number of alignments that are logically the same,
+but with trivial differences between them.  For example, aligning AAACAAA to
+AAAGAAA previously yielded the following three alignments, all with score 6:
+
+     AAACAAA        AAAC-AAA        AAA-CAAA
+     AAAGAAA        AAA-GAAA        AAAG-AAA
+
+With the new default parameter for the gap score, only the first alignment is
+returned.
+
 The ``alphabet`` attribute of the PairwiseAligner class was deprecated in
 Release 1.86. The attribute is still being stored, but it is not used in any
 way.

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -54,11 +54,11 @@ between two sequences:
 
 .. code:: pycon
 
-   >>> target = "GAACT"
-   >>> query = "GAT"
+   >>> target = "GAACTTT"
+   >>> query = "GATTT"
    >>> score = aligner.score(target, query)
    >>> score
-   1.0
+   3.0
 
 The ``aligner.align`` method returns a ``PairwiseAlignments`` object, which is
 an iterator over the alignments found. The ``PairwiseAlignments`` object will
@@ -70,7 +70,7 @@ tell you how many alignments were found, and what their score is:
 
    >>> alignments = aligner.align(target, query)
    >>> alignments  # doctest: +ELLIPSIS
-   <PairwiseAlignments object (2 alignments; score=1) at 0x...>
+   <PairwiseAlignments object (2 alignments; score=3) at 0x...>
 
 Each alignment between the two sequences is stored in an ``Alignment`` object.
 ``Alignment`` objects can be obtained by iterating over the alignments or by
@@ -82,7 +82,7 @@ indexing:
 
    >>> alignment = alignments[0]
    >>> alignment  # doctest: +ELLIPSIS
-   <Alignment object (2 rows x 5 columns) at 0x...>
+   <Alignment object (2 rows x 7 columns) at 0x...>
 
 Iterate over the ``Alignment`` objects and print them to see the
 alignments:
@@ -94,13 +94,13 @@ alignments:
    >>> for alignment in alignments:
    ...     print(alignment)
    ...
-   target            0 GAACT 5
-                     0 ||--| 5
-   query             0 GA--T 3
+   target            0 GAACTTT 7
+                     0 ||--||| 7
+   query             0 GA--TTT 5
    <BLANKLINE>
-   target            0 GAACT 5
-                     0 |-|-| 5
-   query             0 G-A-T 3
+   target            0 GAACTTT 7
+                     0 |-|-||| 7
+   query             0 G-A-TTT 5
    <BLANKLINE>
 
 Use indices to get the aligned sequence (see :ref:`subsec:slicing-indexing-alignment`):
@@ -110,9 +110,9 @@ Use indices to get the aligned sequence (see :ref:`subsec:slicing-indexing-align
 .. code:: pycon
 
    >>> alignment[0]
-   'GAACT'
+   'GAACTTT'
    >>> alignment[1]
-   'G-A-T'
+   'G-A-TTT'
 
 Each alignment stores the alignment score:
 
@@ -121,7 +121,7 @@ Each alignment stores the alignment score:
 .. code:: pycon
 
    >>> alignment.score
-   1.0
+   3.0
 
 as well as pointers to the sequences that were aligned:
 
@@ -130,9 +130,9 @@ as well as pointers to the sequences that were aligned:
 .. code:: pycon
 
    >>> alignment.target
-   'GAACT'
+   'GAACTTT'
    >>> alignment.query
-   'GAT'
+   'GATTT'
 
 Internally, the alignment is stored in terms of the sequence coordinates:
 
@@ -142,8 +142,8 @@ Internally, the alignment is stored in terms of the sequence coordinates:
 
    >>> alignment = alignments[0]
    >>> alignment.coordinates
-   array([[0, 2, 4, 5],
-          [0, 2, 2, 3]])
+   array([[0, 2, 4, 7],
+          [0, 2, 2, 5]])
 
 Here, the two rows refer to the target and query sequence. These
 coordinates show that the alignment consists of the following three
@@ -154,7 +154,7 @@ blocks:
 -  ``target[2:4]`` aligned to a gap, since ``query[2:2]`` is an empty
    string (i.e., a deletion);
 
--  ``target[4:5]`` aligned to ``query[2:3]``.
+-  ``target[4:7]`` aligned to ``query[2:5]``.
 
 The number of aligned sequences is always 2 for a pairwise alignment:
 
@@ -175,7 +175,7 @@ query:
 .. code:: pycon
 
    >>> alignment.length
-   5
+   7
 
 The ``aligned`` property, which returns the start and end indices of
 aligned subsequences, returns two tuples of length 2 for the first
@@ -187,10 +187,10 @@ alignment:
 
    >>> alignment.aligned
    array([[[0, 2],
-           [4, 5]],
+           [4, 7]],
    <BLANKLINE>
           [[0, 2],
-           [2, 3]]])
+           [2, 5]]])
 
 while for the alternative alignment, two tuples of length 3 are
 returned:
@@ -201,18 +201,18 @@ returned:
 
    >>> alignment = alignments[1]
    >>> print(alignment)
-   target            0 GAACT 5
-                     0 |-|-| 5
-   query             0 G-A-T 3
+   target            0 GAACTTT 7
+                     0 |-|-||| 7
+   query             0 G-A-TTT 5
    <BLANKLINE>
    >>> alignment.aligned
    array([[[0, 1],
            [2, 3],
-           [4, 5]],
+           [4, 7]],
    <BLANKLINE>
           [[0, 1],
            [1, 2],
-           [2, 3]]])
+           [2, 5]]])
 
 Note that different alignments may have the same subsequences aligned to
 each other. In particular, this may occur if alignments differ from each
@@ -345,16 +345,14 @@ follow the suggestion by Waterman & Eggert
 
 If ``aligner.mode`` is set to ``"fogsaa"``, then the Fast Optimal Global
 Alignment Algorithm [Chakraborty2013]_ with some modifications is used. This
-mode calculates a global alignment, but it is not like the regular `"global"`
-mode.  It is best suited for long alignments between similar sequences. Rather
-than calculating all possible alignments like other algorithms do, FOGSAA uses
-a heuristic to detect steps in an alignment that cannot lead to an optimal
-alignment. This can speed up alignment, however, the heuristic makes
-assumptions about your match, mismatch, and gap scores. If the match score is
-less than the mismatch score or any gap score, or if any gap score is greater
-than the mismatch score, then a warning is raised and the algorithm may return
-incorrect results. Unlike other modes that may return more than one alignment,
-FOGSAA always returns only one alignment.
+mode also calculates a global alignment, but uses a heuristic to detect steps
+in an alignment that cannot lead to an optimal alignment. This can speed up
+alignment and is best suited for long alignments between similar sequences.
+The heuristic makes assumptions about your match, mismatch, and gap scores. If
+the match score is less than the mismatch score or any gap score, or if any gap
+score is greater than the mismatch score, then a warning is raised and the
+algorithm may return incorrect results. Unlike other modes, which may return
+more than one alignment, FOGSAA always returns only one alignment.
 
 .. cont-doctest
 
@@ -775,14 +773,25 @@ disallows a deletion after two nucleotides in the query sequence:
 Using a pre-defined substitution matrix and gap scores
 ------------------------------------------------------
 
-By default, a ``PairwiseAligner`` object is initialized with a match
-score of +1.0, a mismatch score of 0.0, and all gap scores equal to 0.0,
-While this has the benefit of being a simple scoring scheme, in general
-it does not give the best performance. Instead, you can use the argument
-``scoring`` to select a predefined scoring scheme when initializing a
-``PairwiseAligner`` object. Currently, the provided scoring schemes are
-``blastn`` and ``megablast``, which are suitable for nucleotide
-alignments, and ``blastp``, which is suitable for protein alignments.
+Currently, a ``PairwiseAligner`` object is initialized by default with a match
+score of +1.0, a mismatch score of 0.0, and all gap scores equal to -1.0.
+Biopython versions 1.85 and older used a default gap score of 0.0 (this choice
+was made to be consistent with the older pairwise aligner in ``Bio.pairwise2``,
+which uses a default gap score of 0.0). However, this scheme assigns the same
+score to a mismatch and a insertion or deletion, e.g.
+
+.. code:: pycon
+
+    A      A-      -A
+    C      -C      C-
+
+are evaluated equally, which tends to result in a large number of alignments
+that are only trivially different from each other. While the current scoring
+scheme avoids this problem, in general you may get better performance using
+a predefined scoring scheme, which you can select using the ``scoring``
+argument when initializing a ``PairwiseAligner`` object. Currently, the
+provided scoring schemes are ``blastn`` and ``megablast``, which are suitable
+for nucleotide alignments, and ``blastp``, suitable for protein alignments.
 Selecting these scoring schemes will initialize the ``PairwiseAligner``
 object to the default scoring parameters used by BLASTN, MegaBLAST, and
 BLASTP, respectively.
@@ -1822,7 +1831,7 @@ alignment itself:
 
 Better alignments are usually obtained by penalizing gaps: higher costs
 for opening a gap and lower costs for extending an existing gap. For
-amino acid sequences match scores are usually encoded in matrices like
+amino acid sequences, match scores are usually encoded in matrices like
 ``PAM`` or ``BLOSUM``. Thus, a more meaningful alignment for our example
 can be obtained by using the BLOSUM62 matrix, together with a gap open
 penalty of 10 and a gap extension penalty of 0.5:

--- a/Doc/Tutorial/chapter_pairwise.rst
+++ b/Doc/Tutorial/chapter_pairwise.rst
@@ -58,7 +58,7 @@ between two sequences:
    >>> query = "GAT"
    >>> score = aligner.score(target, query)
    >>> score
-   3.0
+   1.0
 
 The ``aligner.align`` method returns a ``PairwiseAlignments`` object, which is
 an iterator over the alignments found. The ``PairwiseAlignments`` object will
@@ -70,7 +70,7 @@ tell you how many alignments were found, and what their score is:
 
    >>> alignments = aligner.align(target, query)
    >>> alignments  # doctest: +ELLIPSIS
-   <PairwiseAlignments object (2 alignments; score=3) at 0x...>
+   <PairwiseAlignments object (2 alignments; score=1) at 0x...>
 
 Each alignment between the two sequences is stored in an ``Alignment`` object.
 ``Alignment`` objects can be obtained by iterating over the alignments or by
@@ -121,7 +121,7 @@ Each alignment stores the alignment score:
 .. code:: pycon
 
    >>> alignment.score
-   3.0
+   1.0
 
 as well as pointers to the sequences that were aligned:
 
@@ -391,18 +391,18 @@ all parameters, use
      wildcard: None
      match_score: 1.000000
      mismatch_score: 0.000000
-     open_internal_insertion_score: 0.000000
-     extend_internal_insertion_score: 0.000000
-     open_left_insertion_score: 0.000000
-     extend_left_insertion_score: 0.000000
-     open_right_insertion_score: 0.000000
-     extend_right_insertion_score: 0.000000
-     open_internal_deletion_score: 0.000000
-     extend_internal_deletion_score: 0.000000
-     open_left_deletion_score: 0.000000
-     extend_left_deletion_score: 0.000000
-     open_right_deletion_score: 0.000000
-     extend_right_deletion_score: 0.000000
+     open_internal_insertion_score: -1.000000
+     extend_internal_insertion_score: -1.000000
+     open_left_insertion_score: -1.000000
+     extend_left_insertion_score: -1.000000
+     open_right_insertion_score: -1.000000
+     extend_right_insertion_score: -1.000000
+     open_internal_deletion_score: -1.000000
+     extend_internal_deletion_score: -1.000000
+     open_left_deletion_score: -1.000000
+     extend_left_deletion_score: -1.000000
+     open_right_deletion_score: -1.000000
+     extend_right_deletion_score: -1.000000
      mode: local
    <BLANKLINE>
 
@@ -908,7 +908,7 @@ You can perform the following operations on ``alignments``:
    .. code:: pycon
 
       >>> print(alignments.score)
-      2.0
+      1.0
 
 Aligning to the reverse strand
 ------------------------------
@@ -927,6 +927,7 @@ for ``query`` to the reverse strand of ``target``, use ``strand="-"``:
    >>> query = "AACC"
    >>> aligner = Align.PairwiseAligner()
    >>> aligner.mismatch_score = -1
+   >>> aligner.gap_score = 0
    >>> aligner.internal_gap_score = -1
    >>> aligner.score(target, query)  # strand is "+" by default
    4.0
@@ -1767,9 +1768,9 @@ hemoglobin sequences from above (``HBA_HUMAN``, ``HBB_HUMAN``) stored in
    >>> aligner = Align.PairwiseAligner()
    >>> score = aligner.score(seq1.seq, seq2.seq)
    >>> print(score)
-   72.0
+   56.0
 
-showing an alignment score of 72.0. To see the individual alignments, do
+showing an alignment score of 56.0. To see the individual alignments, do
 
 .. cont-doctest
 
@@ -1804,23 +1805,19 @@ alignment itself:
 .. code:: pycon
 
    >>> print(alignment.score)
-   72.0
+   56.0
    >>> print(alignment)
-   target            0 MV-LS-PAD--KTN--VK-AA-WGKV-----GAHAGEYGAEALE-RMFLSF----P-TTK
-                     0 ||-|--|----|----|--|--||||-----|---||--|--|--|--|------|-|--
-   query             0 MVHL-TP--EEK--SAV-TA-LWGKVNVDEVG---GE--A--L-GR--L--LVVYPWT--
+   target            0 MV-LSPADKTNVKAAWGKVGAHAGEYGAEALERMFLSFPTTKTYFPHF-DLSHGSAQ---
+                     0 ||-|.|..|..|.|.||||...--|.|.|||.|.....|.|...|..|-|||...|.---
+   query             0 MVHLTPEEKSAVTALWGKVNVD--EVGGEALGRLLVVYPWTQRFFESFGDLSTPDAVMGN
    <BLANKLINE>
-   target           41 TY--FPHF----DLSHGS---AQVK-G------HGKKV--A--DA-LTNAVAHV-DDMPN
-                    60 ----|--|----|||------|-|--|------|||||--|--|--|--|--|--|---|
-   query            39 --QRF--FESFGDLS---TPDA-V-MGNPKVKAHGKKVLGAFSD-GL--A--H-LD---N
+   target           55 --VKGHGKKVADALTNAVAHVDDMPNALSALSDLHAHKLRVDPVNFKLLSHCLLVTLAAH
+                    60 --||.|||||..|.....||.|........||.||..||.|||.||.||...|...||.|
+   query            58 PKVKAHGKKVLGAFSDGLAHLDNLKGTFATLSELHCDKLHVDPENFRLLGNVLVCVLAHH
    <BLANKLINE>
-   target           79 ALS----A-LSD-LHAH--KLR-VDPV-NFK-LLSHC---LLVT--LAAHLPA----EFT
-                   120 -|-----|-||--||----||--|||--||--||------|-|---||-|-------|||
-   query            81 -L-KGTFATLS-ELH--CDKL-HVDP-ENF-RLL---GNVL-V-CVLA-H---HFGKEFT
-   <BLANKLINE>
-   target          119 PA-VH-ASLDKFLAS---VSTV------LTS--KYR- 142
-                   180 |--|--|------|----|--|------|----||-- 217
-   query           124 P-PV-QA------A-YQKV--VAGVANAL--AHKY-H 147
+   target          113 LPAEFTPAVHASLDKFLASVSTVLTSKYR 142
+                   120 ...||||.|.|...|..|.|...|..||. 149
+   query           118 FGKEFTPPVQAAYQKVVAGVANALAHKYH 147
    <BLANKLINE>
 
 Better alignments are usually obtained by penalizing gaps: higher costs
@@ -2024,7 +2021,7 @@ BLOSUM62 matrix, and align these sequences to each other:
    Asn --- Leu Phe
    <BLANKLINE>
    >>> print(alignments.score)
-   18.0
+   17.0
 
 Generalized pairwise alignments using match/mismatch scores and integer sequences
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2060,7 +2057,7 @@ This step can be bypassed by passing integer arrays directly:
    2 -- 10 13
    <BLANKLINE>
    >>> print(alignments.score)
-   18.0
+   17.0
 
 Note that the indices should consist of 32-bit integers, as specified in
 this example by ``numpy.int32``.

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4207,8 +4207,8 @@ AlignmentCounts object with
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 0:
-                open_internal_deletions = 0,
+            internal_deletions = 1:
+                open_internal_deletions = 1,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -4251,8 +4251,8 @@ AlignmentCounts object with
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 0:
-                open_internal_deletions = 0,
+            internal_deletions = 1:
+                open_internal_deletions = 1,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -4414,8 +4414,8 @@ AlignmentCounts object with
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 0:
-                open_internal_deletions = 0,
+            internal_deletions = 1:
+                open_internal_deletions = 1,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -4458,8 +4458,8 @@ AlignmentCounts object with
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 0:
-                open_internal_deletions = 0,
+            internal_deletions = 1:
+                open_internal_deletions = 1,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -17368,6 +17368,7 @@ AlignmentCounts object with
 class TestOverflowError(unittest.TestCase):
     def test_align_overflow_error(self):
         aligner = Align.PairwiseAligner()
+        aligner.gap_score = 0
         path = os.path.join("Align", "bsubtilis.fa")
         record = SeqIO.read(path, "fasta")
         seq1 = record.seq

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4579,6 +4579,7 @@ AlignmentCounts object with
         aligner.mode = "global"
         aligner.open_deletion_score = -0.1
         aligner.extend_deletion_score = 0.0
+        aligner.insertion_score = 0.0
         self.assertEqual(aligner.algorithm, "Gotoh global alignment algorithm")
         self.assertEqual(
             str(aligner),
@@ -4644,7 +4645,7 @@ AlignmentCounts object with
     aligned = 3:
         identities = 3,
         mismatches = 0.
-    gaps = 0:
+    gaps = 2:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -4652,7 +4653,7 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 0:
+        internal_gaps = 2:
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;
@@ -4688,7 +4689,7 @@ AlignmentCounts object with
     aligned = 3:
         identities = 3,
         mismatches = 0.
-    gaps = 0:
+    gaps = 2:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -4696,7 +4697,7 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 0:
+        internal_gaps = 2:
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;
@@ -4752,7 +4753,7 @@ AlignmentCounts object with
     aligned = 3:
         identities = 3,
         mismatches = 0.
-    gaps = 0:
+    gaps = 2:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -4760,7 +4761,7 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 0:
+        internal_gaps = 2:
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -21836,16 +21836,16 @@ query           582
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 237.0; substitution score = 237.0; gap score = 0.0; 444 aligned letters; 237 identities; 207 mismatches; 36 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 201.0; substitution score = 237.0; gap score = -36.0; 444 aligned letters; 237 identities; 207 mismatches; 36 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 237.0:
+    score = 201.0:
         substitution_score = 237.0,
-        gap_score = 0.0.
+        gap_score = -36.0.
     aligned = 444:
         identities = 237,
         mismatches = 207.
@@ -21875,7 +21875,7 @@ AlignmentCounts object with
         )
         self.check_blastp(counts)
         self.assertIsNone(counts.positives)
-        self.assertAlmostEqual(counts.score, 237.0)
+        self.assertAlmostEqual(counts.score, 201.0)
         counts = alignment.counts(aligner_blastp)
         self.assertEqual(
             repr(counts),

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -16018,6 +16018,7 @@ AlignmentCounts object with
         aligner = Align.PairwiseAligner()
         aligner.mismatch_score = -1
         aligner.deletion_score = gap_score_function
+        aligner.insertion_score = 0
         aligner.internal_insertion_score = -10
         seqA = "AAAAAAAAAAA"
         seqB = "TTAAAAA"
@@ -16144,6 +16145,7 @@ AlignmentCounts object with
         aligner = Align.PairwiseAligner()
         aligner.mismatch_score = -1
         aligner.insertion_score = gap_score_function
+        aligner.deletion_score = 0
         aligner.internal_deletion_score = -10
         seqA = "TTAAAAA"
         seqB = "AAAAAAAAAAA"

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -1172,18 +1172,18 @@ Pairwise sequence aligner with parameters
             aligner.algorithm, "Fast Optimal Global Sequence Alignment Algorithm"
         )
         score = aligner.score(seq1, seq2)
-        self.assertAlmostEqual(score, 3.0)
+        self.assertAlmostEqual(score, 1.0)
         score = aligner.score(seq1, reverse_complement(seq2), "-")
-        self.assertAlmostEqual(score, 3.0)
+        self.assertAlmostEqual(score, 1.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(
             str(alignment),
             """\
@@ -1244,11 +1244,11 @@ AlignmentCounts object with
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(
             str(alignment),
             """\
@@ -1563,7 +1563,7 @@ class TestUnknownCharacter(unittest.TestCase):
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -1710,7 +1710,7 @@ AlignmentCounts object with
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -1563,7 +1563,7 @@ class TestUnknownCharacter(unittest.TestCase):
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
@@ -1710,7 +1710,7 @@ AlignmentCounts object with
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -3072,47 +3072,47 @@ AlignmentCounts object with
         aligner.mode = "fogsaa"
         aligner.wildcard = "?"
         score = aligner.score(seq1, seq2)
-        self.assertAlmostEqual(score, 4.0)
+        self.assertAlmostEqual(score, 3.0)
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
-        self.assertAlmostEqual(score, 4.0)
+        self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 4.0)
+        self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
             str(alignment),
             """\
-target            0 GA?A-T 5
-                  0 ||-|-| 6
-query             0 GA-A?T 5
+target            0 GA?AT 5
+                  0 ||..| 5
+query             0 GAA?T 5
 """,
         )
-        self.assertEqual(alignment.shape, (2, 6))
+        self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             np.array_equal(
                 alignment.aligned,
-                np.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]]),
+                np.array([[[0, 5]], [[0, 5]]]),
             )
         )
         counts = alignment.counts()
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 2 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
-        mismatches = 0.
-    gaps = 2:
+    aligned = 5:
+        identities = 3,
+        mismatches = 2.
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3120,12 +3120,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3136,24 +3136,24 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
-        self.assertEqual(counts.mismatches, 0)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 2)
         self.assertIsNone(counts.score)
         counts = alignment.counts("?")
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3161,12 +3161,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3177,27 +3177,27 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
         self.assertIsNone(counts.score)
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 4.0; substitution score = 4.0; gap score = 0.0; 4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 3.0; substitution score = 3.0; gap score = 0.0; 5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 4.0:
-        substitution_score = 4.0,
+    score = 3.0:
+        substitution_score = 3.0,
         gap_score = 0.0.
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3205,12 +3205,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3221,48 +3221,45 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
-        self.assertAlmostEqual(counts.score, 4.0)
+        self.assertAlmostEqual(counts.score, 3.0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 4.0)
+        self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
             str(alignment),
             """\
-target            0 GA?A-T 5
-                  0 ||-|-| 6
-query             5 GA-A?T 0
+target            0 GA?AT 5
+                  0 ||..| 5
+query             5 GAA?T 0
 """,
         )
-        self.assertEqual(alignment.shape, (2, 6))
+        self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            np.array_equal(
-                alignment.aligned,
-                np.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]]),
-            )
+            np.array_equal(alignment.aligned, np.array([[[0, 5]], [[5, 0]]]))
         )
         counts = alignment.counts()
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 2 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
-        mismatches = 0.
-    gaps = 2:
+    aligned = 5:
+        identities = 3,
+        mismatches = 2.
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3270,12 +3267,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3286,24 +3283,24 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
-        self.assertEqual(counts.mismatches, 0)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 2)
         self.assertIsNone(counts.score)
         counts = alignment.counts("?")
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3311,12 +3308,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3327,27 +3324,27 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
         self.assertIsNone(counts.score)
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 4.0; substitution score = 4.0; gap score = 0.0; 4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 3.0; substitution score = 3.0; gap score = 0.0; 5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 4.0:
-        substitution_score = 4.0,
+    score = 3.0:
+        substitution_score = 3.0,
         gap_score = 0.0.
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3355,12 +3352,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3371,55 +3368,52 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
-        self.assertAlmostEqual(counts.score, 4.0)
+        self.assertAlmostEqual(counts.score, 3.0)
         seq1 = "GAXAT"
         seq2 = "GAAXT"
         aligner.wildcard = "X"
         score = aligner.score(seq1, seq2)
-        self.assertAlmostEqual(score, 4.0)
+        self.assertAlmostEqual(score, 3.0)
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
-        self.assertAlmostEqual(score, 4.0)
+        self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 4.0)
+        self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
             str(alignment),
             """\
-target            0 GAXA-T 5
-                  0 ||-|-| 6
-query             0 GA-AXT 5
+target            0 GAXAT 5
+                  0 ||..| 5
+query             0 GAAXT 5
 """,
         )
-        self.assertEqual(alignment.shape, (2, 6))
+        self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            np.array_equal(
-                alignment.aligned,
-                np.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]]),
-            )
+            np.array_equal(alignment.aligned, np.array([[[0, 5]], [[0, 5]]]))
         )
         counts = alignment.counts()
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 2 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
-        mismatches = 0.
-    gaps = 2:
+    aligned = 5:
+        identities = 3,
+        mismatches = 2.
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3427,12 +3421,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3443,24 +3437,24 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
-        self.assertEqual(counts.mismatches, 0)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 2)
         self.assertIsNone(counts.score)
         counts = alignment.counts("X")
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3468,12 +3462,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3484,27 +3478,27 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
         self.assertIsNone(counts.score)
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 4.0; substitution score = 4.0; gap score = 0.0; 4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 3.0; substitution score = 3.0; gap score = 0.0; 5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 4.0:
-        substitution_score = 4.0,
+    score = 3.0:
+        substitution_score = 3.0,
         gap_score = 0.0.
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3512,12 +3506,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3528,48 +3522,45 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
-        self.assertAlmostEqual(counts.score, 4.0)
+        self.assertAlmostEqual(counts.score, 3.0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 4.0)
+        self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
             str(alignment),
             """\
-target            0 GAXA-T 5
-                  0 ||-|-| 6
-query             5 GA-AXT 0
+target            0 GAXAT 5
+                  0 ||..| 5
+query             5 GAAXT 0
 """,
         )
-        self.assertEqual(alignment.shape, (2, 6))
+        self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            np.array_equal(
-                alignment.aligned,
-                np.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]]),
-            )
+            np.array_equal(alignment.aligned, np.array([[[0, 5]], [[5, 0]]]))
         )
         counts = alignment.counts()
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 2 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
-        mismatches = 0.
-    gaps = 2:
+    aligned = 5:
+        identities = 3,
+        mismatches = 2.
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3577,12 +3568,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3593,24 +3584,24 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
-        self.assertEqual(counts.mismatches, 0)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 2)
         self.assertIsNone(counts.score)
         counts = alignment.counts("X")
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3618,12 +3609,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3634,27 +3625,27 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
         self.assertIsNone(counts.score)
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 4.0; substitution score = 4.0; gap score = 0.0; 4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 3.0; substitution score = 3.0; gap score = 0.0; 5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 4.0:
-        substitution_score = 4.0,
+    score = 3.0:
+        substitution_score = 3.0,
         gap_score = 0.0.
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3662,12 +3653,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3678,10 +3669,10 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
-        self.assertAlmostEqual(counts.score, 4.0)
+        self.assertAlmostEqual(counts.score, 3.0)
 
 
 class TestPairwiseOpenPenalty(unittest.TestCase):
@@ -4216,8 +4207,8 @@ AlignmentCounts object with
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -4260,8 +4251,8 @@ AlignmentCounts object with
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -4423,8 +4414,8 @@ AlignmentCounts object with
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -4467,8 +4458,8 @@ AlignmentCounts object with
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -4653,7 +4644,7 @@ AlignmentCounts object with
     aligned = 3:
         identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -4661,7 +4652,7 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
+        internal_gaps = 0:
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;
@@ -4697,7 +4688,7 @@ AlignmentCounts object with
     aligned = 3:
         identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -4705,7 +4696,7 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
+        internal_gaps = 0:
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;
@@ -4761,7 +4752,7 @@ AlignmentCounts object with
     aligned = 3:
         identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -4769,7 +4760,7 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
+        internal_gaps = 0:
             internal_insertions = 0:
                 open_internal_insertions = 0,
                 extend_internal_insertions = 0;
@@ -8685,7 +8676,7 @@ query             0 GTCCT 5
         counts = alignment.counts()
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 2 identities; 2 mismatches; 1 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 2 identities; 2 mismatches; 1 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -4830,6 +4830,7 @@ AlignmentCounts object with
         aligner.mode = "fogsaa"
         aligner.open_deletion_score = -0.1
         aligner.extend_deletion_score = 0.0
+        aligner.insertion_score = 0.0
         self.assertEqual(
             aligner.algorithm, "Fast Optimal Global Sequence Alignment Algorithm"
         )

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -2460,47 +2460,47 @@ AlignmentCounts object with
         aligner.mode = "global"
         aligner.wildcard = "?"
         score = aligner.score(seq1, seq2)
-        self.assertAlmostEqual(score, 4.0)
+        self.assertAlmostEqual(score, 3.0)
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
-        self.assertAlmostEqual(score, 4.0)
+        self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 4.0)
+        self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
             str(alignment),
             """\
-target            0 GA?A-T 5
-                  0 ||-|-| 6
-query             0 GA-A?T 5
+target            0 GA?AT 5
+                  0 ||..| 5
+query             0 GAA?T 5
 """,
         )
-        self.assertEqual(alignment.shape, (2, 6))
+        self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             np.array_equal(
                 alignment.aligned,
-                np.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]]),
+                np.array([[[0, 5]], [[0, 5]]]),
             )
         )
         counts = alignment.counts()
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 2 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
-        mismatches = 0.
-    gaps = 2:
+    aligned = 5:
+        identities = 3,
+        mismatches = 2.
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -2508,12 +2508,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -2524,24 +2524,24 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
-        self.assertEqual(counts.mismatches, 0)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 2)
         self.assertIsNone(counts.score)
         counts = alignment.counts("?")
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -2549,12 +2549,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -2565,27 +2565,27 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
         self.assertIsNone(counts.score)
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 4.0; substitution score = 4.0; gap score = 0.0; 4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 3.0; substitution score = 3.0; gap score = 0.0; 5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 4.0:
-        substitution_score = 4.0,
+    score = 3.0:
+        substitution_score = 3.0,
         gap_score = 0.0.
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -2593,12 +2593,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -2609,48 +2609,45 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
-        self.assertAlmostEqual(counts.score, 4.0)
+        self.assertAlmostEqual(counts.score, 3.0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 4.0)
+        self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
             str(alignment),
             """\
-target            0 GA?A-T 5
-                  0 ||-|-| 6
-query             5 GA-A?T 0
+target            0 GA?AT 5
+                  0 ||..| 5
+query             5 GAA?T 0
 """,
         )
-        self.assertEqual(alignment.shape, (2, 6))
+        self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            np.array_equal(
-                alignment.aligned,
-                np.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]]),
-            )
+            np.array_equal(alignment.aligned, np.array([[[0, 5]], [[5, 0]]]))
         )
         counts = alignment.counts()
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 2 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
-        mismatches = 0.
-    gaps = 2:
+    aligned = 5:
+        identities = 3,
+        mismatches = 2.
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -2658,12 +2655,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -2674,24 +2671,24 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
-        self.assertEqual(counts.mismatches, 0)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 2)
         self.assertIsNone(counts.score)
         counts = alignment.counts("?")
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -2699,12 +2696,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -2715,27 +2712,27 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
         self.assertIsNone(counts.score)
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 4.0; substitution score = 4.0; gap score = 0.0; 4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 3.0; substitution score = 3.0; gap score = 0.0; 5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 4.0:
-        substitution_score = 4.0,
+    score = 3.0:
+        substitution_score = 3.0,
         gap_score = 0.0.
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -2743,12 +2740,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -2759,55 +2756,52 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
-        self.assertAlmostEqual(counts.score, 4.0)
+        self.assertAlmostEqual(counts.score, 3.0)
         seq1 = "GAXAT"
         seq2 = "GAAXT"
         aligner.wildcard = "X"
         score = aligner.score(seq1, seq2)
-        self.assertAlmostEqual(score, 4.0)
+        self.assertAlmostEqual(score, 3.0)
         score = aligner.score(seq1, reverse_complement(seq2), strand="-")
-        self.assertAlmostEqual(score, 4.0)
+        self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 4.0)
+        self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
             str(alignment),
             """\
-target            0 GAXA-T 5
-                  0 ||-|-| 6
-query             0 GA-AXT 5
+target            0 GAXAT 5
+                  0 ||..| 5
+query             0 GAAXT 5
 """,
         )
-        self.assertEqual(alignment.shape, (2, 6))
+        self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
-            np.array_equal(
-                alignment.aligned,
-                np.array([[[0, 2], [3, 4], [4, 5]], [[0, 2], [2, 3], [4, 5]]]),
-            )
+            np.array_equal(alignment.aligned, np.array([[[0, 5]], [[0, 5]]]))
         )
         counts = alignment.counts()
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 2 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
-        mismatches = 0.
-    gaps = 2:
+    aligned = 5:
+        identities = 3,
+        mismatches = 2.
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -2815,12 +2809,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -2831,24 +2825,24 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
-        self.assertEqual(counts.mismatches, 0)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 2)
         self.assertIsNone(counts.score)
         counts = alignment.counts("?")
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 2 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
-        mismatches = 0.
-    gaps = 2:
+    aligned = 5:
+        identities = 3,
+        mismatches = 2.
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -2856,12 +2850,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -2872,27 +2866,27 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
-        self.assertEqual(counts.mismatches, 0)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 2)
         self.assertIsNone(counts.score)
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 4.0; substitution score = 4.0; gap score = 0.0; 4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 3.0; substitution score = 3.0; gap score = 0.0; 5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 4.0:
-        substitution_score = 4.0,
+    score = 3.0:
+        substitution_score = 3.0,
         gap_score = 0.0.
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -2900,12 +2894,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -2916,48 +2910,48 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
-        self.assertAlmostEqual(counts.score, 4.0)
+        self.assertAlmostEqual(counts.score, 3.0)
         alignments = aligner.align(seq1, reverse_complement(seq2), strand="-")
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=4) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 4.0)
+        self.assertAlmostEqual(alignment.score, 3.0)
         self.assertEqual(
             str(alignment),
             """\
-target            0 GAXA-T 5
-                  0 ||-|-| 6
-query             5 GA-AXT 0
+target            0 GAXAT 5
+                  0 ||..| 5
+query             5 GAAXT 0
 """,
         )
-        self.assertEqual(alignment.shape, (2, 6))
+        self.assertEqual(alignment.shape, (2, 5))
         self.assertTrue(
             np.array_equal(
                 alignment.aligned,
-                np.array([[[0, 2], [3, 4], [4, 5]], [[5, 3], [3, 2], [1, 0]]]),
+                np.array([[[0, 5]], [[5, 0]]]),
             )
         )
         counts = alignment.counts()
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 2 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
-        mismatches = 0.
-    gaps = 2:
+    aligned = 5:
+        identities = 3,
+        mismatches = 2.
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -2965,12 +2959,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -2981,24 +2975,24 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
-        self.assertEqual(counts.mismatches, 0)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 2)
         self.assertIsNone(counts.score)
         counts = alignment.counts("?")
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (5 aligned letters; 3 identities; 2 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    aligned = 4:
-        identities = 4,
-        mismatches = 0.
-    gaps = 2:
+    aligned = 5:
+        identities = 3,
+        mismatches = 2.
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3006,12 +3000,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3022,27 +3016,27 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
-        self.assertEqual(counts.mismatches, 0)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
+        self.assertEqual(counts.mismatches, 2)
         self.assertIsNone(counts.score)
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 4.0; substitution score = 4.0; gap score = 0.0; 4 aligned letters; 4 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 3.0; substitution score = 3.0; gap score = 0.0; 5 aligned letters; 3 identities; 0 mismatches; 0 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 4.0:
-        substitution_score = 4.0,
+    score = 3.0:
+        substitution_score = 3.0,
         gap_score = 0.0.
-    aligned = 4:
-        identities = 4,
+    aligned = 5:
+        identities = 3,
         mismatches = 0.
-    gaps = 2:
+    gaps = 0:
         left_gaps = 0:
             left_insertions = 0:
                 open_left_insertions = 0,
@@ -3050,12 +3044,12 @@ AlignmentCounts object with
             left_deletions = 0:
                 open_left_deletions = 0,
                 extend_left_deletions = 0;
-        internal_gaps = 2:
-            internal_insertions = 1:
-                open_internal_insertions = 1,
+        internal_gaps = 0:
+            internal_insertions = 0:
+                open_internal_insertions = 0,
                 extend_internal_insertions = 0;
-            internal_deletions = 1:
-                open_internal_deletions = 1,
+            internal_deletions = 0:
+                open_internal_deletions = 0,
                 extend_internal_deletions = 0;
         right_gaps = 0:
             right_insertions = 0:
@@ -3066,10 +3060,10 @@ AlignmentCounts object with
                 extend_right_deletions = 0.
 """,
         )
-        self.assertEqual(counts.aligned, 4)
-        self.assertEqual(counts.identities, 4)
+        self.assertEqual(counts.aligned, 5)
+        self.assertEqual(counts.identities, 3)
         self.assertEqual(counts.mismatches, 0)
-        self.assertAlmostEqual(counts.score, 4.0)
+        self.assertAlmostEqual(counts.score, 3.0)
 
     def test_fogsaa_simple2(self):
         seq1 = "GA?AT"

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -8676,7 +8676,7 @@ query             0 GTCCT 5
         counts = alignment.counts()
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (5 aligned letters; 2 identities; 2 mismatches; 1 gaps) at 0x%x>"
+            "<AlignmentCounts object (4 aligned letters; 2 identities; 2 mismatches; 1 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
@@ -13166,6 +13166,7 @@ AlignmentCounts object with
         aligner.match_score = 1
         aligner.mismatch_score = -10
         aligner.insertion_score = gap_score
+        aligner.deletion_score = 0
         self.assertEqual(
             aligner.algorithm, "Waterman-Smith-Beyer global alignment algorithm"
         )

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -16538,6 +16538,7 @@ AlignmentCounts object with
         seq2 = ["Pro", "Pro", "Gly", "Ala", "Ala", "Cys", "Thr", "Leu"]
         aligner = Align.PairwiseAligner()
         aligner.mode = "local"
+        aligner.gap_score = 0.0
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -18084,16 +18084,16 @@ AlignmentCounts object with
             aligner.algorithm, "Fast Optimal Global Sequence Alignment Algorithm"
         )
         score = aligner.score(seq1, seq2)
-        self.assertAlmostEqual(score, 3.0)
+        self.assertAlmostEqual(score, 1.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (1 alignment; score=3) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (1 alignment; score=1) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 1)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(
             str(alignment),
             """\
@@ -18111,16 +18111,16 @@ AlignmentCounts object with
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 3.0; substitution score = 3.0; gap score = 0.0; 3 aligned letters; 3 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 1.0; substitution score = 3.0; gap score = -2.0; 3 aligned letters; 3 identities; 0 mismatches; 2 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 3.0:
+    score = 1.0:
         substitution_score = 3.0,
-        gap_score = 0.0.
+        gap_score = -2.0.
     aligned = 3:
         identities = 3,
         mismatches = 0.
@@ -18153,7 +18153,7 @@ AlignmentCounts object with
         self.assertEqual(counts.mismatches, 0)
         self.assertEqual(counts.deletions, 2)
         self.assertEqual(counts.insertions, 0)
-        self.assertAlmostEqual(counts.score, 3.0)
+        self.assertAlmostEqual(counts.score, 1.0)
 
     def test_align_affine1_score(self):
         aligner = Align.PairwiseAligner()

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -16954,6 +16954,7 @@ class TestArgumentErrors(unittest.TestCase):
             return
         aligner = Align.PairwiseAligner()
         aligner.wildcard = chr(99)
+        aligner.gap_score = 0.0
         s1 = "GGG"
         s2 = np.array([ord("G"), ord("A"), ord("G")], np.int32)
         score = aligner.score(s1, s2)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -862,35 +862,35 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 1.000000
   mismatch_score: 0.000000
-  open_internal_insertion_score: 0.000000
-  extend_internal_insertion_score: 0.000000
-  open_left_insertion_score: 0.000000
-  extend_left_insertion_score: 0.000000
-  open_right_insertion_score: 0.000000
-  extend_right_insertion_score: 0.000000
-  open_internal_deletion_score: 0.000000
-  extend_internal_deletion_score: 0.000000
-  open_left_deletion_score: 0.000000
-  extend_left_deletion_score: 0.000000
-  open_right_deletion_score: 0.000000
-  extend_right_deletion_score: 0.000000
+  open_internal_insertion_score: -1.000000
+  extend_internal_insertion_score: -1.000000
+  open_left_insertion_score: -1.000000
+  extend_left_insertion_score: -1.000000
+  open_right_insertion_score: -1.000000
+  extend_right_insertion_score: -1.000000
+  open_internal_deletion_score: -1.000000
+  extend_internal_deletion_score: -1.000000
+  open_left_deletion_score: -1.000000
+  extend_left_deletion_score: -1.000000
+  open_right_deletion_score: -1.000000
+  extend_right_deletion_score: -1.000000
   mode: global
 """,
         )
         self.assertEqual(aligner.algorithm, "Needleman-Wunsch")
         score = aligner.score(seq1, seq2)
-        self.assertAlmostEqual(score, 3.0)
+        self.assertAlmostEqual(score, 1.0)
         score = aligner.score(seq1, reverse_complement(seq2), "-")
-        self.assertAlmostEqual(score, 3.0)
+        self.assertAlmostEqual(score, 1.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (2 alignments; score=1) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(
             str(alignment),
             """\
@@ -947,7 +947,7 @@ AlignmentCounts object with
         self.assertEqual(counts.mismatches, 0)
         self.assertIsNone(counts.score)
         alignment = alignments[1]
-        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(
             str(alignment),
             """\
@@ -1008,11 +1008,11 @@ AlignmentCounts object with
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (2 alignments; score=1) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(
             str(alignment),
             """\
@@ -1069,7 +1069,7 @@ AlignmentCounts object with
         self.assertEqual(counts.mismatches, 0)
         self.assertIsNone(counts.score)
         alignment = alignments[1]
-        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(
             str(alignment),
             """\

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -22162,6 +22162,7 @@ AlignmentCounts object with
 
     def test_greek(self):
         aligner = Align.PairwiseAligner()
+        aligner.gap_score = 0
         seqA = "αβγγβα"
         seqB = "ABCBAαβγ"
         alignments = aligner.align(seqA, seqB)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -16282,6 +16282,7 @@ class TestAlignerInput(unittest.TestCase):
         seq2 = ["Gly", "Ala", "Ala", "Cys", "Thr"]
         aligner = Align.PairwiseAligner()
         aligner.mode = "global"
+        aligner.gap_score = 0.0
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
         alignments = aligner.align(seq1, seq2)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -15172,6 +15172,7 @@ AlignmentCounts object with
         aligner.match_score = 1
         aligner.mismatch_score = -10
         aligner.insertion_score = gap_score
+        aligner.deletion_score = 0
         self.assertEqual(
             aligner.algorithm, "Waterman-Smith-Beyer local alignment algorithm"
         )

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -68,18 +68,18 @@ Pairwise sequence aligner with parameters
   wildcard: None
   match_score: 3.000000
   mismatch_score: -2.000000
-  open_internal_insertion_score: 0.000000
-  extend_internal_insertion_score: 0.000000
-  open_left_insertion_score: 0.000000
-  extend_left_insertion_score: 0.000000
-  open_right_insertion_score: 0.000000
-  extend_right_insertion_score: 0.000000
-  open_internal_deletion_score: 0.000000
-  extend_internal_deletion_score: 0.000000
-  open_left_deletion_score: 0.000000
-  extend_left_deletion_score: 0.000000
-  open_right_deletion_score: 0.000000
-  extend_right_deletion_score: 0.000000
+  open_internal_insertion_score: -1.000000
+  extend_internal_insertion_score: -1.000000
+  open_left_insertion_score: -1.000000
+  extend_left_insertion_score: -1.000000
+  open_right_insertion_score: -1.000000
+  extend_right_insertion_score: -1.000000
+  open_internal_deletion_score: -1.000000
+  extend_internal_deletion_score: -1.000000
+  open_left_deletion_score: -1.000000
+  extend_left_deletion_score: -1.000000
+  open_right_deletion_score: -1.000000
+  extend_right_deletion_score: -1.000000
   mode: global
 """,
         )

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -21191,16 +21191,16 @@ query             0 TTACGT----CCCTCCC 13
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 12.0; substitution score = 12.0; gap score = 0.0; 13 aligned letters; 12 identities; 1 mismatches; 4 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 8.0; substitution score = 12.0; gap score = -4.0; 13 aligned letters; 12 identities; 1 mismatches; 4 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 12.0:
+    score = 8.0:
         substitution_score = 12.0,
-        gap_score = 0.0.
+        gap_score = -4.0.
     aligned = 13:
         identities = 12,
         mismatches = 1.
@@ -21230,7 +21230,7 @@ AlignmentCounts object with
         )
         self.check_incomplete_nucleotide_sequence(counts)
         self.assertIsNone(counts.positives)
-        self.assertAlmostEqual(counts.score, 12.0)
+        self.assertAlmostEqual(counts.score, 8.0)
         counts = alignment.counts(aligner_blastn)
         self.assertEqual(
             repr(counts),
@@ -21287,16 +21287,16 @@ query            10 TTACGT????CCCCCCC 27
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 12.0; substitution score = 12.0; gap score = 0.0; 13 aligned letters; 12 identities; 1 mismatches; 4 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 8.0; substitution score = 12.0; gap score = -4.0; 13 aligned letters; 12 identities; 1 mismatches; 4 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 12.0:
+    score = 8.0:
         substitution_score = 12.0,
-        gap_score = 0.0.
+        gap_score = -4.0.
     aligned = 13:
         identities = 12,
         mismatches = 1.
@@ -21384,16 +21384,16 @@ query           100 TTACGT----CCCCCCC 113
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 12.0; substitution score = 12.0; gap score = 0.0; 13 aligned letters; 12 identities; 1 mismatches; 4 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 8.0; substitution score = 12.0; gap score = -4.0; 13 aligned letters; 12 identities; 1 mismatches; 4 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 12.0:
+    score = 8.0:
         substitution_score = 12.0,
-        gap_score = 0.0.
+        gap_score = -4.0.
     aligned = 13:
         identities = 12,
         mismatches = 1.
@@ -21423,7 +21423,7 @@ AlignmentCounts object with
         )
         self.check_incomplete_nucleotide_sequence(counts)
         self.assertIsNone(counts.positives)
-        self.assertAlmostEqual(counts.score, 12.0)
+        self.assertAlmostEqual(counts.score, 8.0)
         counts = alignment.counts(aligner_blastn)
         self.assertEqual(
             repr(counts),
@@ -21484,16 +21484,16 @@ query           100 TTACGT----CCCCCCC 113
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 12.0; substitution score = 12.0; gap score = 0.0; 13 aligned letters; 12 identities; 1 mismatches; 4 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 8.0; substitution score = 12.0; gap score = -4.0; 13 aligned letters; 12 identities; 1 mismatches; 4 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 12.0:
+    score = 8.0:
         substitution_score = 12.0,
-        gap_score = 0.0.
+        gap_score = -4.0.
     aligned = 13:
         identities = 12,
         mismatches = 1.
@@ -21523,7 +21523,7 @@ AlignmentCounts object with
         )
         self.check_incomplete_nucleotide_sequence(counts)
         self.assertIsNone(counts.positives)
-        self.assertAlmostEqual(counts.score, 12.0)
+        self.assertAlmostEqual(counts.score, 8.0)
         counts = alignment.counts(aligner_blastn)
         self.assertEqual(
             repr(counts),
@@ -21582,16 +21582,16 @@ query           100 TTACGT----CCCCCCC 87
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 12.0; substitution score = 12.0; gap score = 0.0; 13 aligned letters; 12 identities; 1 mismatches; 4 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 8.0; substitution score = 12.0; gap score = -4.0; 13 aligned letters; 12 identities; 1 mismatches; 4 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 12.0:
+    score = 8.0:
         substitution_score = 12.0,
-        gap_score = 0.0.
+        gap_score = -4.0.
     aligned = 13:
         identities = 12,
         mismatches = 1.
@@ -21621,7 +21621,7 @@ AlignmentCounts object with
         )
         self.check_incomplete_nucleotide_sequence(counts)
         self.assertIsNone(counts.positives)
-        self.assertAlmostEqual(counts.score, 12.0)
+        self.assertAlmostEqual(counts.score, 8.0)
         counts = alignment.counts(aligner_blastn)
         self.assertEqual(
             repr(counts),
@@ -21681,16 +21681,16 @@ query           100 TTACGT----CCCCCCC 87
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 12.0; substitution score = 12.0; gap score = 0.0; 13 aligned letters; 12 identities; 1 mismatches; 4 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 8.0; substitution score = 12.0; gap score = -4.0; 13 aligned letters; 12 identities; 1 mismatches; 4 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 12.0:
+    score = 8.0:
         substitution_score = 12.0,
-        gap_score = 0.0.
+        gap_score = -4.0.
     aligned = 13:
         identities = 12,
         mismatches = 1.
@@ -21720,7 +21720,7 @@ AlignmentCounts object with
         )
         self.check_incomplete_nucleotide_sequence(counts)
         self.assertIsNone(counts.positives)
-        self.assertAlmostEqual(counts.score, 12.0)
+        self.assertAlmostEqual(counts.score, 8.0)
         counts = alignment.counts(aligner_blastn)
         self.assertEqual(
             repr(counts),

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -17941,16 +17941,16 @@ class TestUnicodeStrings(unittest.TestCase):
         aligner.mode = "global"
         self.assertEqual(aligner.algorithm, "Needleman-Wunsch")
         score = aligner.score(seq1, seq2)
-        self.assertAlmostEqual(score, 3.0)
+        self.assertAlmostEqual(score, 1.0)
         alignments = aligner.align(seq1, seq2)
         self.assertEqual(
             repr(alignments),
             f"""\
-<PairwiseAlignments object (2 alignments; score=3) at {hex(id(alignments))}>""",
+<PairwiseAlignments object (2 alignments; score=1) at {hex(id(alignments))}>""",
         )
         self.assertEqual(len(alignments), 2)
         alignment = alignments[0]
-        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(
             str(alignment),
             """\
@@ -17968,16 +17968,16 @@ class TestUnicodeStrings(unittest.TestCase):
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 3.0; substitution score = 3.0; gap score = 0.0; 3 aligned letters; 3 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 1.0; substitution score = 3.0; gap score = -2.0; 3 aligned letters; 3 identities; 0 mismatches; 2 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 3.0:
+    score = 1.0:
         substitution_score = 3.0,
-        gap_score = 0.0.
+        gap_score = -2.0.
     aligned = 3:
         identities = 3,
         mismatches = 0.
@@ -18010,9 +18010,9 @@ AlignmentCounts object with
         self.assertEqual(counts.mismatches, 0)
         self.assertEqual(counts.deletions, 2)
         self.assertEqual(counts.insertions, 0)
-        self.assertAlmostEqual(counts.score, 3.0)
+        self.assertAlmostEqual(counts.score, 1.0)
         alignment = alignments[1]
-        self.assertAlmostEqual(alignment.score, 3.0)
+        self.assertAlmostEqual(alignment.score, 1.0)
         self.assertEqual(
             str(alignment),
             """\
@@ -18031,16 +18031,16 @@ AlignmentCounts object with
         counts = alignment.counts(aligner)
         self.assertEqual(
             repr(counts),
-            "<AlignmentCounts object (score = 3.0; substitution score = 3.0; gap score = 0.0; 3 aligned letters; 3 identities; 0 mismatches; 2 gaps) at 0x%x>"
+            "<AlignmentCounts object (score = 1.0; substitution score = 3.0; gap score = -2.0; 3 aligned letters; 3 identities; 0 mismatches; 2 gaps) at 0x%x>"
             % id(counts),
         )
         self.assertEqual(
             str(counts),
             """\
 AlignmentCounts object with
-    score = 3.0:
+    score = 1.0:
         substitution_score = 3.0,
-        gap_score = 0.0.
+        gap_score = -2.0.
     aligned = 3:
         identities = 3,
         mismatches = 0.
@@ -18073,7 +18073,7 @@ AlignmentCounts object with
         self.assertEqual(counts.mismatches, 0)
         self.assertEqual(counts.deletions, 2)
         self.assertEqual(counts.insertions, 0)
-        self.assertAlmostEqual(counts.score, 3.0)
+        self.assertAlmostEqual(counts.score, 1.0)
 
     def test_needlemanwunsch_simple1_fogsaa(self):
         seq1 = "ĞĀĀČŦ"

--- a/Tests/test_pairwise_alignment_map.py
+++ b/Tests/test_pairwise_alignment_map.py
@@ -42,7 +42,7 @@ class TestSimple(unittest.TestCase):
         transcript.id = "transcript"
         sequence = Seq("GGCCCCCGGG")
         sequence.id = "sequence"
-        alignments1 = aligner.align(chromosome, transcript)
+        alignments1 = aligner.align(chromosome, transcript)  # HIER
         self.assertEqual(len(alignments1), 1)
         alignment1 = alignments1[0]
         self.assertTrue(
@@ -98,7 +98,7 @@ sequence          0 GGCCCCCGGG 10
         transcript.id = "transcript"
         sequence = Seq("GGGGGCCCCCGGG")
         sequence.id = "sequence"
-        alignments1 = aligner.align(chromosome, transcript)
+        alignments1 = aligner.align(chromosome, transcript)  # HIER
         self.assertEqual(len(alignments1), 1)
         alignment1 = alignments1[0]
         self.assertEqual(
@@ -148,7 +148,7 @@ sequence          2 GGGCCCCCGGG 13
         transcript.id = "transcript"
         sequence = Seq("GGCCCCCGGGGG")
         sequence.id = "sequence"
-        alignments1 = aligner.align(chromosome, transcript)
+        alignments1 = aligner.align(chromosome, transcript)  # HIER
         self.assertEqual(len(alignments1), 1)
         alignment1 = alignments1[0]
         self.assertEqual(
@@ -198,7 +198,7 @@ sequence          0 GGCCCCCGGG 10
         transcript.id = "transcript"
         sequence = Seq("GGCCCCCGGG")
         sequence.id = "sequence"
-        alignments1 = aligner.align(chromosome, transcript, strand="-")
+        alignments1 = aligner.align(chromosome, transcript, strand="-")  # HIER
         self.assertEqual(len(alignments1), 1)
         alignment1 = alignments1[0]
         self.assertTrue(
@@ -254,7 +254,7 @@ sequence          0 GGCCCCCGGG 10
         transcript.id = "transcript"
         sequence = Seq("CCCGGGGGCC")
         sequence.id = "sequence"
-        alignments1 = aligner.align(chromosome, transcript)
+        alignments1 = aligner.align(chromosome, transcript)  # HIER
         self.assertEqual(len(alignments1), 1)
         alignment1 = alignments1[0]
         self.assertTrue(
@@ -310,7 +310,7 @@ sequence         10 GGCCCCCGGG  0
         transcript.id = "transcript"
         sequence = Seq("CCCGGGGGCC")
         sequence.id = "sequence"
-        alignments1 = aligner.align(chromosome, transcript, "-")
+        alignments1 = aligner.align(chromosome, transcript, "-")  # HIER
         self.assertEqual(len(alignments1), 1)
         alignment1 = alignments1[0]
         self.assertTrue(
@@ -381,7 +381,7 @@ class TestComplex(unittest.TestCase):
             "TCCAAGGGGCCCCAGCACAGCACATTTTTAACGCGGGGACAGTTGATCCCATCCGCCTTTTACGAATTCATACCGTGGTAGGCGGCATAGTACGACGAAGCGGTTGGGTCGAAAAACAGGTTGCCGTCATATCGGTGGGTTC"
         )
         sequence.id = "sequence"
-        alignments1 = aligner.align(chromosome, transcript)
+        alignments1 = aligner.align(chromosome, transcript)  # HIER
         alignment1 = alignments1[0]
         self.assertEqual(alignment1.coordinates.shape[1], 164)
         self.assertEqual(
@@ -511,7 +511,7 @@ sequence        132 CGGTGG----G--TTC 142
             "TCCCCTTCTAATGGAATCCCCCTCCGAAGGTCGCAGAAGCGGCCACGCCGGAGATACCAGTTCCACGCCTCAGGTTGGACTTGTCACACTTGTACGCGAT"
         )
         sequence.id = "sequence"
-        alignments1 = aligner.align(chromosome, transcript)
+        alignments1 = aligner.align(chromosome, transcript)  # HIER
         alignment1 = alignments1[0]
         self.assertEqual(alignment1.coordinates.shape[1], 126)
         self.assertEqual(


### PR DESCRIPTION
To be consistent with `Bio.pairwise2`, the pairwise aligner in `Bio.Align` uses a match score of +1, a mismatch score of 0, and a gap score of 0 by default.
However, this is almost never a good scoring scheme. In particular, any mismatch can be replaced by an insertion followed by a deletion, or a deletion followed by an insertion, and yield the same score.
This results in a large number of alignments with only trivial differences between them.
For example, aligning two sequences of 75 randomly chosen letters against each other yields >9223372036854775807 alignments (i.e., greater than sys.maxsize).
In contrast, with gap_score = -1 only one or a few alignments are returned.

To alert users to this change, a warning is issued the first time an aligner is used in which the gap score was not set explicitly.

This PR does not change the default parameters for `Bio.pairwise2`, as that module is already deprecated.

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #4956 