### PR TITLE
Permit mixed case for genbank export masking

### DIFF
--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -1011,7 +1011,6 @@ class GenBankWriter(_InsdcWriter):
 
     def _write_sequence(self, record):
         # Loosely based on code from Howard Salis
-        # TODO - Force lower case?
 
         try:
             data = _get_seq_string(record)
@@ -1025,7 +1024,8 @@ class GenBankWriter(_InsdcWriter):
             return
 
         # Catches sequence being None:
-        data = data.lower()
+        if data is None:
+            raise ValueError("No sequence provided")
         seq_len = len(data)
         self.handle.write("ORIGIN\n")
         for line_number in range(0, seq_len, self.LETTERS_PER_LINE):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Previously all genbank export was lowercase - it's not clear that the genbank spec actually requires this. This allows faithful case export.
