### PR TITLE
Fix unstable doctest (key order random)

### DIFF
--- a/Doc/Tutorial/chapter_entrez.rst
+++ b/Doc/Tutorial/chapter_entrez.rst
@@ -250,8 +250,8 @@ Now ``record`` is a dictionary with three keys:
 
 .. code:: pycon
 
-   >>> record.keys()
-   dict_keys(['DbInfo', 'ERROR', 'DbList'])
+   >>> sorted(record.keys())
+   ['DbInfo', 'DbList', 'ERROR']
 
 The values stored in the ``'DbList`` key is the list of database
 names shown in the XML above:


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This was failing for me about half the time, eg

```
❯ python test_Tutorial.py
/Users/peterjc/repositories/biopython/Bio/__init__.py:138: BiopythonWarning: You may be importing Biopython from inside the source tree. This is bad practice and might lead to downstream issues. In particular, you might encounter ImportErrors due to missing compiled C extensions. We recommend that you try running your code from outside the source tree. If you are outside the source tree then you have a setup.py file in an unexpected directory: /Users/peterjc/repositories/biopython
  warnings.warn(
Running Tutorial doctests...
**********************************************************************
File "/Users/peterjc/repositories/biopython/Tests/test_Tutorial.py", line 249, in __main__.TutorialDocTestHolder.doctest_test_chapter_entrez_line_00233
Failed example:
    record.keys()
Expected:
    dict_keys(['DbInfo', 'ERROR', 'DbList'])
Got:
    dict_keys(['ERROR', 'DbInfo', 'DbList'])
/Users/peterjc/repositories/biopython/Bio/Align/__init__.py:4502: BiopythonWarning: One or more gap scores are greater than mismatch score. Algorithm may return incorrect results.
  score, paths = super().align(sA, sB, strand)
**********************************************************************
1 items had failures:
   1 of   6 in __main__.TutorialDocTestHolder.doctest_test_chapter_entrez_line_00233
***Test Failed*** 1 failures.
Traceback (most recent call last):
  File "/Users/peterjc/repositories/biopython/Tests/test_Tutorial.py", line 307, in <module>
    raise RuntimeError("%i/%i tests failed" % tests)
RuntimeError: 1/2599 tests failed
```
