### PR TITLE
doc: Fix typo `Thie` -> `This` in fasta warning

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -217,7 +217,7 @@ class FastaIterator(SequenceIterator):
                     "\n"
                     "(2) Use SeqIO.parse with the 'fasta-pearson' format instead of "
                     "'fasta'. This format is consistent with the FASTA format defined "
-                    "by William Pearson's FASTA aligner software. Thie format allows "
+                    "by William Pearson's FASTA aligner software. This format allows "
                     "for comments before the first sequence; lines starting with the "
                     "';' character anywhere in the file are also regarded as comment "
                     "lines and are ignored.\n"


### PR DESCRIPTION
- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)