### PR TITLE
fix: Deprecate query_letters and database_letters attributes

### DIFF
--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -818,7 +818,6 @@ class BlastParser(_XMLparser):
         # Hack to record the claimed database size as database_length
         # (as well as in num_letters_in_database, see Bug 2176 comment 13):
         self._blast.database_length = self._blast.num_letters_in_database
-        # TODO? Deprecate database_letters next?
 
         # Hack to record the claimed database sequence count as database_sequences
         self._blast.database_sequences = self._blast.num_sequences_in_database

--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -808,13 +808,13 @@ class BlastParser(_XMLparser):
             self._blast.query = self._header.query
         if not hasattr(self._blast, "query_id") or not self._blast.query_id:
             self._blast.query_id = self._header.query_id
-        if not hasattr(self._blast, "query_letters") or not self._blast.query_letters:
-            self._blast.query_letters = self._header.query_letters
+        if not self._blast._query_letters:
+            self._blast._query_letters = self._header._query_letters
 
         # Hack to record the query length as both the query_letters and
         # query_length properties (as in the plain text parser, see
         # Bug 2176 comment 12):
-        self._blast.query_length = self._blast.query_letters
+        self._blast.query_length = self._blast._query_letters
         # Perhaps in the long term we should deprecate one, but I would
         # prefer to drop query_letters - so we need a transition period
         # with both.
@@ -911,7 +911,7 @@ class BlastParser(_XMLparser):
         Important in old pre 2.2.14 BLAST, for recent versions
         <Iteration_query-len> is enough
         """
-        self._header.query_letters = int(self._value)
+        self._header._query_letters = int(self._value)
 
     def _set_record_query_id(self):
         """Record the identifier of the query (PRIVATE)."""
@@ -923,7 +923,7 @@ class BlastParser(_XMLparser):
 
     def _set_record_query_letters(self):
         """Record the length of the query (PRIVATE)."""
-        self._blast.query_letters = int(self._value)
+        self._blast._query_letters = int(self._value)
 
     # def _end_BlastOutput_query_seq(self):
     #     """The query sequence (PRIVATE)."""

--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -59,10 +59,12 @@ class Header:
 
     query               Name of query sequence.
     query_letters       Number of letters in the query sequence.  (int)
+                        DEPRECATED: Use query_length instead.
 
     database            Name of the database.
     database_sequences  Number of sequences in the database.  (int)
     database_letters    Number of letters in the database.  (int)
+                        DEPRECATED: Use database_length instead.
 
     """
 
@@ -74,11 +76,43 @@ class Header:
         self.reference = ""
 
         self.query = ""
-        self.query_letters = None
+        self._query_letters = None
 
         self.database = ""
         self.database_sequences = None
-        self.database_letters = None
+        self._database_letters = None
+
+    @property
+    def query_letters(self):
+        """DEPRECATED: Use query_length instead."""
+        warnings.warn(
+            "The query_letters attribute is deprecated. "
+            "Please use query_length instead.",
+            BiopythonParserWarning,
+            stacklevel=2,
+        )
+        return self._query_letters
+
+    @query_letters.setter
+    def query_letters(self, value):
+        """Set query_letters (deprecated)."""
+        self._query_letters = value
+
+    @property
+    def database_letters(self):
+        """DEPRECATED: Use database_length instead."""
+        warnings.warn(
+            "The database_letters attribute is deprecated. "
+            "Please use database_length instead.",
+            BiopythonParserWarning,
+            stacklevel=2,
+        )
+        return self._database_letters
+
+    @database_letters.setter
+    def database_letters(self, value):
+        """Set database_letters (deprecated)."""
+        self._database_letters = value
 
 
 class Description:

--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -811,13 +811,9 @@ class BlastParser(_XMLparser):
         if not self._blast._query_letters:
             self._blast._query_letters = self._header._query_letters
 
-        # Hack to record the query length as both the query_letters and
-        # query_length properties (as in the plain text parser, see
-        # Bug 2176 comment 12):
+        # Record the query length (query_letters is now deprecated in
+        # favour of query_length, see Bug 2176 comment 12):
         self._blast.query_length = self._blast._query_letters
