### PR TITLE
Update docstrings in PAML modules

### DIFF
--- a/Bio/Phylo/PAML/_paml.py
+++ b/Bio/Phylo/PAML/_paml.py
@@ -12,7 +12,7 @@ import subprocess
 
 
 class PamlError(EnvironmentError):
-    """paml has failed.
+    """PAML has failed.
 
     Run with verbose=True to view the error message.
     """
@@ -71,7 +71,7 @@ class Paml:
     def _set_rel_paths(self):
         """Convert all file/directory locations to paths relative to the current working directory (PRIVATE).
 
-        paml requires that all paths specified in the control file be
+        PAML requires that all paths specified in the control file be
         relative to the directory from which it is called rather than
         absolute paths.
         """
@@ -83,14 +83,14 @@ class Paml:
             self._rel_out_file = os.path.relpath(self.out_file, self.working_dir)
 
     def run(self, ctl_file, verbose, command):
-        """Run a paml program using the current configuration.
+        """Run a PAML program using the current configuration.
 
         Check that the class attributes exist and raise an error
         if not. Then run the command and check if it succeeds with
         a return code of 0, otherwise raise an error.
 
         The arguments may be passed as either absolute or relative
-        paths, despite the fact that paml requires relative paths.
+        paths, despite the fact that PAML requires relative paths.
         """
         if self.alignment is None:
             raise ValueError("Alignment file not specified.")
@@ -127,7 +127,7 @@ class Paml:
                 % (command, result_code)
             )
         if result_code < 0:
-            # If the paml process is killed by a signal somehow
+            # If the PAML process is killed by a signal somehow
             raise OSError(
                 "The %s process was killed (return code %i)." % (command, result_code)
             )

--- a/Bio/Phylo/PAML/baseml.py
+++ b/Bio/Phylo/PAML/baseml.py
@@ -104,7 +104,8 @@ class Baseml(Paml):
 
         Check that the file exists and that the lines in the file are valid.
         Then update each BASEML options to the new option if supplied or None
-        if not supplied. Otherwise raise an exception."""
+        if not supplied. Otherwise raise an exception.
+        """
         temp_options = {}
         if not os.path.isfile(ctl_file):
             raise FileNotFoundError(f"File not found: {ctl_file!r}")
@@ -192,7 +193,8 @@ def read(results_file):
 
     Check that the file exits, that the results file is not empty, and then
     parse the file. Check there is a version in the results and then return
-    the results. Otherwise raise an exception."""
+    the results. Otherwise raise an exception.
+    """
     results = {}
     if not os.path.exists(results_file):
         raise FileNotFoundError("Results file does not exist.")

--- a/Bio/Phylo/PAML/baseml.py
+++ b/Bio/Phylo/PAML/baseml.py
@@ -69,7 +69,7 @@ class Baseml(Paml):
         """Dynamically build a BASEML control file from the options.
 
         The control file is written to the location specified by the
-        ctl_file property of the baseml class.
+        ctl_file property of the BASEML class.
         """
         # Make sure all paths are relative to the working directory
         self._set_rel_paths()
@@ -100,7 +100,11 @@ class Baseml(Paml):
                 ctl_handle.write(f"{option[0]} = {option[1]}\n")
 
     def read_ctl_file(self, ctl_file):
-        """Parse a control file and load the options into the Baseml instance."""
+        """Parse a control file and load the options into the BASEML instance.
+
+        Check that the file exists and that the lines in the file are valid.
+        Then update each BASEML options to the new option if supplied or None
+        if not supplied. Otherwise raise an exception."""
         temp_options = {}
         if not os.path.isfile(ctl_file):
             raise FileNotFoundError(f"File not found: {ctl_file!r}")
@@ -167,8 +171,8 @@ class Baseml(Paml):
         """Run baseml using the current configuration.
 
         Check that the tree attribute is specified and exists, and then
-        run baseml. If parse is True then read and return the result,
-        otherwise return none.
+        run BASEML. If parse is True then read and return the result. If
+        parse is False return None. Otherwise raise an exception.
 
         The arguments may be passed as either absolute or relative paths,
         despite the fact that BASEML requires relative paths.
@@ -184,7 +188,11 @@ class Baseml(Paml):
 
 
 def read(results_file):
-    """Parse a BASEML results file."""
+    """Parse a BASEML results file.
+
+    Check that the file exits, that the results file is not empty, and then
+    parse the file. Check there is a version in the results and then return
+    the results. Otherwise raise an exception."""
     results = {}
     if not os.path.exists(results_file):
         raise FileNotFoundError("Results file does not exist.")

--- a/Bio/Phylo/PAML/baseml.py
+++ b/Bio/Phylo/PAML/baseml.py
@@ -102,9 +102,9 @@ class Baseml(Paml):
     def read_ctl_file(self, ctl_file):
         """Parse a control file and load the options into the Baseml instance.
 
