### PR TITLE
Replace assert with explicit if/raise in production code (#3600)

### DIFF
--- a/Bio/ExPASy/Enzyme.py
+++ b/Bio/ExPASy/Enzyme.py
@@ -141,7 +141,8 @@ def __read(handle):
             else:
                 record["CF"] = value
         elif key == "PR":
-            assert value.startswith("PROSITE; ")
+            if not value.startswith("PROSITE; "):
+                raise ValueError(f"Unexpected PR line value in Enzyme record: {value!r}")
             value = value[9:].rstrip(";")
             record["PR"].append(value)
         elif key == "CC":

--- a/Bio/ExPASy/Enzyme.py
+++ b/Bio/ExPASy/Enzyme.py
@@ -142,7 +142,9 @@ def __read(handle):
                 record["CF"] = value
         elif key == "PR":
             if not value.startswith("PROSITE; "):
-                raise ValueError(f"Unexpected PR line value in Enzyme record: {value!r}")
+                raise ValueError(
+                    f"Unexpected PR line value in Enzyme record: {value!r}"
+                )
             value = value[9:].rstrip(";")
             record["PR"].append(value)
         elif key == "CC":

--- a/Bio/ExPASy/ScanProsite.py
+++ b/Bio/ExPASy/ScanProsite.py
@@ -135,7 +135,11 @@ class ContentHandler(handler.ContentHandler):
 
     def endElement(self, name):
         """Define the end of the search record."""
-        assert name == self.element.pop()
+        expected = self.element.pop()
+        if name != expected:
+            raise ValueError(
+                f"Unexpected XML end element {name!r} (expected {expected!r})"
+            )
         if self.element == ["scanprosite_response", "matchset", "match"]:
             match = self.record[-1]
             if name in ContentHandler.integers:

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -119,12 +119,14 @@ class TabWriter(SequenceWriter):
         """Return record as tab separated (id(tab)seq) string."""
         title = _clean(record.id)
         seq = _get_seq_string(record)  # Catches sequence being None
-        assert "\t" not in title
-        assert "\n" not in title
-        assert "\r" not in title
-        assert "\t" not in seq
-        assert "\n" not in seq
-        assert "\r" not in seq
+        if "\t" in title or "\n" in title or "\r" in title:
+            raise ValueError(
+                f"Record id contains a tab, newline or carriage return: {title!r}"
+            )
+        if "\t" in seq or "\n" in seq or "\r" in seq:
+            raise ValueError(
+                f"Record sequence contains a tab, newline or carriage return: {seq!r}"
+            )
         return f"{title}\t{seq}\n"
 
     def write_record(self, record):

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -125,7 +125,7 @@ class TabWriter(SequenceWriter):
             )
         if "\t" in seq or "\n" in seq or "\r" in seq:
             raise ValueError(
-                f"Record sequence contains a tab, newline or carriage return: {seq!r}"
+                f"Record sequence contains a tab, newline or carriage return: {title!r}"
             )
         return f"{title}\t{seq}\n"
 

--- a/Bio/motifs/alignace.py
+++ b/Bio/motifs/alignace.py
@@ -47,7 +47,8 @@ def read(handle):
             record.sequences = []
         elif line[:5] == "Motif":
             words = line.split()
-            assert words[0] == "Motif"
+            if words[0] != "Motif":
+                raise ValueError(f"Unexpected line format in AlignACE output: {line!r}")
             number = int(words[1])
             instances = []
         elif line[:3] == "MAP":

--- a/Tests/test_Enzyme.py
+++ b/Tests/test_Enzyme.py
@@ -136,6 +136,18 @@ class TestEnzyme(unittest.TestCase):
             f"Did not expect:\n{record}",
         )
 
+    def test_pr_line_invalid_prefix(self):
+        """Reject Enzyme record where PR line lacks the 'PROSITE; ' prefix."""
+        bad_record = (
+            "ID   4.1.1.14\n"
+            "DE   Valine decarboxylase.\n"
+            "PR   NOT_PROSITE; PDOC00110;\n"
+            "//\n"
+        )
+        handle = StringIO(bad_record)
+        with self.assertRaisesRegex(ValueError, "Unexpected PR line"):
+            list(Enzyme.parse(handle))
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)

--- a/Tests/test_ExPASy_offline.py
+++ b/Tests/test_ExPASy_offline.py
@@ -20,3 +20,16 @@ class ExPASyOfflineTests(unittest.TestCase):
             handle = io.BytesIO(example_xml)
             sequences = ScanProsite.read(handle)
             assert len(sequences) == 1081
+
+    def test_scanprosite_mismatched_end_element(self):
+        """Raise ValueError when an end element does not match its start.
+
+        The check guards a defensive invariant in the SAX content handler;
+        well-formed XML can never trip it via the parser, so we drive the
+        handler directly with a mismatched end-element name.
+        """
+        content_handler = ScanProsite.ContentHandler()
+        content_handler.startElement("scanprosite_response", {})
+        content_handler.startElement("matchset", {"n_match": "0", "n_seq": "0"})
+        with self.assertRaisesRegex(ValueError, "Unexpected XML end element"):
+            content_handler.endElement("not_matchset")

