### PR TITLE
Minor style tweaks from ruff v0.11.10 then black 25.9.0

### DIFF
--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -11,7 +11,6 @@ functions which return summary type information about alignments should
 be put into classes in this module.
 """
 
-
 import warnings
 
 from Bio import BiopythonDeprecationWarning

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -30,8 +30,7 @@ except ImportError:
     from Bio import MissingPythonDependencyError
 
     raise MissingPythonDependencyError(
-        "Please install NumPy if you want to use Bio.Align. "
-        "See http://www.numpy.org/"
+        "Please install NumPy if you want to use Bio.Align. See http://www.numpy.org/"
     ) from None
 
 from Bio import BiopythonDeprecationWarning

--- a/Bio/AlignIO/MauveIO.py
+++ b/Bio/AlignIO/MauveIO.py
@@ -217,7 +217,7 @@ class MauveWriter(SequentialAlignmentWriter):
             id_line = id_line.replace("\n", " ").replace("\r", " ")
             self.handle.write(id_line + "\n")
             for i in range(0, len(record.seq), 80):
-                self.handle.write(f"{record.seq[i:i + 80]}\n")
+                self.handle.write(f"{record.seq[i : i + 80]}\n")
 
 
 class MauveIterator(AlignmentIterator):

--- a/Bio/Blast/_parser.py
+++ b/Bio/Blast/_parser.py
@@ -962,9 +962,12 @@ class XMLHandler:
             assert len(query_seq_aligned) == align_len
             assert len(target_seq_aligned) == align_len
             (
-                target_seq_data,
-                query_seq_data,
-            ), coordinates = Alignment.parse_printed_alignment(
+                (
+                    target_seq_data,
+                    query_seq_data,
+                ),
+                coordinates,
+            ) = Alignment.parse_printed_alignment(
                 [target_seq_aligned, query_seq_aligned]
             )
             query_start = hsp.query_from - 1

--- a/Bio/Cluster/__init__.py
+++ b/Bio/Cluster/__init__.py
@@ -20,8 +20,7 @@ except ImportError:
     from Bio import MissingPythonDependencyError
 
     raise MissingPythonDependencyError(
-        "Please install NumPy if you want to use Bio.Cluster. "
-        "See http://www.numpy.org/"
+        "Please install NumPy if you want to use Bio.Cluster. See http://www.numpy.org/"
     ) from None
 
 from . import _cluster  # type: ignore

--- a/Bio/Nexus/Trees.py
+++ b/Bio/Nexus/Trees.py
@@ -100,8 +100,9 @@ class Tree(Nodes.Chain):
             if colon == -1 and nodecomment == -1:  # none
                 branch, comment = tree, [None]
             elif colon == -1 and nodecomment > -1:  # only special comment
-                branch, comment = tree[:nodecomment], self._get_values(
-                    tree[nodecomment:]
+                branch, comment = (
+                    tree[:nodecomment],
+                    self._get_values(tree[nodecomment:]),
                 )
             elif colon > -1 and nodecomment == -1:  # only numerical values
                 branch, comment = tree[:colon], self._get_values(tree[colon + 1 :])
@@ -110,8 +111,9 @@ class Tree(Nodes.Chain):
             ):  # taxon name ends at first colon or with special comment
                 branch, comment = tree[:colon], self._get_values(tree[colon + 1 :])
             else:
-                branch, comment = tree[:nodecomment], self._get_values(
-                    tree[nodecomment:]
+                branch, comment = (
+                    tree[:nodecomment],
+                    self._get_values(tree[nodecomment:]),
                 )
 
             return [branch, comment]

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -563,8 +563,7 @@ class PDBList:
         # Otherwise,retrieve the file(s)
         if self._verbose:
             print(
-                f"Downloading assembly ({assembly_num}) for PDB entry "
-                f"'{pdb_code}'..."
+                f"Downloading assembly ({assembly_num}) for PDB entry '{pdb_code}'..."
             )
         try:
             urlcleanup()

--- a/Bio/PDB/internal_coords.py
+++ b/Bio/PDB/internal_coords.py
@@ -1733,8 +1733,7 @@ class IC_Chain:
             f"[ {d.angle:9.5f}, {hedraNdx[d.h1key]}, {hedraNdx[d.h2key]}, {1 if d.reverse else 0}, "
         )
         fp.write(
-            f"{0 if d.h1key in hedraSet else 1}, "
-            f"{0 if d.h2key in hedraSet else 1}, "
+            f"{0 if d.h1key in hedraSet else 1}, {0 if d.h2key in hedraSet else 1}, "
         )
         fp.write(
             "    // {} [ {} -- {} ] {}\n".format(
@@ -4162,8 +4161,7 @@ class Hedron(Edron):
     def __repr__(self) -> str:
         """Print string for Hedron object."""
         return (
-            f"3-{self.id} {self.re_class} {self.len12!s} "
-            f"{self.angle!s} {self.len23!s}"
+            f"3-{self.id} {self.re_class} {self.len12!s} {self.angle!s} {self.len23!s}"
         )
 
     @property

--- a/Bio/Phylo/NeXMLIO.py
+++ b/Bio/Phylo/NeXMLIO.py
@@ -47,7 +47,7 @@ def qUri(s):
 
 def cdao_to_obo(s):
     """Optionally converts a CDAO-prefixed URI into an OBO-prefixed URI."""
-    return f"obo:{cdao_elements[s[len('cdao:'):]]}"
+    return f"obo:{cdao_elements[s[len('cdao:') :]]}"
 
 
 def matches(s):

--- a/Bio/SearchIO/InfernalIO/__init__.py
+++ b/Bio/SearchIO/InfernalIO/__init__.py
@@ -220,7 +220,6 @@ Rows marked with '*' denotes attributes not available in the default format.
 +-----------------+-------------------------+----------------------------------+
 """
 