-        Check that the file exists and that the lines in the file are valid.
-        Then update each BASEML options to the new option if supplied or None
-        if not supplied. Otherwise raise an exception.
+        Update each BASEML option to the new option if supplied or None if
+        not supplied. Raise an exception if the control file does not exist,
+        a line is malformed, or an option is invalid.
         """
         temp_options = {}
         if not os.path.isfile(ctl_file):
@@ -171,9 +171,10 @@ class Baseml(Paml):
     def run(self, ctl_file=None, verbose=False, command="baseml", parse=True):
         """Run baseml using the current configuration.
 
-        Check that the tree attribute is specified and exists, and then
-        run BASEML. If parse is True then read and return the result. If
-        parse is False return None. Otherwise raise an exception.
+        Check that the tree file is specified and exists, and then
+        run BASEML. If parse is True then read and return the results,
+        otherwise return None. An exception is raised if the return code
+        of the BASEML command is non-zero.
 
         The arguments may be passed as either absolute or relative paths,
         despite the fact that BASEML requires relative paths.
@@ -191,9 +192,8 @@ class Baseml(Paml):
 def read(results_file):
     """Parse a BASEML results file.
 
-    Check that the file exits, that the results file is not empty, and then
-    parse the file. Check there is a version in the results and then return
-    the results. Otherwise raise an exception.
+    Parse the file and return the results. Raise an exception if
+    the results file does not exist, is empty, or is invalid.
     """
     results = {}
     if not os.path.exists(results_file):

--- a/Bio/Phylo/PAML/baseml.py
+++ b/Bio/Phylo/PAML/baseml.py
@@ -5,7 +5,7 @@
 # Please see the LICENSE file that should have been included as part of this
 # package.
 
-"""Classes for the support of baseml.
+"""Classes for the support of BASEML.
 
 Maximum likelihood analysis of nucleotide sequences.
 """
@@ -169,15 +169,15 @@ class Baseml(Paml):
             self._rel_tree = os.path.relpath(self.tree, self.working_dir)
 
     def run(self, ctl_file=None, verbose=False, command="baseml", parse=True):
-        """Run baseml using the current configuration.
+        """Run ``baseml`` using the current configuration.
 
         Check that the tree file is specified and exists, and then
-        run BASEML. If parse is True then read and return the results,
+        run ``baseml``. If parse is True then read and return the results,
         otherwise return None. An exception is raised if the return code
-        of the BASEML command is non-zero.
+        of the ``baseml`` command is non-zero.
 
         The arguments may be passed as either absolute or relative paths,
-        despite the fact that BASEML requires relative paths.
+        despite the fact that ``baseml`` requires relative paths.
         """
         if self.tree is None:
             raise ValueError("Tree file not specified.")

--- a/Bio/Phylo/PAML/baseml.py
+++ b/Bio/Phylo/PAML/baseml.py
@@ -69,7 +69,7 @@ class Baseml(Paml):
         """Dynamically build a BASEML control file from the options.
 
         The control file is written to the location specified by the
-        ctl_file property of the BASEML class.
+        ctl_file property of the Baseml class.
         """
         # Make sure all paths are relative to the working directory
         self._set_rel_paths()
@@ -100,7 +100,7 @@ class Baseml(Paml):
                 ctl_handle.write(f"{option[0]} = {option[1]}\n")
 
     def read_ctl_file(self, ctl_file):
-        """Parse a control file and load the options into the BASEML instance.
+        """Parse a control file and load the options into the Baseml instance.
 
         Check that the file exists and that the lines in the file are valid.
         Then update each BASEML options to the new option if supplied or None

--- a/Bio/Phylo/PAML/codeml.py
+++ b/Bio/Phylo/PAML/codeml.py
@@ -180,15 +180,15 @@ class Codeml(Paml):
             self._rel_tree = os.path.relpath(self.tree, self.working_dir)
 
     def run(self, ctl_file=None, verbose=False, command="codeml", parse=True):
