### PR TITLE
Feature/alphafold proteome bulk download

### DIFF
--- a/Bio/PDB/alphafold_db.py
+++ b/Bio/PDB/alphafold_db.py
@@ -3,15 +3,13 @@
 See the `database website <https://alphafold.com/>`_ and the `API docs <https://alphafold.com/api-docs/>`_.
 """
 
-from functools import lru_cache
+import gzip
 import json
 import os
-import gzip
 import tarfile
-from os import PathLike
 from collections.abc import Iterator
-#from typing import Optional
-#from typing import Union
+from functools import lru_cache
+from os import PathLike
 from urllib.request import urlopen
 
 from Bio.PDB.MMCIFParser import MMCIFParser
@@ -29,7 +27,7 @@ def get_predictions(qualifier: str) -> Iterator[dict]:
     url = f"https://alphafold.com/api/prediction/{qualifier}"
     # Retrieve the AlphaFold predictions with urllib
     with urlopen(url) as response:
-            yield from json.loads(response.read().decode())
+        yield from json.loads(response.read().decode())
 
 
 def _get_mmcif_file_path_for(
@@ -118,6 +116,7 @@ def get_structural_models_for(
 
         yield mmcif_parser.get_structure(qualifier, mmcif_path)
 
+
 @lru_cache(maxsize=1)
 def list_proteomes() -> list[dict]:
     """List all available proteomes in the AlphaFold Database.
@@ -133,11 +132,12 @@ def list_proteomes() -> list[dict]:
     url = "https://ftp.ebi.ac.uk/pub/databases/alphafold/download_metadata.json"
     with urlopen(url) as response:
         return json.loads(response.read().decode())
-    
-    
 
-def download_proteome(species: str, directory: str | bytes| PathLike | None = None,
-    ) -> str: 
+
+def download_proteome(
+    species: str,
+    directory: str | bytes | PathLike | None = None,
+) -> str:
     """Download all AlphaFold predictions for a reference proteome.
 
     Downloads the proteome archive (.tar) from the EMBL-EBI FTP server.
@@ -160,17 +160,16 @@ def download_proteome(species: str, directory: str | bytes| PathLike | None = No
     :rtype: str
     :raises ValueError: If the species cannot be found in the AlphaFold database
     """
-
     if directory is None:
         directory = os.getcwd()
 
-    #find the matching proteome entry
+    # Find the matching proteome entry
     proteomes = list_proteomes()
     match = None
     species_lower = species.lower()
     for proteome in proteomes:
         if proteome.get("type") not in ("proteome", "global_health"):
