### PR TITLE
test_BWA_tool.py: update to bwa 0.7.19 header.

### DIFF
--- a/Tests/test_BWA_tool.py
+++ b/Tests/test_BWA_tool.py
@@ -161,7 +161,7 @@ class BwaTestCase(unittest.TestCase):
             with open(self.samfile1) as handle:
                 headline = handle.readline()
             self.assertTrue(
-                headline.startswith("@SQ"),
+                headline.startswith("@SQ") or headline.startswith("@HD"),
                 f"Error generating sam files:\n{cmdline}\nOutput starts:{headline}",
             )
 
@@ -184,7 +184,7 @@ class BwaTestCase(unittest.TestCase):
             with open(self.samfile) as handle:
                 headline = handle.readline()
             self.assertTrue(
-                headline.startswith("@SQ"),
+                headline.startswith("@SQ") or headline.startswith("@HD"),
                 f"Error generating sam files:\n{cmdline}\nOutput starts:{headline}",
             )
 
@@ -201,7 +201,7 @@ class BwaTestCase(unittest.TestCase):
             with open(self.samfile) as handle:
                 headline = handle.readline()
             self.assertTrue(
-                headline.startswith("@SQ"),
+                headline.startswith("@SQ") or headline.startswith("@HD"),
                 f"Error generating sam files:\n{cmdline}\nOutput starts:{headline}",
             )
 


### PR DESCRIPTION
This change fixes/worksaround the following test failure, which has begun to appear with the introduction of bwa 0.7.19:

	Traceback (most recent call last):
	  File "/<<PKGBUILDDIR>>/.pybuild/cpython3_3.13/build/Tests/test_BWA_tool.py", line 203, in test_mem
	    self.assertTrue(
	    ~~~~~~~~~~~~~~~^
	        headline.startswith("@SQ"),
	        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
	        f"Error generating sam files:\n{cmdline}\nOutput starts:{headline}",
	        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	    )
	    ^
	AssertionError: False is not true : Error generating sam files:
	bwa mem BWA/human_g1k_v37_truncated.fasta BWA/HNSCC1_1_truncated.fastq BWA/HNSCC1_2_truncated.fastq
	Output starts:@HD	VN:1.5	SO:unsorted	GO:query

Bug-Debian: https://bugs.debian.org/1114298

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
