### PR TITLE
pairwisealigner pickle fix

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -4335,6 +4335,7 @@ AlignmentCounts object returned by the .counts method of an Alignment object."""
             "open_right_deletion_score": self.open_right_deletion_score,
             "extend_right_deletion_score": self.extend_right_deletion_score,
             "mode": self.mode,
+            "epsilon": self.epsilon,
         }
         if self.substitution_matrix is None:
             state["match_score"] = self.match_score
@@ -4358,6 +4359,7 @@ AlignmentCounts object returned by the .counts method of an Alignment object."""
         self.open_right_deletion_score = state["open_right_deletion_score"]
         self.extend_right_deletion_score = state["extend_right_deletion_score"]
         self.mode = state["mode"]
+        self.epsilon = state["epsilon"]
         substitution_matrix = state.get("substitution_matrix")
         if substitution_matrix is None:
             self.match_score = state["match_score"]

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -18537,6 +18537,8 @@ class TestAlignerPickling(unittest.TestCase):
             pickled_aligner.extend_right_deletion_score,
         )
         self.assertEqual(aligner.mode, pickled_aligner.mode)
+        self.assertEqual(aligner.epsilon, pickled_aligner.epsilon)
+        self.assertEqual(aligner.algorithm, pickled_aligner.algorithm)
 
     def test_pickle_aligner_substitution_matrix(self):
         try:
@@ -18621,6 +18623,21 @@ class TestAlignerPickling(unittest.TestCase):
             pickled_aligner.extend_right_deletion_score,
         )
         self.assertEqual(aligner.mode, pickled_aligner.mode)
+        self.assertEqual(aligner.epsilon, pickled_aligner.epsilon)
+        self.assertEqual(aligner.algorithm, pickled_aligner.algorithm)
+
+    def test_pickle_aligner_alignment_symmetry(self):
+        import pickle
+
+        targ = "MTPSDISGYDYGRVEKSPITDLEFDLLKKTVMLGEEDVMYLKKAADVLKDQVDEILDLAGGWAASNEHLIYYGSNPDTGAPIKEYLERVRARIGAWVL"
+        query = "MTIKEMPQPKTFGELKNLPLLNTDKPVQALMKIADELGEIFKFEAPGRVTRYLSSQRLIKEACDESRFDKNLSQALKFARDFAGDGLVTSWTHEKNWKKAHNIL"
+        aligner = Align.PairwiseAligner(scoring="blastp")
+        aligner_alignments = aligner.align(targ, query)
+        pickled_aligner = pickle.loads(pickle.dumps(aligner))
+        pickled_aligner_alignments = pickled_aligner.align(targ, query)
+        self.assertEqual(len(aligner_alignments), len(pickled_aligner_alignments))
+        for i in range(len(aligner_alignments)):
+            self.assertEqual(aligner_alignments[i], pickled_aligner_alignments[i])
 
 
 class TestAlignmentFormat(unittest.TestCase):
@@ -20336,7 +20353,6 @@ class TestAlgorithmRestrictions(unittest.TestCase):
 
 
 class TestCounts(unittest.TestCase):
-
     def check_counts(self, counts):
         self.assertEqual(counts.left_insertions, 2)
         self.assertEqual(counts.left_deletions, 0)

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -18482,6 +18482,7 @@ class TestAlignerPickling(unittest.TestCase):
         aligner.extend_left_deletion_score = +1
         aligner.open_right_deletion_score = -1
         aligner.extend_right_deletion_score = -2
+        aligner.epsilon = 0.5e-6
         aligner.mode = "local"
         state = pickle.dumps(aligner)
         pickled_aligner = pickle.loads(state)
@@ -18626,7 +18627,7 @@ class TestAlignerPickling(unittest.TestCase):
         self.assertEqual(aligner.epsilon, pickled_aligner.epsilon)
         self.assertEqual(aligner.algorithm, pickled_aligner.algorithm)
 
-    def test_pickle_aligner_alignment_symmetry(self):
+    def test_pickle_aligner_alignment_consistent(self):
         import pickle
 
         targ = "MTPSDISGYDYGRVEKSPITDLEFDLLKKTVMLGEEDVMYLKKAADVLKDQVDEILDLAGGWAASNEHLIYYGSNPDTGAPIKEYLERVRARIGAWVL"

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -18538,7 +18538,7 @@ class TestAlignerPickling(unittest.TestCase):
             pickled_aligner.extend_right_deletion_score,
         )
         self.assertEqual(aligner.mode, pickled_aligner.mode)
-        self.assertEqual(aligner.epsilon, pickled_aligner.epsilon)
+        self.assertAlmostEqual(aligner.epsilon, pickled_aligner.epsilon)
         self.assertEqual(aligner.algorithm, pickled_aligner.algorithm)
 
     def test_pickle_aligner_substitution_matrix(self):
@@ -18624,7 +18624,7 @@ class TestAlignerPickling(unittest.TestCase):
             pickled_aligner.extend_right_deletion_score,
         )
         self.assertEqual(aligner.mode, pickled_aligner.mode)
-        self.assertEqual(aligner.epsilon, pickled_aligner.epsilon)
+        self.assertAlmostEqual(aligner.epsilon, pickled_aligner.epsilon)
         self.assertEqual(aligner.algorithm, pickled_aligner.algorithm)
 
     def test_pickle_aligner_alignment_consistent(self):


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

Closes #5038 

This change fixes a symmetry issue with alignment using pickled version of the PairwiseAlginer - the epsilon property was missing and thus resulted in differing alignments using the unpickled object. Adds a test for a specific query that is sensitive to the issue, in addition to assertions against the algorithm property (for future proofing).