### PR TITLE
Add docstrings to remaining SeqIO iterator __next__ methods

### DIFF
--- a/Bio/SeqIO/GckIO.py
+++ b/Bio/SeqIO/GckIO.py
@@ -94,6 +94,7 @@ class GckIterator(SequenceIterator):
             raise ValueError("Improper header, cannot read 24 bytes from stream")
 
     def __next__(self):
+        """Return the next SeqRecord from the GCK stream."""
         stream = self.stream
         # Read the actual sequence data
         packet = _read_packet(stream)

--- a/Bio/SeqIO/GfaIO.py
+++ b/Bio/SeqIO/GfaIO.py
@@ -133,6 +133,7 @@ class Gfa1Iterator(SequenceIterator):
         super().__init__(source, fmt="GFA 1.0")
 
     def __next__(self):
+        """Return the next SeqRecord from the GFA 1.0 stream."""
         for line in self.stream:
             if line == "\n":
                 warnings.warn("GFA data has a blank line.", BiopythonWarning)
@@ -180,6 +181,7 @@ class Gfa2Iterator(SequenceIterator):
         super().__init__(source, fmt="GFA 2.0")
 
     def __next__(self):
+        """Return the next SeqRecord from the GFA 2.0 stream."""
         for line in self.stream:
             if line == "\n":
                 warnings.warn("GFA data has a blank line.", BiopythonWarning)

--- a/Bio/SeqIO/SffIO.py
+++ b/Bio/SeqIO/SffIO.py
@@ -849,6 +849,7 @@ class SffIterator(SequenceIterator):
         self._read_counter = 0
 
     def __next__(self):
+        """Return the next SeqRecord from the SFF stream."""
         stream = self.stream
         if self._read_counter == self.number_of_reads:
             self._read_counter = None  # check EOF only once

--- a/Bio/SeqIO/SnapGeneIO.py
+++ b/Bio/SeqIO/SnapGeneIO.py
@@ -340,6 +340,7 @@ class SnapGeneIterator(SequenceIterator):
         _parse_cookie_packet(length, data)
 
     def __next__(self):
+        """Return the next SeqRecord from the SnapGene stream."""
         packets = self.packets
         if packets is None:
             raise StopIteration

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -63,6 +63,7 @@ class UniprotIterator(SequenceIterator):
         )
 
     def __next__(self):
+        """Return the next SeqRecord from the UniProt XML stream."""
         try:
             for event, elem in self._data:
                 if event == "start-ns" and not (

--- a/Bio/SeqIO/XdnaIO.py
+++ b/Bio/SeqIO/XdnaIO.py
@@ -165,6 +165,7 @@ class XdnaIterator(SequenceIterator):
         self._header = header
 
     def __next__(self):
+        """Return the next SeqRecord from the Xdna stream."""
         if self._header is None:
             raise StopIteration
         stream = self.stream

--- a/Bio/SeqIO/__init__.py
+++ b/Bio/SeqIO/__init__.py
@@ -502,6 +502,7 @@ class AlignmentSequenceIterator(SequenceIterator):
         self.iterator = (record for alignment in alignments for record in alignment)
 
     def __next__(self):
+        """Return the next SeqRecord from the underlying alignment iterator."""
         return next(self.iterator)
 
 

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -226,6 +226,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Kuan-Yi Li <https://github.com/kuanyili>
 - Kurt Graff <https://github.com/graph1994>
 - Kyle Ellrott <https://github.com/kellrott>
+- Laura Piñero Roig <https://github.com/laurapiro17>
 - Leighton Pritchard <https://github.com/widdowquinn>
 - Lenna Peterson <ark first-name at gmail dot com>
 - Leonhard Heizinger <https://github.com/he-leon>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -21,6 +21,7 @@ possible, especially the following contributors:
 
 - Peter Cock
 - Al Fattah Suyadi (first contribution)
+- Laura Piñero Roig (first contribution)
 
 30 March 2026: Biopython 1.87
 =============================


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Partial fix for #2116 — finishes off the `__next__` D105 violations in
`Bio/SeqIO/` after #5202 and #5205. Eight one-line docstrings across
GckIO, GfaIO (Gfa1Iterator and Gfa2Iterator), SffIO, SnapGeneIO,
UniprotIO, XdnaIO, and `AlignmentSequenceIterator` in `__init__.py`.