### PR TITLE
Add missing SeqIO iterator context manager docstrings

### DIFF
--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -122,9 +122,11 @@ class SequenceIterator(ABC, Generic[AnyStr]):
         return self
 
     def __enter__(self):
+        """Return the iterator when used as a context manager."""
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
+        """Close the stream when exiting a context manager."""
         try:
             stream = self.stream
         except AttributeError:


### PR DESCRIPTION
Refs #2116.

This is a one-file D105 cleanup for `Bio/SeqIO/Interfaces.py`. It adds the missing docstrings on `SequenceIterator.__enter__` and `SequenceIterator.__exit__` and makes no behavioral changes.

Validation:
- `git diff --check`
- `./.venv/bin/python -m flake8 --isolated --select D1 Bio/SeqIO/Interfaces.py`