### PR TITLE
Replaced print with warn/stderrs in NCBIXML.py

### DIFF
--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -31,6 +31,8 @@ Parameters         Holds information from the parameters.
 
 import xml.sax
 from xml.sax.handler import ContentHandler
+import warnings
+import sys
 
 from Bio.Align import MultipleSeqAlignment
 from Bio.Seq import Seq
@@ -518,11 +520,11 @@ class _XMLparser(ContentHandler):
         if method in self._method_map:
             self._method_map[method]()
             if self._debug > 4:
-                print("NCBIXML: Parsed:  " + method)
+                sys.stderr.write(f"NCBIXML: Parsed:  {method}\n")
         elif self._debug > 3:
             # Doesn't exist (yet) and may want to warn about it
             if method not in self._debug_ignore_list:
-                print("NCBIXML: Ignored: " + method)
+                warnings.warn(f"Ignored method: {method} ({self._value})", stacklevel=2)
                 self._debug_ignore_list.append(method)
 
         # We don't care about white space in parent tags like Hsp,
@@ -559,11 +561,11 @@ class _XMLparser(ContentHandler):
         if method in self._method_map:
             self._method_map[method]()
             if self._debug > 2:
-                print(f"NCBIXML: Parsed:  {method} {self._value}")
+                sys.stderr.write(f"NCBIXML: Parsed:  {method} {self._value}\n")
         elif self._debug > 1:
             # Doesn't exist (yet) and may want to warn about it
             if method not in self._debug_ignore_list:
-                print(f"NCBIXML: Ignored: {method} {self._value}")
+                warnings.warn(f"Ignored method: {method} ({self._value})", stacklevel=2)
                 self._debug_ignore_list.append(method)
 
         # Reset character buffer
@@ -804,7 +806,7 @@ class BlastParser(_XMLparser):
         self._blast = None
 
         if self._debug:
-            print("NCBIXML: Added Blast record to results")
+            warnings.warn("Added Blast record to results", stacklevel=2)
 
     # Header
     def _set_header_application(self):
@@ -970,7 +972,7 @@ class BlastParser(_XMLparser):
         # exist between <Hit> tags, as a result of very large remote
         # BLAST searches.
         if self._value.strip() == "CREATE_VIEW":
-            print(f"NCBIXML: Ignored: {self._value!r}")
+            warnings.warn(f"Ignored value: {self._value!r}", stacklevel=2)
             self._value = ""
 
     def _end_hit(self):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4262 Replaced print statements with warnings.warn or sys.stderr.write in NCBIXML.py for better logging and error handling
