### PR TITLE
Document Entrez timeout behavior while reading responses

### DIFF
--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -50,10 +50,13 @@ All the functions that send requests to the NCBI Entrez API will
 automatically respect the NCBI rate limit (of 3 requests per second
 without an API key, or 10 requests per second with an API key) and
 will automatically retry when encountering transient failures
-(i.e. connection failures or HTTP 5XX codes). By default, Biopython
-does a maximum of three tries before giving up, and sleeps for 15
-seconds between tries. You can tweak these parameters by setting
-``Bio.Entrez.max_tries`` and ``Bio.Entrez.sleep_between_tries``.
+(i.e. connection failures or HTTP 5XX codes) while opening the URL.
+By default, Biopython does a maximum of three tries before giving up,
+and sleeps for 15 seconds between tries. You can tweak these
+parameters by setting ``Bio.Entrez.max_tries`` and
+``Bio.Entrez.sleep_between_tries``. Network problems that occur after
+the handle has been returned, for example while reading the response
+body, are not automatically retried.
 
 The Entrez module also provides an XML parser which takes a handle
 as input.
@@ -564,9 +567,13 @@ def parse(source, validate=True, escape=False, ignore_errors=False):
 def _open(request):
     """Make an HTTP request to Entrez, handling errors and enforcing rate limiting (PRIVATE).
 
-    Does some simple error checking and will try again after certain types of errors, up to
-    ``max_retries`` times. This function also enforces the "up to three queries per second
-    rule" to avoid abusing the NCBI servers (this limit is increased to 10 if using an API key).
+    Does some simple error checking and will try again after certain
+    types of errors, up to ``max_retries`` times, while opening the
+    request. Network errors that happen after this function has returned
+    the handle, for example while reading the response body, are passed
+    to the caller. This function also enforces the "up to three queries
+    per second rule" to avoid abusing the NCBI servers (this limit is
+    increased to 10 if using an API key).
 
     :param req_or_cgi: A Request object returned by ``_build_request``.
     :type req_or_cgi: urllib.request.Request

--- a/Doc/Tutorial/chapter_entrez.rst
+++ b/Doc/Tutorial/chapter_entrez.rst
@@ -1944,32 +1944,47 @@ it is better to download in batches. You use the ``retstart`` and
 ``retmax`` parameters to specify which range of search results you want
 returned (starting entry using zero-based counting, and maximum number
 of results to return). Note that if Biopython encounters a transient
-failure like a HTTP 500 response when communicating with NCBI, it will
-automatically try again a couple of times. For example,
+failure like a HTTP 500 response when communicating with NCBI while
+opening the handle, it will automatically try again a couple of times.
+However, if the network connection drops while you are reading the
+response body, you may still need to retry the current batch in your own
+code. For example,
 
 .. code:: python
 
    # This assumes you have already run a search as shown above,
    # and set the variables count, webenv, query_key
 
+   import time
+
    batch_size = 3
    output = open("orchid_rpl16.fasta", "w")
    for start in range(0, count, batch_size):
        end = min(count, start + batch_size)
        print("Going to download record %i to %i" % (start + 1, end))
-       stream = Entrez.efetch(
-           db="nucleotide",
-           rettype="fasta",
-           retmode="text",
-           retstart=start,
-           retmax=batch_size,
-           webenv=webenv,
-           query_key=query_key,
-           idtype="acc",
-       )
-       data = stream.read()
-       stream.close()
-       output.write(data)
+       for attempt in range(3):
+           stream = Entrez.efetch(
+               db="nucleotide",
+               rettype="fasta",
+               retmode="text",
+               retstart=start,
+               retmax=batch_size,
+               webenv=webenv,
+               query_key=query_key,
+               idtype="acc",
+           )
+           try:
+               data = stream.read()
+           except OSError:
+               stream.close()
+               if attempt == 2:
+                   raise
+               print("Connection error, retrying...")
+               time.sleep(15)
+           else:
+               stream.close()
+               output.write(data)
+               break
    output.close()
 
 For illustrative purposes, this example downloaded the FASTA records in


### PR DESCRIPTION
Fixes #2277.

This documents the current retry boundary in `Bio.Entrez`: transient failures are retried while opening the request, but network problems that occur later while reading the response body are still surfaced to the caller.

The tutorial batch-download example now shows a small caller-side retry loop around `stream.read()` for this case.

Validation:
- `git diff --check`
- `../.venv/bin/python -m pytest test_Entrez.py -q` from `Tests/`; 13 passed
- `chapter_entrez` doctests passed via the `Tests/test_Tutorial.py` harness; 23 doctests