### PR TITLE
typo

### DIFF
--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -245,7 +245,7 @@ class GenericPositionMatrix(dict):
            1.0, then only columns of identical letters contribute to the
            consensus. Default value is zero.
          - setcase             - threshold for the positive matches, divided by
-           the total count in a column, above which the consensus is is
+           the total count in a column, above which the consensus is in
            upper-case and below which the consensus is in lower-case. By
            default, this is equal to 0.5.
         """


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