-        # Perhaps in the long term we should deprecate one, but I would
-        # prefer to drop query_letters - so we need a transition period
-        # with both.
 
         # Hack to record the claimed database size as database_length
         # (as well as in num_letters_in_database, see Bug 2176 comment 13):

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -377,5 +377,6 @@ please open an issue on GitHub or mention it on the mailing list.
 - Yves Bastide <ybastide at domain irisa.fr>
 - Zachary Sailer <https://github.com/Zsailer>
 - Zaid Ur-Rehman <https://github.com/zaidurrehman>
+- Zephyr Cao <https://github.com/A404coder>
 - Zheng Ruan <https://github.com/zruan>
 - Ziyan Rao <https://github.com/starrzy>

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -79,6 +79,12 @@ From now on one should use the following commands:
 Biopython modules, methods, functions
 =====================================
 
+Bio.Blast.NCBIXML
+-----------------
+The ``query_letters`` and ``database_letters`` attributes of the ``Header``
+class (also inherited by the ``Blast`` and ``PSIBlast`` classes) were deprecated.
+Please use ``query_length`` and ``database_length`` instead.
+
 Bio.SeqIO.FastaIO
 -----------------
 Parsing a FASTA file using Bio.SeqIO.parse with ``format='fasta'`` interprets

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -21,6 +21,7 @@ possible, especially the following contributors:
 - Michiel de Hoon
 - Peter Cock
 - Timothy Dennis (first contribution)
+- Zephyr Cao (first contribution)
 - Ziyan Rao (first contribution)
 - Manuel Lera-Ramirez
 

--- a/Tests/test_NCBIXML.py
+++ b/Tests/test_NCBIXML.py
@@ -4402,7 +4402,6 @@ class TestNCBIXML(unittest.TestCase):
             self.assertEqual(len(create_view_warnings), 1)
             self.assertIn("NCBIXML: Ignored:", str(create_view_warnings[0].message))
 
-
     def test_deprecated_query_letters(self):
         """Accessing query_letters should trigger a deprecation warning."""
         filename = "xml_2226_blastp_004.xml"

--- a/Tests/test_NCBIXML.py
+++ b/Tests/test_NCBIXML.py
@@ -2358,7 +2358,7 @@ class TestNCBIXML(unittest.TestCase):
                 record.query,
                 "gi|4104054|gb|AH007193.1|SEG_CVIGS Centaurea vallesiaca 18S ribosomal RNA gene, partial sequence",
             )
-            self.assertEqual(record.query_letters, 1002)
+            self.assertEqual(record.query_length, 1002)
             self.assertEqual(record.num_sequences_in_database, 8994603)
             self.assertEqual(record.database_sequences, 8994603)
             # self.assertEqual(record.database_length, 3078807967)
@@ -2380,7 +2380,7 @@ class TestNCBIXML(unittest.TestCase):
                 record.query,
                 "gi|4218935|gb|AF074388.1|AF074388 Sambucus nigra hevein-like protein HLPf gene, partial cds",
             )
-            self.assertEqual(record.query_letters, 2050)
+            self.assertEqual(record.query_length, 2050)
             self.assertEqual(record.num_sequences_in_database, 8994603)
             self.assertEqual(record.database_sequences, 8994603)
             # self.assertEqual(record.database_length, 3078807967)
@@ -2405,7 +2405,7 @@ class TestNCBIXML(unittest.TestCase):
                 record.query,
                 "gi|5690369|gb|AF158246.1|AF158246 Cricetulus griseus glucose phosphate isomerase (GPI) gene, partial intron sequence",
             )
-            self.assertEqual(record.query_letters, 550)
+            self.assertEqual(record.query_length, 550)
             self.assertEqual(record.num_sequences_in_database, 8994603)
             self.assertEqual(record.database_sequences, 8994603)
             # self.assertEqual(record.database_length, 3078807967)
