### PR TITLE
Added depreciation error to MMTFParser.get_structure_from_url since RCSB no longer serves MMTF

### DIFF
--- a/Bio/PDB/mmtf/__init__.py
+++ b/Bio/PDB/mmtf/__init__.py
@@ -34,12 +34,10 @@ class MMTFParser:
     def get_structure_from_url(pdb_id):
         """Get a structure from a URL - given a PDB id.
 
-        :param pdb_id: the input PDB id
-        :return: the structure
+        Depreciated as RCSB no longer serves MMTF files.
 
         """
-        decoder = fetch(pdb_id)
-        return get_from_decoded(decoder)
+        raise NotImplementedError("RCSB no longer serves MMTF files.")
 
     @staticmethod
     def get_structure(file_path):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
 
Added depreciation error to MMTFParser.get_structure_from_url since RCSB no longer serves MMTF files. MMTF fetching has already been removed elsewhere in Biopython but not here. [EDIT] MMTF previously depreciated from PDBList in https://github.com/biopython/biopython/pull/4938
