### PR TITLE
Fix remaining flake8-docstrings D400, D401 and D402 issues.

### DIFF
--- a/Bio/Align/AlignInfo.py
+++ b/Bio/Align/AlignInfo.py
@@ -17,7 +17,7 @@ from Bio import BiopythonDeprecationWarning
 
 
 class SummaryInfo:
-    """Calculate summary info about the alignment.  (DEPRECATED)
+    """Calculate summary info about the alignment (DEPRECATED).
 
     This class should be used to calculate information summarizing the
     results of an alignment. This may either be straight consensus info

--- a/Bio/PDB/PDBIO.py
+++ b/Bio/PDB/PDBIO.py
@@ -28,7 +28,7 @@ _MAX_B_FACTOR = 999_999
 
 
 def _format_b_factor(value: float) -> str:
-    """Returns the b-factor value as a formatted string
+    """Return b-factor value as a formatted string.
 
     Formats the b-factor value to fit the wwPDB specification of 6 characters
     maximum, otherwise truncating to 6 characters if necessary.

--- a/Bio/SearchIO/InfernalIO/infernal_tab.py
+++ b/Bio/SearchIO/InfernalIO/infernal_tab.py
@@ -209,7 +209,7 @@ _COLUMN_FRAG = {
 
 
 def _infer_tabular_format(handle, is_byte=False):
-    """Infer tabular format from the tabular file header. (PRIVATE)"""
+    """Infer tabular format from the tabular file header (PRIVATE)."""
     # infernal tabular output columns are space separated files with spaces in
     # column names, ex:
     # #target name         accession

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -44,7 +44,7 @@ class SequenceIterator(ABC, Generic[AnyStr]):
     @property
     @abstractmethod
     def modes(self):
-        """File modes (binary or text) that the parser can handle.
+        """Can the parser handle binary and/or text modes.
 
         This property must be "t" (for text mode only), "b" (for binary mode
         only), "tb" (if both text and binary mode are accepted, but text mode
@@ -167,7 +167,7 @@ class SequenceWriter(ABC, Generic[AnyStr]):
     @property
     @abstractmethod
     def modes(self):
-        """File modes (binary or text) that the writer can handle.
+        """Can the parser handle binary and/or text modes.
 
         This property must be "t" (for text mode only), "b" (for binary mode
         only), "tb" (if both text and binary mode are accepted, but text mode

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -2481,8 +2481,10 @@ def _fastq_illumina_convert_qual(
 
 @dataclass
 class InvalidCharError(ValueError):
-    """
-    Custom error for strings that have a character that is invalid for whatever reason (eg: non-ascii, invalid range)
+    """Error for strings that have an invalid character.
+
+    This can be invalid for whatever reason by being non-ASCII or outside the
+    valid ASCII range.
 
     Main attributes:
      - full_string    - the string which contains the invalid character (str)

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -369,7 +369,10 @@ class SeqRecord:
         annotations: dict[str, str | int] | None = None,
         letter_annotations: dict[str, Sequence] | None = None,
     ) -> "SeqRecord":
-        """Faster constructor for post-validated data like copies or validated parsed data"""
+        """Faster constructor for post-validated data (PRIVATE).
+
+        For use with copies or validated parsed data.
+        """
 
         if cls is not SeqRecord:
             # If we subclassed, we'll default to that class's initializer just to be careful


### PR DESCRIPTION
Before:

```
❯ flake8 --statistics --isolated --select D40 Bio
Bio/Align/AlignInfo.py:20:1: D400 First line should end with a period
Bio/PDB/PDBIO.py:31:1: D400 First line should end with a period
Bio/PDB/PDBIO.py:31:1: D401 First line should be in imperative mood
Bio/SearchIO/InfernalIO/infernal_tab.py:212:1: D400 First line should end with a period
Bio/SeqIO/Interfaces.py:47:1: D402 First line should not be the function's "signature"
Bio/SeqIO/Interfaces.py:170:1: D402 First line should not be the function's "signature"
Bio/SeqIO/QualityIO.py:2484:1: D400 First line should end with a period
Bio/SeqRecord.py:372:1: D400 First line should end with a period
5     D400 First line should end with a period
1     D401 First line should be in imperative mood
2     D402 First line should not be the function's "signature"
```

It appears ruff does find these (other than the D402 cases look like false positives from a clumsy docstring), but why wasn't that enforced via our pre-commit setup?

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