-            continue # this skips Swiss-Prot and other non species entries
+            continue  # skip Swiss-Prot and other non-species entries
         if species_lower in (
             proteome["species"].lower(),
             proteome["common_name"].lower(),
@@ -178,20 +177,26 @@ def download_proteome(species: str, directory: str | bytes| PathLike | None = No
         ):
             match = proteome
             break
-    if match is None:
-        raise ValueError(f"Could not find proteome for '{species}'." f"Use list_proteomes() to see available species.")
 
-    #warn user about download size 
+    if match is None:
+        raise ValueError(
+            f"Could not find proteome for '{species}'. "
+            "Use list_proteomes() to see available species."
+        )
+
+    # Warn user about download size
     size_gb = match["size_bytes"] / 1e9
-    print(f"Downloading {match['num_predicted_structures']} structures "
-        f"for {match['species']} ({size_gb:.1f} GB)...")
+    print(
+        f"Downloading {match['num_predicted_structures']} structures "
+        f"for {match['species']} ({size_gb:.1f} GB)..."
+    )
 
     os.makedirs(directory, exist_ok=True)
     archive_name = match["archive_name"]
     file_path = os.path.join(directory, archive_name)
 
     if os.path.exists(file_path):
-        print(f"Archive {file_path} already exists, skipping download.")
+        print(f"Archive {str(file_path)} already exists, skipping download.")
         return str(file_path)
 
     url = f"https://ftp.ebi.ac.uk/pub/databases/alphafold/latest/{archive_name}"
@@ -205,7 +210,7 @@ def download_proteome(species: str, directory: str | bytes| PathLike | None = No
             os.remove(file_path)
         raise
 
-    print(f"Downloaded to {file_path}")
+    print(f"Downloaded to {str(file_path)}")
     return str(file_path)
 
 
@@ -239,24 +244,26 @@ def extract_proteome(
 
     if directory is None:
         directory = os.path.dirname(archive_path)
-    os.makedirs(directory, exist_ok=True)
+    os.makedirs(str(directory), exist_ok=True)
 
-    extracted_paths = []
+    extracted_paths: list[str] = []
     with tarfile.open(archive_path) as tar:
         members = [m for m in tar.getmembers() if m.name.endswith(extension)]
         print(f"Extracting {len(members)} {file_format} files...")
         for member in members:
             # Decompress and write without the .gz extension
             out_name = member.name.replace(".gz", "")
-            out_path = os.path.join(directory, out_name)
+            out_path = os.path.join(str(directory), out_name)
             os.makedirs(os.path.dirname(out_path), exist_ok=True)
-            with tar.extractfile(member) as gz_file:
-                with gzip.open(gz_file) as decompressed:
-                    with open(out_path, "wb") as out_file:
-                        out_file.write(decompressed.read())
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                continue
+            with gzip.open(extracted) as decompressed:
+                with open(out_path, "wb") as out_file:
+                    out_file.write(decompressed.read())
             extracted_paths.append(str(out_path))
 
-    print(f"Extracted {len(extracted_paths)} files to {directory}")
+    print(f"Extracted {len(extracted_paths)} files to {str(directory)}")
     return extracted_paths
 
 
@@ -346,4 +353,3 @@ class AlphaFoldDB:
             mmcif_parser=parser,
             directory=dir_str,
         )
-    

--- a/Bio/PDB/alphafold_db.py
+++ b/Bio/PDB/alphafold_db.py
@@ -3,12 +3,15 @@
 See the `database website <https://alphafold.com/>`_ and the `API docs <https://alphafold.com/api-docs/>`_.
 """
 
+from functools import lru_cache
 import json
 import os
+import gzip
+import tarfile
 from os import PathLike
 from collections.abc import Iterator
-from typing import Optional
-from typing import Union
+#from typing import Optional
+#from typing import Union
 from urllib.request import urlopen
 
 from Bio.PDB.MMCIFParser import MMCIFParser
@@ -26,7 +29,7 @@ def get_predictions(qualifier: str) -> Iterator[dict]:
     url = f"https://alphafold.com/api/prediction/{qualifier}"
     # Retrieve the AlphaFold predictions with urllib
     with urlopen(url) as response:
-        yield from json.loads(response.read().decode())
+            yield from json.loads(response.read().decode())
 
 
 def _get_mmcif_file_path_for(
@@ -114,3 +117,233 @@ def get_structural_models_for(
             mmcif_path = download_cif_for(prediction, directory)
 
         yield mmcif_parser.get_structure(qualifier, mmcif_path)
+
+@lru_cache(maxsize=1)
+def list_proteomes() -> list[dict]:
+    """List all available proteomes in the AlphaFold Database.
+
+    Downloads the metadata index from the EBI FTP server and returns a list
+    of proteome entries. Each entry is a dict with keys such as ``species``,
+    ``common_name``, ``reference_proteome``, ``archive_name``,
+    ``num_predicted_structures``, and ``size_bytes``.
+
+    :return: Available proteome entries
+    :rtype: list[dict]
+    """
+    url = "https://ftp.ebi.ac.uk/pub/databases/alphafold/download_metadata.json"
+    with urlopen(url) as response:
+        return json.loads(response.read().decode())
+    
+    
+
+def download_proteome(species: str, directory: str | bytes| PathLike | None = None,
+    ) -> str: 
+    """Download all AlphaFold predictions for a reference proteome.
+
+    Downloads the proteome archive (.tar) from the EMBL-EBI FTP server.
+    The species can be matched by scientific name, common name, or
+    UniProt reference proteome ID.
+
+    Example usage::
+
+        path = download_proteome("Homo sapiens", directory="~/alphafold")
+        path = download_proteome("Human", directory="~/alphafold")
+        path = download_proteome("UP000005640", directory="~/alphafold")
+
+    :param species: Species identifier - scientific name (e.g. 'Homo sapiens'),
+        common name (e.g. 'Human'), or UniProt proteome ID (e.g. 'UP000005640')
+    :type species: str
+    :param directory: The directory to write the archive to, defaults to
+        the current working directory
+    :type directory: Union[str, bytes, PathLike], optional
+    :return: The path to the downloaded tar archive
+    :rtype: str
+    :raises ValueError: If the species cannot be found in the AlphaFold database
+    """
+
+    if directory is None:
+        directory = os.getcwd()
+
+    #find the matching proteome entry
+    proteomes = list_proteomes()
+    match = None
+    species_lower = species.lower()
+    for proteome in proteomes:
+        if proteome.get("type") not in ("proteome", "global_health"):
+            continue # this skips Swiss-Prot and other non species entries
+        if species_lower in (
+            proteome["species"].lower(),
+            proteome["common_name"].lower(),
+            proteome["reference_proteome"].lower(),
+        ):
+            match = proteome
+            break
+    if match is None:
+        raise ValueError(f"Could not find proteome for '{species}'." f"Use list_proteomes() to see available species.")
+
+    #warn user about download size 
+    size_gb = match["size_bytes"] / 1e9
+    print(f"Downloading {match['num_predicted_structures']} structures "
+        f"for {match['species']} ({size_gb:.1f} GB)...")
+
+    os.makedirs(directory, exist_ok=True)
+    archive_name = match["archive_name"]
+    file_path = os.path.join(directory, archive_name)
+
+    if os.path.exists(file_path):
+        print(f"Archive {file_path} already exists, skipping download.")
+        return str(file_path)
+
+    url = f"https://ftp.ebi.ac.uk/pub/databases/alphafold/latest/{archive_name}"
+    try:
+        with urlopen(url) as response:
+            with open(file_path, "wb") as out_file:
+                while chunk := response.read(8192):
+                    out_file.write(chunk)
+    except Exception:
+        if os.path.exists(file_path):
+            os.remove(file_path)
+        raise
+
+    print(f"Downloaded to {file_path}")
+    return str(file_path)
+
+
+def extract_proteome(
+    archive_path: str | bytes | PathLike,
+    directory: str | bytes | PathLike | None = None,
+    file_format: str = "mmCif",
+) -> list[str]:
+    """Extract an AlphaFold proteome archive downloaded with download_proteome().
+
+    Extracts and decompresses structures of the requested format only.
+
+    :param archive_path: Path to the downloaded .tar archive
+    :type archive_path: Union[str, bytes, PathLike]
+    :param directory: Directory to extract files to, defaults to the same
+        directory as the archive
+    :type directory: Union[str, bytes, PathLike], optional
+    :param file_format: Structure file format to extract, either 'mmCif'
+        or 'pdb', defaults to 'mmCif'
+    :type file_format: str
+    :return: List of paths to the extracted files
+    :rtype: list[str]
+    :raises ValueError: If an invalid file_format is specified
+    """
+    fmt_map = {"mmCif": ".cif.gz", "pdb": ".pdb.gz"}
+    if file_format not in fmt_map:
+        raise ValueError(
+            f"Invalid file_format '{file_format}'. Choose 'mmCif' or 'pdb'."
+        )
+    extension = fmt_map[file_format]
+
+    if directory is None:
+        directory = os.path.dirname(archive_path)
+    os.makedirs(directory, exist_ok=True)
+
+    extracted_paths = []
+    with tarfile.open(archive_path) as tar:
+        members = [m for m in tar.getmembers() if m.name.endswith(extension)]
+        print(f"Extracting {len(members)} {file_format} files...")
+        for member in members:
+            # Decompress and write without the .gz extension
+            out_name = member.name.replace(".gz", "")
+            out_path = os.path.join(directory, out_name)
+            os.makedirs(os.path.dirname(out_path), exist_ok=True)
+            with tar.extractfile(member) as gz_file:
+                with gzip.open(gz_file) as decompressed:
+                    with open(out_path, "wb") as out_file:
+                        out_file.write(decompressed.read())
+            extracted_paths.append(str(out_path))
+
+    print(f"Extracted {len(extracted_paths)} files to {directory}")
+    return extracted_paths
+
+
+class AlphaFoldDB:
+    """A PDBList-like interface for the AlphaFold Protein Structure Database.
+
+    Provides a high-level, database-style API for bulk downloading and local
+    management of AlphaFold predictions.  Inspired by
+    ``Bio.PDB.PDBList.PDBList``.
+
+    Basic usage::
+
+        from Bio.PDB.alphafold_db import AlphaFoldDB
+
+        afdb = AlphaFoldDB(directory="~/alphafold")
+
+        # Download an entire human proteome
+        afdb.download_proteome("Homo sapiens")
+
+        # Extract only mmCIF files
+        afdb.extract_proteome("~/alphafold/UP000005640_9606_HUMAN.tar")
+
+        # Fetch and parse structures for a specific protein (uses local cache)
+        for structure in afdb.get_structural_models_for("P00520"):
+            print(structure)
+    """
+
+    def __init__(
+        self,
+        directory: str | bytes | PathLike | None = None,
+        mmcif_parser: MMCIFParser | None = None,
+    ) -> None:
+        """Initialize AlphaFoldDB.
+
+        :param directory: Base directory for downloaded files, defaults to
+            the current working directory
+        :type directory: Union[str, bytes, PathLike], optional
+        :param mmcif_parser: Pre-configured MMCIFParser instance
+        :type mmcif_parser: MMCIFParser, optional
+        """
+        self.directory = directory
+        self.mmcif_parser = mmcif_parser
+
+    def list_proteomes(self) -> list[dict]:
+        """Wraps :func:`list_proteomes`."""
+        return list_proteomes()
+
+    def download_proteome(
+        self,
+        species: str,
+        directory: str | bytes | PathLike | None = None,
+    ) -> str:
+        """Wraps :func:`download_proteome`.
+
+        If *directory* is not given, uses the instance default.
+        """
+        if directory is None:
+            directory = self.directory
+        return download_proteome(species, directory=directory)
+
+    def extract_proteome(
+        self,
+        archive_path: str | bytes | PathLike,
+        directory: str | bytes | PathLike | None = None,
+        file_format: str = "mmCif",
+    ) -> list[str]:
+        """Wraps :func:`extract_proteome`."""
+        return extract_proteome(
+            archive_path, directory=directory, file_format=file_format
+        )
+
+    def get_structural_models_for(
+        self,
+        qualifier: str,
+        directory: str | bytes | PathLike | None = None,
+    ) -> Iterator[StructuralModel]:
+        """Wraps :func:`get_structural_models_for`.
+
+        Uses the instance default directory and mmcif_parser when available.
+        """
+        if directory is None:
+            directory = self.directory
+        parser = self.mmcif_parser if self.mmcif_parser is not None else MMCIFParser()
+        dir_str = str(directory) if directory is not None else None
+        return get_structural_models_for(
+            qualifier,
+            mmcif_parser=parser,
+            directory=dir_str,
+        )
+    

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -146,6 +146,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Fredric Johansson <https://github.com/fredricj>
 - Fynn Freyer <https://github.com/FynnFreyer>
 - Fábio Madeira <https://github.com/biomadeira>
+- Gabriel Franchet-Schaer <https://github.com/gabufle>
 - Gaetan Lehman <gaetan.lehmann at domain jouy.inra.fr>
 - Gavin E Crooks <https://github.com/gecrooks>
 - Gert Hulselmans <https://github.com/ghuls>

--- a/Tests/test_PDB_alphafold_db.py
+++ b/Tests/test_PDB_alphafold_db.py
@@ -30,7 +30,9 @@ class AlphafoldDBTests(unittest.TestCase):
 
         self.assertIsInstance(proteomes, list)
         self.assertGreater(len(proteomes), 0)
-        species_proteomes = [p for p in proteomes if p.get("type") in ("proteome", "global_health")]
+        species_proteomes = [
+            p for p in proteomes if p.get("type") in ("proteome", "global_health")
+        ]
         self.assertGreater(len(species_proteomes), 0)
 
         for proteome in species_proteomes:
@@ -66,4 +68,3 @@ class AlphafoldDBTests(unittest.TestCase):
                 break
         self.assertIsNotNone(match)
         self.assertEqual(match["reference_proteome"], smallest["reference_proteome"])
-

--- a/Tests/test_PDB_alphafold_db.py
+++ b/Tests/test_PDB_alphafold_db.py
@@ -1,5 +1,6 @@
 """Tests for the alphafold_db module."""
 
+import os
 import unittest
 
 import requires_internet
@@ -22,4 +23,47 @@ class AlphafoldDBTests(unittest.TestCase):
             "cifUrl": "https://alphafold.ebi.ac.uk/files/AF-P00520-F1-model_v4.cif",
         }
         file_path = alphafold_db._get_mmcif_file_path_for(prediction, "test")
-        self.assertEqual(file_path, "test/AF-P00520-F1-model_v4.cif")
+        self.assertEqual(file_path, os.path.join("test", "AF-P00520-F1-model_v4.cif"))
+
+    def test_list_proteomes(self):
+        proteomes = alphafold_db.list_proteomes()
+
+        self.assertIsInstance(proteomes, list)
+        self.assertGreater(len(proteomes), 0)
+        species_proteomes = [p for p in proteomes if p.get("type") in ("proteome", "global_health")]
+        self.assertGreater(len(species_proteomes), 0)
+
+        for proteome in species_proteomes:
+            self.assertIn("species", proteome)
+            self.assertIsInstance(proteome, dict)
+            self.assertIn("species", proteome)
+            self.assertIn("archive_name", proteome)
+            self.assertIn("reference_proteome", proteome)
+            self.assertIn("num_predicted_structures", proteome)
+            self.assertIn("size_bytes", proteome)
+
+    def test_download_proteome_invalid_species(self):
+        with self.assertRaises(ValueError):
+            alphafold_db.download_proteome("NOTASPECIES123")
+
+    def test_download_proteome_match_by_common_name(self):
+        proteomes = alphafold_db.list_proteomes()
+        # find smallest proteome to keep test fast
+
+        smallest = min(proteomes, key=lambda p: p["size_bytes"])
+        # just test matching logic, not actual download
+
+        match = None
+        species_lower = smallest["common_name"].lower()
+
+        for proteome in proteomes:
+            if species_lower in (
+                proteome["species"].lower(),
+                proteome["common_name"].lower(),
+                proteome["reference_proteome"].lower(),
+            ):
+                match = proteome
+                break
+        self.assertIsNotNone(match)
+        self.assertEqual(match["reference_proteome"], smallest["reference_proteome"])
+


### PR DESCRIPTION

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)


Closes #3990.
This PR extends the existing Bio.PDB.alphafold_db module with bulk proteome download functionality as requested in the issue. Note that PR #5176 addresses similar functionality via a new AFDBList class — this PR instead extends the existing module to keep the codebase consistent.
New functions added:

list_proteomes() — fetches the EBI metadata index and returns all 48 available species with their archive names, sizes, and structure counts
download_proteome() — downloads a full proteome archive (.tar) from the EMBL-EBI FTP server, matched by scientific name, common name, or UniProt proteome ID
extract_proteome() — extracts and decompresses individual .cif or .pdb files from a downloaded archive
AlphaFoldDB — a PDBList-style class that wraps the above functions with a persistent directory state

Also fixes a pre-existing test failure on Windows where os.path.join() was producing backslash separators that didn't match hardcoded forward slashes in the test assertions.

Example usage:
from Bio.PDB.alphafold_db import AlphaFoldDB
afdb = AlphaFoldDB(directory="./alphafold")
archive = afdb.download_proteome("Helicobacter pylori")
paths = afdb.extract_proteome(archive)

Tested on Windows 11 with Python 3.13.2