@@ -2426,7 +2426,7 @@ class TestNCBIXML(unittest.TestCase):
                 record.query,
                 "gi|5049839|gb|AI730987.1|AI730987 BNLGHi8354 Six-day Cotton fiber Gossypium hirsutum cDNA 5' similar to TUBULIN BETA-1 CHAIN gi|486734|pir|S35142 tubulin beta chain - white lupine gi|402636 (X70184) Beta tubulin 1 [Lupinus albus], mRNA sequence",
             )
-            self.assertEqual(record.query_letters, 655)
+            self.assertEqual(record.query_length, 655)
             self.assertEqual(record.num_sequences_in_database, 8994603)
             self.assertEqual(record.database_sequences, 8994603)
             # self.assertEqual(record.database_length, 3078807967)
@@ -2449,7 +2449,7 @@ class TestNCBIXML(unittest.TestCase):
                 record.query,
                 "gi|5052071|gb|AF067555.1|AF067555 Phlox stansburyi internal transcribed spacer 1, 5.8S ribosomal RNA gene, and internal transcribed spacer 2, complete sequence",
             )
-            self.assertEqual(record.query_letters, 623)
+            self.assertEqual(record.query_length, 623)
             self.assertEqual(record.num_sequences_in_database, 8994603)
             self.assertEqual(record.database_sequences, 8994603)
             # self.assertEqual(record.database_length, 3078807967)
@@ -2472,7 +2472,7 @@ class TestNCBIXML(unittest.TestCase):
                 record.query,
                 "gi|3176602|gb|U78617.1|LOU78617 Lathyrus odoratus phytochrome A (PHYA) gene, partial cds",
             )
-            self.assertEqual(record.query_letters, 309)
+            self.assertEqual(record.query_length, 309)
             self.assertEqual(record.num_sequences_in_database, 8994603)
             self.assertEqual(record.database_sequences, 8994603)
             # self.assertEqual(record.database_length, 3078807967)
@@ -2495,7 +2495,7 @@ class TestNCBIXML(unittest.TestCase):
                 record.query,
                 "gi|5817701|gb|AF142731.1|AF142731 Wisteria frutescens maturase-like protein (matK) gene, complete cds; chloroplast gene for chloroplast product",
             )
-            self.assertEqual(record.query_letters, 2551)
+            self.assertEqual(record.query_length, 2551)
             self.assertEqual(record.num_sequences_in_database, 8994603)
             self.assertEqual(record.database_sequences, 8994603)
             # self.assertEqual(record.database_length, 3078807967)
@@ -2527,7 +2527,7 @@ class TestNCBIXML(unittest.TestCase):
             )
             self.assertEqual(record.database, "nr")
             self.assertEqual(record.query, "gi|3298468|dbj|BAA31520.1| SAMIPF")
-            self.assertEqual(record.query_letters, 107)
+            self.assertEqual(record.query_length, 107)
             self.assertEqual(record.num_sequences_in_database, 8994603)
             self.assertEqual(record.database_sequences, 8994603)
             # self.assertEqual(record.database_length, 3078807967)
@@ -2549,7 +2549,7 @@ class TestNCBIXML(unittest.TestCase):
                 record.query,
                 "gi|2781234|pdb|1JLY|B Chain B, Crystal Structure Of Amaranthus Caudatus Agglutinin",
             )
-            self.assertEqual(record.query_letters, 304)
+            self.assertEqual(record.query_length, 304)
 
             record = next(records)
             self.assertEqual(record.application, "BLASTP")
@@ -2564,7 +2564,7 @@ class TestNCBIXML(unittest.TestCase):
                 record.query,
                 "gi|4959044|gb|AAD34209.1|AF069992_1 LIM domain interacting RING finger protein",
             )
-            self.assertEqual(record.query_letters, 600)
+            self.assertEqual(record.query_length, 600)
 
             record = next(records)
             self.assertEqual(record.application, "BLASTP")
@@ -2578,7 +2578,7 @@ class TestNCBIXML(unittest.TestCase):
             self.assertEqual(
                 record.query, "gi|671626|emb|CAA85685.1| rubisco large subunit"
             )
-            self.assertEqual(record.query_letters, 473)
+            self.assertEqual(record.query_length, 473)
 
             self.assertRaises(StopIteration, next, records)
 
