### PR TITLE
deprecating the SummaryInfo class in Bio.Align.AlignInfo

### DIFF
--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -17,7 +17,6 @@ import warnings
 from Bio import BiopythonDeprecationWarning
 
 
-
 class SummaryInfo:
     """Calculate summary info about the alignment.  (DEPRECATED)
 

--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -30,7 +30,8 @@ class SummaryInfo:
 
         ic_vector attribute. A list of ic content for each column number.
         """
-        warnings.warn("""\
+        warnings.warn(
+            """\
 The class SummaryInfo has been deprecated. Instead of
 
 >>> align_info = AlignInfo.SummaryInfo(msa)

--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -12,8 +12,14 @@ be put into classes in this module.
 """
 
 
+import warnings
+
+from Bio import BiopythonDeprecationWarning
+
+
+
 class SummaryInfo:
-    """Calculate summary info about the alignment.
+    """Calculate summary info about the alignment.  (DEPRECATED)
 
     This class should be used to calculate information summarizing the
     results of an alignment. This may either be straight consensus info
@@ -25,6 +31,21 @@ class SummaryInfo:
 
         ic_vector attribute. A list of ic content for each column number.
         """
+        warnings.warn("""\
+The class SummaryInfo has been deprecated. Instead of
+
+>>> align_info = AlignInfo.SummaryInfo(msa)
+>>> sequence = align_info.get_column(1)
+
+please use
+
+>>> alignment = msa.alignment  # to get a new-style Alignment object
+>>> sequence = alignment[:, 1]
+
+Here, `msa` is a MultipleSeqAlignment object and `alignment` is an
+`Alignment` object.""",
+            BiopythonDeprecationWarning,
+        )
         self.alignment = alignment
         self.ic_vector = []
 

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -114,8 +114,9 @@ wrapped is no longer available since SCOP moved to the EBI website.
 Bio.AlignInfo
 -------------
 The ``pos_specific_score_matrix`` method of the ``SummaryInfo`` class and the
-``PSSM`` class were deprecated in release 1.82, and removed in release 1.85. As
-an alternative, please use the ``alignment`` property of a ``MultipleSeqAlignment``
+``PSSM`` class were deprecated in release 1.82, and removed in release 1.85.
+The ``SummaryInfo`` class itself was deprecated in release 1.86.  As an
+alternative, please use the ``alignment`` property of a ``MultipleSeqAlignment``
 object to obtains a new-style ``Alignment`` object, and use it to create a
 ``Bio.motifs.Motif`` object. For example,
 

--- a/Tests/test_align.py
+++ b/Tests/test_align.py
@@ -394,7 +394,8 @@ T:   7.00   0.00   7.00   0.00   0.00   0.00   7.00   6.00   0.00   0.00   0.00 
 """,
         )
 
-        align_info = AlignInfo.SummaryInfo(msa)
+        with self.assertWarns(BiopythonDeprecationWarning):
+            align_info = AlignInfo.SummaryInfo(msa)
         self.assertEqual(align_info.get_column(1), "AAAAAAA")
         self.assertEqual(align_info.get_column(7), "TTTATTT")
 


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
