### PR TITLE
SeqUtils: Improve GC123 robustness and modernize SearchIO repr

### DIFF
--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -250,7 +250,7 @@ class QueryResult(_BaseSearchObject):
 
     def __repr__(self):
         """Return string representation of the QueryResult object."""
-        return "QueryResult(id=%r, %r hits)" % (self.id, len(self))
+        return f"QueryResult(id={self.id!r}, {len(self)!r} hits)"
 
     def __str__(self):
         """Return a human readable summary of the QueryResult object."""

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -179,13 +179,16 @@ def GC123(seq):
         try:
             n = d["G"][i] + d["C"][i] + d["T"][i] + d["A"][i]
             gc[i] = (d["G"][i] + d["C"][i]) * 100.0 / n
-        except Exception:  # TODO - ValueError?
+        except ZeroDivisionError:
             gc[i] = 0
 
         gcall = gcall + d["G"][i] + d["C"][i]
         nall = nall + n
 
-    gcall = 100.0 * gcall / nall
+    if nall == 0:
+        gcall = 0
+    else:
+        gcall = 100.0 * gcall / nall
     return gcall, gc[0], gc[1], gc[2]
 
 

--- a/Tests/test_SeqUtils.py
+++ b/Tests/test_SeqUtils.py
@@ -14,6 +14,7 @@ from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from Bio.SeqUtils import CodonAdaptationIndex
 from Bio.SeqUtils import gc_fraction
+from Bio.SeqUtils import GC123
 from Bio.SeqUtils import GC_skew
 from Bio.SeqUtils import seq1
 from Bio.SeqUtils import seq3
@@ -387,6 +388,25 @@ TTT	0.886
 
         with self.assertRaises(ValueError):
             gc_fraction(seq, "other string")
+
+    def test_GC123(self):
+        """Tests GC123 function."""
+        seq = "ATGCGTATCGAT"
+        # GC123 returns (total_gc, gc1, gc2, gc3)
+        # Pos 0: A, C, A, G -> G: 1, C: 1. GC1 = 50%
+        # Pos 1: T, G, T, A -> G: 1. GC2 = 25%
+        # Pos 2: G, T, C, T -> G: 1, C: 1. GC3 = 50%
+        # Total GC: 5/12 = 41.666...%
+        res = GC123(seq)
+        self.assertAlmostEqual(res[0], 41.6666666, places=5)
+        self.assertAlmostEqual(res[1], 50.0)
+        self.assertAlmostEqual(res[2], 25.0)
+        self.assertAlmostEqual(res[3], 50.0)
+
+        # Test with empty sequence or sequence with no valid bases
+        # This triggers the ZeroDivisionError catch
+        res = GC123("")
+        self.assertEqual(res, (0, 0, 0, 0))
 
     def test_GC_skew(self):
         s = "A" * 50


### PR DESCRIPTION
Summary:
- Addresses a long-standing TODO in `Bio.SeqUtils.GC123` by catching `ZeroDivisionError` specifically instead of a broad `Exception`.
- Fixes a potential `ZeroDivisionError` in `GC123` when calculating total GC content for empty sequences.
- Modernizes `QueryResult.__repr__` in `Bio.SearchIO` using Python f-strings.
- Adds comprehensive unit tests for `GC123` in `Tests/test_SeqUtils.py`.
- Verified all SeqUtils and SearchIO model tests pass.