-        """Run CODEML using the current configuration.
+        """Run ``codeml`` using the current configuration.
 
         Check that the tree file is specified and exists, and then
-        run CODEML. If parse is True then read and return the results,
+        run ``codeml``. If parse is True then read and return the results,
         otherwise return None. An exception is raised if the return code
-        of the CODEML command is non-zero.
+        of the ``codeml`` command is non-zero.
 
         The arguments may be passed as either absolute or relative
-        paths, despite the fact that CODEML requires relative paths.
+        paths, despite the fact that ``codeml`` requires relative paths.
         """
         if self.tree is None:
             raise ValueError("Tree file not specified.")

--- a/Bio/Phylo/PAML/codeml.py
+++ b/Bio/Phylo/PAML/codeml.py
@@ -102,7 +102,8 @@ class Codeml(Paml):
 
         Check that the file exists and that the lines in the file are valid.
         Then update each CODEML options to the new option if supplied or None
-        if not supplied. Otherwise raise an exception."""
+        if not supplied. Otherwise raise an exception.
+        """
         temp_options = {}
         if not os.path.isfile(ctl_file):
             raise FileNotFoundError(f"File not found: {ctl_file!r}")
@@ -202,7 +203,8 @@ def read(results_file):
     """Parse a CODEML results file.
 
     Check that the file exists and is not empty. Return the results
-    if there are any. Otherwise raise an exception."""
+    if there are any. Otherwise raise an exception.
+    """
     results = {}
     if not os.path.exists(results_file):
         raise FileNotFoundError("Results file does not exist.")

--- a/Bio/Phylo/PAML/codeml.py
+++ b/Bio/Phylo/PAML/codeml.py
@@ -24,7 +24,7 @@ class Codeml(Paml):
     """An interface to CODEML, part of the PAML package."""
 
     def __init__(self, alignment=None, tree=None, working_dir=None, out_file=None):
-        """Initialize the codeml instance.
+        """Initialize the Codeml instance.
 
         The user may optionally pass in strings specifying the locations
         of the input alignment and tree files, the working directory and
@@ -74,7 +74,7 @@ class Codeml(Paml):
         """Dynamically build a CODEML control file from the options.
 
         The control file is written to the location specified by the
-        ctl_file property of the codeml class.
+        ctl_file property of the CODEML class.
         """
         # Make sure all paths are relative to the working directory
         self._set_rel_paths()
@@ -98,7 +98,11 @@ class Codeml(Paml):
                     ctl_handle.write(f"{option[0]} = {option[1]}\n")
 
     def read_ctl_file(self, ctl_file):
-        """Parse a control file and load the options into the Codeml instance."""
+        """Parse a control file and load the options into the CODEML instance.
+
+        Check that the file exists and that the lines in the file are valid.
+        Then update each CODEML options to the new option if supplied or None
+        if not supplied. Otherwise raise an exception."""
         temp_options = {}
         if not os.path.isfile(ctl_file):
             raise FileNotFoundError(f"File not found: {ctl_file!r}")
@@ -175,10 +179,11 @@ class Codeml(Paml):
             self._rel_tree = os.path.relpath(self.tree, self.working_dir)
 
     def run(self, ctl_file=None, verbose=False, command="codeml", parse=True):
-        """Run codeml using the current configuration.
+        """Run CODEML using the current configuration.
 
-        If parse is True then read and return the results, otherwise
-        return None.
+        Check that the tree attribute is specified and exists, and then
+        run CODEML. If parse is True then read and return the results. If
+        parse is false return None. Otherwise raise an exception.
 
         The arguments may be passed as either absolute or relative
         paths, despite the fact that CODEML requires relative paths.
@@ -194,7 +199,10 @@ class Codeml(Paml):
 
 
 def read(results_file):
-    """Parse a CODEML results file."""
+    """Parse a CODEML results file.
+
+    Check that the file exists and is not empty. Return the results
+    if there are any. Otherwise raise an exception."""
     results = {}
     if not os.path.exists(results_file):
         raise FileNotFoundError("Results file does not exist.")

