### PR TITLE
Fix GenBank variation insert location parsing

### DIFF
--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -944,7 +944,12 @@ class SimpleLocation(Location):
             e_pos = Position.fromstring(e)
             # We have seen Ensembl data in "GenBank Format" with length zero in the LOCUS
             # and variation features with s_pos >= e_pos - they are not origin wrapping!
-            if e_pos <= s_pos and length and s_pos < length:
+            # On circular sequences, equal start/end can still represent a full wrap.
+            if (
+                (e_pos < s_pos or (e_pos == s_pos and circular))
+                and length
+                and s_pos < length
+            ):
                 # Assuming this is meant to be origin wrapping.
                 # Create a CompoundLocation of the wrapped feature,
                 # consisting of two SimpleLocation objects to extend to

--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -7592,6 +7592,39 @@ class GenBankTests(unittest.TestCase):
                 str(cm.exception),
             )
 
+    def test_genbank_variation_insert_location_is_not_origin_wrap(self):
+        """Variation inserts should not be treated as origin wrapping."""
+        from Bio.SeqFeature import SeqFeature
+        from Bio.SeqFeature import SimpleLocation
+
+        original = SeqRecord(
+            Seq("ACGTACGTAA"),
+            id="TEST0001",
+            name="TEST0001",
+            description="insert case",
+            annotations={"molecule_type": "DNA"},
+        )
+        original.features = [
+            SeqFeature(SimpleLocation(0, len(original.seq)), type="source"),
+            SeqFeature(SimpleLocation(6, 6), type="variation"),
+        ]
+        mutated = original.format("gb").replace(
+            "variation       6^7", "variation       7..6"
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiopythonParserWarning)
+            record = SeqIO.read(StringIO(mutated), "genbank")
+
+        insert = record.features[1]
+        self.assertIsNotNone(insert.location)
+        self.assertEqual(int(insert.location.start), 6)
+        self.assertEqual(int(insert.location.end), 6)
+
+        handle = StringIO()
+        self.assertEqual(1, SeqIO.write(record, handle, "gb"))
+        self.assertIn("variation       6^7", handle.getvalue())
+
     def test_001_implicit_orign_wrap_fix(self):
         """Attempt to fix implied origin wrapping."""
         path = "GenBank/bad_origin_wrap.gb"


### PR DESCRIPTION
Fixes #4969.

This narrows the GenBank origin-wrap heuristic so adjacent insert-style coordinates such as 7..6 are not treated as invalid origin-spanning features on records with undefined topology.

The change is intentionally limited to Bio/SeqFeature.py and adds a regression test in Tests/test_GenBank.py covering the variation insert case from the issue.

Validation:
- git diff --check
- ../.venv/bin/python -m pytest test_GenBank.py -q from Tests/; 95 passed
- test_SeqFeature.py passed
- test_SeqIO_features.py passed

Note: full pytest collection in this local environment is blocked by missing optional dependencies/configuration for BioSQL, reportlab, PAML, msgpack, mmtf, rdflib, igraph, matplotlib, networkx, and scipy.