### PR TITLE
Handle possible non-existent attributes in clusterbuster.py

### DIFF
--- a/Bio/motifs/clusterbuster.py
+++ b/Bio/motifs/clusterbuster.py
@@ -93,13 +93,15 @@ def write(motifs, precision=0):
         except AttributeError:
             pass
         else:
-            lines.append(f"# WEIGHT: {weight}\n")
+            if weight:
+                lines.append(f"# WEIGHT: {weight}\n")
         try:
             gap = m.gap
         except AttributeError:
             pass
         else:
-            lines.append(f"# GAP: {gap}\n")
+            if gap:
+                lines.append(f"# GAP: {gap}\n")
         for ACGT_counts in zip(
             m.counts["A"], m.counts["C"], m.counts["G"], m.counts["T"]
         ):

--- a/Bio/motifs/clusterbuster.py
+++ b/Bio/motifs/clusterbuster.py
@@ -88,9 +88,9 @@ def write(motifs, precision=0):
     lines = []
     for m in motifs:
         lines.append(f">{m.name}\n")
-        if m.weight:
+        if hasattr(m, 'weight') and m.weight:
             lines.append(f"# WEIGHT: {m.weight}\n")
-        if m.gap:
+        if hasattr(m, 'gap') and m.gap:
             lines.append(f"# GAP: {m.gap}\n")
         for ACGT_counts in zip(
             m.counts["A"], m.counts["C"], m.counts["G"], m.counts["T"]

--- a/Bio/motifs/clusterbuster.py
+++ b/Bio/motifs/clusterbuster.py
@@ -88,10 +88,18 @@ def write(motifs, precision=0):
     lines = []
     for m in motifs:
         lines.append(f">{m.name}\n")
-        if hasattr(m, 'weight') and m.weight:
-            lines.append(f"# WEIGHT: {m.weight}\n")
-        if hasattr(m, 'gap') and m.gap:
-            lines.append(f"# GAP: {m.gap}\n")
+        try:
+            weight = m.weight
+        except AttributeError:
+            pass
+        else:
+            lines.append(f"# WEIGHT: {weight}\n")
+        try:
+            gap = m.gap
+        except AttributeError:
+            pass
+        else:
+            lines.append(f"# GAP: {gap}\n")
         for ACGT_counts in zip(
             m.counts["A"], m.counts["C"], m.counts["G"], m.counts["T"]
         ):

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -118,6 +118,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Dimitris Kalafatis <https://github.com/dimi1729>
 - Edward Haigh <lambda at edwardhaigh dot com>
 - Edward Liaw <https://github.com/edliaw>
+- Ee Shan Shirley Liau <https://github.com/shirleyliau>
 - Emmanuel Noutahi <https://github.com/maclandrol>
 - Eric Rasche <https://github.com/erasche>
 - Eric Talevich <https://github.com/etal>
@@ -364,6 +365,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Yair Benita <Y.Benita at domain pharm.uu.nl>
 - Yanbo Ye <https://github.com/lijax>
 - Yasar L. Ahmed <https://github.com/pyahmed>
+- Yen-Chung Chen <https://github.com/chenyenchung>
 - Yi Hsiao <https://github.com/hsiaoyi0504>
 - Yiming Qu <https://github.com/whatever60>
 - Yogesh Kulkarni <https://https://github.com/yogeshhk>


### PR DESCRIPTION
- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

The commit bc0d58b4c4 added support for writing gap and weight attributes
to ClusterBuster format, but didn't account for motifs from other formats
(like JASPAR) that don't have these attributes. This caused AttributeError
when trying to convert JASPAR motifs to ClusterBuster format.

To trigger this bug, one can load a JASPAR-formatted motif (`motif.jaspar`):

```
>MA0030.2	FOXF2
A  [     3      7      0     27     27     27      0     27     16 ]
C  [    11      0      0      0      0      0     25      0      4 ]
G  [     8     20      0      0      0      0      0      0      2 ]
```

With version 1.85, the following script will result in `AttributeError: 'Motif' object has no attribute 'weight'`:

```
from Bio import motifs

with open('motif.jaspar', 'rt') as f:
  m = [motifs.read(f, 'jaspar')]

motifs.write(m, 'clusterbuster') // Fail
```

This fix adds hasattr() checks before accessing these optional attributes.