--- a/Bio/Phylo/PAML/codeml.py
+++ b/Bio/Phylo/PAML/codeml.py
@@ -100,9 +100,9 @@ class Codeml(Paml):
     def read_ctl_file(self, ctl_file):
         """Parse a control file and load the options into the Codeml instance.
 
-        Check that the file exists and that the lines in the file are valid.
-        Then update each CODEML options to the new option if supplied or None
-        if not supplied. Otherwise raise an exception.
+        Update each CODEML option to the new option if supplied or None if
+        not supplied. Raise an exception if the control file does not exist,
+        a line is malformed, or an option is invalid.
         """
         temp_options = {}
         if not os.path.isfile(ctl_file):
@@ -182,9 +182,10 @@ class Codeml(Paml):
     def run(self, ctl_file=None, verbose=False, command="codeml", parse=True):
         """Run CODEML using the current configuration.
 
-        Check that the tree attribute is specified and exists, and then
-        run CODEML. If parse is True then read and return the results. If
-        parse is false return None. Otherwise raise an exception.
+        Check that the tree file is specified and exists, and then
+        run CODEML. If parse is True then read and return the results,
+        otherwise return None. An exception is raised if the return code
+        of the CODEML command is non-zero.
 
         The arguments may be passed as either absolute or relative
         paths, despite the fact that CODEML requires relative paths.
@@ -202,8 +203,8 @@ class Codeml(Paml):
 def read(results_file):
     """Parse a CODEML results file.
 
-    Check that the file exists and is not empty. Return the results
-    if there are any. Otherwise raise an exception.
+    Return the results if there are any. Raise an exception if
+    the results file does not exist, is empty, or is invalid.
     """
     results = {}
     if not os.path.exists(results_file):

--- a/Bio/Phylo/PAML/codeml.py
+++ b/Bio/Phylo/PAML/codeml.py
@@ -74,7 +74,7 @@ class Codeml(Paml):
         """Dynamically build a CODEML control file from the options.
 
         The control file is written to the location specified by the
-        ctl_file property of the CODEML class.
+        ctl_file property of the Codeml class.
         """
         # Make sure all paths are relative to the working directory
         self._set_rel_paths()
@@ -98,7 +98,7 @@ class Codeml(Paml):
                     ctl_handle.write(f"{option[0]} = {option[1]}\n")
 
     def read_ctl_file(self, ctl_file):
-        """Parse a control file and load the options into the CODEML instance.
+        """Parse a control file and load the options into the Codeml instance.
 
         Check that the file exists and that the lines in the file are valid.
         Then update each CODEML options to the new option if supplied or None

--- a/Bio/Phylo/PAML/yn00.py
+++ b/Bio/Phylo/PAML/yn00.py
@@ -5,7 +5,7 @@
 # Please see the LICENSE file that should have been included as part of this
 # package.
 
-"""Classes for the support of yn00.
+"""Classes for the support of YN00.
 
 Yang and Nielsen 2000,  estimating synonymous and nonsynonymous substitution
 rates in pairwise comparison of protein-coding DNA sequences.
@@ -18,11 +18,11 @@ from ._paml import Paml
 
 
 class Yn00Error(EnvironmentError):
-    """yn00 failed. Run with verbose=True to view yn00's error message."""
+    """YN00 failed. Run with verbose=True to view YN00's error message."""
 
 
 class Yn00(Paml):
-    """An interface to yn00, part of the PAML package."""
+    """An interface to YN00, part of the PAML package."""
 
     def __init__(self, alignment=None, working_dir=None, out_file=None):
         """Initialize the Yn00 instance.
@@ -42,7 +42,7 @@ class Yn00(Paml):
         }
 
     def write_ctl_file(self):
-        """Dynamically build a yn00 control file from the options.
+        """Dynamically build a YN00 control file from the options.
 
         The control file is written to the location specified by the
         ctl_file property of the Yn00 class.
@@ -103,11 +103,11 @@ class Yn00(Paml):
                 self._options[option] = None
 
     def run(self, ctl_file=None, verbose=False, command="yn00", parse=True):
-        """Run yn00 using the current configuration.
+        """Run ``yn00`` using the current configuration.
 
         If parse is True then read and return the result, otherwise
         return None. An exception is raised if the return code of
-        the yn00 command is non-zero.
+        the ``yn00`` command is non-zero.
         """
         Paml.run(self, ctl_file, verbose, command)
         if parse:
@@ -116,7 +116,7 @@ class Yn00(Paml):
 
 
 def read(results_file):
