### PR TITLE
Correctly clean up files generated by the Phylo tutorial.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,11 +63,6 @@ Tests/Cluster/cyano_result*
 # Created by Tests/test_BWA_tool.py:
 Tests/out.bam
 
-#TODO - The Tutorial doctests should leave example files after
-#running Tests/test_Tutorial.py
-Doc/examples/other_trees.nwk
-Doc/examples/tree1.nwk
-
 #Ignore LaTeX temp files, and compiled output
 Doc/*.aux
 Doc/*.gz

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -263,21 +263,29 @@ class TutorialTestCase(unittest.TestCase):
                     name = test.name
                     assert name.startswith("TutorialDocTestHolder.doctest_")
                     failures.append(name[30:])
-                    # raise ValueError("Tutorial doctest %s failed" % test.name[30:])
         if failures:
             raise ValueError(
                 "%i Tutorial doctests failed: %s" % (len(failures), ", ".join(failures))
             )
 
     def tearDown(self):
-        os.chdir(original_path)
-        # files currently don't get created during test with python3.5 and pypy
-        # remove files created from chapter_phylo.tex
-        delete_phylo_tutorial = ["examples/tree1.nwk", "examples/other_trees.xml"]
+        # make sure we are in the tutorial base directory
+        os.chdir(tutorial_base)
+
+        # clean up files created in chapter_phylo.rst
+        tutorial_phylo_base = os.path.abspath("..")
+
+        delete_phylo_tutorial = [
+            "tree1.nwk",
+            "tree1.xml",
+            "other_trees.xml",
+            "other_trees.nex",
+        ]
+
         for file in delete_phylo_tutorial:
-            if os.path.exists(os.path.join(tutorial_base, file)):
-                os.remove(os.path.join(tutorial_base, file))
-        # remove files created from chapter_cluster.tex
+            if os.path.exists(os.path.join(tutorial_phylo_base, file)):
+                os.remove(os.path.join(tutorial_phylo_base, file))
+        # clean up files created in chapter_cluster.rst
         tutorial_cluster_base = os.path.abspath("../Tests/")
         delete_cluster_tutorial = [
             "Cluster/cyano_result.atr",
@@ -290,19 +298,11 @@ class TutorialTestCase(unittest.TestCase):
         for file in delete_cluster_tutorial:
             if os.path.exists(os.path.join(tutorial_cluster_base, file)):
                 os.remove(os.path.join(tutorial_cluster_base, file))
+        # reset back to the original directory
+        os.chdir(original_path)
 
 
 # This is to run the doctests if the script is called directly:
 if __name__ == "__main__":
-    if missing_deps:
-        print("Skipping tests needing the following:")
-        for dep in sorted(missing_deps):
-            print(f" - {dep}")
-    print("Running Tutorial doctests...")
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", BiopythonDeprecationWarning)
-        warnings.simplefilter("ignore", BiopythonExperimentalWarning)
-        tests = doctest.testmod(optionflags=doctest.ELLIPSIS)
-    if tests.failed:
-        raise RuntimeError("%i/%i tests failed" % tests)
-    print("Tests done")
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

## Contents of the PR

- Fixes the `teardown()` method in `Tests/test_Tutorial.py` so that files created in `chapter_phylo.rst` are correctly deleted.
- Adjusts `.gitignore` to not ignore files which should no longer be generated.

## Solution

Implements clean up analogically to how cleanup for `chapter_cluster.rst` is done. 

Chapter Cluster run the tests that create files in the `..Tests/Cluster` directory.
```rst
.. doctest ../Tests/Cluster lib:numpy
.. code:: pycon

   >>> from Bio import Cluster
   >>> with open("cyano.txt") as handle:
   ...     record = Cluster.read(handle)
```

Chapter Phylogenetics run the tests in the root (`..`) directory.

```rst
.. doctest ..
.. code:: pycon

   >>> from Bio import Phylo
   >>> tree = Phylo.read("Tests/Nexus/int_node_labels.nwk", "newick")
   >>> print(tree)
```


## Results

- `python setup.py test --offline` cleans up the files.
- `cd Tests && python run_tests.py test_Tutorial.TutorialTestCase` cleans up the files.
- `cd Tests && python run_tests.py doctest` cleans up the files.

## Related

Resolves #4942
