### PR TITLE
Add SeqIO read/write support for NCBI 5-column tab-delimited feature tables

### DIFF
--- a/Bio/SeqIO/FeatureTableIO.py
+++ b/Bio/SeqIO/FeatureTableIO.py
@@ -13,6 +13,7 @@ from Bio import BiopythonWarning
 from Bio.File import as_handle
 from Bio.SeqFeature import Reference, Position, SimpleLocation, SeqFeature
 from Bio.SeqRecord import SeqRecord
+from .Interfaces import SequenceWriter
 
 
 def _make_simple_location(start_loc_str, end_loc_str, offset):
@@ -20,7 +21,7 @@ def _make_simple_location(start_loc_str, end_loc_str, offset):
     start_loc = Position.fromstring(start_loc_str, -1 + offset)
     end_loc = Position.fromstring(end_loc_str, offset)
     if start_loc < end_loc:
-        return SimpleLocation(start_loc, end_loc)
+        return SimpleLocation(start_loc, end_loc, strand=1)
     else:
         return SimpleLocation(end_loc - 1, start_loc + 1, strand=-1)
 
@@ -33,10 +34,6 @@ def FeatureTableIterator(source):
 
         for line in handle:
             if line == "\n":
-                warnings.warn(
-                    "5-column tab-delimited feature table has blank line",
-                    BiopythonWarning,
-                )
                 continue
 
             if line.startswith(">Feature"):
@@ -45,7 +42,7 @@ def FeatureTableIterator(source):
                     offset = 0
                     yield rec
 