@@ -2605,7 +2605,7 @@ class TestNCBIXML(unittest.TestCase):
             self.assertEqual(record.version, "2.2.18")
             self.assertEqual(record.date, "Mar-02-2008")
             self.assertEqual(record.query, "tr|Q3V4Q3|Q3V4Q3_9VIRU")
-            self.assertEqual(record.query_letters, 131)
+            self.assertEqual(record.query_length, 131)
             self.assertEqual(record.num_sequences_in_database, 2563094)
             self.assertEqual(record.database_sequences, 2563094)
             self.assertEqual(record.database_length, 864488805)
@@ -2668,7 +2668,7 @@ class TestNCBIXML(unittest.TestCase):
             self.assertEqual(record.version, "2.2.18")
             self.assertEqual(record.date, "Mar-02-2008")
             self.assertEqual(record.query, "tr|Q3V4Q3|Q3V4Q3_9VIRU")
-            self.assertEqual(record.query_letters, 131)
+            self.assertEqual(record.query_length, 131)
             self.assertEqual(record.num_sequences_in_database, 2563094)
             self.assertEqual(record.database_sequences, 2563094)
             self.assertEqual(record.database_length, 864488805)
@@ -2708,7 +2708,7 @@ class TestNCBIXML(unittest.TestCase):
             self.assertEqual(record.version, "2.2.18")
             self.assertEqual(record.date, "Mar-02-2008")
             self.assertEqual(record.query, "tr|Q3V4Q3|Q3V4Q3_9VIRU")
-            self.assertEqual(record.query_letters, 131)
+            self.assertEqual(record.query_length, 131)
             self.assertEqual(record.num_sequences_in_database, 2563094)
             self.assertEqual(record.database_sequences, 2563094)
             self.assertEqual(record.database_length, 864488805)
@@ -2849,7 +2849,7 @@ class TestNCBIXML(unittest.TestCase):
         self.assertEqual(
             record.query, "twin argininte translocase protein A [Escherichia coli K12]"
         )
-        self.assertEqual(record.query_letters, 103)
+        self.assertEqual(record.query_length, 103)
         self.assertEqual(record.num_sequences_in_database, 194611632)
         self.assertEqual(record.database_sequences, 194611632)
         self.assertEqual(record.database_length, 2104817704)
@@ -3207,7 +3207,7 @@ class TestNCBIXML(unittest.TestCase):
         )
         self.assertEqual(record.date, "")
         self.assertEqual(record.query, "human STS STS_D11570, sequence tagged site")
-        self.assertEqual(record.query_letters, 285)
+        self.assertEqual(record.query_length, 285)
         self.assertEqual(record.num_sequences_in_database, 107382)
         self.assertEqual(record.database_sequences, 107382)
         self.assertEqual(record.database_length, 3164670549)
@@ -3593,7 +3593,7 @@ class TestNCBIXML(unittest.TestCase):
             record.query,
             "MAAD0534.RAR Schistosoma mansoni, adult worm (J.C.Parra) Schistosoma mansoni cDNA clone MAAD0534.RAR 5' end similar to S. mansoni actin mRNA, complete cds, mRNA sequence",
         )
-        self.assertEqual(record.query_letters, 365)
+        self.assertEqual(record.query_length, 365)
 
         alignment = record.alignments[0]
         self.assertEqual(alignment.hit_id, "gi|1530504495|emb|VDM03167.1|")
@@ -4022,7 +4022,7 @@ class TestNCBIXML(unittest.TestCase):
         self.assertEqual(record.database, "nr")
         self.assertEqual(record.date, "")
         self.assertEqual(record.query, "tim [Helicobacter acinonychis str. Sheeba]")
-        self.assertEqual(record.query_letters, 234)
+        self.assertEqual(record.query_length, 234)
 
         alignment = record.alignments[4]
         self.assertEqual(alignment.hit_id, "gi|1143706535|gb|CP018823.1|")
@@ -4092,7 +4092,7 @@ class TestNCBIXML(unittest.TestCase):
             record.query,
             "MAAD0534.RAR Schistosoma mansoni, adult worm (J.C.Parra) Schistosoma mansoni cDNA clone MAAD0534.RAR 5' end similar to S. mansoni actin mRNA, complete cds, mRNA sequence",
         )
