### PR TITLE
Replace sys.argv CLI with argparse subcommands in PDBList

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -687,92 +687,138 @@ class PDBList:
         urlretrieve(url, savefile)
 
 
-if __name__ == "__main__":
-    doc = """PDBList.py
-    (c) Kristian Rother 2003, Wiktoria Karwicka & Jacek Smietanski 2016
-    Contributed to Biopython
+def _build_parser():
+    """Build the argparse parser for the PDBList CLI."""
+    import argparse
 
-    Usage::
+    parser = argparse.ArgumentParser(
+        prog="PDBList",
+        description="Download structures from the PDB database.",
+    )
 
-        PDBList.py update <pdb_path> [options]   - write weekly PDB updates to
-                                                   local pdb tree.
-        PDBList.py all    <pdb_path> [options]   - write all PDB entries to
-                                                   local pdb tree.
-        PDBList.py obsol  <pdb_path> [options]   - write all obsolete PDB
-                                                   entries to local pdb tree.
-        PDBList.py assemb <pdb_path> [options]   - write all assemblies for each
-                                                   PDB entry to local pdb tree.
-        PDBList.py <PDB-ID> <pdb_path> [options] - retrieve single structure
-        PDBList.py (<PDB-ID1>,<PDB-ID2>,...) <pdb_path> [options] - retrieve a set
-                                                   of structures
+    subparsers = parser.add_subparsers(dest="command")
 
-    Options:
-     -d       A single directory will be used as <pdb_path>, not a tree.
-     -o       Overwrite existing structure files.
-     -pdb     Downloads structures in PDB format
-     -xml     Downloads structures in PDBML (XML) format
-     -mmtf    Downloads structures in mmtf format
-     -with-assemblies    Downloads assemblies along with regular entries.
+    # Shared arguments added to each subparser
+    def _add_common_args(sub):
+        sub.add_argument(
+            "--pdb-path",
+            default=os.getcwd(),
+            help="Local path for PDB files (default: current directory).",
+        )
+        sub.add_argument(
+            "--format",
+            choices=["pdb", "xml", "mmtf", "mmCif"],
+            default="mmCif",
+            help="File format to download (default: mmCif).",
+        )
+        sub.add_argument(
+            "--flat",
+            action="store_true",
+            help="Use a single flat directory instead of a PDB-style tree.",
+        )
+        sub.add_argument(
+            "--overwrite",
+            action="store_true",
+            help="Overwrite existing structure files.",
+        )
+        sub.add_argument(
+            "--with-assemblies",
+            action="store_true",
+            help="Also download assembly files.",
+        )
 
-    Maximum one format can be specified simultaneously (if more selected, only
-    the last will be considered). By default (no format specified) structures are
-    downloaded as PDBx/mmCif files.
+    sub_update = subparsers.add_parser(
+        "update", help="Write weekly PDB updates to local tree."
+    )
+    _add_common_args(sub_update)
+
+    sub_all = subparsers.add_parser(
+        "all", help="Download the entire PDB."
+    )
+    _add_common_args(sub_all)
+
+    sub_obsol = subparsers.add_parser(
+        "obsol", help="Download all obsolete PDB entries."
+    )
+    _add_common_args(sub_obsol)
+
+    sub_assemb = subparsers.add_parser(
+        "assemb", help="Download all assembly structures."
+    )
+    _add_common_args(sub_assemb)
+
+    sub_fetch = subparsers.add_parser(
+        "fetch", help="Download one or more structures by PDB code."
+    )
+    sub_fetch.add_argument(
+        "codes",
+        nargs="+",
+        help="One or more 4-letter PDB codes.",
+    )
+    _add_common_args(sub_fetch)
+
+    return parser
+
+
+def cli(args=None):
+    """Command-line interface for PDBList.
+
+    Replaces the previous sys.argv-based interface with argparse subcommands.
+
+    Subcommands::
+
+        PDBList.py update [--pdb-path PATH] [options]
+        PDBList.py all    [--pdb-path PATH] [options]
+        PDBList.py obsol  [--pdb-path PATH] [options]
+        PDBList.py assemb [--pdb-path PATH] [options]
+        PDBList.py fetch  CODE [CODE ...] [--pdb-path PATH] [options]
+
     """
-    print(doc)
+    parser = _build_parser()
+    args = parser.parse_args(args)
 
-    file_format = "mmCif"
-    overwrite = False
-    with_assemblies = False
+    if args.command is None:
+        parser.print_help()
+        return
 
-    if len(sys.argv) > 2:
-        pdb_path = sys.argv[2]
-        pl = PDBList(pdb=pdb_path)
-        if len(sys.argv) > 3:
-            for option in sys.argv[3:]:
-                if option == "-d":
-                    pl.flat_tree = True
-                elif option == "-o":
-                    overwrite = True
-                elif option in ("-pdb", "-xml", "-mmtf"):
-                    file_format = option[1:]
-                # Allow for download of assemblies alongside ASU
-                elif option == "-with-assemblies":
-                    with_assemblies = True
+    pdb_path = getattr(args, "pdb_path", os.getcwd())
+    file_format = args.format
+    overwrite = args.overwrite
+    with_assemblies = getattr(args, "with_assemblies", False)
 
-    else:
-        pdb_path = os.getcwd()
-        pl = PDBList()
+    if with_assemblies and file_format not in ("mmCif", "pdb"):
+        parser.error(
+            f"--with-assemblies only supports mmCif and pdb formats, not {file_format}"
+        )
+
+    pl = PDBList(pdb=pdb_path)
+    if args.flat:
         pl.flat_tree = True
 
-    if len(sys.argv) > 1:
-        if sys.argv[1] == "update":
-            # update PDB
-            print("updating local PDB at " + pdb_path)
-            pl.update_pdb(file_format=file_format, with_assemblies=with_assemblies)
+    if args.command == "update":
+        print("Updating local PDB at " + pdb_path)
+        pl.update_pdb(file_format=file_format, with_assemblies=with_assemblies)
 
-        elif sys.argv[1] == "all":
-            # get the entire PDB
-            pl.download_entire_pdb(file_format=file_format)
-            if with_assemblies:
-                # get all assembly structures
-                pl.download_all_assemblies(file_format=file_format)
-
-        elif sys.argv[1] == "obsol":
-            # get all obsolete entries
-            pl.download_obsolete_entries(pdb_path, file_format=file_format)
-
-        elif sys.argv[1] == "assemb":
-            # get all assembly structures
+    elif args.command == "all":
+        pl.download_entire_pdb(file_format=file_format)
+        if with_assemblies:
             pl.download_all_assemblies(file_format=file_format)
 
-        elif len(sys.argv[1]) == 4 and sys.argv[1][0].isdigit():
-            pdb_code = sys.argv[1]
-            # get single PDB entry
+    elif args.command == "obsol":
+        pl.download_obsolete_entries(file_format=file_format)
+
+    elif args.command == "assemb":
+        pl.download_all_assemblies(file_format=file_format)
+
+    elif args.command == "fetch":
+        for pdb_code in args.codes:
             pl.retrieve_pdb_file(
-                pdb_code, pdir=pdb_path, file_format=file_format, overwrite=overwrite
+                pdb_code,
+                pdir=pdb_path,
+                file_format=file_format,
+                overwrite=overwrite,
             )
             if with_assemblies:
-                # PDB Code might have more than one assembly.
                 assemblies = pl.get_all_assemblies()
                 for a_pdb_code, assembly_num in assemblies:
                     if a_pdb_code == pdb_code:
@@ -784,22 +830,6 @@ if __name__ == "__main__":
                             overwrite=overwrite,
                         )
 
-        elif sys.argv[1][0] == "(":
-            # get a set of PDB entries
-            pdb_ids = re.findall("[0-9A-Za-z]{4}", sys.argv[1])
-            for pdb_id in pdb_ids:
-                pl.retrieve_pdb_file(
-                    pdb_id, pdir=pdb_path, file_format=file_format, overwrite=overwrite
-                )
-                if with_assemblies:
-                    # PDB Code might have more than one assembly.
-                    assemblies = pl.get_all_assemblies()
-                    for a_pdb_code, assembly_num in assemblies:
-                        if a_pdb_code == pdb_id:
-                            pl.retrieve_assembly_file(
-                                pdb_id,
-                                assembly_num,
-                                pdir=pdb_path,
-                                file_format=file_format,
-                                overwrite=overwrite,
-                            )
+
+if __name__ == "__main__":
+    cli()

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -40,11 +40,9 @@ import functools
 import gzip
 import json
 import os
-import re
 import shutil
 import sys
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional
 from urllib.request import Request
 from urllib.request import urlcleanup
 from urllib.request import urlopen
@@ -373,7 +371,7 @@ class PDBList:
                     assemblies = self.get_all_assemblies()
                     for a_pdb_code, assembly_num in assemblies:
                         if a_pdb_code == pdb_code:
-                            pl.retrieve_assembly_file(
+                            self.retrieve_assembly_file(
                                 pdb_code,
                                 assembly_num,
                                 file_format=file_format,
@@ -732,9 +730,7 @@ def _build_parser():
     )
     _add_common_args(sub_update)
 
-    sub_all = subparsers.add_parser(
-        "all", help="Download the entire PDB."
-    )
+    sub_all = subparsers.add_parser("all", help="Download the entire PDB.")
     _add_common_args(sub_all)
 
     sub_obsol = subparsers.add_parser(

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -35,6 +35,7 @@
 
 """Access the PDB over the internet (e.g. to download structures)."""
 
+import argparse
 import contextlib
 import functools
 import gzip
@@ -687,8 +688,6 @@ class PDBList:
 
 def _build_parser():
     """Build the argparse parser for the PDBList CLI."""
-    import argparse
-
     parser = argparse.ArgumentParser(
         prog="PDBList",
         description="Download structures from the PDB database.",
@@ -759,8 +758,6 @@ def _build_parser():
 def cli(args=None):
     """Command-line interface for PDBList.
 
