### PR TITLE
Refactor PSEA to use tempfile for secure, isolated execution

### DIFF
--- a/Bio/PDB/PSEA.py
+++ b/Bio/PDB/PSEA.py
@@ -17,7 +17,7 @@ ftp://ftp.lmcp.jussieu.fr/pub/sincris/software/protein/p-sea/
 """
 
 import tempfile  # <-- Add this at the very top of the file!
-import shutil    # <-- Add this at the very top too!
+import shutil  # <-- Add this at the very top too!
 import os
 import subprocess
 
@@ -26,18 +26,19 @@ from Bio.PDB.Polypeptide import is_aa
 
 from pathlib import Path
 
+
 def run_psea(fname, verbose=False):
     """Run PSEA and return the output."""
-    
+
     # We create a secure temporary directory
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = Path(tmp_dir)
-        
+
         # Determine the expected output name
         # If input is "protein.pdb", PSEA will name output "protein.sea"
         input_file = Path(fname)
         output_name = input_file.stem + ".sea"
-        
+
         # Run PSEA, but set the 'cwd' (current working directory) to our temp folder
         p = subprocess.run(["psea", fname], capture_output=True, text=True, cwd=tmp_dir)
 
@@ -47,10 +48,10 @@ def run_psea(fname, verbose=False):
         temp_output = tmp_path / output_name
 
         if p.returncode == 0 and temp_output.exists():
-            # IMPORTANT: Since the temp folder will be deleted, 
-            # we should probably read the data or move the file 
+            # IMPORTANT: Since the temp folder will be deleted,
+            # we should probably read the data or move the file
             # to a permanent location before the 'with' block ends.
-            return temp_output.read_text() 
+            return temp_output.read_text()
         else:
             raise RuntimeError(f"Error running p-sea: {p.stderr}")
 


### PR DESCRIPTION
# Description
This PR updates Bio.PDB.PSEA.run_psea to use tempfile.TemporaryDirectory for executing the PSEA binary.

## Why this is needed
Currently, PSEA writes output files directly to the current working directory. This can lead to file name collisions in multi-threaded environments or permission errors in read-only file systems (common in HPC environments).

## Changes
Integrated tempfile to create a sandboxed execution environment.

Updated path handling using pathlib for better cross-platform compatibility.

Ensured automatic cleanup of temporary files after execution.

## Verification
Verified the logic with a standalone test script to ensure correct directory creation, file writing, and cleanup, as local C-extensions (cealign) were unavailable for full suite testing on my Windows environment.