-
 from .infernal_tab import InfernalTabParser
 from .infernal_tab import InfernalTabIndexer
 from .infernal_text import InfernalTextParser

--- a/Bio/SearchIO/InfernalIO/_base.py
+++ b/Bio/SearchIO/InfernalIO/_base.py
@@ -8,7 +8,6 @@
 
 """Bio.SearchIO base classes for Infernal-related code."""
 
-
 from Bio.SearchIO._model import Hit
 
 

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -474,8 +474,7 @@ class _InsdcWriter(SequenceWriter):
         f_type = feature.type.replace(" ", "_")
         if not _allowed_table_component_name_chars.issuperset(f_type):
             warnings.warn(
-                f"Feature key '{f_type}' contains characters not allowed by"
-                " standard.",
+                f"Feature key '{f_type}' contains characters not allowed by standard.",
                 BiopythonWarning,
             )
         if len(f_type) > 15:
@@ -1033,7 +1032,7 @@ class GenBankWriter(_InsdcWriter):
             for words in range(
                 line_number, min(line_number + self.LETTERS_PER_LINE, seq_len), 10
             ):
-                self.handle.write(f" {data[words:words + 10]}")
+                self.handle.write(f" {data[words : words + 10]}")
             self.handle.write("\n")
 
     def write_record(self, record):
@@ -1231,7 +1230,7 @@ class EmblWriter(_InsdcWriter):
                 index = (
                     self.LETTERS_PER_LINE * line_number + self.LETTERS_PER_BLOCK * block
                 )