-                parts = line.split(" ")
+                parts = line.strip().split(" ")
                 if len(parts) < 2:
                     raise ValueError(
                         f"First line of table has no sequence identifier: {line}"
@@ -80,15 +77,15 @@ def FeatureTableIterator(source):
                             raise ValueError(
                                 f"Expected qualifier key-value pair: {ref_line}"
                             )
-                        if parts[0] != "PUBMED":
+                        if parts[0] != "PubMed":
                             warnings.warn(
-                                f"Reference qualifier key is not PUBMED: {ref_line}",
+                                f"Reference qualifier key is not PubMed: {ref_line}",
                                 BiopythonWarning,
                             )
 
                         ref = Reference()
                         ref.location = loc
-                        if parts[0] == "PUBMED":
+                        if parts[0] == "PubMed":
                             ref.pubmed_id = parts[1]
                         else:
                             ref.title = f"{parts[0]} {parts[1]}"
@@ -112,10 +109,67 @@ def FeatureTableIterator(source):
                 parts = line.strip().split("\t")
                 if len(parts) != 2:
                     raise ValueError(f"Expected qualifier key-value pair: {line}")
-                if parts[1].isdigit():
-                    rec.features[-1].qualifiers[parts[0]] = int(parts[1])
+                key, value = parts
+
+                if key not in rec.features[-1].qualifiers:
+                    rec.features[-1].qualifiers[key] = [value]
                 else:
-                    rec.features[-1].qualifiers[parts[0]] = parts[1]
+                    rec.features[-1].qualifiers[key].append(value)
 
         if rec is not None:
             yield rec
+
+
+class FeatureTableWriter(SequenceWriter):
+    """Writer for GenBank's 5-column tab-delimited feature table"""
+
+    modes = "t"
+
+    def _simplelocation_to_string(self, loc):
+        """Convert a SimpleLocation into a tab-delimited string (PRIVATE)."""
+        if loc.strand == 1:
+            return f"{loc.start + 1}\t{loc.end}"
+        elif loc.strand == -1:
+            return f"{loc.end}\t{loc.start + 1}"
+        else:
+            warnings.warn(
+                "Feature or reference location is on mixed strands. Writing as if stand=1.",
+                BiopythonWarning,
+            )
+            return f"{loc.start + 1}\t{loc.end}"
+
+    def _write_feature_header(self, loc, name):
+        """Write the header of a feature/references (PRIVATE)."""
+        loc_str = self._simplelocation_to_string(loc.parts[0])
+        self.handle.write(f"{loc_str}\t{name}\n")
+        for parent_loc in loc.parts[1:]:
+            loc_str = self._simplelocation_to_string(parent_loc)
+            self.handle.write(f"{loc_str}\n")
+
+    def write_record(self, rec):
+        """Write a single record to the output file."""
+
+        seq_id = self.clean(rec.id)
+        self.handle.write(f">Feature {seq_id}\n")
+
+        if "references" in rec.annotations:
+            for ref in rec.annotations["references"]:
+                self._write_feature_header(ref.location, "REFERENCE")
+                if ref.pubmed_id != "":
+                    self.handle.write(f"\t\t\tPubMed\t{self.clean(ref.pubmed_id)}\n")
+                elif ref.medline_id != "":
+                    warnings.warn(
+                        "Reference does not have a PubMed ID. Using the Medline"
+                        " ID, but 5-column tab-delimited feature tables only"
+                        " officially support PubMed IDs.",
+                        BiopythonWarning,
+                    )
+                    self.handle.write(f"\t\t\tMedline\t{self.clean(ref.medline_id)}\n")
+                else:
+                    raise TypeError("Reference has no medline_id or pubmed_id.")
+
+        for feature in rec.features:
+            self._write_feature_header(feature.location, feature.type)
+            for qualifier in feature.qualifiers:
+                for value in feature.qualifiers[qualifier]:
+                    self.handle.write(f"\t\t\t{self.clean(qualifier)}\t{str(value)}\n")

--- a/Bio/SeqIO/FeatureTableIO.py
+++ b/Bio/SeqIO/FeatureTableIO.py
@@ -1,0 +1,121 @@
+"""Bio.SeqIO support for GenBank's 5-column tab-delimited feature table
+
+This format is used when preparing GenBank submissions. It contains features and
+no actual sequences.
+
+Documentation: https://www.ncbi.nlm.nih.gov/genbank/feature_table/
+"""
+
+import re
+import warnings
+
+from Bio import BiopythonWarning
+from Bio.File import as_handle
+from Bio.SeqFeature import Reference, Position, SimpleLocation, SeqFeature
+from Bio.SeqRecord import SeqRecord
+
+
+def _make_simple_location(start_loc_str, end_loc_str, offset):
+    """Constructs a SimpleLocation from start location and end location strings (PRIVATE)."""
+    start_loc = Position.fromstring(start_loc_str, -1 + offset)
+    end_loc = Position.fromstring(end_loc_str, offset)
+    if start_loc < end_loc:
+        return SimpleLocation(start_loc, end_loc)
+    else:
+        return SimpleLocation(end_loc - 1, start_loc + 1, strand=-1)
+
+
+def FeatureTableIterator(source):
+    """Parser for GenBank's 5-column tab-delimited feature table"""
+    with as_handle(source) as handle:
+        rec = None
+        offset = 0
+
+        for line in handle:
+            if line == "\n":
+                warnings.warn(
+                    "5-column tab-delimited feature table has blank line",
+                    BiopythonWarning,
+                )
+                continue
+
+            if line.startswith(">Feature"):
+                # First line of a new table
+                if rec is not None:
+                    offset = 0
+                    yield rec
+
+                parts = line.split(" ")
+                if len(parts) < 2:
+                    raise ValueError(
+                        f"First line of table has no sequence identifier: {line}"
+                    )
+                rec = SeqRecord(None, id=parts[1], name=parts[1])
+            elif line.startswith("[offset="):
+                try:
+                    offset = re.findall(r"\d+", "[offset=2000]")[0]
+                except IndexError:
+                    raise ValueError(f"Malformed offset: {line}")
+            elif not line.startswith("\t"):
+                # New feature in the current table
+                if rec is None:
+                    raise ValueError(f"Feature found outside of a table: {line}")
+
+                parts = line.strip().split("\t")
+                if len(parts) == 3:
+                    start_loc, end_loc, feature_key = parts
+                    loc = _make_simple_location(start_loc, end_loc, offset)
+
+                    if feature_key == "REFERENCE":
+                        # REFERENCEs are annotations, not features, so they need
+                        # special handling
+                        try:
+                            ref_line = next(handle)
+                        except StopIteration:
+                            raise ValueError(
+                                f"Expected qualifier key-value pair line to follow REFERENCE: {line}"
+                            )
+                        parts = ref_line.strip().split("\t")
+                        if len(parts) != 2:
+                            raise ValueError(
+                                f"Expected qualifier key-value pair: {ref_line}"
+                            )
+                        if parts[0] != "PUBMED":
+                            warnings.warn(
+                                f"Reference qualifier key is not PUBMED: {ref_line}",
+                                BiopythonWarning,
+                            )
+
+                        ref = Reference()
+                        ref.location = loc
+                        if parts[0] == "PUBMED":
+                            ref.pubmed_id = parts[1]
+                        else:
+                            ref.title = f"{parts[0]} {parts[1]}"
+                        if "references" not in rec.annotations:
+                            rec.annotations["references"] = [ref]
+                        else:
+                            rec.annotations["references"].append(ref)
+                    else:
+                        rec.features.append(SeqFeature(loc, type=feature_key))
+                    pass
+                elif len(parts) == 2:
+                    # add new location to current feature
+                    start_loc, end_loc = parts
+                    rec.features[-1].location += _make_simple_location(
+                        start_loc, end_loc, offset
+                    )
+                else:
+                    raise ValueError(f"Malformed first line of feature: {line}")
+            else:
+                # New qualifier in the current feature
+                parts = line.strip().split("\t")
+                if len(parts) != 2:
+                    raise ValueError(f"Expected qualifier key-value pair: {line}")
+                if parts[1].isdigit():
+                    rec.features[-1].qualifiers[parts[0]] = int(parts[1])
+                else:
+                    rec.features[-1].qualifiers[parts[0]] = parts[1]
+
+        if rec is not None:
+            yield rec

--- a/Bio/SeqIO/FeatureTableIO.py
+++ b/Bio/SeqIO/FeatureTableIO.py
@@ -13,9 +13,12 @@ import warnings
 
 from Bio import BiopythonWarning, BiopythonParserWarning
 from Bio.File import as_handle
+from Bio.Seq import Seq
 from Bio.SeqFeature import Reference, Position, SimpleLocation, SeqFeature
 from Bio.SeqRecord import SeqRecord
-from .Interfaces import SequenceWriter
+
+from .Interfaces import _TextIOSource
+from .Interfaces import SequenceIterator, SequenceWriter
 
 
 def _split_by_tabs(line):
@@ -50,6 +53,47 @@ def _make_simple_location(start_loc_str, end_loc_str, offset):
         return SimpleLocation(end_loc - 1 + offset, start_loc + offset, strand=-1)
 
 
+def _fix_references(rec):
+    """Convert REFERENCE features from SeqFeature to annotations (PRIVATE)."""
+    ref_features = [feature for feature in rec.features if feature.type == "REFERENCE"]
+    for feature in ref_features:
+        rec.features.remove(feature)
+
+    refs = []
+    for ref_feature in ref_features:
+        ref = Reference()
+        ref.location = ref_feature.location.parts
+        if "PubMed" in ref_feature.qualifiers:
+            if len(ref_feature.qualifiers["PubMed"]) > 1:
+                raise ValueError(f"Reference has multiple PubMed IDs: {ref_feature}")
+            ref.pubmed_id = ref_feature.qualifiers["PubMed"][0]
+        if "Medline" in ref_feature.qualifiers:
+            warnings.warn(
+                f"Reference has Medline ID, but only PubMed IDs are officially supported in .tbl files: {ref_feature}",
+                BiopythonParserWarning,
+            )
+            if len(ref_feature.qualifiers["Medline"]) > 1:
+                raise ValueError(f"Reference has multiple Medline IDs: {ref_feature}")
+            ref.medline_id = ref_feature.qualifiers["Medline"][0]
+        if ref.pubmed_id == "" and ref.medline_id == "":
+            warnings.warn(
+                f"Ignoring reference without PubMed or Medline ID: {ref_feature}",
+                BiopythonParserWarning,
+            )
+            continue
+        refs.append(ref)
+    if len(refs) > 0:
+        rec.annotations["references"] = refs
+
+
+def _set_seq_len(rec):
+    """If there is only one reference, set the sequence length to the length of the reference (PRIVATE)."""
+    if "references" in rec.annotations and len(rec.annotations["references"]) == 1:
+        ref = rec.annotations["references"][0]
+        rec.seq = Seq(None, length=len(sum(ref.location)))
+    pass
+
+
 def _add_codon_start(rec):
     """Add codon_start=1 to CDS features without a codon_start qualifier (PRIVATE)."""
     for feature in rec.features:
@@ -74,92 +118,72 @@ def _find_overlap(rec):
 
 def _record_fixups(rec):
     """Modify the record as needed before it is yielded (PRIVATE)."""
+    _fix_references(rec)
+    _set_seq_len(rec)
     _add_codon_start(rec)
     _find_overlap(rec)
 
 
-def FeatureTableIterator(source):
+class FeatureTableIterator(SequenceIterator):
     """Parser for GenBank's 5-column tab-delimited feature table"""
-    with as_handle(source) as handle:
-        rec = None
-        offset = 0
 
-        for line in handle:
+    modes = "t"
+
+    def __init__(
+        self,
+        source: _TextIOSource,
+    ) -> None:
+        """Iterate over a .tbl file as SeqRecord objects.
+
+        Arguments:
+         - source - input stream opened in text mode, or a path to a file
+        """
+        super().__init__(source, fmt="5-column tab-delimited feature table")
+        self.rec = None
+        self.offset = 0
+
+    def __next__(self):
+        for line in self.stream:
             if line == "\n":
                 continue
 
             if line.startswith(">Feature"):
                 # First line of a new table
-                if rec is not None:
-                    offset = 0
-                    _record_fixups(rec)
-                    yield rec
-
                 parts = line.strip().split(" ")
                 if len(parts) < 2:
                     raise ValueError(
                         f"First line of table has no sequence identifier: {line}"
                     )
-                rec = SeqRecord(None, id=parts[1], name=parts[1])
+                new_rec = SeqRecord(None, id=parts[1], name=parts[1])
+
+                if self.rec is not None:
+                    self.offset = 0
+                    _record_fixups(self.rec)
+                    old_rec = self.rec
+                    self.rec = new_rec
+                    return old_rec
+                else:
+                    self.rec = new_rec
             elif line.startswith("[offset="):
                 matches = re.findall(r"\d+", line)
                 if len(matches) != 1:
                     raise ValueError(f"Malformed offset: {line}")
-                offset = int(matches[0])
+                self.offset = int(matches[0])
             elif not (line.startswith("\t") or line.startswith(" ")):
                 # New feature in the current table
-                if rec is None:
+                if self.rec is None:
                     raise ValueError(f"Feature found outside of a table: {line}")
 
                 parts = _split_by_tabs(line.strip())
                 if len(parts) == 3:
                     start_loc, end_loc, feature_key = parts
-                    loc = _make_simple_location(start_loc, end_loc, offset)
-
-                    if feature_key == "REFERENCE":
-                        # REFERENCEs are annotations, not features, so they need
-                        # special handling
-                        try:
-                            ref_line = next(handle)
-                        except StopIteration:
-                            raise ValueError(
-                                f"Expected qualifier key-value pair line to follow REFERENCE: {line}"
-                            )
-                        parts = _split_by_tabs(ref_line.strip())
-                        if len(parts) != 2:
-                            raise ValueError(
-                                f"Expected qualifier key-value pair: {ref_line}"
-                            )
-                        if parts[0] != "PubMed":
-                            warnings.warn(
-                                f"Reference qualifier key is not PubMed: {ref_line}",
-                                BiopythonParserWarning,
-                            )
-
-                        ref = Reference()
-                        ref.location = loc
-                        if parts[0] == "PubMed":
-                            ref.pubmed_id = parts[1]
-                        elif parts[0] == "Medline":
-                            ref.medline_id = parts[1]
-                        else:
-                            warnings.warn(
-                                f"Ignoring unknown reference qualifier key: {ref_line}",
-                                BiopythonParserWarning,
-                            )
-                            continue
-                        if "references" not in rec.annotations:
-                            rec.annotations["references"] = [ref]
-                        else:
-                            rec.annotations["references"].append(ref)
-                    else:
-                        rec.features.append(SeqFeature(loc, type=feature_key))
-                    pass
+                    loc = _make_simple_location(start_loc, end_loc, self.offset)
+                    self.rec.features.append(SeqFeature(loc, type=feature_key))
                 elif len(parts) == 2:
                     # Add new location to current feature
                     start_loc, end_loc = parts
-                    rec.features[-1].location += _make_simple_location(
-                        start_loc, end_loc, offset
+                    self.rec.features[-1].location += _make_simple_location(
+                        start_loc, end_loc, self.offset
                     )
                 else:
                     raise ValueError(f"Malformed first line of feature: {line}")
@@ -170,7 +194,7 @@ def FeatureTableIterator(source):
                     raise ValueError(f"Expected qualifier key-value pair: {line}")
                 key, value = parts
 
-                feature = rec.features[-1]
+                feature = self.rec.features[-1]
                 if (
                     "product" in feature.qualifiers
                     and len(feature.qualifiers["product"]) == 1
@@ -185,9 +209,12 @@ def FeatureTableIterator(source):
                 else:
                     feature.qualifiers[key].append(value)
 
-        if rec is not None:
-            _record_fixups(rec)
-            yield rec
+        if self.rec is not None:
+            _record_fixups(self.rec)
+            rec = self.rec
+            self.rec = None
+            return rec
+        raise StopIteration
 
 
 class FeatureTableWriter(SequenceWriter):
@@ -209,11 +236,16 @@ class FeatureTableWriter(SequenceWriter):
             return f"{loc.start + 1}\t{loc.end}"
 
     def _write_feature_header(self, loc, name):
-        """Write the header of a feature/references (PRIVATE)."""
+        """Write the header of a feature/references (PRIVATE).
+
+        If name is "REFERENCE", then loc may be a list of SimpleLocations
+        instead of one CompoundLocation, but the list must be non-empty.
+        """
         if isinstance(loc, list):
             # Reference's locations is a list of locations, not one
             # CompoundLocation, so make it a CompoundLocation
             assert name == "REFERENCE"
+            assert len(loc) > 0
             loc = sum(loc)
 
         loc_str = self._simplelocation_to_string(loc.parts[0])
@@ -231,7 +263,10 @@ class FeatureTableWriter(SequenceWriter):
         if "references" in rec.annotations:
             for ref in rec.annotations["references"]:
                 if ref.location == []:
-                    raise TypeError(f"Reference has no location: {ref}")
+                    warnings.warn(
+                        f"Ignoring reference with no location: {ref}", BiopythonWarning
+                    )
+                    continue
                 if ref.pubmed_id == "" and ref.medline_id == "":
                     warnings.warn(
                         f"Ignoring reference with no pubmed_id or medline_id: {ref}",
@@ -265,5 +300,11 @@ class FeatureTableWriter(SequenceWriter):
                 if qualifier == "translation":
                     # Features tables don't care about translations
                     continue
+                elif self.clean(qualifier).strip() == "":
+                    raise TypeError(f"Qualifier is empty when cleaned: '{qualifier}'")
                 for value in feature.qualifiers[qualifier]:
-                    self.handle.write(f"\t\t\t{self.clean(qualifier)}\t{str(value)}\n")
+                    if self.clean(value).strip() == "":
+                        raise TypeError(f"Value is empty when cleaned: '{value}'")
+                    self.handle.write(
+                        f"\t\t\t{self.clean(qualifier)}\t{self.clean(value)}\n"
+                    )

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -464,6 +464,7 @@ _FormatToIterator = {
 _FormatToWriter = {
     "fasta": FastaIO.FastaWriter,
     "fasta-2line": FastaIO.FastaTwoLineWriter,
+    "feature-table": FeatureTableIO.FeatureTableWriter,
     "gb": InsdcIO.GenBankWriter,
     "genbank": InsdcIO.GenBankWriter,
     "embl": InsdcIO.EmblWriter,

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -288,6 +288,8 @@ names are also used in Bio.AlignIO and include the following:
       which encodes PHRED quality scores with an ASCII offset of 64
       (not 33). Note as of version 1.8 of the CASAVA pipeline Illumina
       will produce FASTQ files using the standard Sanger encoding.
+    - feature-table - GenBank's 5-column tab-delimited feature table format
+      used for preparing submissions.
     - gck     - Gene Construction Kit's format.
     - genbank - The GenBank or GenPept flat file format.
     - gb      - An alias for "genbank", for consistency with NCBI Entrez Utilities
@@ -385,6 +387,7 @@ from Bio import AlignIO
 from Bio.SeqIO import AbiIO
 from Bio.SeqIO import AceIO
 from Bio.SeqIO import FastaIO
+from Bio.SeqIO import FeatureTableIO
 from Bio.SeqIO import GckIO
 from Bio.SeqIO import GfaIO
 from Bio.SeqIO import IgIO  # IntelliGenetics or MASE format
@@ -423,6 +426,7 @@ _FormatToIterator = {
     "fasta-2line": FastaIO.FastaTwoLineIterator,
     "fasta-blast": FastaIO.FastaBlastIterator,
     "fasta-pearson": FastaIO.FastaPearsonIterator,
+    "feature-table": FeatureTableIO.FeatureTableIterator,
     "ig": IgIO.IgIterator,
     "embl": InsdcIO.EmblIterator,
     "embl-cds": InsdcIO.EmblCdsFeatureIterator,

--- a/Tests/FeatureTable/example1.gb
+++ b/Tests/FeatureTable/example1.gb
@@ -1,0 +1,88 @@
+LOCUS       Sc_16        7000 bp    DNA             PLN       08-MAY-2000
+DEFINITION  Saccharomyces cerevisiae strain S288C chromosome XVI, partial sequence.
+ACCESSION   Sc_16
+VERSION
+KEYWORDS    .
+SOURCE      baker's yeast.
+  ORGANISM  Saccharomyces cerevisiae
+            Eukaryota; Fungi; Ascomycota; Hemiascomycetes; Saccharomycetales;
+            Saccharomycetaceae; Saccharomyces.
+REFERENCE   1  (bases 1 to 7000)
+  AUTHORS   Goffeau,A., Barrell,B.G., Bussey,H., Davis,R.W., Dujon,B.,
+            Feldmann,H., Galibert,F., Hoheisel,J.D., Jacq,C., Johnston,M.,
+            Louis,E.J., Mewes,H.W., Murakami,Y., Philippsen,P., Tettelin,H. and
+            Oliver,S.G.
+  TITLE     Life with 6000 genes
+  JOURNAL   Science 274 (5287), 546 (1996)
+   PUBMED   8849441
+REFERENCE   2  (bases 1 to 7000)
+  AUTHORS   Ouellette,B.F.F.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (08-MAY-2000) NCBI/NLM, National Institutes of Health,
+            Building 38A, Room 8N805, Bethesda, MD 20894, USA
+FEATURES             Location/Qualifiers
+     source          1..7000
+                     /organism="Saccharomyces cerevisiae"
+                     /strain="S288C"
+                     /chromosome="XVI"
+     mRNA            <1..1050
+                     /gene="ATH1"
+                     /product="acid trehalase"
+     gene            <1..1050
+                     /gene="ATH1"
+     CDS             <1..1009
+                     /gene="ATH1"
+                     /note="Ath1p"
+                     /codon_start=2
+                     /product="acid trehalase"
+                     /translation="DHNGTIVHKSGDVPIHIKIPNRSLIHDQDINFYNGSENERKPNL
+                     ERRDVDRVGDPMRMDRYGTYYLLKPKQELTVQLFKPGLNARNNIAENKQITNLTAGVP
+                     GDVAFSALDGNNYTHWQPLDKIHRAKLLIDLGEYNEKEITKGMILWGQRPAKNISISI
+                     LPHSEKVENLFANVTEIMQNSGNDQLLNETIGQLLDNAGIPVENVIDFDGIEQEDDES
+                     LDDVQALLHWKKEDLAKLIEQIPRLNFLKRKFVKILDNVPVSPSEPYYEASRNQSLIE
+                     ILPSNRTTFTIDYDKLQVGDKGNTDWRKTRYIVVAVQGVYDDYDDDNKGATIKEIVLN
+                     D"
+     mRNA            complement(2420..3253)
+                     /gene="YPR027C"
+                     /product="Ypr027cp"
+     gene            complement(2420..3253)
+                     /gene="YPR027C"
+     CDS             complement(2420..3253)
+                     /gene="YPR027C"
+                     /note="hypothetical protein"
+                     /codon_start=1
+                     /product="Ypr027cp"
+                     /translation="MVGIYRILASFVPLLGLLFAFHDDDMIDTVTIIKTVYETVTSTS
+                     TAPAPAATKSVSEKKLDDTKLTLQVIQTMVSCFSVGENPANMISCGLGVVILMFSLII
+                     ELINKLENDGINEPQRLYDLIKPKYVELPSNYVNEKIKTTFEPLDLYLGVNMNTSGSE
+                     LNQNCLILKLGEKTALPFPGLAQQICYTKGASNEFTNYKLSDIQGNLNENSQGIANGV
+                     FQKISNIRKISGNFKSQLYQISEKITDENWDGSAVGFTAHGREKGPNKSQISVSFYRD
+                     N"
+     gene            complement(4535..4626)
+                     /gene="trnF"
+     tRNA            complement(join(4535..4570,4590..4626))
+                     /product="tRNA-Phe"
+                     /gene="trnF"
+     exon            complement(4535..4570)
+                     /number=1
+     exon            complement(4590..4626)
+                     /number=2
+     mRNA            join(5450..5572,5706..6536)
+                     /gene="YIP2"
+                     /product="Yip2p"
+     gene            5450..6536
+                     /gene="YIP2"
+     CDS             join(5522..5572,5706..6197)
+                     /gene="YIP2"
+                     /note="similar to human polyposis locus protein 1 (YPD)"
+                     /codon_start=1
+                     /product="Yip2p"
+                     /translation="MSEYASSIHSQMKQFDTKYSGNRILQQLENKTNLPKSYLVAGLG
+                     FAYLLLIFINVGGVGEILSNFAGFVLPAYLSLVALKTPTSTDDTQLLTYWIVFSFLSV
+                     IEFWSKAILYLIPFYWFLKTVFLIYIALPQTGGARMIYQKIVAPLTDRYILRDVSKTE
+                     KDEIRASVNEASKATGASVH"
+BASE COUNT     2201 a   1276 c   1255 g   2268 t
+ORIGIN
+        1 cgaccacaat ggtacgattg ttcataaatc aggagatgtt cctattcata taaagatacc
+       61 aaacagatct ctaatacatg accaggatat caacttctat aatggttccg aaaacgaaag
+      121 aaaaccaaat ctagagcgta gagacgtcga ccgtgttggt gatccaatga ggatggatag [etc.]

--- a/Tests/FeatureTable/example1.tbl
+++ b/Tests/FeatureTable/example1.tbl
@@ -1,0 +1,37 @@
+>Feature Sc_16
+1    7000    REFERENCE
+                        PubMed         8849441
+<1    1050    mRNA
+                        product        acid trehalase
+<1    1050    gene
+                        gene           ATH1
+<1    1009    CDS
+                        product        acid trehalase
+                        product        Ath1p
+                        codon_start    2
+[offset=2000]
+1253    420    mRNA
+                        product        Ypr027cp
+1253    420    gene
+                        gene           YPR027C
+1253    420    CDS
+                        product        Ypr027cp
+                        note           hypothetical protein
+2626    2535    gene
+                        gene           trnF
+2626    2590    tRNA
+2570    2535
+                        product        tRNA-Phe
+2570    2535    exon
+                        number         1
+2626    2590    exon
+                        number         2
+3450    3572    mRNA
+3706    4536
+                        product        Yip2p
+3450    4536    gene
+                        gene           YIP2
+3522    3572    CDS
+3706    4197
+                        product        Yip2p
+                        note      similar to human polyposis locus protein 1 (YPD)

--- a/Tests/FeatureTable/example2.tbl
+++ b/Tests/FeatureTable/example2.tbl
@@ -1,0 +1,22 @@
+>Feature Seq1
+1     1210    CDS
+                        product        acid trehalase 1
+>Feature Seq2                        
+<1    >1050    gene
+                        gene           ATH2
+<1    >1050    CDS
+                        product        acid trehalase 2
+                        codon_start    3
+>Feature Seq3                        
+<1    1600    gene
+                        gene           ATH4
+<1    9       5'UTR                         
+10    1550    CDS
+                        product        acid trehalase 4                         
+1551  1600    3'UTR
+>Feature Seq4                        
+1150  1       gene
+                        gene           ATH3
+1150  1       CDS        
+                        product        acid trehalase 3
+                        note           alternatively spliced

--- a/Tests/FeatureTable/example3.tbl
+++ b/Tests/FeatureTable/example3.tbl
@@ -1,0 +1,41 @@
+>Feature Chr_1
+1	8618836	REFERENCE
+			CFMR	12345
+1495	550	gene
+			locus_tag	Tatro_000001
+1495	1230	mRNA
+1171	550
+			product	hypothetical protein
+			transcript_id	gnl|ncbi|Tatro_000001-T1_mrna
+			protein_id	gnl|ncbi|Tatro_000001-T1
+1495	1230	CDS
+1171	550
+			codon_start	1
+			db_xref	InterPro:IPR002410
+			db_xref	PFAM:PF08386
+			db_xref	InterPro:IPR000073
+			db_xref	InterPro:IPR029058
+			db_xref	InterPro:IPR013595
+			db_xref	InterPro:IPR050266
+			db_xref	PFAM:PF12697
+			note	MEROPS:MER0025512
+			product	hypothetical protein
+			transcript_id	gnl|ncbi|Tatro_000001-T1_mrna
+			protein_id	gnl|ncbi|Tatro_000001-T1
+5108	3585	gene
+			locus_tag	Tatro_000002
+5108	4516	mRNA
+4452	3585
+			product	hypothetical protein
+			transcript_id	gnl|ncbi|Tatro_000002-T1_mrna
+			protein_id	gnl|ncbi|Tatro_000002-T1
+4959	4516	CDS
+4452	3781
+			codon_start	1
+			db_xref	PFAM:PF00172
+			db_xref	InterPro:IPR001138
+			db_xref	InterPro:IPR036864
+			product	hypothetical protein
+			transcript_id	gnl|ncbi|Tatro_000002-T1_mrna
+			protein_id	gnl|ncbi|Tatro_000002-T1
+

--- a/Tests/FeatureTable/invalid1.tbl
+++ b/Tests/FeatureTable/invalid1.tbl
@@ -1,0 +1,4 @@
+>Feature 
+1	1000	gene
+			gene	test
+200	500	mRNA

--- a/Tests/FeatureTable/invalid2.tbl
+++ b/Tests/FeatureTable/invalid2.tbl
@@ -1,0 +1,7 @@
+>Feature Invalid2
+1	1000	gene
+			gene	one
+[offset=a]
+1500	2000	gene
+			gene	two
+

--- a/Tests/FeatureTable/invalid3.tbl
+++ b/Tests/FeatureTable/invalid3.tbl
@@ -1,0 +1,5 @@
+1	1000	gene
+			gene	one
+[offset=a]
+1500	2000	gene
+			gene	two

--- a/Tests/FeatureTable/invalid4.tbl
+++ b/Tests/FeatureTable/invalid4.tbl
@@ -1,0 +1,2 @@
+>Feature Invalid4
+1	1000	REFERENCE

--- a/Tests/FeatureTable/invalid5.tbl
+++ b/Tests/FeatureTable/invalid5.tbl
@@ -1,0 +1,3 @@
+>Feature Invalid5
+1	1000	REFERENCE
+			PubMed

--- a/Tests/FeatureTable/invalid6.tbl
+++ b/Tests/FeatureTable/invalid6.tbl
@@ -1,0 +1,3 @@
+>Feature Invalid6
+gene
+			gene	test

--- a/Tests/FeatureTable/invalid7.tbl
+++ b/Tests/FeatureTable/invalid7.tbl
@@ -1,0 +1,3 @@
+>Feature Invalid7
+1	1000	gene
+			gene

--- a/Tests/FeatureTable/references.tbl
+++ b/Tests/FeatureTable/references.tbl
@@ -1,0 +1,5 @@
+>Feature ReferencesTest
+1	1000	REFERENCE
+			PubMed	1
+1	1000	REFERENCE
+			Medline	1

--- a/Tests/test_SeqIO_FeatureTableIO.py
+++ b/Tests/test_SeqIO_FeatureTableIO.py
@@ -16,6 +16,7 @@ class TestRead(unittest.TestCase):
         # make sure they share every feature they should.
         records = list(SeqIO.parse("FeatureTable/example1.tbl", "feature-table"))
         self.assertEqual(len(records), 1)
+        self.assertEqual(len(records[0]), 7000)
         tbl_record = records[0]
         tbl_record_i = 0
         with self.assertWarns(BiopythonParserWarning):
@@ -79,7 +80,7 @@ class TestRead(unittest.TestCase):
         with self.assertRaises(ValueError):
             records = list(SeqIO.parse("FeatureTable/invalid3.tbl", "feature-table"))
         # Empty reference
-        with self.assertRaises(ValueError):
+        with self.assertWarns(BiopythonParserWarning):
             records = list(SeqIO.parse("FeatureTable/invalid4.tbl", "feature-table"))
         # Invalid reference syntax
         with self.assertRaises(ValueError):
@@ -98,10 +99,12 @@ class TestWrite(unittest.TestCase):
         handle = StringIO()
         records = list(SeqIO.parse("FeatureTable/example1.tbl", "feature-table"))
         self.assertEqual(len(records), 1)
+        self.assertEqual(len(records[0]), 7000)
         SeqIO.write(records, handle, "feature-table")
         handle.seek(0)
         records2 = list(SeqIO.parse(handle, "feature-table"))
         self.assertEqual(len(records), 1)
+        self.assertEqual(len(records[0]), 7000)
         self.assertEqual(records[0].id, records2[0].id)
         self.assertEqual(records[0].annotations, records2[0].annotations)
         self.assertEqual(records[0].features, records2[0].features)
@@ -142,7 +145,7 @@ class TestWrite(unittest.TestCase):
         rec = SeqRecord(None)
         rec.annotations["references"] = [Reference()]
         rec.annotations["references"][0].pubmed_id = "1"
-        with self.assertRaises(TypeError):
+        with self.assertWarns(BiopythonWarning):
             SeqIO.write([rec], handle, "feature-table")
 
         # Reference with no pubmed_id or medline_id

--- a/Tests/test_SeqIO_FeatureTableIO.py
+++ b/Tests/test_SeqIO_FeatureTableIO.py
@@ -1,0 +1,95 @@
+"""Tests for SeqIO FeatureTable module."""
+
+from io import StringIO
+import unittest
+
+from Bio import BiopythonWarning, BiopythonParserWarning
+from Bio import SeqIO
+
+
+class TestRead(unittest.TestCase):
+    def test_read_tbl1(self):
+        """Test parsing valid .tbl files."""
+        # Documentation gives example1.tbl as the equivalent of example1.gb, so
+        # make sure they share every feature they should.
+        records = list(SeqIO.parse("FeatureTable/example1.tbl", "feature-table"))
+        self.assertEqual(len(records), 1)
+        tbl_record = records[0]
+        tbl_record_i = 0
+        with self.assertWarns(BiopythonParserWarning):
+            gb_record = next(SeqIO.parse("FeatureTable/example1.gb", "genbank"))
+        gb_record_i = 0
+        self.assertEqual(tbl_record.id, gb_record.id)
+        while tbl_record_i < len(tbl_record.features):
+            tbl_feature = tbl_record.features[tbl_record_i]
+            gb_feature = gb_record.features[gb_record_i]
+
+            if gb_feature.type == "source":
+                # Feature tables don't have source features
+                gb_record_i += 1
+                continue
+            self.assertEqual(tbl_feature.type, gb_feature.type)
+            self.assertEqual(tbl_feature.location, gb_feature.location)
+            for qualifier in gb_feature.qualifiers:
+                if qualifier == "translation":
+                    # Feature tables don't have translation qualifiers
+                    continue
+                self.assertEqual(
+                    tbl_feature.qualifiers[qualifier], gb_feature.qualifiers[qualifier]
+                )
+            tbl_record_i += 1
+            gb_record_i += 1
+
+    def test_read_tbl2(self):
+        """Test parsing multiple records."""
+        records = list(SeqIO.parse("FeatureTable/example2.tbl", "feature-table"))
+        self.assertEqual(len(records), 4)
+        self.assertEqual(len(records[0].features), 1)
+        self.assertEqual(len(records[1].features), 2)
+        self.assertEqual(len(records[2].features), 4)
+        self.assertEqual(len(records[3].features), 2)
+
+    def test_read_tbl3(self):
+        """Test parsing .tbl files not from documentation."""
+        with self.assertWarns(BiopythonParserWarning):
+            records = list(SeqIO.parse("FeatureTable/example3.tbl", "feature-table"))
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].id, "Chr_1")
+        self.assertNotIn("references", records[0].annotations)
+        self.assertEqual(len(records[0].features), 6)
+
+
+class TestWrite(unittest.TestCase):
+    def test_write_tbl1(self):
+        """Test writing valid .tbl files."""
+        handle = StringIO()
+        records = list(SeqIO.parse("FeatureTable/example1.tbl", "feature-table"))
+        self.assertEqual(len(records), 1)
+        SeqIO.write(records, handle, "feature-table")
+        handle.seek(0)
+        records2 = list(SeqIO.parse(handle, "feature-table"))
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].id, records2[0].id)
+        self.assertEqual(records[0].annotations, records2[0].annotations)
+        self.assertEqual(records[0].features, records2[0].features)
+
+    def test_write_tbl2(self):
+        """Test converting GenBank to .tbl."""
+        handle = StringIO()
+        with self.assertWarns(BiopythonParserWarning):
+            gb_records = list(SeqIO.parse("FeatureTable/example1.gb", "genbank"))
+        with self.assertWarns(BiopythonParserWarning):
+            SeqIO.write(gb_records, handle, "feature-table")
+        handle.seek(0)
+        records = list(SeqIO.parse(handle, "feature-table"))
+        self.assertEqual(len(records), 1)
+        records2 = list(SeqIO.parse("FeatureTable/example1.tbl", "feature-table"))
+        self.assertEqual(len(records2), 1)
+        self.assertEqual(records[0].id, records2[0].id)
+        self.assertEqual(records[0].annotations, records2[0].annotations)
+        self.assertEqual(records[0].features, records2[0].features)
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #4943

This PR adds a SeqIO parser and writer for the 5-column tab-delimited feature table (.tbl) format used for preparing GenBank submissions.

@AgustinPardo's feedback on this may be helpful, as he opened the linked issue and wrote his own parser too. 