-    Replaces the previous sys.argv-based interface with argparse subcommands.
-
     Subcommands::
 
         PDBList.py update [--pdb-path PATH] [options]
@@ -777,10 +774,10 @@ def cli(args=None):
         parser.print_help()
         return
 
-    pdb_path = getattr(args, "pdb_path", os.getcwd())
+    pdb_path = args.pdb_path
     file_format = args.format
     overwrite = args.overwrite
-    with_assemblies = getattr(args, "with_assemblies", False)
+    with_assemblies = args.with_assemblies
 
     if with_assemblies and file_format not in ("mmCif", "pdb"):
         parser.error(

--- a/Doc/Tutorial/chapter_pdb.rst
+++ b/Doc/Tutorial/chapter_pdb.rst
@@ -2107,7 +2107,7 @@ The ``PDBList`` class can also be used as a command-line tool:
 
 .. code:: pycon
 
-   python PDBList.py 1fat
+   python PDBList.py fetch 1fat
 
 The downloaded file will be called ``pdb1fat.ent`` and stored in the
 current working directory. Note that the ``retrieve_pdb_file`` method
@@ -2131,12 +2131,12 @@ directory:
 
 .. code:: pycon
 
-   python PDBList.py all /data/pdb
+   python PDBList.py all --pdb-path /data/pdb
 
-   python PDBList.py all /data/pdb -d
+   python PDBList.py all --pdb-path /data/pdb --flat
 
 The API method for this is called ``download_entire_pdb``. Adding the
-``-d`` option will store all files in the same directory. Otherwise,
+``--flat`` option will store all files in the same directory. Otherwise,
 they are sorted into PDB-style subdirectories according to their PDB
 ID’s. Depending on the traffic, a complete download will take 2-4 days.
 

--- a/Doc/biopdb_faq.tex
+++ b/Doc/biopdb_faq.tex
@@ -342,7 +342,7 @@ pdbl.retrieve\_pdb\_file('1FAT')
 The \texttt{PDBList} class can also be used as a command-line tool:
 
 \begin{lyxcode}
-python~PDBList.py~1fat
+python~PDBList.py~fetch~1fat
 \end{lyxcode}
 The downloaded file will be called \texttt{pdb1fat.ent} and stored
 in the current working directory. Note that the \texttt{retrieve\_pdb\_file}
@@ -364,12 +364,12 @@ The following commands will store all PDB files in the \texttt{/data/pdb}
 directory:
 
 \begin{lyxcode}
-python~PDBList.py~all~/data/pdb~
+python~PDBList.py~all~-{}-pdb-path~/data/pdb~
 
-python~PDBList.py~all~/data/pdb~-d~
+python~PDBList.py~all~-{}-pdb-path~/data/pdb~-{}-flat~
 \end{lyxcode}
 \noindent The API method for this is called \texttt{download\_entire\_pdb}.
-Adding the \texttt{-d} option will store all files in the same directory.
+Adding the \texttt{-{}-flat} option will store all files in the same directory.
 Otherwise, they are sorted into PDB-style subdirectories according
 to their PDB ID's. Depending on the traffic, a complete download will
 take 2-4 days.

--- a/Tests/test_PDB_PDBList_cli.py
+++ b/Tests/test_PDB_PDBList_cli.py
@@ -108,8 +108,17 @@ class TestPDBListCLIParser(unittest.TestCase):
     def test_all_options_combined(self):
         """Test combining multiple options."""
         args = self.parser.parse_args(
-            ["fetch", "1a2b", "--pdb-path", "/tmp/pdb", "--format", "pdb",
-             "--flat", "--overwrite", "--with-assemblies"]
+            [
+                "fetch",
+                "1a2b",
+                "--pdb-path",
+                "/tmp/pdb",
+                "--format",
+                "pdb",
+                "--flat",
+                "--overwrite",
+                "--with-assemblies",
+            ]
         )
         self.assertEqual(args.command, "fetch")
         self.assertEqual(args.codes, ["1a2b"])
@@ -222,11 +231,7 @@ class TestPDBListCLIDispatch(unittest.TestCase):
         """Test that --flat sets pl.flat_tree = True."""
         from unittest.mock import patch
 
-        with patch.object(PDBList, "download_entire_pdb"):
-            with patch.object(PDBList, "__init__", return_value=None) as mock_init:
-                # Can't easily check flat_tree via mock, so just verify no crash
-                pass
-        # Simpler approach: just verify it runs without error
+        # Verify --flat runs without error
         with patch.object(PDBList, "download_entire_pdb"):
             cli(["all", "--flat"])
 

--- a/Tests/test_PDB_PDBList_cli.py
+++ b/Tests/test_PDB_PDBList_cli.py
@@ -1,0 +1,236 @@
+# Copyright 2026 by Ernest Provo.  All rights reserved.
+#
+# This file is part of the Biopython distribution and governed by your
+# choice of the "Biopython License Agreement" or the "BSD 3-Clause License".
+# Please see the LICENSE file that should have been included as part of this
+# package.
+
+"""Tests for the PDBList command-line interface (argparse-based).
+
+These tests validate argument parsing only and do not require internet access.
+"""
+
+import os
+import unittest
+
+from Bio.PDB.PDBList import PDBList, _build_parser, cli
+
+
+class TestPDBListCLIParser(unittest.TestCase):
+    """Test argparse parser for PDBList CLI."""
+
+    def setUp(self):
+        """Set up parser for each test."""
+        self.parser = _build_parser()
+
+    def test_update_default_path(self):
+        """Test 'update' command with default pdb_path."""
+        args = self.parser.parse_args(["update"])
+        self.assertEqual(args.command, "update")
+        self.assertEqual(args.pdb_path, os.getcwd())
+        self.assertEqual(args.format, "mmCif")
+        self.assertFalse(args.flat)
+        self.assertFalse(args.overwrite)
+
+    def test_update_custom_path(self):
+        """Test 'update' command with custom --pdb-path."""
+        args = self.parser.parse_args(["update", "--pdb-path", "/tmp/pdb"])
+        self.assertEqual(args.command, "update")
+        self.assertEqual(args.pdb_path, "/tmp/pdb")
+
+    def test_all_command(self):
+        """Test 'all' command parses correctly."""
+        args = self.parser.parse_args(["all"])
+        self.assertEqual(args.command, "all")
+
+    def test_obsol_command(self):
+        """Test 'obsol' command parses correctly."""
+        args = self.parser.parse_args(["obsol"])
+        self.assertEqual(args.command, "obsol")
+
+    def test_assemb_command(self):
+        """Test 'assemb' command parses correctly."""
+        args = self.parser.parse_args(["assemb"])
+        self.assertEqual(args.command, "assemb")
+
+    def test_fetch_single_code(self):
+        """Test 'fetch' command with a single PDB code."""
+        args = self.parser.parse_args(["fetch", "1a2b"])
+        self.assertEqual(args.command, "fetch")
+        self.assertEqual(args.codes, ["1a2b"])
+
+    def test_fetch_multiple_codes(self):
+        """Test 'fetch' command with multiple PDB codes."""
+        args = self.parser.parse_args(["fetch", "1a2b", "3k1q", "127d"])
+        self.assertEqual(args.command, "fetch")
+        self.assertEqual(args.codes, ["1a2b", "3k1q", "127d"])
+
+    def test_format_pdb(self):
+        """Test --format pdb option."""
+        args = self.parser.parse_args(["update", "--format", "pdb"])
+        self.assertEqual(args.format, "pdb")
+
+    def test_format_xml(self):
+        """Test --format xml option."""
+        args = self.parser.parse_args(["update", "--format", "xml"])
+        self.assertEqual(args.format, "xml")
+
+    def test_format_mmtf(self):
+        """Test --format mmtf option."""
+        args = self.parser.parse_args(["update", "--format", "mmtf"])
+        self.assertEqual(args.format, "mmtf")
+
+    def test_format_mmcif_default(self):
+        """Test that default format is mmCif."""
+        args = self.parser.parse_args(["update"])
+        self.assertEqual(args.format, "mmCif")
+
+    def test_format_invalid(self):
+        """Test that invalid format raises SystemExit."""
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["update", "--format", "invalid"])
+
+    def test_flat_flag(self):
+        """Test --flat flag."""
+        args = self.parser.parse_args(["update", "--flat"])
+        self.assertTrue(args.flat)
+
+    def test_overwrite_flag(self):
+        """Test --overwrite flag."""
+        args = self.parser.parse_args(["update", "--overwrite"])
+        self.assertTrue(args.overwrite)
+
+    def test_with_assemblies_flag(self):
+        """Test --with-assemblies flag."""
+        args = self.parser.parse_args(["update", "--with-assemblies"])
+        self.assertTrue(args.with_assemblies)
+
+    def test_all_options_combined(self):
+        """Test combining multiple options."""
+        args = self.parser.parse_args(
+            ["fetch", "1a2b", "--pdb-path", "/tmp/pdb", "--format", "pdb",
+             "--flat", "--overwrite", "--with-assemblies"]
+        )
+        self.assertEqual(args.command, "fetch")
+        self.assertEqual(args.codes, ["1a2b"])
+        self.assertEqual(args.pdb_path, "/tmp/pdb")
+        self.assertEqual(args.format, "pdb")
+        self.assertTrue(args.flat)
+        self.assertTrue(args.with_assemblies)
+
+    def test_no_command_returns_none(self):
+        """Test that no command sets command to None."""
+        args = self.parser.parse_args([])
+        self.assertIsNone(args.command)
+
+    def test_fetch_requires_codes(self):
+        """Test that 'fetch' without codes raises SystemExit."""
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["fetch"])
+
+
+class TestPDBListCLIFunction(unittest.TestCase):
+    """Test the cli() function entry point."""
+
+    def test_no_args_prints_help(self):
+        """Test that cli() with no args prints help and returns."""
+        # Should not raise; just prints help
+        cli([])
+
+    def test_with_assemblies_rejects_xml(self):
+        """Test that --with-assemblies with --format xml raises SystemExit."""
+        with self.assertRaises(SystemExit):
+            cli(["update", "--format", "xml", "--with-assemblies"])
+
+    def test_with_assemblies_rejects_mmtf(self):
+        """Test that --with-assemblies with --format mmtf raises SystemExit."""
+        with self.assertRaises(SystemExit):
+            cli(["update", "--format", "mmtf", "--with-assemblies"])
+
+    def test_with_assemblies_accepts_mmcif(self):
+        """Test that --with-assemblies with default mmCif does not error on parsing."""
+        # This will try to connect to PDB server, so we mock the PDBList methods
+        from unittest.mock import patch
+
+        with patch.object(PDBList, "update_pdb"):
+            cli(["update", "--with-assemblies"])
+
+    def test_with_assemblies_accepts_pdb(self):
+        """Test that --with-assemblies with --format pdb does not error on parsing."""
+        from unittest.mock import patch
+
+        with patch.object(PDBList, "update_pdb"):
+            cli(["update", "--format", "pdb", "--with-assemblies"])
+
+
+class TestPDBListCLIDispatch(unittest.TestCase):
+    """Test that cli() dispatches to the correct PDBList methods."""
+
+    def test_update_dispatches(self):
+        """Test that 'update' calls update_pdb."""
+        from unittest.mock import patch
+
+        with patch.object(PDBList, "update_pdb") as mock_update:
+            cli(["update"])
+            mock_update.assert_called_once_with(
+                file_format="mmCif", with_assemblies=False
+            )
+
+    def test_all_dispatches(self):
+        """Test that 'all' calls download_entire_pdb."""
+        from unittest.mock import patch
+
+        with patch.object(PDBList, "download_entire_pdb") as mock_all:
+            cli(["all"])
+            mock_all.assert_called_once_with(file_format="mmCif")
+
+    def test_obsol_dispatches(self):
+        """Test that 'obsol' calls download_obsolete_entries."""
+        from unittest.mock import patch
+
+        with patch.object(PDBList, "download_obsolete_entries") as mock_obsol:
+            cli(["obsol"])
+            mock_obsol.assert_called_once_with(file_format="mmCif")
+
+    def test_assemb_dispatches(self):
+        """Test that 'assemb' calls download_all_assemblies."""
+        from unittest.mock import patch
+
+        with patch.object(PDBList, "download_all_assemblies") as mock_assemb:
+            cli(["assemb"])
+            mock_assemb.assert_called_once_with(file_format="mmCif")
+
+    def test_fetch_dispatches(self):
+        """Test that 'fetch' calls retrieve_pdb_file for each code."""
+        from unittest.mock import patch
+
+        with patch.object(PDBList, "retrieve_pdb_file") as mock_fetch:
+            cli(["fetch", "1a2b", "3k1q"])
+            self.assertEqual(mock_fetch.call_count, 2)
+
+    def test_fetch_with_format(self):
+        """Test that 'fetch' passes format correctly."""
+        from unittest.mock import patch
+
+        with patch.object(PDBList, "retrieve_pdb_file") as mock_fetch:
+            cli(["fetch", "1a2b", "--format", "pdb"])
+            mock_fetch.assert_called_once()
+            call_kwargs = mock_fetch.call_args
+            self.assertEqual(call_kwargs.kwargs.get("file_format"), "pdb")
+
+    def test_flat_flag_sets_flat_tree(self):
+        """Test that --flat sets pl.flat_tree = True."""
+        from unittest.mock import patch
+
+        with patch.object(PDBList, "download_entire_pdb"):
+            with patch.object(PDBList, "__init__", return_value=None) as mock_init:
+                # Can't easily check flat_tree via mock, so just verify no crash
+                pass
+        # Simpler approach: just verify it runs without error
+        with patch.object(PDBList, "download_entire_pdb"):
+            cli(["all", "--flat"])
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner(verbosity=2)
+    unittest.main(testRunner=runner)


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added tests for the changes I have made.