-                handle.write(f" {data[index:index + self.LETTERS_PER_BLOCK]}")
+                handle.write(f" {data[index : index + self.LETTERS_PER_BLOCK]}")
             handle.write(
                 str((line_number + 1) * self.LETTERS_PER_LINE).rjust(
                     self.POSITION_PADDING
@@ -1246,7 +1245,9 @@ class EmblWriter(_InsdcWriter):
                 index = (
                     self.LETTERS_PER_LINE * line_number + self.LETTERS_PER_BLOCK * block
                 )
-                handle.write(f" {data[index:index + self.LETTERS_PER_BLOCK]}".ljust(11))
+                handle.write(
+                    f" {data[index : index + self.LETTERS_PER_BLOCK]}".ljust(11)
+                )
             handle.write(str(seq_len).rjust(self.POSITION_PADDING))
             handle.write("\n")
 

--- a/Bio/SeqIO/PhdIO.py
+++ b/Bio/SeqIO/PhdIO.py
@@ -129,8 +129,7 @@ class PhdWriter(SequenceWriter):
         if peak_locations:
             if len(record.seq) != len(peak_locations):
                 raise ValueError(
-                    "Number of peak location scores does not "
-                    "match length of sequence"
+                    "Number of peak location scores does not match length of sequence"
                 )
         if None in phred_qualities:
             raise ValueError("A quality value of None was found")

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -1030,7 +1030,11 @@ class SeqRecord:
             for k, v in self.letter_annotations.items():  # type: ignore
                 if k in other.letter_annotations:
                     # avoid length checks, but otherwise equivalent to answer.letter_annotations[k] = v + other.letter_annotations[k]
-                    dict.__setitem__(answer.letter_annotations, k, v + other.letter_annotations[k])  # type: ignore
+                    dict.__setitem__(
+                        answer.letter_annotations,
+                        k,
+                        v + other.letter_annotations[k],  # type: ignore
+                    )
         except TypeError:
             print("Failed while try to concatenate letter annotations")
             raise

--- a/Bio/codonalign/__init__.py
+++ b/Bio/codonalign/__init__.py
@@ -594,8 +594,7 @@ def _get_codon_rec(
     if mode in (0, 1):
         if len(pro.seq.replace(gap_char, "")) * 3 != (span[1] - span[0]):
             raise ValueError(
-                f"Protein Record {pro.id} and "
-                f"Nucleotide Record {nucl.id} do not match!"
+                f"Protein Record {pro.id} and Nucleotide Record {nucl.id} do not match!"
             )
         aa_num = 0
         codon_seq = CodonSeq()

--- a/Bio/codonalign/codonalignment.py
+++ b/Bio/codonalign/codonalignment.py
@@ -211,8 +211,7 @@ class CodonAlignment(MultipleSeqAlignment):
             ds_tree = ds_constructor.nj(ds_dm)
         else:
             raise RuntimeError(
-                f"Unknown tree method ({tree_method})."
-                " Only NJ and UPGMA are accepted."
+                f"Unknown tree method ({tree_method}). Only NJ and UPGMA are accepted."
             )
         return dn_tree, ds_tree
 

--- a/Tests/pairwise2_testCases.py
+++ b/Tests/pairwise2_testCases.py
@@ -906,8 +906,7 @@ if __name__ == "__main__":
         unittest.main(testRunner=runner, exit=False)
     else:
         print(
-            "Import of C functions failed. Only testing pure Python "
-            "fallback functions."
+            "Import of C functions failed. Only testing pure Python fallback functions."
         )
 
     # Now, we switch explicitly to the fallback Python functions:

--- a/Tests/test_AlignIO_ClustalIO.py
+++ b/Tests/test_AlignIO_ClustalIO.py
@@ -3,6 +3,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 """Tests for Bio.AlignIO.ClustalIO module."""
+
 import unittest
 from io import StringIO
 

--- a/Tests/test_AlignIO_EmbossIO.py
+++ b/Tests/test_AlignIO_EmbossIO.py
@@ -4,6 +4,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 """Tests for Bio.AlignIO.EmbossIO module."""
+
 import unittest
 from io import StringIO
 

--- a/Tests/test_AlignIO_FastaIO.py
+++ b/Tests/test_AlignIO_FastaIO.py
@@ -3,6 +3,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 """Unit tests for the Bio.AlignIO.FastaIO module."""
+
 import unittest
 
 from Bio.AlignIO import FastaIO
@@ -41,17 +42,13 @@ class FastaIOTests(unittest.TestCase):
             self.assertEqual(alignments[1].get_alignment_length(), 64)
             self.assertEqual(
                 alignments[1][0].seq,
-                "AAECGKTVSGFLRAAALGKKVNSLTDD"
-                "RVLKEV-MRLGALQKKLFIDGKRVGDR"
-                "EYAEVLIAIT",
+                "AAECGKTVSGFLRAAALGKKVNSLTDDRVLKEV-MRLGALQKKLFIDGKRVGDREYAEVLIAIT",
             )
             self.assertEqual(alignments[1][0].id, "gi|10955263|ref|NP_052604.1|")
             self.assertEqual(alignments[1][0].annotations["original_length"], 107)
             self.assertEqual(
                 alignments[1][1].seq,
-                "ASRQGCTVGG--KMDSVQDKASDKDKE"
-                "RVMKNINIMWNALSKNRLFDG----NK"
-                "ELKEFIMTLT",
+                "ASRQGCTVGG--KMDSVQDKASDKDKERVMKNINIMWNALSKNRLFDG----NKELKEFIMTLT",
             )
             self.assertEqual(alignments[1][1].id, "gi|152973588|ref|YP_001338639.1|")
             self.assertEqual(alignments[1][1].annotations["original_length"], 459)
@@ -366,17 +363,13 @@ class FastaIOTests(unittest.TestCase):
             self.assertEqual(alignments[1].get_alignment_length(), 64)
             self.assertEqual(
                 alignments[1][0].seq,
-                "AAECGKTVSGFLRAAALGKKVNS"
-                "LTDDRVLKEV-MRLGALQKKLFI"
-                "DGKRVGDREYAEVLIAIT",
+                "AAECGKTVSGFLRAAALGKKVNSLTDDRVLKEV-MRLGALQKKLFIDGKRVGDREYAEVLIAIT",
             )
             self.assertEqual(alignments[1][0].id, "gi|10955263|ref|NP_052604.1|")
             self.assertEqual(alignments[1][0].annotations["original_length"], 107)
             self.assertEqual(
                 alignments[1][1].seq,
-                "ASRQGCTVGG--KMDSVQDKASD"
-                "KDKERVMKNINIMWNALSKNRLF"
-                "DG----NKELKEFIMTLT",
+                "ASRQGCTVGG--KMDSVQDKASDKDKERVMKNINIMWNALSKNRLFDG----NKELKEFIMTLT",
             )
             self.assertEqual(alignments[1][1].id, "gi|152973588|ref|YP_001338639.1|")
             self.assertEqual(alignments[1][1].annotations["original_length"], 459)
@@ -448,17 +441,13 @@ class FastaIOTests(unittest.TestCase):
             self.assertEqual(alignments[8].get_alignment_length(), 64)
             self.assertEqual(
                 alignments[8][0].seq,
-                "ISGTYKGIDFLIKLMPSGGNTTI"
-                "GRASGQNNTYFDEIALIIKENCL"
-                "Y--SDTKNFEYTIPKFSD",
+                "ISGTYKGIDFLIKLMPSGGNTTIGRASGQNNTYFDEIALIIKENCLY--SDTKNFEYTIPKFSD",
             )
             self.assertEqual(alignments[8][0].id, "gi|10955265|ref|NP_052606.1|")
             self.assertEqual(alignments[8][0].annotations["original_length"], 346)
             self.assertEqual(
                 alignments[8][1].seq,
-                "IDGVITAFD-LRTGMNISKDKVV"
-                "AQIQGMDPVW---ISAAVPESIA"
-                "YLLKDTSQFEISVPAYPD",
+                "IDGVITAFD-LRTGMNISKDKVVAQIQGMDPVW---ISAAVPESIAYLLKDTSQFEISVPAYPD",
             )
             self.assertEqual(alignments[8][1].id, "gi|152973505|ref|YP_001338556.1|")
             self.assertEqual(alignments[8][1].annotations["original_length"], 430)
@@ -473,17 +462,13 @@ class FastaIOTests(unittest.TestCase):
             self.assertEqual(alignments[0].get_alignment_length(), 65)
             self.assertEqual(
                 alignments[0][0].seq,
-                "LQHRHPHQQQQQQQQQQQQQQQQ"
-                "QQQQQQQQQQQH---HHHHHHHL"
-                "LQDAYMQQYQHATQQQQML",
+                "LQHRHPHQQQQQQQQQQQQQQQQQQQQQQQQQQQH---HHHHHHHLLQDAYMQQYQHATQQQQML",
             )
             self.assertEqual(alignments[0][0].id, "sp|Q9NSY1|BMP2K_HUMAN")
             self.assertEqual(alignments[0][0].annotations["original_length"], 1161)
             self.assertEqual(
                 alignments[0][1].seq,
-                "IPHQLPHALRHRPAQEAAHASQL"
-                "HPAQPGCGQPLHGLWRLHHHPVY"
-                "LYAWILRLRGHGMQSGGLL",
+                "IPHQLPHALRHRPAQEAAHASQLHPAQPGCGQPLHGLWRLHHHPVYLYAWILRLRGHGMQSGGLL",
             )
             self.assertEqual(alignments[0][1].id, "gi|283855822|gb|GQ290312.1|")
             self.assertEqual(alignments[0][1].annotations["original_length"], 983)

--- a/Tests/test_AlignIO_MauveIO.py
+++ b/Tests/test_AlignIO_MauveIO.py
@@ -4,6 +4,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 """Tests for Bio.AlignIO.MauveIO module."""
+
 import os
 import unittest
 from io import StringIO

--- a/Tests/test_AlignIO_PhylipIO.py
+++ b/Tests/test_AlignIO_PhylipIO.py
@@ -4,6 +4,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 """Tests for Bio.AlignIO.PhylipIO module."""
+
 import unittest
 from io import StringIO
 

--- a/Tests/test_AlignIO_convert.py
+++ b/Tests/test_AlignIO_convert.py
@@ -3,6 +3,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 """Unit tests for Bio.SeqIO.convert(...) function."""
+
 import unittest
 from io import StringIO
 

--- a/Tests/test_Align_format_matrix.py
+++ b/Tests/test_Align_format_matrix.py
@@ -22,6 +22,7 @@ These tests ensure that the new feature of showing ':' for positive
 substitution scores is consistently applied across different input
 styles and substitution matrices.
 """
+
 import unittest
 import numpy as np
 from Bio.Align import PairwiseAligner

--- a/Tests/test_Align_msf.py
+++ b/Tests/test_Align_msf.py
@@ -4,6 +4,7 @@
 # license.  Please see the LICENSE file that should have been included
 # as part of this package.
 """Tests for Bio.Align.msf module."""
+
 import unittest
 import warnings
 from io import StringIO

--- a/Tests/test_File.py
+++ b/Tests/test_File.py
@@ -58,16 +58,13 @@ class AsHandleTestCase(unittest.TestCase):
                 self.assertEqual(
                     fp,
                     handle,
-                    "as_handle should "
-                    "return argument when given a "
-                    "file-like object",
+                    "as_handle should return argument when given a file-like object",
                 )
                 self.assertFalse(handle.closed)
 
             self.assertFalse(
                 handle.closed,
-                "Exiting as_handle given a file-like object "
-                "should not close the file",
+                "Exiting as_handle given a file-like object should not close the file",
             )
 
     def test_string_path(self):

--- a/Tests/test_PDB_SMCRA.py
+++ b/Tests/test_PDB_SMCRA.py
@@ -61,7 +61,13 @@ class Atom_Element(unittest.TestCase):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", PDBConstructionWarning)
             a = Atom.Atom(
-                "XE1", None, None, None, None, " XE1", None  # serial 5170 - 4CP4
+                "XE1",
+                None,
+                None,
+                None,
+                None,
+                " XE1",
+                None,  # serial 5170 - 4CP4
             )
         self.assertEqual(a.element, "X")
 

--- a/Tests/test_PDB_vectors.py
+++ b/Tests/test_PDB_vectors.py
@@ -170,8 +170,7 @@ class VectorTests(unittest.TestCase):
         self.assertAlmostEqual(angle, cangle, places=3)
         self.assertTrue(
             np.allclose(list(map(int, (axis - caxis).get_array())), [0, 0, 0]),
-            f"Want {axis.get_array()!r} and {caxis.get_array()!r}"
-            " to be almost equal",
+            f"Want {axis.get_array()!r} and {caxis.get_array()!r} to be almost equal",
         )
 
     def test_get_spherical_coordinates(self):

--- a/Tests/test_Phylo_matplotlib.py
+++ b/Tests/test_Phylo_matplotlib.py
@@ -51,7 +51,9 @@ class UtilTests(unittest.TestCase):
         # Fancier options
         Phylo.draw(apaf, do_show=False, branch_labels={apaf.root: "Root"})
         Phylo.draw(
-            apaf, do_show=False, branch_labels=lambda c: c.branch_length  # noqa: E731
+            apaf,
+            do_show=False,
+            branch_labels=lambda c: c.branch_length,  # noqa: E731
         )
 
     def test_draw_with_label_colors_dict(self):

--- a/Tests/test_SearchIO_blast_xml.py
+++ b/Tests/test_SearchIO_blast_xml.py
@@ -1291,8 +1291,7 @@ class BlastpXmlCases(unittest.TestCase):
         counter += 1
         self.assertEqual("gi|16080617|ref|NP_391444.1|", qresult.id)
         self.assertEqual(
-            "membrane bound lipoprotein [Bacillus subtilis "
-            "subsp. subtilis str. 168]",
+            "membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168]",
             qresult.description,
         )
         self.assertEqual(102, qresult.seq_len)
@@ -1526,8 +1525,7 @@ class BlastpXmlCases(unittest.TestCase):
 
         self.assertEqual("gi|16080617|ref|NP_391444.1|", qresult.id)
         self.assertEqual(
-            "membrane bound lipoprotein [Bacillus subtilis "
-            "subsp. subtilis str. 168]",
+            "membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168]",
             qresult.description,
         )
         self.assertEqual(102, qresult.seq_len)
@@ -1801,8 +1799,7 @@ class BlastpXmlCases(unittest.TestCase):
         hit = qresult[0]
         self.assertEqual("gi|16080617|ref|NP_391444.1|", hit.id)
         self.assertEqual(
-            "membrane bound lipoprotein [Bacillus "
-            "subtilis subsp. subtilis str. 168]",
+            "membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168]",
             hit.description,
         )
         self.assertEqual(6, len(hit.id_all))
@@ -2773,8 +2770,7 @@ class TblastnXmlCases(unittest.TestCase):
         counter += 1
         self.assertEqual("gi|16080617|ref|NP_391444.1|", qresult.id)
         self.assertEqual(
-            "membrane bound lipoprotein [Bacillus subtilis "
-            "subsp. subtilis str. 168]",
+            "membrane bound lipoprotein [Bacillus subtilis subsp. subtilis str. 168]",
             qresult.description,
         )
         self.assertEqual(102, qresult.seq_len)

--- a/Tests/test_SearchIO_infernal_text_index.py
+++ b/Tests/test_SearchIO_infernal_text_index.py
@@ -8,7 +8,6 @@
 
 """Tests for SearchIO InfernalIO infernal-text indexing"""
 
-
 import os
 import unittest
 

--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -992,7 +992,6 @@ class TestSFF(unittest.TestCase):
 
 
 class NonFastqTests(unittest.TestCase):
-
     def test_fasta_as_fastq(self):
         for f in ("fastq", "fastq-sanger", "fastq-solexa", "fastq-illumina"):
             generator = SeqIO.parse("Fasta/elderberry.nu", f)

--- a/Tests/test_SeqIO_features.py
+++ b/Tests/test_SeqIO_features.py
@@ -7,6 +7,7 @@
 Initially this takes matched tests of GenBank and FASTA files from the NCBI
 and confirms they are consistent using our different parsers.
 """
+
 import datetime
 import locale
 import os

--- a/Tests/test_UniGene.py
+++ b/Tests/test_UniGene.py
@@ -1194,8 +1194,7 @@ class TestUniGene(unittest.TestCase):
 
         self.assertEqual(
             repr(record),
-            "<Record> Hs.2 NAT2 N-acetyltransferase 2 "
-            "(arylamine N-acetyltransferase)",
+            "<Record> Hs.2 NAT2 N-acetyltransferase 2 (arylamine N-acetyltransferase)",
         )
 
     def test_read_value_error(self):

--- a/Tests/test_UniProt_GOA.py
+++ b/Tests/test_UniProt_GOA.py
@@ -96,11 +96,7 @@ class GoaTests(unittest.TestCase):
         self.assertEqual(recs[0]["DB_Object_Symbol"], "YMR084W")
         self.assertEqual(
             recs[0]["DB_Object_Name"],
-            [
-                "Putative glutamine--fructose"
-                "-6-phosphate aminotransferase"
-                " [isomerizing]"
-            ],
+            ["Putative glutamine--fructose-6-phosphate aminotransferase [isomerizing]"],
         )
         self.assertEqual(recs[0]["DB_Object_Synonym"], ["YM084_YEAST", "YMR084W"])
         self.assertEqual(recs[0]["DB_Object_Type"], "protein")


### PR DESCRIPTION
These changes are mainly in blank lines, code within f-strings, and using longer lines. These are all things we would have to update anyway when we finally update to the latest black or ruff for faster very similar output.

Note ruff still ignores the fmt off/on comments (so most of the alignment files are _not_ touched here), and latest versions of both ruff and black remove trailing whitespace in doctest output (there are open issues on this, for us pairwise alignment doctests are an issue). These issues are keeping us on the older black for now.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
