### PR TITLE
BioSQL: fix rank reserved word error on MySQL 8+ with pymysql driver

### DIFF
--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -113,7 +113,7 @@ def open_database(driver="MySQLdb", **kwargs):
         server = DBServer(conn, module)
 
     # Sets MySQL to allow double quotes, rather than only backticks
-    if driver in ["MySQLdb", "mysql.connector"]:
+    if driver in ["MySQLdb", "mysql.connector", "pymysql"]:
         server.adaptor.execute("SET sql_mode='ANSI_QUOTES';")
 
     # TODO - Remove the following once BioSQL Bug 2839 is fixed.


### PR DESCRIPTION
- I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.
- I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.
- I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed.

Closes #1882

Added `pymysql` to the ANSI_QUOTES driver list in BioSeqDatabase.py
so the rank reserved word fix also applies when using the pymysql driver
on MySQL 8.0.2+.