### PR TITLE
Percent to f-strings using flynt v1.0.6

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -245,20 +245,12 @@ class MultipleSeqAlignment:
             if len(record.seq) <= length:
                 return f"{record.seq} {record.id}"
             else:
-                return "%s...%s %s" % (
-                    record.seq[: length - 3],
-                    record.seq[-3:],
-                    record.id,
-                )
+                return f"{record.seq[:length - 3]}...{record.seq[-3:]} {record.id}"
         else:
             if len(record.seq) <= length:
                 return f"{record.seq} {record.id}"
             else:
-                return "%s...%s %s" % (
-                    record.seq[: length - 6],
-                    record.seq[-3:],
-                    record.id,
-                )
+                return f"{record.seq[:length - 6]}...{record.seq[-3:]} {record.id}"
 
     def __str__(self):
         """Return a multi-line string summary of the alignment.
@@ -2874,10 +2866,7 @@ class Alignment:
         <Alignment object (2 rows x 5 columns) at 0x...>
         """
         if self.coordinates is None:
-            return "<%s object at 0x%x>" % (
-                self.__class__.__name__,
-                id(self),
-            )
+            return f"<{self.__class__.__name__} object at 0x{id(self):x}>"
         n, m = self.shape
         return "<%s object (%i rows x %i columns) at 0x%x>" % (
             self.__class__.__name__,
@@ -4343,7 +4332,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
             self.open_gap_score = -12.0
             self.extend_gap_score = -1.0
         else:
-            raise ValueError("Unknown scoring scheme '%s'" % scoring)
+            raise ValueError(f"Unknown scoring scheme '{scoring}'")
         for name, value in kwargs.items():
             setattr(self, name, value)
 
@@ -4407,7 +4396,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
                 # On CPython, __slots__ can be used for this, but currently
                 # __slots__ does not behave the same way on PyPy at least.
                 raise AttributeError(
-                    "'PairwiseAligner' object has no attribute '%s'" % key
+                    f"'PairwiseAligner' object has no attribute '{key}'"
                 )
         else:
             warnings.warn(
@@ -4844,7 +4833,7 @@ def _load(fmt: str) -> types.ModuleType:
     except KeyError:
         pass
     if fmt not in formats:
-        raise ValueError("Unknown file format %s" % fmt)
+        raise ValueError(f"Unknown file format {fmt}")
     module = importlib.import_module(f"Bio.Align.{fmt}")
     _modules[fmt] = module
     return module

--- a/Bio/Align/a2m.py
+++ b/Bio/Align/a2m.py
@@ -98,7 +98,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             elif c == "." or c.islower():
                 state += "I"  # Insertion state
             else:
-                raise Exception("Unexpected letter '%s' in alignment" % c)
+                raise Exception(f"Unexpected letter '{c}' in alignment")
         for line in lines[1:]:
             for c, m in zip(line, state):
                 if m == "D":  # Match/deletion state
@@ -106,7 +106,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 elif m == "I":  # Insertion state
                     assert c == "." or c.islower()
                 else:
-                    raise Exception("Unexpected letter '%s' in alignment" % c)
+                    raise Exception(f"Unexpected letter '{c}' in alignment")
         for i, line in enumerate(lines):
             lines[i] = line.upper().replace(".", "-").encode()
         seqdata, coordinates = Alignment.parse_printed_alignment(lines)

--- a/Bio/Align/bigbed.py
+++ b/Bio/Align/bigbed.py
@@ -134,8 +134,8 @@ class AutoSQLTable(list):
         type_width = max(len(str(field.as_type)) for field in self)
         name_width = max(len(field.name) for field in self) + 1
         lines = []
-        lines.append("table %s\n" % self.name)
-        lines.append('"%s"\n' % self.comment)
+        lines.append(f"table {self.name}\n")
+        lines.append(f'"{self.comment}"\n')
         lines.append("(\n")
         for field in self:
             name = field.name + ";"
@@ -792,7 +792,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             elif field_type in ("float", "char", "string", "lstring"):
                 converter = str
             else:
-                raise Exception("Unknown field type %s" % field_type)
+                raise Exception(f"Unknown field type {field_type}")
             if make_array:
                 item_converter = converter
 
@@ -1066,7 +1066,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 if target.id == chromosome:
                     break
             else:
-                raise ValueError("Failed to find %s in alignments" % chromosome)
+                raise ValueError(f"Failed to find {chromosome} in alignments")
             if start is None:
                 if end is None:
                     start = 0

--- a/Bio/Align/bigmaf.py
+++ b/Bio/Align/bigmaf.py
@@ -250,7 +250,7 @@ class AlignmentIterator(bigbed.AlignmentIterator, maf.AlignmentIterator):
                         annotations["pass"] = value
                     else:
                         raise ValueError(
-                            "Unknown annotation variable '%s'" % key.decode()
+                            f"Unknown annotation variable '{key.decode()}'"
                         )
             elif prefix == b"s":
                 m = re.match(rb"^s\s*\S*\s*\d*\s*\d*\s*[+-]\s*\d*\s*", buffer[i:])

--- a/Bio/Align/bigpsl.py
+++ b/Bio/Align/bigpsl.py
@@ -479,9 +479,7 @@ class AlignmentIterator(bigbed.AlignmentIterator):
         assert rest[dataEnd - 1] == 0
         words = rest[dataStart : dataEnd - 1].decode().split("\t")
         if len(words) != 22:
-            raise ValueError(
-                "Unexpected number of fields (%d, expected 22)" % len(words)
-            )
+            raise ValueError(f"Unexpected number of fields ({len(words)}, expected 22)")
         target_record = self.targets[chromId]
         tSize = int(words[16])
         if len(target_record) != tSize:
@@ -540,7 +538,7 @@ class AlignmentIterator(bigbed.AlignmentIterator):
             query_record.annotations["molecule_type"] = "protein"
             qBlockSizes = tBlockSizes // 3
         else:
-            raise ValueError("Unexpected sequence type '%s'" % seqType)
+            raise ValueError(f"Unexpected sequence type '{seqType}'")
         tStarts += tStart
         qStrand = words[11]
         if qStrand == "-" and strand == "-":

--- a/Bio/Align/clustal.py
+++ b/Bio/Align/clustal.py
@@ -154,7 +154,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 # We expect there to be two fields, there can be an optional
                 # "sequence number" field containing the letter count.
                 if len(fields) < 2 or len(fields) > 3:
-                    raise ValueError("Could not parse line:\n%s" % line)
+                    raise ValueError(f"Could not parse line:\n{line}")
 
                 seqid, aligned_seq = fields[:2]
                 ids.append(seqid)
@@ -170,11 +170,11 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                         count = int(fields[2])
                     except ValueError:
                         raise ValueError(
-                            "Could not parse line, bad sequence count:\n%s" % line
+                            f"Could not parse line, bad sequence count:\n{line}"
                         ) from None
                     if len(aligned_seq) - aligned_seq.count("-") != count:
                         raise ValueError(
-                            "Could not parse line, incorrect sequence count:\n%s" % line
+                            f"Could not parse line, incorrect sequence count:\n{line}"
                         ) from None
             else:
                 # no consensus line
@@ -210,7 +210,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 # We expect there to be two fields, there can be an optional
                 # "sequence number" field containing the letter count.
                 if len(fields) < 2 or len(fields) > 3:
-                    raise ValueError("Could not parse line:\n%s" % line)
+                    raise ValueError(f"Could not parse line:\n{line}")
 
                 assert seqid == fields[0]
                 aligned_seq = fields[1]
@@ -222,11 +222,11 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                         count = int(fields[2])
                     except ValueError:
                         raise ValueError(
-                            "Could not parse line, bad sequence number:\n%s" % line
+                            f"Could not parse line, bad sequence number:\n{line}"
                         ) from None
                     if len(aligned_seqs[i]) - aligned_seqs[i].count("-") != count:
                         raise ValueError(
-                            "Could not parse line, incorrect sequence count:\n%s" % line
+                            f"Could not parse line, incorrect sequence count:\n{line}"
                         ) from None
                 i += 1
                 if i == n:

--- a/Bio/Align/emboss.py
+++ b/Bio/Align/emboss.py
@@ -77,7 +77,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 sequences = None
                 break
             else:
-                raise ValueError("Unexpected line: %s" % line)
+                raise ValueError(f"Unexpected line: {line}")
         for line in stream:
             line = line.rstrip("\r\n")
             if line == "#=======================================":
@@ -137,7 +137,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             elif key == "Shortest_Similarity":
                 annotations[key] = value.strip()
             else:
-                raise ValueError("Failed to parse line '%s'" % line)
+                raise ValueError(f"Failed to parse line '{line}'")
         else:
             return
         if len(identifiers) == 0:

--- a/Bio/Align/exonerate.py
+++ b/Bio/Align/exonerate.py
@@ -59,7 +59,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             self.format_alignment = self._format_alignment_cigar
         else:
             raise ValueError(
-                "argument fmt should be 'vulgar' or 'cigar' (received %s)" % fmt
+                f"argument fmt should be 'vulgar' or 'cigar' (received {fmt})"
             )
 
     def write_header(self, stream, alignments):
@@ -265,7 +265,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
                     else:
                         raise ValueError("Expected target step or query step to be 0")
                 else:
-                    raise ValueError("Unknown operation %s" % operation)
+                    raise ValueError(f"Unknown operation {operation}")
                 words.append(operation)
                 words.append(str(step))
         line = " ".join(words) + "\n"
@@ -408,7 +408,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
                 elif operation == "F":  # Frame shift
                     step = target_step
                 else:
-                    raise ValueError("Unknown operation %s" % operation)
+                    raise ValueError(f"Unknown operation {operation}")
                 words.append(operation)
                 words.append(str(query_step))
                 words.append(str(target_step))
@@ -478,7 +478,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 else:
                     ts += step
             else:
-                raise ValueError("Unknown operation %s in cigar string" % operation)
+                raise ValueError(f"Unknown operation {operation} in cigar string")
             coordinates[0, i + 1] = ts
             coordinates[1, i + 1] = qs
         if target_strand == "+":
@@ -589,7 +589,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             elif operation == "F":  # Frame shift
                 pass
             else:
-                raise ValueError("Unknown operation %s in vulgar string" % operation)
+                raise ValueError(f"Unknown operation {operation} in vulgar string")
             ts += target_step
             qs += query_step
             coordinates[0, i + 1] = ts

--- a/Bio/Align/hhr.py
+++ b/Bio/Align/hhr.py
@@ -48,7 +48,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             elif key == "Command":
                 metadata["Command line"] = value
             else:
-                raise ValueError("Unknown key '%s'" % key)
+                raise ValueError(f"Unknown key '{key}'")
         self.metadata = metadata
         line = stream.readline()
         if not line:
@@ -224,7 +224,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                     target_start = start
                 target_sequence += sequence
             else:
-                raise ValueError("Failed to parse line '%s...'" % line[:30])
+                raise ValueError(f"Failed to parse line '{line[:30]}...'")
         alignment = create_alignment()
         length = self._length
         counter = self._counter

--- a/Bio/Align/interfaces.py
+++ b/Bio/Align/interfaces.py
@@ -254,7 +254,7 @@ class AlignmentWriter(ABC):  # noqa: B024
                 else:
                     stream = target
             else:
-                raise RuntimeError("Unknown mode '%s'" % self.mode)
+                raise RuntimeError(f"Unknown mode '{self.mode}'")
             self._stream = stream
         self._target = target
 

--- a/Bio/Align/maf.py
+++ b/Bio/Align/maf.py
@@ -50,7 +50,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             elif key == "mafDot":
                 if value not in ("on", "off"):
                     raise ValueError(
-                        "mafDot value must be 'on' or 'off' (received '%s')" % value
+                        f"mafDot value must be 'on' or 'off' (received '{value}')"
                     )
             elif key == "visibility":
                 if value not in ("dense", "pack", "full"):
@@ -63,7 +63,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             else:
                 continue
             if " " in value:
-                value = '"%s"' % value
+                value = f'"{value}"'
             stream.write(f" {key}={value}")
         stream.write("\n")
 
@@ -100,7 +100,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             elif key == "Program":
                 key = "program"
             else:
-                raise ValueError("Unexpected key '%s' for header" % key)
+                raise ValueError(f"Unexpected key '{key}' for header")
             stream.write(f" {key}={value}")
         stream.write("\n")
         comments = metadata.get("Comments")
@@ -298,7 +298,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 elif key == "speciesOrder":
                     value = value.split()
                 else:
-                    raise ValueError("Unexpected variable '%s' in track line" % key)
+                    raise ValueError(f"Unexpected variable '{key}' in track line")
                 metadata[key] = value
             line = stream.readline()
         words = line.split()
@@ -313,7 +313,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             elif key == "program":
                 key = "Program"
             else:
-                raise ValueError("Unexpected variable '%s' in header line" % key)
+                raise ValueError(f"Unexpected variable '{key}' in header line")
             metadata[key] = value
         if metadata.get("MAF Version") != "1":
             raise ValueError("MAF version must be 1")
@@ -354,7 +354,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                     raise ValueError("pass value must be positive (found %d)" % value)
                 annotations["pass"] = value
             else:
-                raise ValueError("Unknown annotation variable '%s'" % key)
+                raise ValueError(f"Unknown annotation variable '{key}'")
 
         for line in stream:
             if line.startswith("#"):

--- a/Bio/Align/mauve.py
+++ b/Bio/Align/mauve.py
@@ -157,7 +157,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                     if key.endswith(suffix):
                         break
                 else:
-                    raise ValueError("Unexpected keyword '%s'" % key)
+                    raise ValueError(f"Unexpected keyword '{key}'")
                 if suffix == "Entry":
                     value = int(value) - 1  # Switch to 0-based counting
                 seq_num = int(key[len(prefix) : -len(suffix)])
@@ -227,7 +227,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                     elif strand == "-":
                         coordinates[index, :] = len(seq) - coordinates[index, :]
                     else:
-                        raise ValueError("Unexpected strand '%s'" % strand)
+                        raise ValueError(f"Unexpected strand '{strand}'")
                     coordinates[index] += start
                     if start == 0:
                         seq = Seq(seq)

--- a/Bio/Align/msf.py
+++ b/Bio/Align/msf.py
@@ -191,7 +191,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             seq = "".join(words[1:])
             length = remaining[index] - (len(seq) - seq.count("-"))
             if length < 0:
-                raise ValueError("Received longer sequence than expected for %s" % name)
+                raise ValueError(f"Received longer sequence than expected for {name}")
             seqs[index] += seq
             remaining[index] = length
             if all(length == 0 for length in remaining):

--- a/Bio/Align/nexus.py
+++ b/Bio/Align/nexus.py
@@ -97,7 +97,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             raise ValueError("Non-empty sequences are required")
         datatype = self._classify_mol_type_for_nexus(alignment)
         minimal_record = (
-            "begin data; dimensions ntax=0 nchar=0; format datatype=%s; end;" % datatype
+            f"begin data; dimensions ntax=0 nchar=0; format datatype={datatype}; end;"
         )
         n = Nexus.Nexus(minimal_record)
         for record, aligned_sequence in zip(alignment.sequences, alignment):

--- a/Bio/Align/phylip.py
+++ b/Bio/Align/phylip.py
@@ -88,9 +88,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 return
             except ValueError:
                 pass
-        raise ValueError(
-            "Expected two integers in the first line, received '%s'" % line
-        )
+        raise ValueError(f"Expected two integers in the first line, received '{line}'")
 
     def _parse_interleaved_first_block(self, lines, seqs, names):
         for line in lines:

--- a/Bio/Align/psl.py
+++ b/Bio/Align/psl.py
@@ -322,7 +322,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         if line.startswith("psLayout "):
             words = line.split()
             if words[1] != "version":
-                raise ValueError("Unexpected word '%s' in header line" % words[1])
+                raise ValueError(f"Unexpected word '{words[1]}' in header line")
             self.metadata = {"psLayout version": words[2]}
             line = stream.readline()
             line = stream.readline()
@@ -348,7 +348,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             elif len(words) == 21:
                 pslx = False
             else:
-                raise ValueError("line has %d columns; expected 21 or 23" % len(words))
+                raise ValueError(f"line has {len(words)} columns; expected 21 or 23")
             strand = words[8]
             qName = words[9]
             qSize = int(words[10])

--- a/Bio/Align/sam.py
+++ b/Bio/Align/sam.py
@@ -65,7 +65,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
         values = metadata.get("HD")
         if values is not None:
             # if HD is present, then VN is required and must come first
-            fields = ["@HD", "VN:%s" % values["VN"]]
+            fields = ["@HD", f"VN:{values['VN']}"]
             for key, value in values.items():
                 if key == "VN":
                     continue
@@ -74,25 +74,25 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             stream.write(line)
         for record in targets:
             fields = ["@SQ"]
-            fields.append("SN:%s" % record.id)
+            fields.append(f"SN:{record.id}")
             length = len(record.seq)
             fields.append("LN:%d" % length)
             for key, value in record.annotations.items():
                 if key == "alternate_locus":
-                    fields.append("AH:%s" % value)
+                    fields.append(f"AH:{value}")
                 elif key == "names":
-                    fields.append("AN:%s" % ",".join(value))
+                    fields.append(f"AN:{','.join(value)}")
                 elif key == "assembly":
-                    fields.append("AS:%s" % value)
+                    fields.append(f"AS:{value}")
                 elif key == "MD5":
-                    fields.append("M5:%s" % value)
+                    fields.append(f"M5:{value}")
                 elif key == "species":
-                    fields.append("SP:%s" % value)
+                    fields.append(f"SP:{value}")
                 elif key == "topology":
                     assert value in ("linear", "circular")
-                    fields.append("PP:%s" % value)
+                    fields.append(f"PP:{value}")
                 elif key == "URI":
-                    fields.append("UR:%s" % value)
+                    fields.append(f"UR:{value}")
                 else:
                     fields.append(f"{key[:2]}:{value}")
             try:
@@ -101,7 +101,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
                 pass
             else:
                 if description != "<unknown description>":
-                    fields.append("DS:%s" % description)
+                    fields.append(f"DS:{description}")
             line = "\t".join(fields) + "\n"
             stream.write(line)
         for tag, rows in metadata.items():
@@ -323,14 +323,14 @@ class AlignmentWriter(interfaces.AlignmentWriter):
                         qStart = qEnd
                 if number:
                     md += str(number)
-            field = "MD:Z:%s" % md
+            field = f"MD:Z:{md}"
             fields.append(field)
         try:
             score = alignment.score
         except AttributeError:
             pass
         else:
-            field = "AS:i:%.0f" % score
+            field = f"AS:i:{score:.0f}"
             fields.append(field)
         try:
             annotations = alignment.annotations
@@ -470,7 +470,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             fields = line.split()
             if len(fields) < 11:
                 raise ValueError(
-                    "line has %d columns; expected at least 11" % len(fields)
+                    f"line has {len(fields)} columns; expected at least 11"
                 )
             qname = fields[0]
             flag = int(fields[1])

--- a/Bio/Align/stockholm.py
+++ b/Bio/Align/stockholm.py
@@ -523,7 +523,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
         key = "comment"
         value = alignment_annotations.get(key)
         if value is not None:
-            prefix = "#=GF %s   " % self.gf_mapping[key]
+            prefix = f"#=GF {self.gf_mapping[key]}   "
             lines.append(AlignmentWriter._format_long_text(prefix, value))
         for key in alignment_annotations:
             if key in self.gf_mapping:
@@ -534,9 +534,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
                 continue
             if key == "database references":
                 continue
-            raise ValueError(
-                "Unknown annotation %s found in alignment.annotations" % key
-            )
+            raise ValueError(f"Unknown annotation {key} found in alignment.annotations")
         lines.append("#=GF SQ   %i\n" % rows)
         # #=GS Above the alignment or just below the corresponding sequence;
         #    record.annotations

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -90,7 +90,7 @@ class Array(_arraycore.Array):
                 if dims is None:
                     dims = 1
                 elif dims not in (1, 2):
-                    raise ValueError("dims should be 1 or 2 (found %s)" % dims)
+                    raise ValueError(f"dims should be 1 or 2 (found {dims})")
                 shape = (n,) * dims
             else:
                 if dims is None:
@@ -139,14 +139,14 @@ class Array(_arraycore.Array):
                     try:
                         index = self.alphabet.index(index)
                     except ValueError:
-                        raise IndexError("'%s'" % index) from None
+                        raise IndexError(f"'{index}'") from None
                 indices.append(index)
             key = tuple(indices)
         elif isinstance(key, str):
             try:
                 key = self.alphabet.index(key)
             except ValueError:
-                raise IndexError("'%s'" % key) from None
+                raise IndexError(f"'{key}'") from None
         return key
 
     def __getitem__(self, key):
@@ -279,7 +279,7 @@ class Array(_arraycore.Array):
                     value = np.ndarray.__getitem__(self, (i1, i2))
                     yield key, value
         else:
-            raise RuntimeError("array has unexpected shape %s" % self.shape)
+            raise RuntimeError(f"array has unexpected shape {self.shape}")
 
     def keys(self):
         """Return a tuple with the keys associated with the array."""
@@ -290,7 +290,7 @@ class Array(_arraycore.Array):
         elif dims == 2:
             return tuple((c1, c2) for c2 in alphabet for c1 in alphabet)
         else:
-            raise RuntimeError("array has unexpected shape %s" % self.shape)
+            raise RuntimeError(f"array has unexpected shape {self.shape}")
 
     def values(self):
         """Return a tuple with the values stored in the array."""
@@ -306,7 +306,7 @@ class Array(_arraycore.Array):
                 for i1 in range(n1)
             )
         else:
-            raise RuntimeError("array has unexpected shape %s" % self.shape)
+            raise RuntimeError(f"array has unexpected shape {self.shape}")
 
     def update(self, E=None, **F):
         """Update the array from dict/iterable E and F."""
@@ -351,7 +351,7 @@ class Array(_arraycore.Array):
             pass
         else:
             for line in header:
-                line = "#  %s\n" % line
+                line = f"#  {line}\n"
                 lines.append(line)
         maxwidth = 0
         for i, key in enumerate(alphabet):
@@ -380,7 +380,7 @@ class Array(_arraycore.Array):
             pass
         else:
             for line in header:
-                line = "#  %s\n" % line
+                line = f"#  {line}\n"
                 lines.append(line)
         keywidth = max(len(c) for c in alphabet)
         keyfmt = "%" + str(keywidth) + "s"
@@ -442,7 +442,7 @@ class Array(_arraycore.Array):
         alphabet = self.alphabet
         if isinstance(alphabet, str):
             assert text.endswith(")")
-            text = text[:-1] + ",\n         alphabet='%s')" % self.alphabet
+            text = text[:-1] + f",\n         alphabet='{self.alphabet}')"
         return text
 
 

--- a/Bio/Align/tabular.py
+++ b/Bio/Align/tabular.py
@@ -248,7 +248,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
             elif field == "sbjct frame":
                 target_annotations["frame"] = column
             else:
-                raise ValueError("Unexpected field '%s'" % field)
+                raise ValueError(f"Unexpected field '{field}'")
         program = self.metadata["Program"]
         if coordinates is None:
             if alignment_length is not None:
@@ -297,7 +297,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
                 query_annotations["end"] = query_end
                 query_seq = Seq(query_sequence)
             else:
-                raise Exception("Unknown program %s" % program)
+                raise Exception(f"Unknown program {program}")
         query = SeqRecord(query_seq, id=query_id)
         if self._query_description is not None:
             query.description = self._query_description

--- a/Bio/AlignIO/MafIO.py
+++ b/Bio/AlignIO/MafIO.py
@@ -72,7 +72,7 @@ class MafWriter(SequentialAlignmentWriter):
         fields = [
             "s",
             # In the MAF file format, spaces are not allowed in the id
-            "%-40s" % record.id.replace(" ", "_"),
+            f"{record.id.replace(' ', '_'):40}",
             "%15s" % record.annotations.get("start", 0),
             "%5s"
             % record.annotations.get("size", len(str(record.seq).replace("-", ""))),

--- a/Bio/AlignIO/PhylipIO.py
+++ b/Bio/AlignIO/PhylipIO.py
@@ -114,7 +114,7 @@ class PhylipWriter(SequentialAlignmentWriter):
         # defined in the PHYLIP documentation, simply "These are in free
         # format, separated by blanks".  We'll use spaces to keep EMBOSS
         # happy.
-        handle.write(" %i %s\n" % (len(alignment), length_of_seqs))
+        handle.write(f" {len(alignment)} {length_of_seqs}\n")
         block = 0
         while True:
             for name, sequence in zip(names, seqs):
@@ -338,7 +338,7 @@ class SequentialPhylipWriter(SequentialAlignmentWriter):
         # defined in the PHYLIP documentation, simply "These are in free
         # format, separated by blanks".  We'll use spaces to keep EMBOSS
         # happy.
-        handle.write(" %i %s\n" % (len(alignment), length_of_seqs))
+        handle.write(f" {len(alignment)} {length_of_seqs}\n")
         for name, record in zip(names, alignment):
             sequence = str(record.seq)
             if "." in sequence:

--- a/Bio/Blast/__init__.py
+++ b/Bio/Blast/__init__.py
@@ -257,7 +257,7 @@ class Hit(Alignments):
 
         # set query id line
         query = self[0].query
-        qid_line = "Query: %s" % query.id
+        qid_line = f"Query: {query.id}"
         lines.append(qid_line)
         indent = " " * 7
         description_lines = textwrap.wrap(
@@ -270,7 +270,7 @@ class Hit(Alignments):
 
         # set hit id line
         target = self.target
-        hid_line = "  Hit: %s (length=%i)" % (target.id, len(target))
+        hid_line = f"  Hit: {target.id} (length={len(target)})"
         lines.append(hid_line)
         description_lines = textwrap.wrap(
             target.description,
@@ -282,8 +282,7 @@ class Hit(Alignments):
 
         # set hsp line and table
         lines.append(
-            " HSPs: %s  %s  %s  %s  %s  %s"
-            % ("-" * 4, "-" * 8, "-" * 9, "-" * 6, "-" * 15, "-" * 21)
+            f" HSPs: {'-' * 4}  {'-' * 8}  {'-' * 9}  {'-' * 6}  {'-' * 15}  {'-' * 21}"
         )
         pattern = "%11s  %8s  %9s  %6s  %15s  %21s"
         lines.append(
@@ -472,7 +471,7 @@ class Record(list):
             lines.append(f"     db: {db}")
         if self.query is not None:
             # self.query may be None with legacy Blast if there are no hits
-            lines.append("  Query: %s (length=%d)" % (self.query.id, len(self.query)))
+            lines.append(f"  Query: {self.query.id} (length={len(self.query)})")
             indent = " " * 9
             description_lines = textwrap.wrap(
                 self.query.description,
@@ -484,19 +483,19 @@ class Record(list):
         if len(self) == 0:
             lines.append("   Hits: No hits found")
         else:
-            lines.append("   Hits: %s  %s  %s" % ("-" * 4, "-" * 5, "-" * 58))
+            lines.append(f"   Hits: {'-' * 4}  {'-' * 5}  {'-' * 58}")
             pattern = "%13s  %5s  %s"
             lines.append(pattern % ("#", "# HSP", "ID + description"))
             lines.append(pattern % ("-" * 4, "-" * 5, "-" * 58))
             for idx, hit in enumerate(self):
                 n = len(hit)  # Number of HSPs
                 if idx < 30:
-                    hid_line = "%s  %s" % (hit.target.id, hit.target.description)
+                    hid_line = f"{hit.target.id}  {hit.target.description}"
                     if len(hid_line) > 58:
                         hid_line = hid_line[:55] + "..."
                     lines.append(pattern % (idx, len(hit), hid_line))
                 elif idx > len(self) - 4:
-                    hid_line = "%s  %s" % (hit.target.id, hit.target.description)
+                    hid_line = f"{hit.target.id}  {hit.target.description}"
                     if len(hid_line) > 58:
                         hid_line = hid_line[:55] + "..."
                     lines.append(pattern % (idx, len(hit), hid_line))
@@ -872,12 +871,8 @@ class Records(UserList):
         return f"<Bio.Blast.Records source={self.source!r} program={self.program!r} version={self.version!r} db={self.db!r}>"
 
     def __str__(self):
-        text = """\
-Program: %s
-     db: %s""" % (
-            self.version,
-            self.db,
-        )
+        text = f"""Program: {self.version}
+     db: {self.db}"""
         records = self[:]  # to ensure that the records are read in
         for record in self._records:
             text += "\n\n" + str(record)

--- a/Bio/Blast/_parser.py
+++ b/Bio/Blast/_parser.py
@@ -208,7 +208,7 @@ class XMLHandler:
         uri, localname = name.split(" ")
         assert uri == "http://www.ncbi.nlm.nih.gov"
         assert localname in ("BlastXML2", "BlastOutput2")
-        key = "%s schemaLocation" % XMLHandler.schema_namespace
+        key = f"{XMLHandler.schema_namespace} schemaLocation"
         domain, url = attributes[key].split()
         assert domain == "http://www.ncbi.nlm.nih.gov"
         if XMLHandler._schema_methods is None:
@@ -1047,7 +1047,7 @@ class XMLHandler:
                 target.features.append(feature)
                 target.seq = Seq(target_seq_data, target_length)
             else:
-                raise RuntimeError("Unexpected program name '%s'" % program)
+                raise RuntimeError(f"Unexpected program name '{program}'")
         query.seq = Seq(query_seq_data, query_length)
         sequences = [target, query]
         alignment = HSP(sequences, coordinates)
@@ -1191,7 +1191,7 @@ class XMLHandler:
         """
         method = self._end_methods.get(name)
         if method is None:
-            raise ValueError("Failed to find method for %s" % name)
+            raise ValueError(f"Failed to find method for {name}")
         method(self, name)
 
     def _characterDataHandler(self, characters):

--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -69,7 +69,7 @@ class NoneElement:
             attributes = self.attributes
         except AttributeError:
             return "NoneElement"
-        return "NoneElement(attributes=%r)" % attributes
+        return f"NoneElement(attributes={attributes!r})"
 
     def __eq__(self, other):
         if isinstance(other, NoneElement):
@@ -147,7 +147,7 @@ class ListElement(list):
         """Append an element to the list, checking tags."""
         key = value.key
         if self.allowed_tags is not None and key not in self.allowed_tags:
-            raise ValueError("Unexpected item '%s' in list" % key)
+            raise ValueError(f"Unexpected item '{key}' in list")
         del value.key
         self.append(value)
 
@@ -182,7 +182,7 @@ class DictionaryElement(dict):
         key = value.key
         tag = value.tag
         if self.allowed_tags is not None and tag not in self.allowed_tags:
-            raise ValueError("Unexpected item '%s' in dictionary" % key)
+            raise ValueError(f"Unexpected item '{key}' in dictionary")
         del value.key
         if self.repeated_tags and key in self.repeated_tags:
             self[key].append(value)
@@ -221,7 +221,7 @@ class OrderedListElement(list):
         """Append an element to the list, checking tags."""
         key = value.key
         if self.allowed_tags is not None and key not in self.allowed_tags:
-            raise ValueError("Unexpected item '%s' in list" % key)
+            raise ValueError(f"Unexpected item '{key}' in list")
         if key == self.first_tag:
             self.append([])
         self[-1].append(value)
@@ -564,7 +564,7 @@ class DataHandler(metaclass=DataHandlerMeta):
 
     def schemaHandler(self, name, attrs):
         """Process the XML schema (before processing the element)."""
-        key = "%s noNamespaceSchemaLocation" % self.schema_namespace
+        key = f"{self.schema_namespace} noNamespaceSchemaLocation"
         schema = attrs[key]
         self.verify_security(schema)
         handle = self.open_xsd_file(os.path.basename(schema))
@@ -660,7 +660,7 @@ class DataHandler(metaclass=DataHandlerMeta):
                 self.parser.EndElementHandler = self.endStringElementHandler
                 self.parser.CharacterDataHandler = self.characterDataHandler
             else:
-                raise ValueError("Unknown item type %s" % name)
+                raise ValueError(f"Unknown item type {name}")
         elif tag in self.errors:
             self.parser.EndElementHandler = self.endErrorElementHandler
             self.parser.CharacterDataHandler = self.characterDataHandler
@@ -729,7 +729,7 @@ class DataHandler(metaclass=DataHandlerMeta):
             key = name
         # self.allowed_tags is ignored for now. Anyway we know what to do
         # with this tag.
-        tag = "<%s" % name
+        tag = f"<{name}"
         for key, value in attrs.items():
             tag += f' {key}="{value}"'
         tag += ">"
@@ -783,7 +783,7 @@ class DataHandler(metaclass=DataHandlerMeta):
                 uri, name = name.split()
             except ValueError:
                 pass
-        tag = "</%s>" % name
+        tag = f"</{name}>"
         self.data.append(tag)
 
     def endSkipElementHandler(self, name):
@@ -1123,7 +1123,7 @@ class DataHandler(metaclass=DataHandlerMeta):
             # urls always have a forward slash, don't use os.path.join
             url = source.rstrip("/") + "/" + systemId
         else:
-            raise ValueError("Unexpected URL scheme %r" % urlinfo.scheme)
+            raise ValueError(f"Unexpected URL scheme {urlinfo.scheme!r}")
 
         # NOTE: This trusts any external references from a trusted parent,
         #       even if these external references go to unknown hosts,

--- a/Bio/ExPASy/Enzyme.py
+++ b/Bio/ExPASy/Enzyme.py
@@ -105,7 +105,7 @@ class Record(dict):
             "CF: " + self["CF"],
             "CC: " + repr(self["CC"]),
             "PR: " + repr(self["PR"]),
-            "DR: %d Records" % len(self["DR"]),
+            f"DR: {len(self['DR'])} Records",
         ]
         return "\n".join(output)
 

--- a/Bio/ExPASy/__init__.py
+++ b/Bio/ExPASy/__init__.py
@@ -89,7 +89,7 @@ def get_prosite_raw(id, cgi=None):
         handle = _open(f"https://prosite.expasy.org/{id}.txt")
     except HTTPError as exception:
         if exception.code == 404:
-            raise ValueError("Failed to find entry '%s' on ExPASy" % id) from None
+            raise ValueError(f"Failed to find entry '{id}' on ExPASy") from None
         else:
             raise
     # This has happened historically, redirected to main page:

--- a/Bio/GenBank/Record.py
+++ b/Bio/GenBank/Record.py
@@ -246,7 +246,7 @@ class Record:
         """Provide the output string for the LOCUS line (PRIVATE)."""
         output = "LOCUS"
         output += " " * 7  # 6-12 spaces
-        output += "%-9s" % self.locus
+        output += f"{self.locus:9}"
         output += " "  # 22 space
         output += "%7s" % self.size
         if "PROTEIN" in self.residue_type:
@@ -264,7 +264,7 @@ class Record:
             output += " " * 10  # spaces for circular
         else:
             output += " " * 3  # spaces for stuff like ss-
-            output += "%-4s" % self.residue_type
+            output += f"{self.residue_type:4}"
             output += " " * 10  # spaces for circular
 
         output += " " * 2
@@ -541,7 +541,7 @@ class Reference:
         output = Record.BASE_FORMAT % "REFERENCE"
         if self.number:
             if self.bases:
-                output += "%-3s" % self.number
+                output += f"{self.number:3}"
                 output += f"{self.bases}"
             else:
                 output += f"{self.number}"

--- a/Bio/Graphics/GenomeDiagram/_Diagram.py
+++ b/Bio/Graphics/GenomeDiagram/_Diagram.py
@@ -404,7 +404,7 @@ class Diagram:
     def __str__(self):
         """Return a formatted string describing the diagram."""
         outstr = [f"\n<{self.__class__}: {self.name}>"]
-        outstr.append("%d tracks" % len(self.tracks))
+        outstr.append(f"{len(self.tracks)} tracks")
         for level in self.get_levels():
             outstr.append("Track %d: %s\n" % (level, self.tracks[level]))
         outstr = "\n".join(outstr)

--- a/Bio/Graphics/GenomeDiagram/_FeatureSet.py
+++ b/Bio/Graphics/GenomeDiagram/_FeatureSet.py
@@ -186,7 +186,7 @@ class FeatureSet:
             return f"{self}"
         else:  # Long account desired
             outstr = [f"\n<{self.__class__}: {self.name}>"]
-            outstr.append("%d features" % len(self.features))
+            outstr.append(f"{len(self.features)} features")
             for key in self.features:
                 outstr.append(f"feature: {self.features[key]}")
             return "\n".join(outstr)
@@ -201,7 +201,5 @@ class FeatureSet:
 
     def __str__(self):
         """Return a formatted string with information about the feature set."""
-        outstr = [
-            "\n<%s: %s %d features>" % (self.__class__, self.name, len(self.features))
-        ]
+        outstr = [f"\n<{self.__class__}: {self.name} {len(self.features)} features>"]
         return "\n".join(outstr)

--- a/Bio/Graphics/GenomeDiagram/_Graph.py
+++ b/Bio/Graphics/GenomeDiagram/_Graph.py
@@ -180,7 +180,7 @@ class GraphData:
     def __str__(self):
         """Return a string describing the graph data."""
         outstr = [f"\nGraphData: {self.name}, ID: {self.id}"]
-        outstr.append("Number of points: %d" % len(self.data))
+        outstr.append(f"Number of points: {len(self.data)}")
         outstr.append(f"Mean data value: {self.mean()}")
         outstr.append(f"Sample SD: {self.stdev():.3f}")
         outstr.append(

--- a/Bio/Graphics/GenomeDiagram/_GraphSet.py
+++ b/Bio/Graphics/GenomeDiagram/_GraphSet.py
@@ -150,7 +150,7 @@ class GraphSet:
             return f"{self}"
         else:
             outstr = [f"\n<{self.__class__}: {self.name}>"]
-            outstr.append("%d graphs" % len(self._graphs))
+            outstr.append(f"{len(self._graphs)} graphs")
             for key in self._graphs:
                 outstr.append(f"{self._graphs[key]}")
             return "\n".join(outstr)
@@ -166,6 +166,6 @@ class GraphSet:
     def __str__(self):
         """Return a formatted string with information about the feature set."""
         outstr = [f"\n<{self.__class__}: {self.name}>"]
-        outstr.append("%d graphs" % len(self._graphs))
+        outstr.append(f"{len(self._graphs)} graphs")
         outstr = "\n".join(outstr)
         return outstr

--- a/Bio/Graphics/GenomeDiagram/_Track.py
+++ b/Bio/Graphics/GenomeDiagram/_Track.py
@@ -268,7 +268,7 @@ class Track:
             return f"{self}"  # Use __str__ method instead
         else:  # Return the long description
             outstr = [f"\n<{self.__class__}: {self.name}>"]
-            outstr.append("%d sets" % len(self._sets))
+            outstr.append(f"{len(self._sets)} sets")
             for key in self._sets:
                 outstr.append(f"set: {self._sets[key]}")
             return "\n".join(outstr)
@@ -280,5 +280,5 @@ class Track:
     def __str__(self):
         """Return a formatted string with information about the Track."""
         outstr = [f"\n<{self.__class__}: {self.name}>"]
-        outstr.append("%d sets" % len(self._sets))
+        outstr.append(f"{len(self._sets)} sets")
         return "\n".join(outstr)

--- a/Bio/KEGG/KGML/KGML_pathway.py
+++ b/Bio/KEGG/KGML/KGML_pathway.py
@@ -149,13 +149,13 @@ class Pathway:
             f"KEGG ID: {self.name}",
             f"Image file: {self.image}",
             f"Organism: {self.org}",
-            "Entries: %d" % len(self.entries),
+            f"Entries: {len(self.entries)}",
             "Entry types:",
         ]
         for t in ["ortholog", "enzyme", "reaction", "gene", "group", "compound", "map"]:
             etype = [e for e in self.entries.values() if e.type == t]
             if len(etype):
-                outstr.append("\t%s: %d" % (t, len(etype)))
+                outstr.append(f"\t{t}: {len(etype)}")
         return "\n".join(outstr) + "\n"
 
     # Assert correct formatting of the pathway name, and other attributes
@@ -300,7 +300,7 @@ class Entry:
             f"Type: {self.type}",
             f"Components: {self.components}",
             f"Reactions: {self.reaction}",
-            "Graphics elements: %d %s" % (len(self.graphics), self.graphics),
+            f"Graphics elements: {len(self.graphics)} {self.graphics}",
         ]
         return "\n".join(outstr) + "\n"
 
@@ -690,8 +690,7 @@ class Reaction:
         if self._pathway is not None:
             if int(substrate_id) not in self._pathway.entries:
                 raise ValueError(
-                    "Couldn't add substrate, no node ID %d in Pathway"
-                    % int(substrate_id)
+                    f"Couldn't add substrate, no node ID {int(substrate_id)} in Pathway"
                 )
         self._substrates.add(substrate_id)
 
@@ -803,7 +802,7 @@ class Relation:
     def __str__(self):
         """Return a useful human-readable string."""
         outstr = [
-            "Relation (subtypes: %d):" % len(self.subtypes),
+            f"Relation (subtypes: {len(self.subtypes)}):",
             "Entry1:",
             str(self.entry1),
             "Entry2:",

--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -231,7 +231,7 @@ class StepMatrix:
 
     def smprint(self, name="your_name_here"):
         """Print a stepmatrix."""
-        matrix = "usertype %s stepmatrix=%d\n" % (name, len(self.symbols))
+        matrix = f"usertype {name} stepmatrix={len(self.symbols)}\n"
         matrix += f"        {'        '.join(self.symbols)}\n"
         for x in self.symbols:
             matrix += "[%s]".ljust(8) % x

--- a/Bio/PDB/MMCIFParser.py
+++ b/Bio/PDB/MMCIFParser.py
@@ -349,7 +349,7 @@ class MMCIFParser:
         This method catches an exception that occurs in the StructureBuilder
         object (if PERMISSIVE), or raises it again.
         """
-        message = "%s" % (message)
+        message = f"{message}"
         if self.PERMISSIVE:
             # just print a warning - some residues/atoms may be missing
             warnings.warn(

--- a/Bio/PDB/PICIO.py
+++ b/Bio/PDB/PICIO.py
@@ -1094,9 +1094,7 @@ def write_PIC(
                 dd = pdb_date(entity.header.get("deposition_date", None))
                 if hdr:
                     fp.write(
-                        ("HEADER    {:40}{:8}   {:4}\n").format(
-                            hdr.upper(), (dd or ""), (pdbid or "")
-                        )
+                        f"HEADER    {hdr.upper():40}{dd or '':8}   {pdbid or '':4}\n"
                     )
                 name = entity.header.get("name", None)
                 if name:

--- a/Bio/PDB/ic_rebuild.py
+++ b/Bio/PDB/ic_rebuild.py
@@ -489,9 +489,7 @@ def write_PDB(
 
                 if hdr:
                     fp.write(
-                        ("HEADER    {:40}{:8}   {:4}\n").format(
-                            hdr.upper(), (dd or ""), (pdbid or "")
-                        )
+                        f"HEADER    {hdr.upper():40}{dd or '':8}   {pdbid or '':4}\n"
                     )
                 name = entity.header.get("name", None)
                 if name:

--- a/Bio/Restriction/Restriction.py
+++ b/Bio/Restriction/Restriction.py
@@ -1880,8 +1880,7 @@ class NotDefined(AbstractCut):
         #
         # return False
         raise ValueError(
-            "%s.mod2(%s), %s : NotDefined. pas glop pas glop!"
-            % (str(cls), str(other), str(cls))
+            f"{cls!s}.mod2({other!s}), {cls!s} : NotDefined. pas glop pas glop!"
         )
 
     @classmethod

--- a/Bio/SearchIO/BlastIO/blast_tab.py
+++ b/Bio/SearchIO/BlastIO/blast_tab.py
@@ -330,9 +330,7 @@ class BlastTabParser:
         fields = self.fields
         columns = self.line.strip().split("\t")
         if len(fields) != len(columns):
-            raise ValueError(
-                "Expected %i columns, found: %i" % (len(fields), len(columns))
-            )
+            raise ValueError(f"Expected {len(fields)} columns, found: {len(columns)}")
 
         qresult, hit, hsp, frag = {}, {}, {}, {}
         for idx, value in enumerate(columns):
@@ -446,10 +444,10 @@ class BlastTabParser:
                 for seq_type in ("hit", "query"):
                     # try to set hit and query frame
                     frame = self._get_frag_frame(frag, seq_type, prev["frag"])
-                    setattr(frag, "%s_frame" % seq_type, frame)
+                    setattr(frag, f"{seq_type}_frame", frame)
                     # try to set hit and query strand
                     strand = self._get_frag_strand(frag, seq_type, prev["frag"])
-                    setattr(frag, "%s_strand" % seq_type, strand)
+                    setattr(frag, f"{seq_type}_strand", strand)
 
                 hsp = HSP([frag])
                 for attr, value in prev["hsp"].items():
@@ -489,7 +487,7 @@ class BlastTabParser:
         and its parsed dictionary values.
         """
         assert seq_type in ("query", "hit")
-        frame = getattr(frag, "%s_frame" % seq_type, None)
+        frame = getattr(frag, f"{seq_type}_frame", None)
         if frame is not None:
             return frame
         else:
@@ -509,14 +507,14 @@ class BlastTabParser:
         # queries / hits, since we can't detect the blast flavors
         # from the columns alone.
         assert seq_type in ("query", "hit")
-        strand = getattr(frag, "%s_strand" % seq_type, None)
+        strand = getattr(frag, f"{seq_type}_strand", None)
         if strand is not None:
             return strand
         else:
             # using parsedict instead of the fragment object since
             # we need the unadjusted coordinated values
-            start = parsedict.get("%s_start" % seq_type)
-            end = parsedict.get("%s_end" % seq_type)
+            start = parsedict.get(f"{seq_type}_start")
+            end = parsedict.get(f"{seq_type}_end")
             if start is not None and end is not None:
                 return 1 if start <= end else -1
             # else implicit None return
@@ -768,7 +766,7 @@ class BlastTabWriter:
         # determine sequence type to operate on based on field's first letter
         seq_type = "query" if field.startswith("q") else "hit"
 
-        strand = getattr(hsp, "%s_strand" % seq_type, None)
+        strand = getattr(hsp, f"{seq_type}_strand", None)
         if strand is None:
             raise ValueError(
                 "Required attribute %r not found." % ("%s_strand" % (seq_type))
@@ -776,9 +774,9 @@ class BlastTabWriter:
         # switch start <--> end coordinates if strand is -1
         if strand < 0:
             if field.endswith("start"):
-                value = getattr(hsp, "%s_end" % seq_type)
+                value = getattr(hsp, f"{seq_type}_end")
             elif field.endswith("end"):
-                value = getattr(hsp, "%s_start" % seq_type) + 1
+                value = getattr(hsp, f"{seq_type}_start") + 1
         elif field.endswith("start"):
             # adjust start coordinate for positive strand
             value += 1
@@ -797,36 +795,36 @@ class BlastTabWriter:
             if value < 1.0e-180:
                 value = "0.0"
             elif value < 1.0e-99:
-                value = "%2.0e" % value
+                value = f"{value:2.0e}"
             elif value < 0.0009:
-                value = "%3.0e" % value
+                value = f"{value:3.0e}"
             elif value < 0.1:
-                value = "%4.3f" % value
+                value = f"{value:4.3f}"
             elif value < 1.0:
-                value = "%3.2f" % value
+                value = f"{value:3.2f}"
             elif value < 10.0:
-                value = "%2.1f" % value
+                value = f"{value:2.1f}"
             else:
-                value = "%5.0f" % value
+                value = f"{value:5.0f}"
 
         # pident and ppos formatting
         elif field in ("pident", "ppos"):
-            value = "%.2f" % value
+            value = f"{value:.2f}"
 
         # evalue formatting, adapted from BLAST+ source:
         # src/objtools/align_format/align_format_util.cpp#L723
         elif field == "bitscore":
             if value > 9999:
-                value = "%4.3e" % value
+                value = f"{value:4.3e}"
             elif value > 99.9:
                 value = "%4.0d" % value
             else:
-                value = "%4.1f" % value
+                value = f"{value:4.1f}"
 
         # coverages have no comma (using floats still ~ a more proper
         # representation)
         elif field in ("qcovhsp", "qcovs"):
-            value = "%.0f" % value
+            value = f"{value:.0f}"
 
         # list into '<>'-delimited string
         elif field == "salltitles":
@@ -862,28 +860,28 @@ class BlastTabWriter:
         try:
             version = qres.version
         except AttributeError:
-            program_line = "# %s" % program
+            program_line = f"# {program}"
         else:
             program_line = f"# {program} {version}"
         comments.append(program_line)
         # description may or may not be None
         if qres.description is None:
-            comments.append("# Query: %s" % qres.id)
+            comments.append(f"# Query: {qres.id}")
         else:
             comments.append(f"# Query: {qres.id} {qres.description}")
         # try appending RID line, if present
         try:
-            comments.append("# RID: %s" % qres.rid)
+            comments.append(f"# RID: {qres.rid}")
         except AttributeError:
             pass
-        comments.append("# Database: %s" % qres.target)
+        comments.append(f"# Database: {qres.target}")
         # qresults without hits don't show the Fields comment
         if qres:
             comments.append(
                 "# Fields: %s"
                 % ", ".join(inv_field_map[field] for field in self.fields)
             )
-        comments.append("# %i hits found" % len(qres))
+        comments.append(f"# {len(qres)} hits found")
 
         return "\n".join(comments) + "\n"
 

--- a/Bio/SearchIO/BlastIO/blast_xml.py
+++ b/Bio/SearchIO/BlastIO/blast_xml.py
@@ -606,8 +606,8 @@ class BlastXmlIndexer(SearchIndexer):
                     block.append(line)
                 assert line.rstrip().endswith(qend_mark), line
                 block = b"".join(block)
-            assert block.count(qstart_mark) == 1, "XML without line breaks? %r" % block
-            assert block.count(qend_mark) == 1, "XML without line breaks? %r" % block
+            assert block.count(qstart_mark) == 1, f"XML without line breaks? {block!r}"
+            assert block.count(qend_mark) == 1, f"XML without line breaks? {block!r}"
             # Now we have a full <Iteration>...</Iteration> block, find the ID
             regx = re.search(re_desc, block)
             try:

--- a/Bio/SearchIO/ExonerateIO/exonerate_text.py
+++ b/Bio/SearchIO/ExonerateIO/exonerate_text.py
@@ -246,7 +246,7 @@ def _comp_intron_lens(seq_type, inter_blocks, raw_inter_lens):
             elif parsed_len[2]:
                 intron_len = int(parsed_len[2])
             else:
-                raise ValueError("Unexpected intron parsing result: %r" % parsed_len)
+                raise ValueError(f"Unexpected intron parsing result: {parsed_len!r}")
         else:
             intron_len = 0
 
@@ -259,8 +259,8 @@ def _comp_coords(hsp, seq_type, inter_lens):
     """Fill the block coordinates of the given hsp dictionary (PRIVATE)."""
     assert seq_type in ("hit", "query")
     # manually fill the first coord
-    seq_step = 1 if hsp["%s_strand" % seq_type] >= 0 else -1
-    fstart = hsp["%s_start" % seq_type]
+    seq_step = 1 if hsp[f"{seq_type}_strand"] >= 0 else -1
+    fstart = hsp[f"{seq_type}_start"]
     # fend is fstart + number of residues in the sequence, minus gaps
     fend = (
         fstart
@@ -294,8 +294,8 @@ def _comp_split_codons(hsp, seq_type, scodon_moves):
         else:
             assert not all(pair)
         a, b = pair
-        anchor_pair = hsp["%s_ranges" % seq_type][idx // 2]
-        strand = 1 if hsp["%s_strand" % seq_type] >= 0 else -1
+        anchor_pair = hsp[f"{seq_type}_ranges"][idx // 2]
+        strand = 1 if hsp[f"{seq_type}_strand"] >= 0 else -1
 
         if a:
             func = max if strand == 1 else min
@@ -417,21 +417,21 @@ class ExonerateTextParser(_BaseExonerateParser):
                     % (len(inter_lens), len(hsp[opp_type]) - 1)
                 )
             # fill the hsp query and hit coordinates
-            hsp["%s_ranges" % opp_type] = _comp_coords(hsp, opp_type, inter_lens)
+            hsp[f"{opp_type}_ranges"] = _comp_coords(hsp, opp_type, inter_lens)
             # and fill the split codon coordinates, if model != ner
             # can't do this in the if-else clause above since we need to
             # compute the ranges first
             if not has_ner:
-                hsp["%s_split_codons" % opp_type] = _comp_split_codons(
+                hsp[f"{opp_type}_split_codons"] = _comp_split_codons(
                     hsp, opp_type, scodon_moves
                 )
 
         # now that we've finished parsing coords, we can set the hit and start
         # coord according to Biopython's convention (start <= end)
         for seq_type in ("query", "hit"):
-            if hsp["%s_strand" % seq_type] == -1:
-                n_start = "%s_start" % seq_type
-                n_end = "%s_end" % seq_type
+            if hsp[f"{seq_type}_strand"] == -1:
+                n_start = f"{seq_type}_start"
+                n_end = f"{seq_type}_end"
                 hsp[n_start], hsp[n_end] = hsp[n_end], hsp[n_start]
 
         return {"qresult": qresult, "hit": hit, "hsp": hsp}

--- a/Bio/SearchIO/ExonerateIO/exonerate_vulgar.py
+++ b/Bio/SearchIO/ExonerateIO/exonerate_vulgar.py
@@ -59,7 +59,7 @@ def parse_vulgar_comp(hsp, vulgar_comp):
     for idx, match in enumerate(vcomps):
         label, qstep, hstep = match[0], int(match[1]), int(match[2])
         # check for label, must be recognized
-        assert label in "MCGF53INS", "Unexpected vulgar label: %r" % label
+        assert label in "MCGF53INS", f"Unexpected vulgar label: {label!r}"
         # match, codon, or gaps
         if label in "MCGS":
             # if the previous comp is not an MCGS block, it's the

--- a/Bio/SearchIO/FastaIO.py
+++ b/Bio/SearchIO/FastaIO.py
@@ -508,7 +508,7 @@ class FastaM10Parser:
                         parsed_hsp["hit"][name] = value
                 # for values in the hit block
                 else:
-                    raise ValueError("Unexpected line: %r" % line)
+                    raise ValueError(f"Unexpected line: {line!r}")
             # otherwise, it must be lines containing the sequences
             else:
                 assert ">" not in line
@@ -521,7 +521,7 @@ class FastaM10Parser:
                     hsp.fragment.aln_annotation["similarity"] += line.strip("\r\n")
                 # we should not get here!
                 else:
-                    raise ValueError("Unexpected line: %r" % line)
+                    raise ValueError(f"Unexpected line: {line!r}")
             line = self.line
 
 

--- a/Bio/SearchIO/HmmerIO/hmmer3_tab.py
+++ b/Bio/SearchIO/HmmerIO/hmmer3_tab.py
@@ -38,7 +38,7 @@ class Hmmer3TabParser:
         """Return a dictionary of parsed row values (PRIVATE)."""
         cols = [x for x in self.line.strip().split(" ") if x]
         if len(cols) < 18:
-            raise ValueError("Less columns than expected, only %i" % len(cols))
+            raise ValueError(f"Less columns than expected, only {len(cols)}")
         # if len(cols) > 19, we have extra description columns
         # combine them all into one string in the 19th column
         cols[18] = " ".join(cols[18:])

--- a/Bio/SearchIO/InterproscanIO/interproscan_xml.py
+++ b/Bio/SearchIO/InterproscanIO/interproscan_xml.py
@@ -101,7 +101,7 @@ class InterproscanXmlParser:
 
         for hit_elem in root_hit_elem:
             # store the match/location type
-            hit_type = re.sub(r"%s(\w+)-match" % self.NS, r"\1", hit_elem.find(".").tag)
+            hit_type = re.sub(rf"{self.NS}(\w+)-match", r"\1", hit_elem.find(".").tag)
             # store the hit id
             signature = hit_elem.find(self.NS + "signature")
             hit_id = signature.attrib["ac"]

--- a/Bio/SearchIO/__init__.py
+++ b/Bio/SearchIO/__init__.py
@@ -418,7 +418,7 @@ def to_dict(qresults, key_function=None):
     for qresult in qresults:
         key = key_function(qresult)
         if key in qdict:
-            raise ValueError("Duplicate key %r" % key)
+            raise ValueError(f"Duplicate key {key!r}")
         qdict[key] = qresult
     return qdict
 

--- a/Bio/SearchIO/_model/hit.py
+++ b/Bio/SearchIO/_model/hit.py
@@ -133,7 +133,7 @@ class Hit(_BaseSearchObject):
             # however, since all its cascading properties are empty.
             if len({getattr(hsp, attr) for hsp in hsps}) > 1:
                 raise ValueError(
-                    "Hit object can not contain HSPs with more than one %s." % attr
+                    f"Hit object can not contain HSPs with more than one {attr}."
                 )
 
         self._items = []
@@ -168,15 +168,15 @@ class Hit(_BaseSearchObject):
         lines = []
 
         # set query id line
-        qid_line = "Query: %s" % self.query_id
+        qid_line = f"Query: {self.query_id}"
         lines.append(qid_line)
         if self.query_description:
-            line = "       %s" % self.query_description
+            line = f"       {self.query_description}"
             line = line[:77] + "..." if len(line) > 80 else line
             lines.append(line)
 
         # set hit id line
-        hid_line = "  Hit: %s" % self.id
+        hid_line = f"  Hit: {self.id}"
         try:
             seq_len = self.seq_len
         except AttributeError:
@@ -185,7 +185,7 @@ class Hit(_BaseSearchObject):
             hid_line += " (%i)" % seq_len
         lines.append(hid_line)
         if self.description:
-            line = "       %s" % self.description
+            line = f"       {self.description}"
             line = line[:77] + "..." if len(line) > 80 else line
             lines.append(line)
 

--- a/Bio/SearchIO/_model/hsp.py
+++ b/Bio/SearchIO/_model/hsp.py
@@ -282,7 +282,7 @@ class HSP(_BaseHSP):
         ):
             if len({getattr(frag, attr) for frag in fragments}) != 1:
                 raise ValueError(
-                    "HSP object can not contain fragments with more than one %s." % attr
+                    f"HSP object can not contain fragments with more than one {attr}."
                 )
 
         self.output_index = output_index
@@ -334,9 +334,7 @@ class HSP(_BaseHSP):
                 [self._str_hsp_header(), "\n".join(lines), self.fragments[0]._str_aln()]
             )
         else:
-            lines.append(
-                "  Fragments: %s  %s  %s  %s" % ("-" * 3, "-" * 14, "-" * 22, "-" * 22)
-            )
+            lines.append(f"  Fragments: {'-' * 3}  {'-' * 14}  {'-' * 22}  {'-' * 22}")
             pattern = "%16s  %14s  %22s  %22s"
             lines.append(pattern % ("#", "Span", "Query range", "Hit range"))
             lines.append(pattern % ("-" * 3, "-" * 14, "-" * 22, "-" * 22))
@@ -347,7 +345,7 @@ class HSP(_BaseHSP):
                 # query region
                 query_start = getattr_str(block, "query_start")
                 query_end = getattr_str(block, "query_end")
-                query_range = "[%s:%s]" % (query_start, query_end)
+                query_range = f"[{query_start}:{query_end}]"
                 # max column length is 20
                 query_range = (
                     query_range[:20] + "~]" if len(query_range) > 22 else query_range
@@ -355,7 +353,7 @@ class HSP(_BaseHSP):
                 # hit region
                 hit_start = getattr_str(block, "hit_start")
                 hit_end = getattr_str(block, "hit_end")
-                hit_range = "[%s:%s]" % (hit_start, hit_end)
+                hit_range = f"[{hit_start}:{hit_end}]"
                 hit_range = hit_range[:20] + "~]" if len(hit_range) > 22 else hit_range
                 # append the hsp row
                 lines.append(pattern % (str(idx), aln_span, query_range, hit_range))
@@ -431,11 +429,11 @@ class HSP(_BaseHSP):
     def _get_coords(self, seq_type, coord_type):
         assert seq_type in ("hit", "query")
         assert coord_type in ("start", "end")
-        coord_name = "%s_%s" % (seq_type, coord_type)
+        coord_name = f"{seq_type}_{coord_type}"
         coords = [getattr(frag, coord_name) for frag in self.fragments]
         if None in coords:
             warnings.warn(
-                "'None' exist in %s coordinates; ignored" % (coord_name),
+                f"'None' exist in {coord_name} coordinates; ignored",
                 BiopythonWarning,
             )
         return coords
@@ -506,8 +504,8 @@ class HSP(_BaseHSP):
     def _inter_ranges_get(self, seq_type):
         # this property assumes that there are no mixed strands in a hit/query
         assert seq_type in ("query", "hit")
-        strand = getattr(self, "%s_strand_all" % seq_type)[0]
-        coords = getattr(self, "%s_range_all" % seq_type)
+        strand = getattr(self, f"{seq_type}_strand_all")[0]
+        coords = getattr(self, f"{seq_type}_range_all")
         # determine function used to set inter range
         # start and end coordinates, given two pairs
         # of fragment start and end coordinates
@@ -541,7 +539,7 @@ class HSP(_BaseHSP):
 
     def _inter_spans_get(self, seq_type):
         assert seq_type in ("query", "hit")
-        attr_name = "%s_inter_ranges" % seq_type
+        attr_name = f"{seq_type}_inter_ranges"
         return [coord[1] - coord[0] for coord in getattr(self, attr_name)]
 
     def _hit_inter_spans_get(self):
@@ -766,11 +764,11 @@ class HSPFragment(_BaseHSP):
 
         for seq_type in ("query", "hit"):
             # query or hit attributes default attributes
-            setattr(self, "_%s_description" % seq_type, "<unknown description>")
-            setattr(self, "_%s_features" % seq_type, [])
+            setattr(self, f"_{seq_type}_description", "<unknown description>")
+            setattr(self, f"_{seq_type}_features", [])
             # query or hit attributes whose default attribute is None
             for attr in ("strand", "frame", "start", "end"):
-                setattr(self, "%s_%s" % (seq_type, attr), None)
+                setattr(self, f"{seq_type}_{attr}", None)
             # self.query or self.hit
             if eval(seq_type):
                 setattr(self, seq_type, eval(seq_type))
@@ -779,12 +777,12 @@ class HSPFragment(_BaseHSP):
 
     def __repr__(self):
         """Return HSPFragment info; hit id, query id, number of columns."""
-        info = "hit_id=%r, query_id=%r" % (self.hit_id, self.query_id)
+        info = f"hit_id={self.hit_id!r}, query_id={self.query_id!r}"
         try:
-            info += ", %i columns" % len(self)
+            info += f", {len(self)} columns"
         except AttributeError:
             pass
-        return "%s(%s)" % (self.__class__.__name__, info)
+        return f"{self.__class__.__name__}({info})"
 
     def __len__(self):
         """Return alignment span."""
@@ -814,7 +812,7 @@ class HSPFragment(_BaseHSP):
             # description, strand, frame
             for attr in ("description", "strand", "frame"):
                 for seq_type in ("hit", "query"):
-                    attr_name = "%s_%s" % (seq_type, attr)
+                    attr_name = f"{seq_type}_{attr}"
                     self_val = getattr(self, attr_name)
                     setattr(obj, attr_name, self_val)
             # alignment annotation should be transferred, since we can compute
@@ -833,7 +831,7 @@ class HSPFragment(_BaseHSP):
         lines = []
         # alignment length
         aln_span = getattr_str(self, "aln_span")
-        lines.append("  Fragments: 1 (%s columns)" % aln_span)
+        lines.append(f"  Fragments: 1 ({aln_span} columns)")
         # sequences
         if self.query is not None and self.hit is not None:
             try:
@@ -855,7 +853,7 @@ class HSPFragment(_BaseHSP):
             if self.aln_span <= 67:
                 lines.append("%10s - %s" % ("Query", qseq))
                 if simil:
-                    lines.append("             %s" % simil)
+                    lines.append(f"             {simil}")
                 lines.append("%10s - %s" % ("Hit", hseq))
             else:
                 # adjust continuation character length, so we don't display
@@ -866,7 +864,7 @@ class HSPFragment(_BaseHSP):
                     cont = "~" * (self.aln_span - 66)
                 lines.append("%10s - %s%s%s" % ("Query", qseq[:59], cont, qseq[-5:]))
                 if simil:
-                    lines.append("             %s%s%s" % (simil[:59], cont, simil[-5:]))
+                    lines.append(f"             {simil[:59]}{cont}{simil[-5:]}")
                 lines.append("%10s - %s%s%s" % ("Hit", hseq[:59], cont, hseq[-5:]))
 
         return "\n".join(lines)
@@ -887,11 +885,11 @@ class HSPFragment(_BaseHSP):
         else:
             if not isinstance(seq, (str, SeqRecord)):
                 raise TypeError(
-                    "%s sequence must be a string or a SeqRecord object." % seq_type
+                    f"{seq_type} sequence must be a string or a SeqRecord object."
                 )
         # check length if the opposite sequence is not None
         opp_type = "hit" if seq_type == "query" else "query"
-        opp_seq = getattr(self, "_%s" % opp_type, None)
+        opp_seq = getattr(self, f"_{opp_type}", None)
         if opp_seq is not None:
             if len(seq) != len(opp_seq):
                 raise ValueError(
@@ -899,10 +897,10 @@ class HSPFragment(_BaseHSP):
                     % (len(opp_seq), opp_type, len(seq), seq_type)
                 )
 
-        seq_id = getattr(self, "%s_id" % seq_type)
-        seq_desc = getattr(self, "%s_description" % seq_type)
-        seq_feats = getattr(self, "%s_features" % seq_type)
-        seq_name = "aligned %s sequence" % seq_type
+        seq_id = getattr(self, f"{seq_type}_id")
+        seq_desc = getattr(self, f"{seq_type}_description")
+        seq_feats = getattr(self, f"{seq_type}_features")
+        seq_name = f"aligned {seq_type} sequence"
 
         if isinstance(seq, SeqRecord):
             seq.id = seq_id
@@ -1028,22 +1026,22 @@ class HSPFragment(_BaseHSP):
     def _prep_strand(self, strand):
         # follow SeqFeature's convention
         if strand not in (-1, 0, 1, None):
-            raise ValueError("Strand should be -1, 0, 1, or None; not %r" % strand)
+            raise ValueError(f"Strand should be -1, 0, 1, or None; not {strand!r}")
         return strand
 
     def _get_strand(self, seq_type):
         assert seq_type in ("hit", "query")
-        strand = getattr(self, "_%s_strand" % seq_type)
+        strand = getattr(self, f"_{seq_type}_strand")
 
         if strand is None:
             # try to compute strand from frame
-            frame = getattr(self, "%s_frame" % seq_type)
+            frame = getattr(self, f"{seq_type}_frame")
             if frame is not None:
                 try:
                     strand = frame // abs(frame)
                 except ZeroDivisionError:
                     strand = 0
-                setattr(self, "%s_strand" % seq_type, strand)
+                setattr(self, f"{seq_type}_strand", strand)
 
         return strand
 
@@ -1075,7 +1073,7 @@ class HSPFragment(_BaseHSP):
     def _prep_frame(self, frame):
         if frame not in (-3, -2, -1, 0, 1, 2, 3, None):
             raise ValueError(
-                "Strand should be an integer between -3 and 3, or None; not %r" % frame
+                f"Strand should be an integer between -3 and 3, or None; not {frame!r}"
             )
         return frame
 

--- a/Bio/SearchIO/_model/query.py
+++ b/Bio/SearchIO/_model/query.py
@@ -250,17 +250,17 @@ class QueryResult(_BaseSearchObject):
 
     def __repr__(self):
         """Return string representation of the QueryResult object."""
-        return "QueryResult(id=%r, %r hits)" % (self.id, len(self))
+        return f"QueryResult(id={self.id!r}, {len(self)!r} hits)"
 
     def __str__(self):
         """Return a human readable summary of the QueryResult object."""
         lines = []
 
         # set program and version line
-        lines.append("Program: %s (%s)" % (self.program, self.version))
+        lines.append(f"Program: {self.program} ({self.version})")
 
         # set query id line
-        qid_line = "  Query: %s" % self.id
+        qid_line = f"  Query: {self.id}"
         try:
             seq_len = self.seq_len
         except AttributeError:
@@ -269,29 +269,29 @@ class QueryResult(_BaseSearchObject):
             qid_line += " (%i)" % seq_len
         lines.append(qid_line)
         if self.description:
-            line = "         %s" % self.description
+            line = f"         {self.description}"
             line = line[:77] + "..." if len(line) > 80 else line
             lines.append(line)
 
         # set target line
-        lines.append(" Target: %s" % self.target)
+        lines.append(f" Target: {self.target}")
 
         # set hit lines
         if not self.hits:
             lines.append("   Hits: 0")
         else:
-            lines.append("   Hits: %s  %s  %s" % ("-" * 4, "-" * 5, "-" * 58))
+            lines.append(f"   Hits: {'-' * 4}  {'-' * 5}  {'-' * 58}")
             pattern = "%13s  %5s  %s"
             lines.append(pattern % ("#", "# HSP", "ID + description"))
             lines.append(pattern % ("-" * 4, "-" * 5, "-" * 58))
             for idx, hit in enumerate(self.hits):
                 if idx < 30:
-                    hid_line = "%s  %s" % (hit.id, hit.description)
+                    hid_line = f"{hit.id}  {hit.description}"
                     if len(hid_line) > 58:
                         hid_line = hid_line[:55] + "..."
                     lines.append(pattern % (idx, len(hit), hid_line))
                 elif idx > len(self.hits) - 4:
-                    hid_line = "%s  %s" % (hit.id, hit.description)
+                    hid_line = f"{hit.id}  {hit.description}"
                     if len(hid_line) > 58:
                         hid_line = hid_line[:55] + "..."
                     lines.append(pattern % (idx, len(hit), hid_line))
@@ -347,7 +347,7 @@ class QueryResult(_BaseSearchObject):
         if qid is not None:
             if hqid != qid:
                 raise ValueError(
-                    "Expected Hit with query ID %r, found %r instead." % (qid, hqid)
+                    f"Expected Hit with query ID {qid!r}, found {hqid!r} instead."
                 )
         else:
             self.id = hqid

--- a/Bio/SearchIO/_utils.py
+++ b/Bio/SearchIO/_utils.py
@@ -51,7 +51,7 @@ def get_processor(format, mapping):
         elif not isinstance(format, str):
             raise TypeError("Need a string for the file format (lower case)") from None
         elif format != format.lower():
-            raise ValueError("Format string %r should be lower case" % format) from None
+            raise ValueError(f"Format string {format!r} should be lower case") from None
         else:
             raise ValueError(
                 "Unknown format %r. Supported formats are %r"
@@ -59,7 +59,7 @@ def get_processor(format, mapping):
             ) from None
 
     mod_name, obj_name = obj_info
-    mod = __import__("Bio.SearchIO.%s" % mod_name, fromlist=[""])
+    mod = __import__(f"Bio.SearchIO.{mod_name}", fromlist=[""])
 
     return getattr(mod, obj_name)
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -390,7 +390,7 @@ class _SeqAbstractBaseClass(ABC):
                 else:
                     seq = seq.decode("ASCII")
                 d[position] = seq
-            return "Seq(%r, length=%d)" % (d, len(self))
+            return f"Seq({d!r}, length={len(self)})"
         if len(data) > 60:
             # Shows the last three letters as it is often useful to see if
             # there is a stop codon at the end of a sequence.

--- a/Bio/SeqFeature.py
+++ b/Bio/SeqFeature.py
@@ -127,15 +127,12 @@ _pair_location = r"[<>]?-?\d+\.\.[<>]?-?\d+"
 _between_location = r"\d+\^\d+"
 
 _within_position = r"\(\d+\.\d+\)"
-_within_location = r"([<>]?\d+|%s)\.\.([<>]?\d+|%s)" % (
-    _within_position,
-    _within_position,
-)
+_within_location = rf"([<>]?\d+|{_within_position})\.\.([<>]?\d+|{_within_position})"
 _within_position = r"\((\d+)\.(\d+)\)"
 _re_within_position = re.compile(_within_position)
 assert _re_within_position.match("(3.9)")
 
-_oneof_location = r"([<>]?\d+|%s)\.\.([<>]?\d+|%s)" % (_oneof_position, _oneof_position)
+_oneof_location = rf"([<>]?\d+|{_oneof_position})\.\.([<>]?\d+|{_oneof_position})"
 _oneof_position = r"one\-of\((\d+[,\d+]+)\)"
 _re_oneof_position = re.compile(_oneof_position)
 assert _re_oneof_position.match("one-of(6,9)")
@@ -144,7 +141,7 @@ assert _re_oneof_position.match("one-of(3,6)")
 assert _re_oneof_position.match("one-of(3,6,9)")
 
 _solo_location = r"[<>]?\d+"
-_solo_bond = r"bond\(%s\)" % _solo_location
+_solo_bond = rf"bond\({_solo_location}\)"
 
 _re_location_category = re.compile(
     r"^(?P<pair>%s)|(?P<between>%s)|(?P<within>%s)|(?P<oneof>%s)|(?P<bond>%s)|(?P<solo>%s)$"
@@ -1861,7 +1858,7 @@ class ExactPosition(int, Position):
 
     def __repr__(self):
         """Represent the ExactPosition object as a string for debugging."""
-        return "%s(%i)" % (self.__class__.__name__, int(self))
+        return f"{self.__class__.__name__}({int(self)})"
 
     def __add__(self, offset):
         """Return a copy of the position object with its location shifted (PRIVATE)."""
@@ -2162,7 +2159,7 @@ class BeforePosition(int, Position):
 
     def __repr__(self):
         """Represent the location as a string for debugging."""
-        return "%s(%i)" % (self.__class__.__name__, int(self))
+        return f"{self.__class__.__name__}({int(self)})"
 
     def __str__(self):
         """Return a representation of the BeforePosition object (with python counting)."""
@@ -2226,7 +2223,7 @@ class AfterPosition(int, Position):
 
     def __repr__(self):
         """Represent the location as a string for debugging."""
-        return "%s(%i)" % (self.__class__.__name__, int(self))
+        return f"{self.__class__.__name__}({int(self)})"
 
     def __str__(self):
         """Return a representation of the AfterPosition object (with python counting)."""

--- a/Bio/SeqIO/InsdcIO.py
+++ b/Bio/SeqIO/InsdcIO.py
@@ -1051,10 +1051,7 @@ class GenBankWriter(_InsdcWriter):
         acc_with_version = accession
         if record.id.startswith(accession + "."):
             try:
-                acc_with_version = "%s.%i" % (
-                    accession,
-                    int(record.id.split(".", 1)[1]),
-                )
+                acc_with_version = f"{accession}.{int(record.id.split('.', 1)[1])}"
             except ValueError:
                 pass
         gi = self._get_annotation_str(record, "gi", just_first=True)

--- a/Bio/SeqIO/UniprotIO.py
+++ b/Bio/SeqIO/UniprotIO.py
@@ -327,7 +327,7 @@ class UniprotIterator(SequenceIterator):
                 )
         elif element.attrib["type"] == "alternative products":
             for alt_element in element.iter(NS + "isoform"):
-                ann_key = "comment_%s_isoform" % element.attrib["type"].replace(" ", "")
+                ann_key = f"comment_{element.attrib['type'].replace(' ', '')}_isoform"
                 for id_element in alt_element.iter(NS + "id"):
                     self._append_to_annotations(ann_key, id_element.text)
         elif element.attrib["type"] == "mass spectrometry":

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -236,7 +236,7 @@ def xGC_skew(seq, window=1000, zoom=100, r=300, px=100, py=100):
     x1, x2, y1, y2 = X0 - r, X0 + r, Y0 - r, Y0 + r
 
     ty = Y0
-    canvas.create_text(X0, ty, text="%s...%s (%d nt)" % (seq[:7], seq[-7:], len(seq)))
+    canvas.create_text(X0, ty, text=f"{seq[:7]}...{seq[-7:]} ({len(seq)} nt)")
     ty += 20
     canvas.create_text(X0, ty, text=f"GC {gc_fraction(seq):3.2f}%")
     ty += 20
@@ -566,7 +566,7 @@ def six_frame_translations(seq, genetic_code=1):
         res += " " + "  ".join(frames[2][p : p + 20]) + "\n"
         res += "  ".join(frames[1][p : p + 20]) + "\n"
         # seq
-        res += subseq.lower() + "%5d %%\n" % int(gc)
+        res += subseq.lower() + f"{int(gc):5} %\n"
         res += csubseq.lower() + "\n"
         # - frames
         res += "  ".join(frames[-2][p : p + 20]) + "\n"

--- a/Bio/motifs/__init__.py
+++ b/Bio/motifs/__init__.py
@@ -123,7 +123,7 @@ def parse(handle, fmt, strict=True):
 
         return jaspar.read(handle, fmt)
     else:
-        raise ValueError("Unknown format %s" % fmt)
+        raise ValueError(f"Unknown format {fmt}")
 
 
 def read(handle, fmt, strict=True):
@@ -240,7 +240,7 @@ class Motif:
                     self.__mask.append(0)
                 else:
                     raise ValueError(
-                        "Mask should contain only '*' or ' ' and not a '%s'" % char
+                        f"Mask should contain only '*' or ' ' and not a '{char}'"
                     )
             self.__mask = tuple(self.__mask)
         else:
@@ -597,7 +597,7 @@ class Motif:
             # Follow python convention and default to using __str__
             return str(self)
         else:
-            raise ValueError("Unknown format type %s" % format_spec)
+            raise ValueError(f"Unknown format type {format_spec}")
 
     def format(self, format_spec):
         """Return a string representation of the Motif in the given format.
@@ -636,7 +636,7 @@ def write(motifs, fmt, **kwargs):
 
         return clusterbuster.write(motifs, **kwargs)
     else:
-        raise ValueError("Unknown format type %s" % fmt)
+        raise ValueError(f"Unknown format type {fmt}")
 
 
 if __name__ == "__main__":

--- a/Bio/motifs/jaspar/__init__.py
+++ b/Bio/motifs/jaspar/__init__.py
@@ -166,7 +166,7 @@ def read(handle, format):
         record = _read_jaspar(handle)
         return record
     else:
-        raise ValueError("Unknown JASPAR format %s" % format)
+        raise ValueError(f"Unknown JASPAR format {format}")
 
 
 def write(motifs, format):
@@ -194,7 +194,7 @@ def write(motifs, format):
                 line = f"{letter} [{' '.join(terms)}]\n"
                 lines.append(line)
     else:
-        raise ValueError("Unknown JASPAR format %s" % format)
+        raise ValueError(f"Unknown JASPAR format {format}")
 
     # Finished; glue the lines together
     text = "".join(lines)

--- a/Bio/motifs/jaspar/db.py
+++ b/Bio/motifs/jaspar/db.py
@@ -572,7 +572,7 @@ class JASPAR5:
                 clause = "".join([clause, "')"])
             else:
                 # A single collection - typical usage
-                clause = "m.COLLECTION = '%s'" % collection
+                clause = f"m.COLLECTION = '{collection}'"
 
             where_clauses.append(clause)
 
@@ -585,7 +585,7 @@ class JASPAR5:
                 clause = "".join([clause, "')"])
             else:
                 # A single name
-                clause = "m.NAME = '%s'" % tf_name
+                clause = f"m.NAME = '{tf_name}'"
 
             where_clauses.append(clause)
 
@@ -605,7 +605,7 @@ class JASPAR5:
                 clause = "".join([clause, "')"])
             else:
                 # A single tax ID
-                clause = "ms.TAX_ID = '%s'" % species
+                clause = f"ms.TAX_ID = '{species}'"
 
             where_clauses.append(clause)
 
@@ -644,7 +644,7 @@ class JASPAR5:
                 clause = "".join([clause, "')"])
             else:
                 # A single TF class
-                clause = "".join([clause, " and ma1.VAL = '%s' " % tf_class])
+                clause = "".join([clause, f" and ma1.VAL = '{tf_class}' "])
 
             where_clauses.append(clause)
 
@@ -661,7 +661,7 @@ class JASPAR5:
                 clause = "".join([clause, "')"])
             else:
                 # A single TF family
-                clause = "".join([clause, " and ma2.VAL = '%s' " % tf_family])
+                clause = "".join([clause, f" and ma2.VAL = '{tf_family}' "])
 
             where_clauses.append(clause)
 
@@ -678,7 +678,7 @@ class JASPAR5:
                 clause = "".join([clause, "')"])
             else:
                 # A single PAZAR ID
-                clause = "".join([" and ma3.VAL = '%s' " % pazar_id])
+                clause = "".join([f" and ma3.VAL = '{pazar_id}' "])
 
             where_clauses.append(clause)
 
@@ -695,7 +695,7 @@ class JASPAR5:
                 clause = "".join([clause, "')"])
             else:
                 # A single PubMed ID
-                clause = "".join([" and ma4.VAL = '%s' " % medline])
+                clause = "".join([f" and ma4.VAL = '{medline}' "])
 
             where_clauses.append(clause)
 
@@ -713,7 +713,7 @@ class JASPAR5:
                 clause = "".join([clause, "')"])
             else:
                 # A single data type
-                clause = "".join([" and ma5.VAL = '%s' " % data_type])
+                clause = "".join([f" and ma5.VAL = '{data_type}' "])
 
             where_clauses.append(clause)
 
@@ -730,7 +730,7 @@ class JASPAR5:
                 clause = "".join([clause, "')"])
             else:
                 # A single tax ID
-                clause = "".join([clause, " and ma6.VAL = '%s' " % tax_group])
+                clause = "".join([clause, f" and ma6.VAL = '{tax_group}' "])
 
             where_clauses.append(clause)
 

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -42,8 +42,8 @@ class GenericPositionMatrix(dict):
         line = "   " + " ".join(words)
         lines = [line]
         for letter in self.alphabet:
-            words = ["%6.2f" % value for value in self[letter]]
-            line = "%c: " % letter + " ".join(words)
+            words = [f"{value:6.2f}" for value in self[letter]]
+            line = f"{letter:c}: " + " ".join(words)
             lines.append(line)
         text = "\n".join(lines) + "\n"
         return text
@@ -71,7 +71,7 @@ class GenericPositionMatrix(dict):
                     else:
                         raise KeyError(key1)
                 else:
-                    raise KeyError("Cannot understand key %s" % key1)
+                    raise KeyError(f"Cannot understand key {key1}")
                 if isinstance(key2, slice):
                     start2, stop2, stride2 = key2.indices(self.length)
                     indices2 = range(start2, stop2, stride2)
@@ -80,7 +80,7 @@ class GenericPositionMatrix(dict):
                     index2 = key2
                     dim2 = 1
                 else:
-                    raise KeyError("Cannot understand key %s" % key2)
+                    raise KeyError(f"Cannot understand key {key2}")
                 if dim1 == 1 and dim2 == 1:
                     return dict.__getitem__(self, letter1)[index2]
                 elif dim1 == 1 and dim2 == 2:
@@ -122,7 +122,7 @@ class GenericPositionMatrix(dict):
             else:
                 raise KeyError(key)
         else:
-            raise KeyError("Cannot understand key %s" % key)
+            raise KeyError(f"Cannot understand key {key}")
         if dim == 1:
             return dict.__getitem__(self, letter)
         elif dim == 2:
@@ -413,7 +413,7 @@ class PositionSpecificScoringMatrix(GenericPositionMatrix):
         # TODO - Code itself tolerates ambiguous bases (as NaN).
         if sorted(self.alphabet) != ["A", "C", "G", "T"]:
             raise ValueError(
-                "PSSM has wrong alphabet: %s - Use only with DNA motifs" % self.alphabet
+                f"PSSM has wrong alphabet: {self.alphabet} - Use only with DNA motifs"
             )
 
         # NOTE: The C code handles mixed case input as this could be large

--- a/Bio/motifs/matrix.py
+++ b/Bio/motifs/matrix.py
@@ -43,7 +43,7 @@ class GenericPositionMatrix(dict):
         lines = [line]
         for letter in self.alphabet:
             words = [f"{value:6.2f}" for value in self[letter]]
-            line = f"{letter:c}: " + " ".join(words)
+            line = "%c: " % letter + " ".join(words)
             lines.append(line)
         text = "\n".join(lines) + "\n"
         return text

--- a/Bio/motifs/minimal.py
+++ b/Bio/motifs/minimal.py
@@ -147,7 +147,7 @@ def _read_alphabet(record, handle):
             "Unexpected end of stream: Expected to find line starting with 'ALPHABET'"
         )
     if not line.startswith("ALPHABET= "):
-        raise ValueError("Line does not start with 'ALPHABET':\n%s" % line)
+        raise ValueError(f"Line does not start with 'ALPHABET':\n{line}")
     line = line.strip().replace("ALPHABET= ", "")
     if line == "ACGT":
         al = "ACGT"

--- a/Bio/motifs/pfm.py
+++ b/Bio/motifs/pfm.py
@@ -37,7 +37,7 @@ def read(handle, pfm_format):
         record = _read_pfm_four_rows(handle)
         return record
     else:
-        raise ValueError("Unknown Position Frequency matrix format '%s'" % pfm_format)
+        raise ValueError(f"Unknown Position Frequency matrix format '{pfm_format}'")
 
 
 def _read_pfm_four_columns(handle):

--- a/Bio/motifs/transfac.py
+++ b/Bio/motifs/transfac.py
@@ -234,14 +234,10 @@ def write(motifs):
         pass
     else:
         if version is not None:
-            block = (
-                """\
-VV  %s
+            block = f"""VV  {version}
 XX
 //
 """
-                % version
-            )
             blocks.append(block)
     multiple_value_keys = Motif.multiple_value_keys
     sections = (

--- a/Bio/phenotype/phen_micro.py
+++ b/Bio/phenotype/phen_micro.py
@@ -569,11 +569,11 @@ class PlateRecord:
         lines = []
         if self.id:
             lines.append(f"Plate ID: {self.id}")
-        lines.append("Well: %i" % len(self))
+        lines.append(f"Well: {len(self)}")
         # Here we assume that all well ID start with a char
-        lines.append("Rows: %d" % len({x.id[0] for x in self}))
+        lines.append(f"Rows: {len({x.id[0] for x in self})}")
         # Here we assume that well number is a two-digit number
-        lines.append("Columns: %d" % len({x.id[1:3] for x in self}))
+        lines.append(f"Columns: {len({x.id[1:3] for x in self})}")
         lines.append(repr(self))
         return "\n".join(lines)
 
@@ -824,7 +824,7 @@ class WellRecord:
             lines.append(f"Plate ID: {self.plate.id}")
         if self.id:
             lines.append(f"Well ID: {self.id}")
-        lines.append("Time points: %i" % len(self))
+        lines.append(f"Time points: {len(self)}")
         lines.append("Minum signal %.2f at time %.2f" % min(self, key=lambda x: x[1]))
         lines.append("Maximum signal %.2f at time %.2f" % max(self, key=lambda x: x[1]))
         lines.append(repr(self))
@@ -966,9 +966,9 @@ def JsonIterator(handle):
                 plateID = _platesPrefix + str(abs(int(pID)))
             else:
                 if plateID.startswith(_platesPrefixMammalian):
-                    plateID = _platesPrefixMammalian + "%02d" % int(pID)
+                    plateID = _platesPrefixMammalian + f"{int(pID):02}"
                 else:
-                    plateID = _platesPrefix + "%02d" % int(pID)
+                    plateID = _platesPrefix + f"{int(pID):02}"
 
         try:
             times = pobj[_measurements][_hour]
@@ -1068,9 +1068,9 @@ def CsvIterator(handle):
                     plateID = _platesPrefix + str(abs(int(pID)))
                 else:
                     if plateID.startswith(_platesPrefixMammalian):
-                        plateID = _platesPrefixMammalian + "%02d" % int(pID)
+                        plateID = _platesPrefixMammalian + f"{int(pID):02}"
                     else:
-                        plateID = _platesPrefix + "%02d" % int(pID)
+                        plateID = _platesPrefix + f"{int(pID):02}"
 
             plate.id = plateID
 

--- a/BioSQL/Loader.py
+++ b/BioSQL/Loader.py
@@ -220,9 +220,7 @@ class DatabaseLoader:
             # Its natural that several distinct taxa will have the same common
             # name - in which case we can't resolve the taxon uniquely.
             if len(taxa) > 1:
-                raise ValueError(
-                    "Taxa: %d species have name %r" % (len(taxa), common_name)
-                )
+                raise ValueError(f"Taxa: {len(taxa)} species have name {common_name!r}")
             if taxa:
                 # Good, mapped the common name to a taxon table entry
                 return taxa[0]

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -326,7 +326,7 @@ def insert_github_link(filename):
         source = filename[4:-4].replace(".", "/") + ".py"
     if not os.path.isfile(os.path.join("../", source)):
         sys.stderr.write(
-            "WARNING: Could not map %s to a Python file, e.g. %s\n" % (filename, source)
+            f"WARNING: Could not map {filename} to a Python file, e.g. {source}\n"
         )
         return
 

--- a/Doc/examples/ACT_example.py
+++ b/Doc/examples/ACT_example.py
@@ -30,7 +30,7 @@ file_a_vs_b = "af063097_v_b132222.crunch"
 
 for f in [file_a, file_b, file_a_vs_b]:
     if not os.path.isfile(os.path.join(input_folder, f)):
-        print("Missing input file %s.fna" % f)
+        print(f"Missing input file {f}.fna")
         sys.exit(1)
 
 # Only doing a_vs_b here, could also have b_vs_c and c_vs_d etc

--- a/Doc/examples/clustal_run.py
+++ b/Doc/examples/clustal_run.py
@@ -33,8 +33,8 @@ alignment = Align.read("test.aln", "clustal")
 
 print(alignment)
 
-print("first description: %s" % alignment.sequences[0].description)
-print("first sequence: %s" % alignment.sequences[0].seq)
+print(f"first description: {alignment.sequences[0].description}")
+print(f"first sequence: {alignment.sequences[0].seq}")
 
 # get the length of the alignment
 print("length %i" % alignment.length)
@@ -44,8 +44,8 @@ counts = motif.counts
 
 # print out interesting information about the alignment
 consensus = motif.counts.calculate_consensus(identity=0.7)
-print("consensus %s" % consensus)
+print(f"consensus {consensus}")
 
 motif.background = {"A": 0.3, "G": 0.2, "T": 0.3, "C": 0.2}
 relative_entropy = motif.relative_entropy
-print("relative entropy for columns [5:30]: %f" % sum(relative_entropy[5:30]))
+print(f"relative entropy for columns [5:30]: {sum(relative_entropy[5:30]):f}")

--- a/Doc/examples/fasta_dictionary.py
+++ b/Doc/examples/fasta_dictionary.py
@@ -43,9 +43,9 @@ rec_iterator = SeqIO.parse("ls_orchid.fasta", "fasta")
 orchid_dict = SeqIO.to_dict(rec_iterator, get_accession_num)
 
 for id_num in orchid_dict:
-    print("id number: %s" % id_num)
-    print("description: %s" % orchid_dict[id_num].description)
-    print("sequence: %s" % orchid_dict[id_num].seq)
+    print(f"id number: {id_num}")
+    print(f"description: {orchid_dict[id_num].description}")
+    print(f"sequence: {orchid_dict[id_num].seq}")
 
 
 # Indexed
@@ -58,6 +58,6 @@ for id_num in orchid_dict:
 orchid_dict = SeqIO.index("ls_orchid.fasta", "fasta")
 
 for id_num in orchid_dict:
-    print("id number: %s" % id_num)
-    print("description: %s" % orchid_dict[id_num].description)
-    print("sequence: %s" % orchid_dict[id_num].seq)
+    print(f"id number: {id_num}")
+    print(f"description: {orchid_dict[id_num].description}")
+    print(f"sequence: {orchid_dict[id_num].seq}")

--- a/Doc/examples/fasta_iterator.py
+++ b/Doc/examples/fasta_iterator.py
@@ -26,5 +26,5 @@ def extract_organisms(file_to_parse, fmt):
 if __name__ == "__main__":
     print("Using Bio.SeqIO on a FASTA file")
     all_species = extract_organisms("ls_orchid.fasta", "fasta")
-    print("number of species: %i" % len(all_species))
-    print("species names: %s" % all_species)
+    print(f"number of species: {len(all_species)}")
+    print(f"species names: {all_species}")

--- a/Doc/examples/swissprot.py
+++ b/Doc/examples/swissprot.py
@@ -17,10 +17,10 @@ ids = ["O23729", "O23730", "O23731"]
 for id in ids:
     handle = ExPASy.get_sprot_raw(id)
     record = SwissProt.read(handle)
-    print("description: %s" % record.description)
+    print(f"description: {record.description}")
     for ref in record.references:
-        print("authors: %s" % ref.authors)
-        print("title: %s" % ref.title)
+        print(f"authors: {ref.authors}")
+        print(f"title: {ref.title}")
 
-    print("classification: %s" % record.organism_classification)
+    print(f"classification: {record.organism_classification}")
     print("")

--- a/Doc/examples/www_blast.py
+++ b/Doc/examples/www_blast.py
@@ -44,9 +44,9 @@ for alignment in b_record.alignments:
     for hsp in alignment.hsps:
         if hsp.expect < E_VALUE_THRESH:
             print("****Alignment****")
-            print("sequence: %s" % alignment.title)
+            print(f"sequence: {alignment.title}")
             print("length: %i" % alignment.length)
-            print("e value: %f" % hsp.expect)
+            print(f"e value: {hsp.expect:f}")
             print(hsp.query[0:75] + "...")
             print(hsp.match[0:75] + "...")
             print(hsp.sbjct[0:75] + "...")

--- a/Scripts/GenBank/check_output.py
+++ b/Scripts/GenBank/check_output.py
@@ -57,7 +57,7 @@ def write_format(file):
     """Write a GenBank record from a Genbank file and compare them."""
     record_parser = GenBank.RecordParser(debug_level=2)
 
-    print("Testing GenBank writing for %s..." % os.path.basename(file))
+    print(f"Testing GenBank writing for {os.path.basename(file)}...")
     # be able to handle gzipped files
     if ".gz" in file:
         cur_handle = gzip.open(file, "rb")

--- a/Scripts/PDB/generate_three_to_one_dict.py
+++ b/Scripts/PDB/generate_three_to_one_dict.py
@@ -71,7 +71,7 @@ while line:
         one = line.strip().split()[-1]
         found_one = True
     if line.startswith("_chem_comp.three_letter_code"):
-        three = "%-3s" % (line.strip().split()[-1],)  # make it three-letter
+        three = f"{line.strip().split()[-1]:3}"  # make it three-letter
         found_three = True
 
     if found_one and found_three:

--- a/Scripts/Restriction/ranacompiler.py
+++ b/Scripts/Restriction/ranacompiler.py
@@ -139,11 +139,11 @@ def double_quote_repr(value):  # TODO similar not to produce long horizontal lis
     elif isinstance(value, tuple):
         if len(value) == 1:
             # Need trailing comma
-            return "(%s,)" % double_quote_repr(list(value)[0])
+            return f"({double_quote_repr(list(value)[0])},)"
         else:
-            return "(%s)" % ", ".join(double_quote_repr(_) for _ in value)
+            return f"({', '.join(double_quote_repr(_) for _ in value)})"
     elif isinstance(value, list):
-        return "[%s]" % ", ".join(double_quote_repr(_) for _ in value)
+        return f"[{', '.join(double_quote_repr(_) for _ in value)}]"
     return repr(value)
 
 
@@ -519,7 +519,7 @@ class DictionaryBuilder:
         #
         #   How many enzymes this time?
         #
-        print("\nThe new database contains %i enzymes.\n" % len(classdict))
+        print(f"\nThe new database contains {len(classdict)} enzymes.\n")
         #
         #   the dictionaries are done. Build the file
         #
@@ -535,8 +535,7 @@ class DictionaryBuilder:
                 results.write("rest_dict[%s] = {\n" % double_quote_repr(name))
                 for key, value in sorted(classdict[name].items()):
                     results.write(
-                        "    %s: %s,\n"
-                        % (double_quote_repr(key), double_quote_repr(value))
+                        f"    {double_quote_repr(key)}: {double_quote_repr(value)},\n"
                     )
                 results.write("}\n\n")
             print("OK.\n")
@@ -547,9 +546,9 @@ class DictionaryBuilder:
             results.write("suppliers = {}\n")
             results.write("\n")
             for name in sorted(suppliersdict):
-                results.write("suppliers[%s] = (\n" % double_quote_repr(name))
+                results.write(f"suppliers[{double_quote_repr(name)}] = (\n")
                 for value in suppliersdict[name]:
-                    results.write("    %s,\n" % double_quote_repr(value))
+                    results.write(f"    {double_quote_repr(value)},\n")
                 results.write(")\n\n")
             print("OK.\n")
             print("Writing the dictionary containing the Restriction types...")
@@ -557,9 +556,9 @@ class DictionaryBuilder:
             results.write("typedict = {}\n")
             results.write("\n")
             for name in sorted(typedict):
-                results.write("typedict[%s] = (\n" % double_quote_repr(name))
+                results.write(f"typedict[{double_quote_repr(name)}] = (\n")
                 for value in typedict[name]:
-                    results.write("    %s,\n" % double_quote_repr(value))
+                    results.write(f"    {double_quote_repr(value)},\n")
                 results.write(")\n\n")
             results.write("# Turn black code style on\n# fmt: on\n")
             print("OK.\n")
@@ -665,9 +664,9 @@ class DictionaryBuilder:
             #
             #   nothing to be done
             #
-            print("\n Using the bairoch file : %s" % bairoch_now)
+            print(f"\n Using the bairoch file : {bairoch_now}")
             enzyme_id_dict = load_enzyme_ids(bairoch_now)
-            print("\n Using the emboss files : %s" % ", ".join(emboss_now))
+            print(f"\n Using the emboss files : {', '.join(emboss_now)}")
             return tuple(open(os.path.join(base, n)) for n in emboss_now) + (
                 enzyme_id_dict,
             )
@@ -683,7 +682,7 @@ class DictionaryBuilder:
             if r in ["y", "yes", "Y", "Yes"]:
                 get_files()
                 print("\n Update complete. Creating the dictionaries.\n")
-                print("\n Using the files : %s" % ", ".join(emboss_now))
+                print(f"\n Using the files : {', '.join(emboss_now)}")
                 return tuple(open(os.path.join(base, n)) for n in emboss_now)
             else:
                 #

--- a/Scripts/query_pubmed.py
+++ b/Scripts/query_pubmed.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         print_usage()
         sys.exit(0)
 
-    print("Doing a PubMed search for %r..." % query)
+    print(f"Doing a PubMed search for {query!r}...")
 
     if count_only:
         handle = Entrez.esearch(db="pubmed", term=query)

--- a/Scripts/xbbtools/xbb_translations.py
+++ b/Scripts/xbbtools/xbb_translations.py
@@ -83,11 +83,11 @@ class xbb_translations:
                 res += "%d/%d\n" % (i + 1, p + 1)
                 res += " " * (frame - 1) + protein[i : i + 60] + "\n"
                 # seq
-                res += subseq.lower() + "%5d %%\n" % int(self.gc(subseq)) + "\n"
+                res += subseq.lower() + f"{int(self.gc(subseq)):5} %\n" + "\n"
             else:
                 res += "%d/%d\n" % (i + 1, protein_length - len(protein[:i].split()))
                 # seq
-                res += subseq.lower() + "%5d %%\n" % int(self.gc(subseq))
+                res += subseq.lower() + f"{int(self.gc(subseq)):5} %\n"
                 res += protein[i : i + 60] + "\n\n"
         return res
 
@@ -119,7 +119,7 @@ class xbb_translations:
                 res += " " + "  ".join(frames[2][p : p + 20]) + "\n"
                 res += "  ".join(frames[1][p : p + 20]) + "\n"
             # seq
-            res += subseq.lower() + "%5d %%\n" % int(self.gc(subseq))
+            res += subseq.lower() + f"{int(self.gc(subseq)):5} %\n"
             res += csubseq.lower() + "\n"
             if direction == "plus":
                 res += "\n"

--- a/Tests/search_tests_common.py
+++ b/Tests/search_tests_common.py
@@ -112,8 +112,7 @@ class CheckIndex(SearchTestBaseClass):
         self.assertEqual(
             len(parsed),
             len(indexed),
-            "Should be %i records in %s, index says %i"
-            % (len(parsed), filename, len(indexed)),
+            f"Should be {len(parsed)} records in {filename}, index says {len(indexed)}",
         )
         # compare values by index_db, only if sqlite3 is present
         if sqlite3 is not None:

--- a/Tests/test_Align_Alignment.py
+++ b/Tests/test_Align_Alignment.py
@@ -32,7 +32,7 @@ class TestAlignment(unittest.TestCase):
         alignment = Align.Alignment([])
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (0 rows x 0 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (0 rows x 0 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 0)
         self.assertEqual(len(alignment.sequences), 0)
@@ -55,7 +55,7 @@ class TestPairwiseAlignment(unittest.TestCase):
         msg = f"{cls.__name__}, {strand} strand"
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (2 rows x 12 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (2 rows x 12 columns) at 0x{id(alignment):x}>",
         )
         if strand == "forward":
             self.assertEqual(
@@ -1454,10 +1454,10 @@ class TestMultipleAlignment(unittest.TestCase):
         self.assertGreaterEqual(other, alignment)
 
     def check_indexing_slicing(self, alignment, strand):
-        msg = "%s strand" % strand
+        msg = f"{strand} strand"
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (7 rows x 156 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (7 rows x 156 columns) at 0x{id(alignment):x}>",
         )
         if strand == "forward":
             self.assertEqual(
@@ -3607,7 +3607,7 @@ class TestAlign_mapall(unittest.TestCase):
             path = os.path.join("Blat", filename)
             alignment = Align.read(path, "chain")
             alignments.append(alignment)
-            filename = "%s.fa" % new_assembly
+            filename = f"{new_assembly}.fa"
             path = os.path.join("Align", filename)
             record = SeqIO.read(path, "fasta")
             chromosome, location = record.id.split(":")

--- a/Tests/test_Align_a2m.py
+++ b/Tests/test_Align_a2m.py
@@ -63,7 +63,7 @@ class TestA2MReadingWriting(unittest.TestCase):
     def check_clustalw(self, alignment):
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (2 rows x 601 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (2 rows x 601 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 2)
         self.assertEqual(alignment.sequences[0].id, "gi|4959044|gb|AAD34209.1|AF069")
@@ -213,7 +213,7 @@ AlignmentCounts object with
                 next(alignments)
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (8 rows x 298 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (8 rows x 298 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 8)
         self.assertEqual(alignment.shape, (8, 298))
@@ -438,7 +438,7 @@ AlignmentCounts object with
                 next(alignments)
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (3 rows x 687 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (3 rows x 687 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 3)
         self.assertEqual(alignment.sequences[0].id, "Test1seq")
@@ -598,7 +598,7 @@ AlignmentCounts object with
                 next(alignments)
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (2 rows x 27 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (2 rows x 27 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 2)
         self.assertEqual(alignment.sequences[0].id, "Test1seq")
@@ -705,7 +705,7 @@ AlignmentCounts object with
                 next(alignments)
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (5 rows x 101 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (5 rows x 101 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 5)
         self.assertEqual(alignment.sequences[0].id, "plas_horvu")

--- a/Tests/test_Align_clustal.py
+++ b/Tests/test_Align_clustal.py
@@ -70,7 +70,7 @@ class TestClustalReadingWriting(unittest.TestCase):
             next(alignments)
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (2 rows x 601 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (2 rows x 601 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 2)
         self.assertEqual(alignment.sequences[0].id, "gi|4959044|gb|AAD34209.1|AF069")
@@ -266,7 +266,7 @@ AlignmentCounts object with
                 next(alignments)
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (8 rows x 298 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (8 rows x 298 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 8)
         self.assertEqual(alignment.shape, (8, 298))
@@ -539,7 +539,7 @@ AlignmentCounts object with
                 next(alignments)
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (3 rows x 687 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (3 rows x 687 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 3)
         self.assertEqual(alignment.sequences[0].id, "Test1seq")
@@ -779,7 +779,7 @@ np.array([['G', 'C', 'T', 'G', 'G', 'G', 'G', 'A', 'T', 'G', 'G', 'A', 'G', 'A',
         )
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (2 rows x 27 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (2 rows x 27 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 2)
         self.assertEqual(alignment.sequences[0].id, "Test1seq")
@@ -918,7 +918,7 @@ np.array([['D', '-', 'V', 'L', 'L', 'G', 'A', 'N', 'G', 'G', 'V', 'L', 'V',
         )
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (5 rows x 101 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (5 rows x 101 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 5)
         self.assertEqual(alignment.sequences[0].id, "plas_horvu")

--- a/Tests/test_Align_fasta.py
+++ b/Tests/test_Align_fasta.py
@@ -59,7 +59,7 @@ class TestFASTAReadingWriting(unittest.TestCase):
             next(alignments)
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (2 rows x 601 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (2 rows x 601 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 2)
         self.assertEqual(alignment.sequences[0].id, "gi|4959044|gb|AAD34209.1|AF069")
@@ -205,7 +205,7 @@ AlignmentCounts object with
                 next(alignments)
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (8 rows x 298 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (8 rows x 298 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 8)
         self.assertEqual(alignment.shape, (8, 298))
@@ -426,7 +426,7 @@ AlignmentCounts object with
                 next(alignments)
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (3 rows x 687 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (3 rows x 687 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 3)
         self.assertEqual(alignment.sequences[0].id, "Test1seq")
@@ -594,7 +594,7 @@ np.array([['G', 'C', 'T', 'G', 'G', 'G', 'G', 'A', 'T', 'G', 'G', 'A', 'G', 'A',
         )
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (2 rows x 27 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (2 rows x 27 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 2)
         self.assertEqual(alignment.sequences[0].id, "Test1seq")
@@ -732,7 +732,7 @@ np.array([['D', '-', 'V', 'L', 'L', 'G', 'A', 'N', 'G', 'G', 'V', 'L', 'V',
         )
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (5 rows x 101 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (5 rows x 101 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 5)
         self.assertEqual(alignment.sequences[0].id, "plas_horvu")

--- a/Tests/test_Align_phylip.py
+++ b/Tests/test_Align_phylip.py
@@ -77,7 +77,7 @@ class TestPhylipReading(unittest.TestCase):
             next(alignments)
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (8 rows x 286 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (8 rows x 286 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 8)
         self.assertEqual(alignment.sequences[0].id, "V_Harveyi_")
@@ -330,7 +330,7 @@ AlignmentCounts object with
                     next(alignments)
             self.assertEqual(
                 repr(alignment),
-                "<Alignment object (5 rows x 60 columns) at 0x%x>" % id(alignment),
+                f"<Alignment object (5 rows x 60 columns) at 0x{id(alignment):x}>",
             )
             self.assertEqual(len(alignment), 5)
             self.assertEqual(alignment.sequences[0].id, "Tax1")
@@ -504,7 +504,7 @@ np.array([['A', 'A', 'G', 'C', 'T', 'N', 'G', 'G', 'G', 'C', 'A', 'T', 'T',
         )
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (5 rows x 42 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (5 rows x 42 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 5)
         self.assertEqual(alignment.sequences[0].id, "Turkey")
@@ -624,7 +624,7 @@ AlignmentCounts object with
                     next(alignments)
             self.assertEqual(
                 repr(alignment),
-                "<Alignment object (5 rows x 42 columns) at 0x%x>" % id(alignment),
+                f"<Alignment object (5 rows x 42 columns) at 0x{id(alignment):x}>",
             )
             self.assertEqual(len(alignment), 5)
             self.assertEqual(alignment.sequences[0].id, "Turkey")
@@ -773,7 +773,7 @@ AlignmentCounts object with
             next(alignments)
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (3 rows x 384 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (3 rows x 384 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 3)
         self.assertEqual(alignment.sequences[0].id, "CYS1_DICDI")
@@ -957,7 +957,7 @@ AlignmentCounts object with
             next(alignments)
         self.assertEqual(
             repr(alignment),
-            "<Alignment object (4 rows x 131 columns) at 0x%x>" % id(alignment),
+            f"<Alignment object (4 rows x 131 columns) at 0x{id(alignment):x}>",
         )
         self.assertEqual(len(alignment), 4)
         self.assertEqual(alignment.sequences[0].id, "IXI_234")

--- a/Tests/test_Align_psl.py
+++ b/Tests/test_Align_psl.py
@@ -11783,7 +11783,7 @@ AlignmentCounts object with
 class TestAlign_dnax_prot(unittest.TestCase):
     @classmethod
     def read_dna(cls, assembly, sequence):
-        path = "Blat/%s.fa" % assembly
+        path = f"Blat/{assembly}.fa"
         records = SeqIO.parse(path, "fasta")
         for record in records:
             name, start_end = record.id.split(":")

--- a/Tests/test_Blast_parser.py
+++ b/Tests/test_Blast_parser.py
@@ -14805,7 +14805,7 @@ class TestPSIBlast(unittest.TestCase):
         self.assertEqual(record.num, 1)
         self.assertEqual(
             repr(record),
-            "<Bio.Blast.Record query.id='%s'; 2 hits>" % record.query.id,
+            f"<Bio.Blast.Record query.id='{record.query.id}'; 2 hits>",
         )
         self.assertIsInstance(record.query, SeqRecord)
         if xml2:

--- a/Tests/test_Entrez.py
+++ b/Tests/test_Entrez.py
@@ -111,7 +111,7 @@ def deconstruct_request(request, testcase=None):
 
     else:
         raise ValueError(
-            "Expected method to be either GET or POST, got %r" % request.method
+            f"Expected method to be either GET or POST, got {request.method!r}"
         )
 
     return get_base_url(parsed), params

--- a/Tests/test_Phylo.py
+++ b/Tests/test_Phylo.py
@@ -123,7 +123,7 @@ class IOTests(unittest.TestCase):
         value = mem_file.getvalue().strip()
         self.assertTrue(value.startswith("A:"))
         self.assertTrue(value.endswith(";"))
-        self.assertEqual(value[2:-1], "%.0e" % 0.1)
+        self.assertEqual(value[2:-1], f"{0.1:.0e}")
 
     def test_convert(self):
         """Convert a tree between all supported formats."""

--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -363,11 +363,7 @@ class TestReadWrite(unittest.TestCase):
 
     def test_fastq_1000(self):
         """Read and write back simple example with mixed case 1000bp read."""
-        data = "@%s\n%s\n+\n%s\n" % (
-            "id descr goes here",
-            "ACGTNncgta" * 100,
-            "abcd!!efgh" * 100,
-        )
+        data = f"@id descr goes here\n{'ACGTNncgta' * 100}\n+\n{'abcd!!efgh' * 100}\n"
         handle = StringIO()
         self.assertEqual(
             1, SeqIO.write(SeqIO.parse(StringIO(data), "fastq"), handle, "fastq")

--- a/Tests/test_SeqIO_UniprotIO.py
+++ b/Tests/test_SeqIO_UniprotIO.py
@@ -571,7 +571,7 @@ class ParserTests(SeqRecordTestBaseClass):
         self.assertEqual(
             len(old.features),
             len(new.features),
-            "Features in %s, %i vs %i" % (old.id, len(old.features), len(new.features)),
+            f"Features in {old.id}, {len(old.features)} vs {len(new.features)}",
         )
         for f1, f2 in zip(old.features, new.features):
             self.assertEqual(

--- a/Tests/test_Tutorial.py
+++ b/Tests/test_Tutorial.py
@@ -265,7 +265,7 @@ class TutorialTestCase(unittest.TestCase):
                     failures.append(name[30:])
         if failures:
             raise ValueError(
-                "%i Tutorial doctests failed: %s" % (len(failures), ", ".join(failures))
+                f"{len(failures)} Tutorial doctests failed: {', '.join(failures)}"
             )
 
     def tearDown(self):

--- a/Tests/test_pairwise_aligner.py
+++ b/Tests/test_pairwise_aligner.py
@@ -9293,9 +9293,8 @@ class TestPairwiseMatchDictionary(unittest.TestCase):
         self.assertEqual(aligner.algorithm, "Gotoh local alignment algorithm")
         self.assertEqual(
             str(aligner),
-            """\
-Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at 0x%x>
+            f"""Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at 0x{id(substitution_matrix):x}>
   open_internal_insertion_score: -0.500000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.500000
@@ -9309,8 +9308,7 @@ Pairwise sequence aligner with parameters
   open_right_deletion_score: -0.500000
   extend_right_deletion_score: 0.000000
   mode: local
-"""
-            % id(substitution_matrix),
+""",
         )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
@@ -9913,9 +9911,8 @@ AlignmentCounts object with
         aligner.extend_gap_score = 0.0
         self.assertEqual(
             str(aligner),
-            """\
-Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at 0x%x>
+            f"""Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at 0x{id(substitution_matrix):x}>
   open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -1.000000
@@ -9929,8 +9926,7 @@ Pairwise sequence aligner with parameters
   open_right_deletion_score: -1.000000
   extend_right_deletion_score: 0.000000
   mode: local
-"""
-            % id(substitution_matrix),
+""",
         )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
@@ -10244,9 +10240,8 @@ AlignmentCounts object with
         aligner.extend_gap_score = 0.0
         self.assertEqual(
             str(aligner),
-            """\
-Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at 0x%x>
+            f"""Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at 0x{id(substitution_matrix):x}>
   open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -1.000000
@@ -10260,8 +10255,7 @@ Pairwise sequence aligner with parameters
   open_right_deletion_score: -1.000000
   extend_right_deletion_score: 0.000000
   mode: local
-"""
-            % id(substitution_matrix),
+""",
         )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
@@ -10578,9 +10572,8 @@ AlignmentCounts object with
         self.assertEqual(aligner.algorithm, "Gotoh local alignment algorithm")
         self.assertEqual(
             str(aligner),
-            """\
-Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at 0x%x>
+            f"""Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at 0x{id(substitution_matrix):x}>
   open_internal_insertion_score: -0.500000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -0.500000
@@ -10594,8 +10587,7 @@ Pairwise sequence aligner with parameters
   open_right_deletion_score: -0.500000
   extend_right_deletion_score: 0.000000
   mode: local
-"""
-            % id(substitution_matrix),
+""",
         )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
@@ -11193,9 +11185,8 @@ AlignmentCounts object with
         aligner.extend_gap_score = 0.0
         self.assertEqual(
             str(aligner),
-            """\
-Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at 0x%x>
+            f"""Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at 0x{id(substitution_matrix):x}>
   open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -1.000000
@@ -11209,8 +11200,7 @@ Pairwise sequence aligner with parameters
   open_right_deletion_score: -1.000000
   extend_right_deletion_score: 0.000000
   mode: local
-"""
-            % id(substitution_matrix),
+""",
         )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)
@@ -11526,9 +11516,8 @@ AlignmentCounts object with
         aligner.extend_gap_score = 0.0
         self.assertEqual(
             str(aligner),
-            """\
-Pairwise sequence aligner with parameters
-  substitution_matrix: <Array object at 0x%x>
+            f"""Pairwise sequence aligner with parameters
+  substitution_matrix: <Array object at 0x{id(substitution_matrix):x}>
   open_internal_insertion_score: -1.000000
   extend_internal_insertion_score: 0.000000
   open_left_insertion_score: -1.000000
@@ -11542,8 +11531,7 @@ Pairwise sequence aligner with parameters
   open_right_deletion_score: -1.000000
   extend_right_deletion_score: 0.000000
   mode: local
-"""
-            % id(substitution_matrix),
+""",
         )
         score = aligner.score(seq1, seq2)
         self.assertAlmostEqual(score, 3.0)


### PR DESCRIPTION
Follow up on #5218 but with a lot more changes (277 new f-strings), for #2510.

```
$ flynt .
Running flynt v.1.0.6
Using config file at /Users/peterjc/repositories/biopython/pyproject.toml Modified 157 of 876 files in 21.49s
```

Then ran black on files as needed, and reverted a `c` formatting change in `Bio/motifs/matrix.py` due to https://github.com/ikamensh/flynt/issues/253

Before:

```
$ flake8 --isolated --select SFS --quiet --statistics BioSQL Bio
...
730   SFS101 String literal formatting using percent operator.
111   SFS102 Bytes literal formatting using percent operator.
19    SFS201 String literal formatting using format method.
1348  SFS301 String literal formatting using f-string.
```

After:

```
$ flake8 --isolated --select SFS --quiet --statistics BioSQL Bio
...
483   SFS101 String literal formatting using percent operator.
111   SFS102 Bytes literal formatting using percent operator.
17    SFS201 String literal formatting using format method.
1626  SFS301 String literal formatting using f-string.
```

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->
