### PR TITLE
Add AFDBList class for PDBList-like AlphaFold downloads (#3990)

### DIFF
--- a/Bio/PDB/__init__.py
+++ b/Bio/PDB/__init__.py
@@ -67,6 +67,9 @@ from .PDBIO import Select
 
 # Download from the PDB
 from .PDBList import PDBList
+
+# Download from the AlphaFold database
+from .alphafold_db import AFDBList
 from .PDBMLParser import PDBMLParser
 from .PDBParser import PDBParser
 from .Polypeptide import CaPPBuilder

--- a/Bio/PDB/alphafold_db.py
+++ b/Bio/PDB/alphafold_db.py
@@ -140,7 +140,7 @@ class AFDBList:
     def __init__(
         self,
         server: str = "https://alphafold.ebi.ac.uk",
-        pdb: Optional[str] = None,
+        pdb: str | None = None,
         verbose: bool = True,
     ):
         """Set up the download interface.
@@ -156,11 +156,11 @@ class AFDBList:
     def retrieve_pdb_file(
         self,
         uniprot_id: str,
-        pdir: Optional[str] = None,
-        file_format: Optional[str] = None,
+        pdir: str | None = None,
+        file_format: str | None = None,
         overwrite: bool = False,
         model_index: int = 0,
-    ) -> Optional[str]:
+    ) -> str | None:
         """Download an AlphaFold structure for a UniProt accession.
 
         :param uniprot_id: UniProt accession (e.g. P00520, Q9Y2X3)

--- a/Bio/PDB/alphafold_db.py
+++ b/Bio/PDB/alphafold_db.py
@@ -1,6 +1,7 @@
 """A module for interacting with the AlphaFold Protein Structure Database.
 
-See the `database website <https://alphafold.com/>`_ and the `API docs <https://alphafold.com/api-docs/>`_.
+See the `database website <https://alphafold.ebi.ac.uk/>`_ and the
+`API docs <https://alphafold.ebi.ac.uk/api-docs/>`_.
 """
 
 import json
@@ -10,6 +11,8 @@ from collections.abc import Iterator
 from typing import Optional
 from typing import Union
 from urllib.request import urlopen
+from urllib.request import urlretrieve
+from urllib.request import urlcleanup
 
 from Bio.PDB.MMCIFParser import MMCIFParser
 from Bio.PDB.Structure import Structure as StructuralModel
@@ -23,7 +26,7 @@ def get_predictions(qualifier: str) -> Iterator[dict]:
     :return: The AlphaFold predictions
     :rtype: Iterator[dict]
     """
-    url = f"https://alphafold.com/api/prediction/{qualifier}"
+    url = f"https://alphafold.ebi.ac.uk/api/prediction/{qualifier}"
     # Retrieve the AlphaFold predictions with urllib
     with urlopen(url) as response:
         yield from json.loads(response.read().decode())
@@ -114,3 +117,119 @@ def get_structural_models_for(
             mmcif_path = download_cif_for(prediction, directory)
 
         yield mmcif_parser.get_structure(qualifier, mmcif_path)
+
+
+class AFDBList:
+    """Download AlphaFold structures by UniProt ID, similar to PDBList for PDB.
+
+    This class provides a PDBList-like interface for the AlphaFold Protein
+    Structure Database. You can download predicted structures for any UniProt
+    accession that has an AlphaFold model.
+
+    Example::
+
+        from Bio.PDB import AFDBList
+
+        afdb = AFDBList()
+        # Download the canonical model for P00520 (ABL1) as mmCIF
+        path = afdb.retrieve_pdb_file("P00520")
+        # Or as PDB format
+        path = afdb.retrieve_pdb_file("P00520", file_format="pdb")
+    """
+
+    def __init__(
+        self,
+        server: str = "https://alphafold.ebi.ac.uk",
+        pdb: Optional[str] = None,
+        verbose: bool = True,
+    ):
+        """Set up the download interface.
+
+        :param server: Base URL for the AlphaFold API (default: EBI)
+        :param pdb: Local directory to store files (default: current directory)
+        :param verbose: Whether to print progress messages
+        """
+        self.server = server.rstrip("/")
+        self.local_pdb = pdb if pdb else os.getcwd()
+        self._verbose = verbose
+
+    def retrieve_pdb_file(
+        self,
+        uniprot_id: str,
+        pdir: Optional[str] = None,
+        file_format: Optional[str] = None,
+        overwrite: bool = False,
+        model_index: int = 0,
+    ) -> Optional[str]:
+        """Download an AlphaFold structure for a UniProt accession.
+
+        :param uniprot_id: UniProt accession (e.g. P00520, Q9Y2X3)
+        :param pdir: Directory to save the file (default: local_pdb)
+        :param file_format: "mmCif" (default) or "pdb"
+        :param overwrite: If True, re-download even if file exists
+        :param model_index: Which model to use when multiple exist (0 = canonical)
+        :return: Path to the downloaded file, or None if not found
+        """
+        if file_format is None:
+            file_format = "mmCif"
+
+        if file_format not in ("mmCif", "pdb"):
+            raise ValueError(
+                f"file_format must be 'mmCif' or 'pdb', got {file_format!r}"
+            )
+
+        url = f"{self.server}/api/prediction/{uniprot_id}"
+        try:
+            with urlopen(url) as response:
+                predictions = json.loads(response.read().decode())
+        except OSError as e:
+            if self._verbose:
+                print(f"Could not fetch predictions for {uniprot_id}: {e}")
+            return None
+
+        if not predictions:
+            if self._verbose:
+                print(f"No AlphaFold model found for {uniprot_id}")
+            return None
+
+        # Prefer the canonical model (exact uniprot_id match) when available
+        canonical = [
+            p for p in predictions if p.get("uniprotAccession") == uniprot_id
+        ]
+        prediction_list = canonical if canonical else predictions
+        try:
+            prediction = prediction_list[model_index]
+        except IndexError:
+            raise ValueError(
+                f"model_index {model_index} out of range "
+                f"(max {len(prediction_list) - 1})"
+            )
+
+        if file_format == "mmCif":
+            download_url = prediction["cifUrl"]
+            filename = download_url.split("/")[-1]
+        else:
+            download_url = prediction["pdbUrl"]
+            filename = download_url.split("/")[-1]
+
+        path = pdir if pdir else self.local_pdb
+        os.makedirs(path, exist_ok=True)
+        filepath = os.path.join(path, filename)
+
+        if os.path.exists(filepath) and not overwrite:
+            if self._verbose:
+                print(f"File already exists: {filepath}")
+            return filepath
+
+        if self._verbose:
+            print(f"Downloading AlphaFold model for {uniprot_id}...")
+
+        try:
+            urlcleanup()
+            urlretrieve(download_url, filepath)
+        except OSError as e:
+            if self._verbose:
+                print(f"Download failed for {uniprot_id}: {e}")
+            return None
+
+        return filepath

--- a/Tests/test_PDB_alphafold_db.py
+++ b/Tests/test_PDB_alphafold_db.py
@@ -1,10 +1,13 @@
 """Tests for the alphafold_db module."""
 
+import os
+import tempfile
 import unittest
 
 import requires_internet
 
 from Bio.PDB import alphafold_db
+from Bio.PDB import AFDBList
 
 requires_internet.check()
 
@@ -23,3 +26,29 @@ class AlphafoldDBTests(unittest.TestCase):
         }
         file_path = alphafold_db._get_mmcif_file_path_for(prediction, "test")
         self.assertEqual(file_path, "test/AF-P00520-F1-model_v4.cif")
+
+
+class AFDBListTests(unittest.TestCase):
+    def test_retrieve_pdb_file(self):
+        """Download a single AlphaFold structure by UniProt ID."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            afdb = AFDBList(pdb=tmpdir, verbose=False)
+            path = afdb.retrieve_pdb_file("P00520", pdir=tmpdir)
+            self.assertIsNotNone(path)
+            self.assertTrue(os.path.exists(path))
+            self.assertTrue(path.endswith(".cif"))
+
+    def test_retrieve_pdb_file_pdb_format(self):
+        """Download as PDB format."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            afdb = AFDBList(pdb=tmpdir, verbose=False)
+            path = afdb.retrieve_pdb_file("P00520", pdir=tmpdir, file_format="pdb")
+            self.assertIsNotNone(path)
+            self.assertTrue(os.path.exists(path))
+            self.assertTrue(path.endswith(".pdb"))
+
+    def test_retrieve_pdb_file_invalid_format(self):
+        """Invalid file_format raises ValueError."""
+        afdb = AFDBList(verbose=False)
+        with self.assertRaises(ValueError):
+            afdb.retrieve_pdb_file("P00520", file_format="xyz")


### PR DESCRIPTION
Hi,

I worked on issue #3990. The idea was to add a PDBList-like interface for the AlphaFold database, so users can download predicted structures by UniProt ID in a familiar way.

I added an `AFDBList` class that mirrors the main `PDBList` workflow:

- `__init__(server, pdb, verbose)` – same pattern as PDBList
- `retrieve_pdb_file(uniprot_id, pdir, file_format, overwrite)` – same idea as PDBList’s `retrieve_pdb_file`, but for UniProt accessions

Supported formats are mmCIF (default) and PDB. When there are multiple models for a single accession (e.g. isoforms), the canonical one is preferred by default, with an optional `model_index` parameter to choose another.

I also switched the API base URL from alphafold.com to alphafold.ebi.ac.uk (the official EBI server) and added the missing `AFDBList` export to `Bio.PDB`.

Example usage::

    from Bio.PDB import AFDBList

    afdb = AFDBList()
    path = afdb.retrieve_pdb_file("P00520")
    # or as PDB format
    path = afdb.retrieve_pdb_file("P00520", file_format="pdb")

Closes #3990