--- a/Tests/test_SeqIO_TabIO.py
+++ b/Tests/test_SeqIO_TabIO.py
@@ -15,9 +15,9 @@ class TestTabIOInvalidInput(unittest.TestCase):
     """Tab format rejects records whose id or sequence contain reserved chars."""
 
     def test_tab_id_with_tab_raises(self):
-        """Reject tab-format write when record.id contains a tab character.
+        r"""Reject tab-format write when record.id contains a tab character.
 
-        Note: ``_clean`` already replaces ``\\n`` and ``\\r`` in the id with
+        Note: ``_clean`` already replaces ``\n`` and ``\r`` in the id with
         spaces before this check runs, so only the tab branch of the id check
         is reachable from a normal write call.
         """

--- a/Tests/test_SeqIO_TabIO.py
+++ b/Tests/test_SeqIO_TabIO.py
@@ -1,0 +1,43 @@
+# Copyright 2026 by the Biopython contributors. All rights reserved.
+# This code is part of the Biopython distribution and governed by its
+# license. Please see the LICENSE file that should have been included
+# as part of this package.
+"""Tests for SeqIO TabIO module — error paths."""
+
+import unittest
+
+from Bio.Seq import Seq
+from Bio.SeqIO.TabIO import TabWriter
+from Bio.SeqRecord import SeqRecord
+
+
+class TestTabIOInvalidInput(unittest.TestCase):
+    """Tab format rejects records whose id or sequence contain reserved chars."""
+
+    def test_tab_id_with_tab_raises(self):
+        """Reject tab-format write when record.id contains a tab character.
+
+        Note: ``_clean`` already replaces ``\\n`` and ``\\r`` in the id with
+        spaces before this check runs, so only the tab branch of the id check
+        is reachable from a normal write call.
+        """
+        record = SeqRecord(Seq("ACGT"), id="bad\tid", description="")
+        with self.assertRaisesRegex(ValueError, "Record id contains"):
+            TabWriter.to_string(record)
+
+    def test_tab_seq_with_tab_raises(self):
+        """Reject tab-format write when the sequence contains a tab character."""
+        record = SeqRecord(Seq("AC\tGT"), id="ok_id", description="")
+        with self.assertRaisesRegex(ValueError, "Record sequence contains"):
+            TabWriter.to_string(record)
+
+    def test_tab_seq_with_newline_raises(self):
+        """Reject tab-format write when the sequence contains a newline."""
+        record = SeqRecord(Seq("AC\nGT"), id="ok_id", description="")
+        with self.assertRaisesRegex(ValueError, "Record sequence contains"):
+            TabWriter.to_string(record)
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -11,6 +11,7 @@
 import math
 import tempfile
 import unittest
+from io import StringIO
 
 try:
     import numpy as np
@@ -1318,6 +1319,26 @@ GCTCGCACGTAGCTG
 ACGCCGCCATGCGAC
 CCTCCAGGTCGCATG""",
         )
+
+    def test_alignace_malformed_motif_line(self):
+        """Reject AlignACE output where a 'Motif' line is malformed."""
+        # Line starts with "Motif" (passes the cheap prefix check) but the
+        # first whitespace-delimited token is not exactly "Motif".
+        bad_output = (
+            "AlignACE 4.0 05/13/04\n"
+            "./AlignACE -i test.fa\n"
+            "Parameter values:\n"
+            " expect = \t10\n"
+            "\n"
+            "Input sequences:\n"
+            "#0\tSEQ1; M: ACGT at 1\n"
+            "\n"
+            "MotifX 1\n"
+            "TCTACGATTGAG\t0\t51\t0\n"
+        )
+        handle = StringIO(bad_output)
+        with self.assertRaisesRegex(ValueError, "Unexpected line format in AlignACE"):
+            motifs.parse(handle, "AlignAce")
 
 
 class TestClusterBuster(unittest.TestCase):


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #3600.

Replaces `assert` statements in production code with explicit `if/raise ValueError`
blocks, so input validation isn't silently skipped when Python runs with `-O`.

Files touched:

- `Bio/SeqIO/TabIO.py` — six asserts on tab/newline/CR in IDs and sequences,
  grouped into two `if/raise` blocks. Following @peterjc's review, the
  sequence-error message now references the record title rather than the
  sequence itself, so the exception text stays bounded for very large records.
- `Bio/ExPASy/Enzyme.py` — one assert on the PR line PROSITE prefix.
- `Bio/ExPASy/ScanProsite.py` — one assert on XML element-stack consistency.
- `Bio/motifs/alignace.py` — one assert on the `Motif` line format.

Code formatted with `black`. Manually checked that valid inputs still parse
and that the new `ValueError` paths fire on malformed inputs.
