### PR TITLE
Fix AlphaFoldDB path test on Windows

### DIFF
--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -149,6 +149,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Gaetan Lehman <gaetan.lehmann at domain jouy.inra.fr>
 - Gavin E Crooks <https://github.com/gecrooks>
 - Gert Hulselmans <https://github.com/ghuls>
+- Gian Carlo D Dumpit <https://github.com/GeneratedScript-RL>
 - Gleb Kuznetsov <https://github.com/glebkuznetsov>
 - Gokcen Eraslan <https://github.com/gokceneraslan>
 - Harry Jubb <https://github.com/harryjubb>

--- a/Tests/test_PDB_alphafold_db.py
+++ b/Tests/test_PDB_alphafold_db.py
@@ -23,5 +23,4 @@ class AlphafoldDBTests(unittest.TestCase):
             "cifUrl": "https://alphafold.ebi.ac.uk/files/AF-P00520-F1-model_v4.cif",
         }
         file_path = alphafold_db._get_mmcif_file_path_for(prediction, "test")
-        expected = os.path.join("test", "AF-P00520-F1-model_v4.cif")
-        self.assertEqual(file_path, expected)
+        self.assertEqual(file_path, os.path.join("test", "AF-P00520-F1-model_v4.cif"))

--- a/Tests/test_PDB_alphafold_db.py
+++ b/Tests/test_PDB_alphafold_db.py
@@ -1,5 +1,6 @@
 """Tests for the alphafold_db module."""
 
+import os
 import unittest
 
 import requires_internet
@@ -22,4 +23,5 @@ class AlphafoldDBTests(unittest.TestCase):
             "cifUrl": "https://alphafold.ebi.ac.uk/files/AF-P00520-F1-model_v4.cif",
         }
         file_path = alphafold_db._get_mmcif_file_path_for(prediction, "test")
-        self.assertEqual(file_path, "test/AF-P00520-F1-model_v4.cif")
+        expected = os.path.join("test", "AF-P00520-F1-model_v4.cif")
+        self.assertEqual(file_path, expected)


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, I am listed. I wish to be listed.

I fixed a Windows-only assertion failure in `Tests/test_PDB_alphafold_db.py::AlphafoldDBTests.test_get_mmcif_file_path_for`

Right now, the test currently expects the mmCIF path to contain a hard-coded forward slash:

```
test/AF-P00520-F1-model_v4.cif
```
However, ``Bio.PDB.alphafold_db._get_mmcif_file_path_for`` builds the path with
``os.path.join``, which correctly returns a backslash on Windows:

```
test\AF-P00520-F1-model_v4.cif
```

This PR updates the test expectation to use ``os.path.join`` as well, making the
assertion portable across Windows, macOS, and Linux.

On Windows, before applying the fix, I git cloned the repo fork and tried to run python Tests/run_tests.py:

```
FAIL: test_get_mmcif_file_path_for (test_PDB_alphafold_db.AlphafoldDBTests.test_get_mmcif_file_path_for)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "...\Tests\test_PDB_alphafold_db.py", line 25, in test_get_mmcif_file_path_for
    self.assertEqual(file_path, "test/AF-P00520-F1-model_v4.cif")
AssertionError: 'test\\AF-P00520-F1-model_v4.cif' != 'test/AF-P00520-F1-model_v4.cif'
- test\AF-P00520-F1-model_v4.cif
?     ^
+ test/AF-P00520-F1-model_v4.cif
?     ^
```

After applying the change, the same focused test should pass:

```
cd Tests
python -m unittest test_PDB_alphafold_db.AlphafoldDBTests.test_get_mmcif_file_path_for
```

Expected output:

```
.
----------------------------------------------------------------------
Ran 1 test in 0.722s (atleast for my machine)

OK
```

The module should also pass through Biopython's test runner:

```
cd Tests
python run_tests.py test_PDB_alphafold_db
```

I didnt think opening an issue was needed for an unsolicited PR, please correct me if needed, as this is my first PR.
I used pre-commit, and ran `pre-commit run --all-files`

```
check that executables have shebangs.....................................Passed
check json...............................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
ruff check...............................................................Passed
black....................................................................Passed
flake8...................................................................Passed
mypy.....................................................................Passed
blacken-docs.............................................................Passed
rstcheck.................................................................Passed
doc8.....................................................................Passed
codespell................................................................Passed
Enforce https://doi.org/ style...........................................Passed
Contributor sorting......................................................Passed
```



I also double checked if this was a pattern in the codebase, or if this was meant to be here/was a standard, I think it was not, correct me if I am wrong. in Bio/Entrez/Parser.py line 1123 `# urls always have a forward slash, don't use os.path.join` - this comment is present.

Same with Bio/AlignIO/MafIO.py line 347 `# Would be stored with Unix / path separator, so convert`, and Bio/File.py line 389 `# Would be stored with Unix / path separator, so convert`