### PR TITLE
Fix degenerate consensus for fully ambiguous columns

### DIFF
--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -207,7 +207,7 @@ class GenericPositionMatrix(dict):
                 key = nucleotides[0]
             elif 4 * sum(counts[:2]) > 3 * sum(counts):
                 key = "".join(sorted(nucleotides[:2]))
-            elif counts[3] == 0:
+            elif counts[3] == 0 and sum(counts[:3]) > 0:
                 key = "".join(sorted(nucleotides[:3]))
             else:
                 key = "ACGT"

--- a/Tests/test_motifs.py
+++ b/Tests/test_motifs.py
@@ -57,6 +57,12 @@ XX
 """
         self.assertEqual(s3, expected_transfac)
         self.assertRaises(ValueError, format, m, "foo_bar")
+        
+    def test_degenerate_consensus_ambiguous_columns(self):
+        """Test degenerate consensus preserves fully ambiguous columns."""
+        instances = [Seq("ACGTN"), Seq("CGTAN")]
+        motif = motifs.create(instances)
+        self.assertEqual(motif.degenerate_consensus, "MSKWN")
 
     def test_relative_entropy(self):
         m = motifs.create([Seq("ATATA"), Seq("ATCTA"), Seq("TTGTA")])


### PR DESCRIPTION
Summary
Fix `motifs.degenerate_consensus` handling for fully ambiguous columns.
Previously, a motif column derived from ambiguous bases such as `N` could produce a partially ambiguous IUPAC code such as `V` instead of preserving full ambiguity as `N`.

Changes
- Updated `degenerate_consensus` logic to avoid selecting a three-base degenerate code when the top three nucleotide counts sum to zero
- Added regression coverage for fully ambiguous motif columns

Testing
- `python -m pytest test_motifs.py -k degenerate_consensus`
- `python -m pytest test_motifs.py`