### PR TITLE
Switch some percent formatting to f-strings with pyupgrade v3.19.1

### DIFF
--- a/Bio/Align/bigbed.py
+++ b/Bio/Align/bigbed.py
@@ -771,9 +771,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         for i in range(self.bedN):
             name = fields[i].name
             if name != names[i]:
-                raise ValueError(
-                    "Expected field name '%s'; found '%s'" % (names[i], name)
-                )
+                raise ValueError(f"Expected field name '{names[i]}'; found '{name}'")
         if fieldCount > definedFieldCount:
             self._custom_fields = []
         for i in range(definedFieldCount, fieldCount):

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -211,7 +211,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
         if self.reference is None:
             self.reference = self._read_reference(stream)
             self._index = 0
-        self.targets[0].id = "%s.%s" % (self.reference, self.targets[0].id)
+        self.targets[0].id = f"{self.reference}.{self.targets[0].id}"
 
     def _create_alignment(
         self, chromId, chromStart, chromEnd, data, dataStart, dataEnd

--- a/Bio/Align/bigpsl.py
+++ b/Bio/Align/bigpsl.py
@@ -472,7 +472,7 @@ class AlignmentIterator(bigbed.AlignmentIterator):
         for i, name in enumerate(names):
             if name != fields[i].name:
                 raise ValueError(
-                    "Expected field name '%s'; found '%s'" % (name, fields[i].name)
+                    f"Expected field name '{name}'; found '{fields[i].name}'"
                 )
 
     def _create_alignment(self, chromId, tStart, tEnd, rest, dataStart, dataEnd):

--- a/Bio/Align/sam.py
+++ b/Bio/Align/sam.py
@@ -69,7 +69,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             for key, value in values.items():
                 if key == "VN":
                     continue
-                fields.append("%s:%s" % (key, value))
+                fields.append(f"{key}:{value}")
             line = "\t".join(fields) + "\n"
             stream.write(line)
         for record in targets:
@@ -94,7 +94,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
                 elif key == "URI":
                     fields.append("UR:%s" % value)
                 else:
-                    fields.append("%s:%s" % (key[:2], value))
+                    fields.append(f"{key[:2]}:{value}")
             try:
                 description = record.description
             except AttributeError:
@@ -110,7 +110,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             for row in rows:
                 fields = ["@" + tag]
                 for key, value in row.items():
-                    fields.append("%s:%s" % (key, value))
+                    fields.append(f"{key}:{value}")
                 line = "\t".join(fields) + "\n"
                 stream.write(line)
 

--- a/Bio/Blast/_parser.py
+++ b/Bio/Blast/_parser.py
@@ -1178,7 +1178,7 @@ class XMLHandler:
         method = self._start_methods.get(name)
         if method is None:
             raise ValueError(
-                "Failed to find method for %s (%s)" % (name, self._start_methods.keys())
+                f"Failed to find method for {name} ({self._start_methods.keys()})"
             )
         method(self, name, attributes)
 

--- a/Bio/PDB/internal_coords.py
+++ b/Bio/PDB/internal_coords.py
@@ -4242,7 +4242,7 @@ class Hedron(Edron):
         elif all(ak in self.atomkeys[1:] for ak in ak_tpl):
             self.cic.hedraL23[self.ndx] = newLength
         else:
-            raise TypeError("%s not found in %s" % (str(ak_tpl), self))
+            raise TypeError(f"{str(ak_tpl)} not found in {self}")
         self._invalidate_atoms()
 
 

--- a/Tests/test_Align_Alignment.py
+++ b/Tests/test_Align_Alignment.py
@@ -52,7 +52,7 @@ class TestPairwiseAlignment(unittest.TestCase):
     )
 
     def check_indexing_slicing(self, alignment, cls, strand):
