### PR TITLE
Fix PDBList multi-server path support for EBI/PDBj/RCSB mirrors

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -118,6 +118,23 @@ class PDBList:
         self.flat_tree = False
 
     @staticmethod
+    def _detect_pdb_path_prefix(server):
+        """Detect the correct PDB path prefix for a given server.
+
+        Different PDB mirror servers use different base URL paths:
+        - RCSB (US), PDBj (Japan), wwPDB: /pub/pdb/...
+        - EBI / PDBe (Europe): /pub/databases/pdb/...
+
+        This method auto-detects the correct prefix so that users can
+        switch between mirrors without manually adjusting URL paths.
+        """
+        # EBI/PDBe uses a different directory structure
+        if "ebi.ac.uk" in server:
+            return "/pub/databases/pdb"
+        # RCSB, PDBj, wwPDB, and others use the standard path
+        return "/pub/pdb"
+
+    @staticmethod
     def _print_default_format_warning(file_format):
         """Print a warning to stdout (PRIVATE).
 
@@ -161,7 +178,8 @@ class PDBList:
             drwxrwxr-x   2 1002     sysadmin     512 Oct 14 02:14 20031013
             -rw-r--r--   1 1002     sysadmin    1327 Mar 12  2001 README
         """
-        path = self.pdb_server + "/pub/pdb/data/status/latest/"
+        prefix = self._detect_pdb_path_prefix(self.pdb_server)
+        path = self.pdb_server + f"{prefix}/data/status/latest/"
 
         # Retrieve the lists
         added = self.get_status_list(path + "added.pdb")
@@ -174,7 +192,8 @@ class PDBList:
 
         Returns a list of PDB codes in the index file.
         """
-        url = self.pdb_server + "/pub/pdb/derived_data/index/entries.idx"
+        prefix = self._detect_pdb_path_prefix(self.pdb_server)
+        url = self.pdb_server + f"{prefix}/derived_data/index/entries.idx"
         if self._verbose:
             print("Retrieving index file. Takes about 27 MB.")
         with contextlib.closing(urlopen(url)) as handle:
@@ -206,7 +225,8 @@ class PDBList:
             ...
 
         """
-        url = self.pdb_server + "/pub/pdb/data/status/obsolete.dat"
+        prefix = self._detect_pdb_path_prefix(self.pdb_server)
+        url = self.pdb_server + f"{prefix}/data/status/obsolete.dat"
         with contextlib.closing(urlopen(url)) as handle:
             # Extract pdb codes. Could use a list comprehension, but I want
             # to include an assert to check for mis-reading the data.
@@ -294,12 +314,12 @@ class PDBList:
             )
             url = (
                 self.pdb_server
-                + f"/pub/pdb/data/structures/{pdb_dir}/{file_type}/{pdb_code[1:3]}/{archive}"
+                + f"{self._detect_pdb_path_prefix(self.pdb_server)}/data/structures/{pdb_dir}/{file_type}/{pdb_code[1:3]}/{archive}"
             )
         elif file_format == "bundle":
             url = (
                 self.pdb_server
-                + f"/pub/pdb/compatible/pdb_bundle/{pdb_code[1:3]}/{pdb_code}/{archive}"
+                + f"{self._detect_pdb_path_prefix(self.pdb_server)}/compatible/pdb_bundle/{pdb_code[1:3]}/{pdb_code}/{archive}"
             )
         else:
             url = f"http://mmtf.rcsb.org/v1.0/full/{pdb_code}"
@@ -534,9 +554,11 @@ class PDBList:
         archive_fn = archive[file_format]
 
         if file_format == "mmcif":
-            url = self.pdb_server + f"/pub/pdb/data/assemblies/mmCIF/all/{archive_fn}"
+            prefix = self._detect_pdb_path_prefix(self.pdb_server)
+            url = self.pdb_server + f"{prefix}/data/assemblies/mmCIF/all/{archive_fn}"
         elif file_format == "pdb":
-            url = self.pdb_server + f"/pub/pdb/data/biounit/PDB/all/{archive_fn}"
+            prefix = self._detect_pdb_path_prefix(self.pdb_server)
+            url = self.pdb_server + f"{prefix}/data/biounit/PDB/all/{archive_fn}"
         else:  # better safe than sorry
             raise ValueError(f"file_format '{file_format}' not supported")
 
@@ -683,7 +705,8 @@ class PDBList:
         """Retrieve and save a (big) file containing all the sequences of PDB entries."""
         if self._verbose:
             print("Retrieving sequence file (takes over 110 MB).")
-        url = self.pdb_server + "/pub/pdb/derived_data/pdb_seqres.txt"
+        prefix = self._detect_pdb_path_prefix(self.pdb_server)
+        url = self.pdb_server + f"{prefix}/derived_data/pdb_seqres.txt"
         urlretrieve(url, savefile)
 
 


### PR DESCRIPTION
Fixes #3987: PDBList hardcoded `/pub/pdb/` in all URL paths, which breaks access to the EBI/PDBe mirror.

## Problem
The EBI PDB server (`ftp.ebi.ac.uk`) uses `/pub/databases/pdb/...` instead of `/pub/pdb/...`, so PDBList fails when pointed at the European mirror.

## Fix
- Added `_detect_pdb_path_prefix()` static method that auto-detects the correct path prefix based on the server URL
- EBI servers (`ebi.ac.uk`) → `/pub/databases/pdb`
- RCSB, PDBj, wwPDB → `/pub/pdb` (standard, backward compatible)
- Replaced all 8 hardcoded `/pub/pdb/` occurrences with dynamic prefix

## Usage
```python
# All three mirrors now work correctly:
PDBList(server="https://ftp.ebi.ac.uk")      # EBI/PDBe (was broken, now fixed)
PDBList(server="https://ftp.pdbj.org")        # PDBj (continues to work)
PDBList(server="https://files.rcsb.org")      # RCSB (continues to work)
```

## Changes
- 1 file changed: `Bio/PDB/PDBList.py`
- No breaking changes for existing RCSB/PDBj/wwPDB users
- No new dependencies