### PR TITLE
Fix error message raised when the target is not found in a tree

### DIFF
--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -434,7 +434,7 @@ class TreeMixin:
         """
         paths = [self.get_path(t) for t in _combine_args(targets, *more_targets)]
         # Validation -- otherwise izip throws a spooky error below
-        for p, t in zip(paths, targets):
+        for p, t in zip(paths, _combine_args(targets, *more_targets)):
             if p is None:
                 raise ValueError(f"target {t!r} is not in this tree")
         mrca = self.root

--- a/Tests/test_Phylo.py
+++ b/Tests/test_Phylo.py
@@ -368,6 +368,13 @@ class MixinTests(unittest.TestCase):
         self.assertAlmostEqual(path[2].branch_length, 0.4)
         self.assertEqual(path[2].name, "C")
 
+    def test_missing_target_trace(self):
+        """TreeMixin: trace() method with missing target."""
+        tree = self.phylogenies[1]
+        with self.assertRaises(ValueError) as cm:
+            tree.trace("Aaa", "C")
+        self.assertEqual(str(cm.exception), "target 'Aaa' is not in this tree")
+
     # Information methods
 
     def test_common_ancestor(self):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #5098

Fix the error message that is raised when the target specified in `tree.trace()` is not found in the tree. The error message now includes the full target. Included a test for this.

### Testing

Given `simple_modified.dnd`
```
(((Aaa,Bbb)AB,(Ccc,Ddd)CD)AD,(Eee,Fff,Ggg)EG)AG;
```
Ran
```
from Bio import Phylo
tree = Phylo.read("..\\biopython-issues\\5098\\simple_modified.dnd", "newick")
tree.trace("AAA", "Ggg")
```
Raises:
```
ValueError: target 'AAA' is not in this tree
```

