### PR TITLE
Add docstrings to SeqIO iterator __next__ methods

### DIFF
--- a/Bio/SeqIO/AceIO.py
+++ b/Bio/SeqIO/AceIO.py
@@ -75,6 +75,7 @@ class AceIterator(SequenceIterator):
         self.ace_contigs = Ace.parse(self.stream)
 
     def __next__(self):
+        """Return the next SeqRecord from the ACE stream."""
         try:
             ace_contig = next(self.ace_contigs)
         except StopIteration:

--- a/Bio/SeqIO/PdbIO.py
+++ b/Bio/SeqIO/PdbIO.py
@@ -352,6 +352,7 @@ class PdbAtomIterator(SequenceIterator):
         self.records = iter(records)
 
     def __next__(self):
+        """Return the next SeqRecord from the PDB ATOM stream."""
         return next(self.records)
 
 
@@ -498,6 +499,7 @@ class CifSeqresIterator(SequenceIterator):
         self.records = iter(records)
 
     def __next__(self):
+        """Return the next SeqRecord from the mmCIF chain stream."""
         return next(self.records)
 
 
@@ -565,6 +567,7 @@ class CifAtomIterator(SequenceIterator):
         self.records = AtomIterator(pdb_id, structure)
 
     def __next__(self):
+        """Return the next SeqRecord from the mmCIF ATOM stream."""
         return next(self.records)
 
 

--- a/Bio/SeqIO/PhdIO.py
+++ b/Bio/SeqIO/PhdIO.py
@@ -80,6 +80,7 @@ class PhdIterator(SequenceIterator):
         super().__init__(source, fmt="PHD")
 
     def __next__(self):
+        """Return the next SeqRecord from the PHD stream."""
         phd_record = Phd._read(self.stream)
         if phd_record is None:
             raise StopIteration

--- a/Bio/SeqIO/SwissIO.py
+++ b/Bio/SeqIO/SwissIO.py
@@ -52,6 +52,7 @@ class SwissIterator(SequenceIterator):
         super().__init__(source, fmt="SwissProt")
 
     def __next__(self):
+        """Return the next SeqRecord from the Swiss-Prot/UniProt stream."""
         swiss_record = SwissProt._read(self.stream)
         if swiss_record is None:
             raise StopIteration

--- a/Bio/SeqIO/TabIO.py
+++ b/Bio/SeqIO/TabIO.py
@@ -83,6 +83,7 @@ class TabIterator(SequenceIterator):
         super().__init__(source, fmt="Tab-separated plain-text")
 
     def __next__(self):
+        """Return the next SeqRecord from the tab-delimited stream."""
         for line in self.stream:
             try:
                 title, seq = line.split("\t")  # will fail if more than one tab!


### PR DESCRIPTION
- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Partial fix for #2116.

Adds one-line docstrings to the seven `__next__` methods across `Bio/SeqIO/` that were flagged by `flake8 --select D105`:

- `AceIterator.__next__` in `Bio/SeqIO/AceIO.py` (line 77)
- `PhdIterator.__next__` in `Bio/SeqIO/PhdIO.py` (line 82)
- `SwissIterator.__next__` in `Bio/SeqIO/SwissIO.py` (line 54)
- `TabIterator.__next__` in `Bio/SeqIO/TabIO.py` (line 85)
- `PdbAtomIterator.__next__` in `Bio/SeqIO/PdbIO.py` (line 354)
- `CifSeqresIterator.__next__` in `Bio/SeqIO/PdbIO.py` (line 500)
- `CifAtomIterator.__next__` in `Bio/SeqIO/PdbIO.py` (line 567)

Each docstring briefly states what the method returns and which file format the iterator handles, matching the abstract `SequenceIterator.__next__` in `Bio/SeqIO/Interfaces.py`.

This continues the incremental cleanup started in #2078 (Entrez XML), #3573 (ExPASy, motifs, SeqIO), and #5202 (FastaIO).