-        msg = "%s, %s strand" % (cls.__name__, strand)
+        msg = f"{cls.__name__}, {strand} strand"
         self.assertEqual(
             repr(alignment),
             "<Alignment object (2 rows x 12 columns) at 0x%x>" % id(alignment),
@@ -3617,7 +3617,7 @@ class TestAlign_mapall(unittest.TestCase):
             data = {start: str(record.seq)}
             length = len(alignment.query)
             seq = Seq(data, length=length)
-            name = "%s.%s" % (new_assembly, chromosome)
+            name = f"{new_assembly}.{chromosome}"
             record = SeqRecord(seq, id=name)
             records.append(record)
         path = os.path.join("Blat", "panTro5.maf")

--- a/Tests/test_Align_psl.py
+++ b/Tests/test_Align_psl.py
@@ -1549,7 +1549,7 @@ class TestAlign_dna(unittest.TestCase):
 
     def check_reading_psl_34_001(self, fmt):
         """Check parsing psl_34_001.psl or pslx_34_001.pslx."""
-        path = "Blat/%s_34_001.%s" % (fmt, fmt)
+        path = f"Blat/{fmt}_34_001.{fmt}"
         alignments = Align.parse(path, "psl")
         self.assertEqual(alignments.metadata["psLayout version"], "3")
         alignment = next(alignments)
@@ -4971,7 +4971,7 @@ AlignmentCounts object with
 
     def check_reading_psl_34_003(self, fmt):
         """Check parsing psl_34_003.psl or pslx_34_003.pslx."""
-        path = "Blat/%s_34_003.%s" % (fmt, fmt)
+        path = f"Blat/{fmt}_34_003.{fmt}"
         alignments = Align.parse(path, "psl")
         self.assertEqual(alignments.metadata["psLayout version"], "3")
         alignment = next(alignments)
@@ -5451,7 +5451,7 @@ AlignmentCounts object with
 
     def check_reading_psl_34_004(self, fmt):
         """Check parsing psl_34_004.psl or pslx_34_004.pslx."""
-        path = "Blat/%s_34_004.%s" % (fmt, fmt)
+        path = f"Blat/{fmt}_34_004.{fmt}"
         alignments = Align.parse(path, "psl")
         self.assertEqual(alignments.metadata["psLayout version"], "3")
         alignment = next(alignments)
@@ -8392,7 +8392,7 @@ AlignmentCounts object with
 
     def check_reading_psl_34_005(self, fmt):
         """Check parsing psl_34_005.psl or pslx_34_005.pslx."""
-        path = "Blat/%s_34_005.%s" % (fmt, fmt)
+        path = f"Blat/{fmt}_34_005.{fmt}"
         alignments = Align.parse(path, "psl")
         alignment = next(alignments)
         self.assertEqual(alignment.matches, 16)
@@ -11806,7 +11806,7 @@ class TestAlign_dnax_prot(unittest.TestCase):
 
     def check_reading_psl_35_001(self, fmt):
         """Check parsing psl_35_001.psl or pslx_35_001.pslx."""
-        path = "Blat/%s_35_001.%s" % (fmt, fmt)
+        path = f"Blat/{fmt}_35_001.{fmt}"
         alignments = Align.parse(path, "psl")
         self.assertEqual(alignments.metadata["psLayout version"], "3")
         alignment = next(alignments)
@@ -13089,7 +13089,7 @@ CAG33136.        60 YEL 63
 
     def check_reading_psl_35_002(self, fmt):
         """Check parsing psl_35_002.psl or pslx_35_002.pslx."""
-        path = "Blat/%s_35_002.%s" % (fmt, fmt)
+        path = f"Blat/{fmt}_35_002.{fmt}"
         alignments = Align.parse(path, "psl")
         self.assertEqual(alignments.metadata["psLayout version"], "3")
         alignment = next(alignments)


### PR DESCRIPTION
Ran this twice (for percent to format method to f-string):

```
$ pyupgrade --py310-plus BioSQL/*.py Bio/*.py Bio/*/*.py Bio/*/*/*.py Tests/*.py
```

Then reverted the changes still stuck at the format method.

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

See #2510, with this applied:

```
$ flake8 --isolated --select SFS --quiet --statistics BioSQL Bio
...
730   SFS101 String literal formatting using percent operator.
111   SFS102 Bytes literal formatting using percent operator.
19    SFS201 String literal formatting using format method.
1348  SFS301 String literal formatting using f-string.
```