### PR TITLE
Add gc_content() function to Bio.SeqUtils

### DIFF
--- a/Bio/SeqUtils/gc_content.py
+++ b/Bio/SeqUtils/gc_content.py
@@ -1,0 +1,24 @@
+"""GC content calculation."""
+
+from Bio.SeqUtils import gc_fraction
+
+
+def gc_content(seq, ambiguous="remove"):
+    """Calculate GC content percentage.
+
+    Parameters
+    ----------
+    seq : str, Seq, or SeqRecord
+        DNA or RNA sequence.
+    ambiguous : {"remove", "ignore", "weighted"}, optional
+        How to handle ambiguous nucleotides.
+        'remove' (default) removes ambiguous nucleotides from the sequence.
+        'ignore' counts only G and C; ambiguous nucleotides are not counted.
+        'weighted' weights ambiguous nucleotides based on their GC content.
+
+    Returns
+    -------
+    float
+        GC content percentage (0-100).
+    """
+    return gc_fraction(seq, ambiguous) * 100.0


### PR DESCRIPTION
This PR adds a `gc_content()` function to `Bio.SeqUtils` that returns GC percentage (0-100). It is a convenience wrapper around the existing `gc_fraction()` function.

The function signature matches `gc_fraction` with the same `ambiguous` parameter options ("remove", "ignore", "weighted"). It multiplies the fraction by 100.

This addition is useful for users who prefer percentage values, e.g., in primer design or DNA nanostructure analysis.

Closes # (issue number to be added later)