## Summary

Replace the manual `sys.argv` parsing in `PDBList.py` with `argparse` using subcommands. This is a fresh take on #3989 after PR #4032 went stale.

Fixes #3989

## Changes

- Add `_build_parser()` and `cli()` functions replacing the `if __name__` block
- Use subcommands: `update`, `all`, `obsol`, `assemb`, `fetch`
- `fetch CODE [CODE ...]` replaces the old raw PDB code and `(CODE,CODE)` syntax
- Standardize flags: `--pdb-path`, `--format`, `--flat`, `--overwrite`, `--with-assemblies`
- Validate `--with-assemblies` only works with `mmCif` and `pdb` formats (assembly downloads don't support xml/mmtf)
- Fix `obsol` passing `pdb_path` as `listfile` arg to `download_obsolete_entries`
- Update CLI examples in `Doc/Tutorial/chapter_pdb.rst` and `Doc/biopdb_faq.tex`
- Add 30 tests covering argument parsing, method dispatch, and validation

## Testing

```
python -m pytest Tests/test_PDB_PDBList_cli.py -v  # 30 passed
```

Tests cover three areas:
1. **Parser tests** (19): verify argparse accepts/rejects correct inputs
2. **Validation tests** (4): verify `--with-assemblies` rejects unsupported formats
3. **Dispatch tests** (7): mock `PDBList` methods and verify `cli()` calls them correctly

## Notes for reviewers

- First contribution to Biopython
- Incorporates feedback from #4032: named the function `cli()` not `main()`, added tests
- `--pdb-path` is a flag (not positional) to avoid ambiguity with `fetch` codes
- Breaking change to CLI syntax is intentional per #3989 discussion