-        self.assertEqual(record.query_letters, 365)
+        self.assertEqual(record.query_length, 365)
 
         alignment = record.alignments[4]
         self.assertEqual(alignment.hit_id, "gi|1590279025|ref|XM_028307351.1|")
@@ -4401,6 +4401,34 @@ class TestNCBIXML(unittest.TestCase):
             ]
             self.assertEqual(len(create_view_warnings), 1)
             self.assertIn("NCBIXML: Ignored:", str(create_view_warnings[0].message))
+
+
+    def test_deprecated_query_letters(self):
+        """Accessing query_letters should trigger a deprecation warning."""
+        filename = "xml_2226_blastp_004.xml"
+        datafile = os.path.join("Blast", filename)
+        with open(datafile, "rb") as handle:
+            record = NCBIXML.read(handle)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", BiopythonParserWarning)
+            value = record.query_letters
+        self.assertEqual(value, record.query_length)
+        self.assertEqual(len(caught), 1)
+        self.assertIn("query_letters", str(caught[0].message))
+        self.assertIn("query_length", str(caught[0].message))
+
+    def test_deprecated_database_letters(self):
+        """Accessing database_letters should trigger a deprecation warning."""
+        filename = "xml_2226_blastp_004.xml"
+        datafile = os.path.join("Blast", filename)
+        with open(datafile, "rb") as handle:
+            record = NCBIXML.read(handle)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", BiopythonParserWarning)
+            value = record.database_letters
+        self.assertEqual(len(caught), 1)
+        self.assertIn("database_letters", str(caught[0].message))
+        self.assertIn("database_length", str(caught[0].message))
 
 
 if __name__ == "__main__":

--- a/Tests/test_NCBI_qblast.py
+++ b/Tests/test_NCBI_qblast.py
@@ -269,13 +269,13 @@ class TestQblast(unittest.TestCase):
 
         if record.query == "No definition line":
             # We used a sequence as the query
-            self.assertEqual(len(query), record.query_letters)
+            self.assertEqual(len(query), record.query_length)
         elif query.startswith(">"):
             # We used a FASTA record as the query
             expected = query[1:].split("\n", 1)[0]
             self.assertEqual(expected, record.query)
         elif (
-            record.query_id.startswith("Query_") and len(query) == record.query_letters
+            record.query_id.startswith("Query_") and len(query) == record.query_length
         ):
             # We used a sequence as the entry and it was given a placeholder name
             pass

--- a/Tests/test_NCBI_qblast.py
+++ b/Tests/test_NCBI_qblast.py
@@ -274,9 +274,7 @@ class TestQblast(unittest.TestCase):
             # We used a FASTA record as the query
             expected = query[1:].split("\n", 1)[0]
             self.assertEqual(expected, record.query)
-        elif (
-            record.query_id.startswith("Query_") and len(query) == record.query_length
-        ):
+        elif record.query_id.startswith("Query_") and len(query) == record.query_length:
             # We used a sequence as the entry and it was given a placeholder name
             pass
         else:


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #1000

## Changes
- Convert `query_letters` and `database_letters` to properties in `Header` class with deprecation warnings via `BiopythonParserWarning`
- Use `_query_letters` directly in parser internals to avoid triggering warnings during XML parsing
- Update all tests in `test_NCBIXML.py` and `test_NCBI_qblast.py` to use `query_length` instead of `query_letters`
- Add tests confirming deprecation warnings are raised for both `query_letters` and `database_letters`
- Add deprecation entry to `DEPRECATED.rst`
- Add contributor name to `NEWS.rst` and `CONTRIB.rst`

## Context
The issue has been open since 2016. The XML parser sets both `query_letters` and `query_length`, as well as `database_letters` and `database_length`. This change helps users migrate to the preferred attributes while maintaining backward compatibility.

## Testing
- All 24 existing NCBIXML tests pass with `query_length` replacing `query_letters`
- 2 new tests verify `BiopythonParserWarning` is raised when accessing deprecated attributes
- No warnings triggered during normal XML parsing (parser uses private attributes internally)