### PR TITLE
Replace print statements with warnings/stderr in NCBIXML

### DIFF
--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -522,7 +522,7 @@ class _XMLparser(ContentHandler):
         if method in self._method_map:
             self._method_map[method]()
             if self._debug > 4:
-                sys.stderr.write("NCBIXML: Parsed:  " + method + "\n")
+                sys.stderr.write("NCBIXML: Parsed: " + method + "\n")
         elif self._debug > 3:
             # Doesn't exist (yet) and may want to warn about it
             if method not in self._debug_ignore_list:
@@ -563,7 +563,7 @@ class _XMLparser(ContentHandler):
         if method in self._method_map:
             self._method_map[method]()
             if self._debug > 2:
-                sys.stderr.write(f"NCBIXML: Parsed:  {method} {self._value}\n")
+                sys.stderr.write(f"NCBIXML: Parsed: {method} {self._value}\n")
         elif self._debug > 1:
             # Doesn't exist (yet) and may want to warn about it
             if method not in self._debug_ignore_list:

--- a/Tests/test_NCBIXML.py
+++ b/Tests/test_NCBIXML.py
@@ -4394,7 +4394,8 @@ class TestNCBIXML(unittest.TestCase):
             self.assertEqual(len(records), 1)
             # Check that the CREATE_VIEW warning was raised
             create_view_warnings = [
-                w for w in caught
+                w
+                for w in caught
                 if issubclass(w.category, BiopythonParserWarning)
                 and "CREATE_VIEW" in str(w.message)
             ]


### PR DESCRIPTION
## Summary
This PR replaces print statements in `Bio/Blast/NCBIXML.py` with appropriate alternatives:

- **Debug mode prints** → `sys.stderr.write()`: For debug output that should go to stderr
- **CREATE_VIEW warning** → `warnings.warn()` with `BiopythonParserWarning`: For user-facing warnings

### Changes Made
1. Added imports for `sys`, `warnings`, and `BiopythonParserWarning`
2. Replaced 5 debug print statements with `sys.stderr.write()`
3. Replaced CREATE_VIEW print with `warnings.warn()` using `BiopythonParserWarning`
4. Added a test case to verify the CREATE_VIEW warning is properly raised

### Motivation
This addresses the concern that print statements in library code are not appropriate for user-facing output. Using `warnings` module allows users to control warning behavior (suppress, filter, etc.) and `sys.stderr` is the proper destination for debug messages.


- [x]  I hereby agree to dual licence this and any previous contributions under both the Biopython License Agreement AND the BSD 3-Clause License.

- [x]  have read the CONTRIBUTING.rst file, have run pre-commit locally, and understand that continuous integration checks will be used to confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files NEWS.rst and CONTRIB.rst as part of this pull request, am listed already, or do not wish to be listed. (This acknowledgement is optional.)

Fixes #4262