### PR TITLE
Remove Jython specific code in BioSQL

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -77,5 +77,3 @@ ignore_missing_imports = True
 # deprecated module
 ignore_errors = True
 
-[mypy-com.ziclix.*]
-ignore_missing_imports = True

--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -16,8 +16,6 @@ This provides interfaces for loading biological objects from a relational
 database, and is compatible with the BioSQL standards.
 """
 
-import os
-
 from . import BioSeq
 from . import DBUtils
 from . import Loader
@@ -49,25 +47,12 @@ def open_database(driver="MySQLdb", **kwargs):
             "Using BioSQL with psycopg (version one) is no "
             "longer supported. Use psycopg2 instead."
         )
-
-    if os.name == "java":
-        from com.ziclix.python.sql import zxJDBC
-
-        module = zxJDBC
-        if driver in ["MySQLdb"]:
-            jdbc_driver = "com.mysql.jdbc.Driver"
-            url_pref = "jdbc:mysql://" + kwargs["host"] + "/"
-        elif driver in ["psycopg2"]:
-            jdbc_driver = "org.postgresql.Driver"
-            url_pref = "jdbc:postgresql://" + kwargs["host"] + "/"
-
-    else:
-        module = __import__(driver, fromlist=["connect"])
+    module = __import__(driver, fromlist=["connect"])
     connect = module.connect
 
     # Different drivers use different keywords...
     kw = kwargs.copy()
-    if driver in ["MySQLdb", "mysql.connector"] and os.name != "java":
+    if driver in ["MySQLdb", "mysql.connector"]:
         if "database" in kw:
             kw["db"] = kw["database"]
             del kw["database"]
@@ -87,30 +72,12 @@ def open_database(driver="MySQLdb", **kwargs):
     if driver in ["psycopg2", "pgdb"] and not kw.get("database"):
         kw["database"] = "template1"
     # SQLite connect takes the database name as input
-    if os.name == "java":
-        if driver in ["MySQLdb"]:
-            conn = connect(
-                url_pref + kw.get("database", "mysql"),
-                kw["user"],
-                kw["password"],
-                jdbc_driver,
-            )
-        elif driver in ["psycopg2"]:
-            conn = connect(
-                url_pref + kw.get("database", "postgresql") + "?stringtype=unspecified",
-                kw["user"],
-                kw["password"],
-                jdbc_driver,
-            )
-    elif driver in ["sqlite3"]:
+    if driver in ["sqlite3"]:
         conn = connect(kw["database"])
     else:
         conn = connect(**kw)
 
-    if os.name == "java":
-        server = DBServer(conn, module, driver)
-    else:
-        server = DBServer(conn, module)
+    server = DBServer(conn, module)
 
     # Sets MySQL to allow double quotes, rather than only backticks
     if driver in ["MySQLdb", "mysql.connector"]:
@@ -542,14 +509,10 @@ class Adaptor:
 
     def execute(self, sql, args=None):
         """Just execute an sql command."""
-        if os.name == "java":
-            sql = sql.replace("%s", "?")
         self.dbutils.execute(self.cursor, sql, args)
 
     def executemany(self, sql, args):
         """Execute many sql commands."""
-        if os.name == "java":
-            sql = sql.replace("%s", "?")
         self.dbutils.executemany(self.cursor, sql, args)
 
     def get_subseq_as_string(self, seqid, start, end):

--- a/Tests/common_BioSQL.py
+++ b/Tests/common_BioSQL.py
@@ -87,27 +87,17 @@ def check_config(dbdriver, dbtype, dbhost, dbuser, dbpasswd, testdb):
         raise MissingExternalDependencyError("Incomplete BioSQL test settings")
 
     # Check the database driver is installed:
-    if SYSTEM == "Java":
-        try:
-            if DBDRIVER in ["MySQLdb"]:
-                import com.mysql.jdbc.Driver  # noqa: F401
-            elif DBDRIVER in ["psycopg2", "pgdb"]:
-                import org.postgresql.Driver  # noqa: F401
-        except ImportError:
-            message = f"Install the JDBC driver for {DBTYPE} to use BioSQL "
-            raise MissingExternalDependencyError(message) from None
-    else:
-        try:
-            __import__(DBDRIVER)
-        except ImportError:
-            if DBDRIVER in ["MySQLdb"]:
-                message = (
-                    "Install MySQLdb or mysqlclient if you want to use %s with BioSQL "
-                    % (DBTYPE)
-                )
-            else:
-                message = f"Install {DBDRIVER} if you want to use {DBTYPE} with BioSQL "
-            raise MissingExternalDependencyError(message) from None
+    try:
+        __import__(DBDRIVER)
+    except ImportError:
+        if DBDRIVER in ["MySQLdb"]:
+            message = (
+                "Install MySQLdb or mysqlclient if you want to use %s with BioSQL "
+                % (DBTYPE)
+            )
+        else:
+            message = f"Install {DBDRIVER} if you want to use {DBTYPE} with BioSQL "
+        raise MissingExternalDependencyError(message) from None
 
     try:
         if DBDRIVER in ["sqlite3"]:


### PR DESCRIPTION
Spotted while trying out zuban as a faster mypy, see https://github.com/zubanls/zuban/issues/368

We dropped Jython support in Biopython 1.77 with the end of Python 2 support. 

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

