### PR TITLE
Fix FastaBlastIterator typo that mis-pairs IDs with sequences

### DIFF
--- a/Bio/SeqIO/FastaIO.py
+++ b/Bio/SeqIO/FastaIO.py
@@ -16,6 +16,7 @@ You are expected to use this module via the Bio.SeqIO functions.
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio import BiopythonDeprecationWarning
+from Bio import BiopythonParserWarning
 
 
 from .Interfaces import _clean
@@ -50,12 +51,20 @@ def SimpleFastaParser(handle):
 
     """
     # Skip any text before the first record (e.g. blank lines, comments)
+    seen = False
     for line in handle:
+        seen = True
         if line[0] == ">":
             title = line[1:].rstrip()
             break
     else:
-        # no break encountered - probably an empty file
+        # The handle was non-empty but had no '>' line — almost certainly a
+        # non-FASTA file. Warn rather than fail silently so callers notice.
+        if seen:
+            warnings.warn(
+                "No FASTA records found (no '>' line in input).",
+                BiopythonParserWarning,
+            )
         return
 
     # Main logic
@@ -341,7 +350,9 @@ class FastaBlastIterator(SequenceIterator):
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
         super().__init__(source, fmt="FASTA")
+        seen = False
         for line in self.stream:
+            seen = True
             if line[0] not in "#!;":
                 if not line.startswith(">"):
                     raise ValueError(
@@ -354,6 +365,10 @@ class FastaBlastIterator(SequenceIterator):
                 self._line = line
                 break
         else:
+            if seen:
+                raise ValueError(
+                    "No FASTA records found (no '>' line in input)."
+                )
             self._line = None
 
     def __next__(self):
@@ -370,7 +385,7 @@ class FastaBlastIterator(SequenceIterator):
             if line[0] in "#!;":
                 pass
             elif line[0] == ">":
-                self_line = line
+                self._line = line
                 break
             else:
                 lines.append(line.rstrip())
@@ -441,11 +456,17 @@ class FastaPearsonIterator(SequenceIterator):
         if alphabet is not None:
             raise ValueError("The alphabet argument is no longer supported")
         super().__init__(source, fmt="Fasta")
+        seen = False
         for line in self.stream:
+            seen = True
             if line.startswith(">"):
                 self._line = line
                 break
         else:
+            if seen:
+                raise ValueError(
+                    "No FASTA records found (no '>' line in input)."
+                )
             self._line = None
 
     def __next__(self):

--- a/Tests/Fasta/multi_blast.pro
+++ b/Tests/Fasta/multi_blast.pro
@@ -1,0 +1,8 @@
+# synthetic multi-record fasta-blast fixture for regression coverage
+>alpha description one
+ACGTACGT
+>beta description two
+GGGGAAAA
+# mid-file comment line
+>gamma description three
+TTTTCCCC

--- a/Tests/test_SeqIO_FastaIO.py
+++ b/Tests/test_SeqIO_FastaIO.py
@@ -6,8 +6,10 @@
 """Tests for Bio.SeqIO.FastaIO module."""
 
 import unittest
+import warnings
 from io import StringIO
 
+from Bio import BiopythonParserWarning
 from Bio import SeqIO
 from Bio.SeqIO.FastaIO import FastaTwoLineParser
 from Bio.SeqIO.FastaIO import SimpleFastaParser
@@ -226,6 +228,45 @@ class TestFastaWithComments(unittest.TestCase):
         )
         self.assertRaises(ValueError, SeqIO.read, "Fasta/aster_pearson.pro", "fasta")
         self.assertRaises(ValueError, SeqIO.read, "Fasta/aster_blast.pro", "fasta")
+
+    def test_fasta_blast_multi(self):
+        """fasta-blast must keep id/seq pairing across multiple records."""
+        records = list(SeqIO.parse("Fasta/multi_blast.pro", "fasta-blast"))
+        self.assertEqual(
+            [(r.id, str(r.seq)) for r in records],
+            [
+                ("alpha", "ACGTACGT"),
+                ("beta", "GGGGAAAA"),
+                ("gamma", "TTTTCCCC"),
+            ],
+        )
+        self.assertEqual(records[1].description, "beta description two")
+        self.assertEqual(records[2].description, "gamma description three")
+
+    def test_fasta_blast_no_records(self):
+        """fasta-blast must raise on non-empty input with no '>' line."""
+        with self.assertRaises(ValueError):
+            list(SeqIO.parse(StringIO("# comment only\n"), "fasta-blast"))
+
+    def test_fasta_pearson_no_records(self):
+        """fasta-pearson must raise on non-empty input with no '>' line."""
+        with self.assertRaises(ValueError):
+            list(SeqIO.parse(StringIO("; pearson comment\nheader text\n"),
+                             "fasta-pearson"))
+
+
+class TestSimpleFastaParserNoRecords(unittest.TestCase):
+    """SimpleFastaParser must warn rather than silently yield zero records."""
+
+    def test_warns_when_no_records(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = list(SimpleFastaParser(StringIO("just text\nmore text\n")))
+        self.assertEqual(result, [])
+        self.assertTrue(
+            any(issubclass(w.category, BiopythonParserWarning) for w in caught),
+            f"Expected BiopythonParserWarning, got {[w.category for w in caught]}",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In FastaBlastIterator.__next__, the line that should advance self._line to the next record's title was misspelled as self_line, creating a local variable instead of updating instance state. As a result, every record after the first was yielded with the first record's id, name, and description while the inner loop kept consuming subsequent '>' lines from the stream — silent data corruption with no error raised.

Also make zero-record cases loud rather than silent: SimpleFastaParser now emits a BiopythonParserWarning, and FastaBlastIterator and FastaPearsonIterator raise ValueError, when input is non-empty but contains no '>' line. Empty streams continue to yield zero records.

Add Tests/Fasta/multi_blast.pro and four new tests covering the multi-record fasta-blast path and the warn/raise behavior. The existing tests only used single-record fixtures, which is why the typo had not been caught.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [ ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ ] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...
