### PR TITLE
Declare Python 3.10 support deprecated.

### DIFF
--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -7,6 +7,10 @@ followed by code (modules, methods, functions).
 Python
 ======
 
+Python 3.10
+-----------
+First supported in release 1.80. Support deprecated as of Release 1.88.
+
 Python 3.9
 ----------
 No longer supported as of Release 1.86, having triggered a deprecation


### PR DESCRIPTION
No obvious way to add a warning with `pyproject.toml` like we used to do with `setup.py`? CC @xelandernt

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