-    """Parse a yn00 results file."""
+    """Parse a YN00 results file."""
     results = {}
     if not os.path.exists(results_file):
         raise FileNotFoundError("Results file does not exist.")

--- a/Bio/Phylo/PAML/yn00.py
+++ b/Bio/Phylo/PAML/yn00.py
@@ -61,7 +61,12 @@ class Yn00(Paml):
                 ctl_handle.write(f"{option[0]} = {option[1]}\n")
 
     def read_ctl_file(self, ctl_file):
-        """Parse a control file and load the options into the Yn00 instance."""
+        """Parse a control file and load the options into the Yn00 instance.
+
+        Update each YN00 option to the new option if supplied or None if
+        not supplied. Raise an exception if the control file does not exist,
+        a line is malformed, or an option is invalid.
+        """
         temp_options = {}
         if not os.path.isfile(ctl_file):
             raise FileNotFoundError(f"File not found: {ctl_file!r}")
@@ -116,7 +121,11 @@ class Yn00(Paml):
 
 
 def read(results_file):
-    """Parse a YN00 results file."""
+    """Parse a YN00 results file.
+
+    Return the results if there are any. Raise an exception if
+    the results file does not exist, is empty, or is invalid.
+    """
     results = {}
     if not os.path.exists(results_file):
         raise FileNotFoundError("Results file does not exist.")

--- a/Bio/Phylo/PAML/yn00.py
+++ b/Bio/Phylo/PAML/yn00.py
@@ -45,7 +45,7 @@ class Yn00(Paml):
         """Dynamically build a yn00 control file from the options.
 
         The control file is written to the location specified by the
-        ctl_file property of the yn00 class.
+        ctl_file property of the Yn00 class.
         """
         # Make sure all paths are relative to the working directory
         self._set_rel_paths()
@@ -61,7 +61,7 @@ class Yn00(Paml):
                 ctl_handle.write(f"{option[0]} = {option[1]}\n")
 
     def read_ctl_file(self, ctl_file):
-        """Parse a control file and load the options into the yn00 instance."""
+        """Parse a control file and load the options into the Yn00 instance."""
         temp_options = {}
         if not os.path.isfile(ctl_file):
             raise FileNotFoundError(f"File not found: {ctl_file!r}")

--- a/Bio/Phylo/PAML/yn00.py
+++ b/Bio/Phylo/PAML/yn00.py
@@ -106,7 +106,8 @@ class Yn00(Paml):
         """Run yn00 using the current configuration.
 
         If parse is True then read and return the result, otherwise
-        return None.
+        return None. An exception is raised if the return code of
+        the yn00 command is non-zero.
         """
         Paml.run(self, ctl_file, verbose, command)
         if parse:

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -116,6 +116,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Diana Jaunzeikare
 - Diego Brouard <diego at domain conysis.com>
 - Dimitris Kalafatis <https://github.com/dimi1729>
+- Edward Haigh <lambda at edwardhaigh dot com>
 - Edward Liaw <https://github.com/edliaw>
 - Emmanuel Noutahi <https://github.com/maclandrol>
 - Eric Rasche <https://github.com/erasche>


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This PR aims to address the issues with PAML docstrings highlighted in [issue 1708](https://github.com/biopython/biopython/issues/1708).

It builds on the changes in #1793, and incorporates the work of @funcylambda in #1824 and @farAtGitHub in #2489 in a way that strives to address the feedback to their respective pull requests.

Changes include:
- elaboration of docstrings in PAML modules, to include descriptions (as appropriate) of what is done, what is returned, and what triggers an exception;
- case and formatting updates, with PAML classes in camel case (e.g. `Codeml`), PAML software in all caps (e.g. `CODEML`), and PAML commands in reStructuredText inline code formatting (e.g. ``codeml``);
- an update to the `CONTRIB.rst` file.

I've used all caps for PAML software names, partly because this would result in fewer changes to the code than using an all-lowercase convention, and partly because this is the convention used in recent PAML-related papers (e.g. [Yang 2007](https://doi.org/10.1093/molbev/msm088) ; [Xu & Yang 2013](https://doi.org/10.1093/molbev/mst179) ; [Álvarez-Carretero, Kapli & Yang 2023](https://doi.org/10.1093/molbev/msad041)). That said, I'm happy to adjust this if necessary.
