### PR TITLE
Appveyor.yml try catch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,27 @@ build_script:
         https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
         throw "There are newer queued builds for this pull request, failing early." }
-  - ps: Start-FileDownload "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge$env:PY_MAJOR_VER-Windows-$env:PYTHON_ARCH.exe" C:\Miniconda.exe; echo "Finished downloading miniconda"
+  - ps: |
+      $ErrorActionPreference = "Stop"
+      $url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge$env:PY_MAJOR_VER-Windows-$env:PYTHON_ARCH.exe"
+      $destination = "C:\Miniconda.exe"
+      $maxAttempts = 3
+      for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+          try {
+              if (Test-Path $destination) {
+                  Remove-Item $destination -Force
+              }
+              Start-FileDownload $url $destination
+              Write-Host "Finished downloading miniconda"
+              break
+          } catch {
+              Write-Host "Miniconda download attempt $attempt of $maxAttempts failed: $($_.Exception.Message)"
+              if ($attempt -eq $maxAttempts) {
+                  throw
+              }
+              Start-Sleep -Seconds (15 * $attempt) 
+          }
+      }
   - ps: start -Wait -FilePath C:\Miniconda.exe -ArgumentList "/S /D=C:\Py"
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,26 +31,9 @@ build_script:
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
         throw "There are newer queued builds for this pull request, failing early." }
   - ps: |
-      $ErrorActionPreference = "Stop"
       $url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge$env:PY_MAJOR_VER-Windows-$env:PYTHON_ARCH.exe"
-      $destination = "C:\Miniconda.exe"
-      $maxAttempts = 3
-      for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
-          try {
-              if (Test-Path $destination) {
-                  Remove-Item $destination -Force
-              }
-              Start-FileDownload $url $destination
-              Write-Host "Finished downloading miniconda"
-              break
-          } catch {
-              Write-Host "Miniconda download attempt $attempt of $maxAttempts failed: $($_.Exception.Message)"
-              if ($attempt -eq $maxAttempts) {
-                  throw
-              }
-              Start-Sleep -Seconds (15 * $attempt) 
-          }
-      }
+      curl.exe -fsSL --retry 2 --retry-delay 15 --retry-all-errors -o C:\Miniconda.exe $url
+      if ($LASTEXITCODE -ne 0) { throw "curl download failed with exit code $LASTEXITCODE" }
   - ps: start -Wait -FilePath C:\Miniconda.exe -ArgumentList "/S /D=C:\Py"
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%
   - conda config --set always_yes yes

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,7 @@ build_script:
         throw "There are newer queued builds for this pull request, failing early." }
   - ps: |
       $url = "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge$env:PY_MAJOR_VER-Windows-$env:PYTHON_ARCH.exe"
-      curl.exe -fsSL --retry 2 --retry-delay 15 --retry-all-errors -o C:\Miniconda.exe $url
+      curl.exe -fsSL --retry 2 --retry-delay 15 -o C:\Miniconda.exe $url
       if ($LASTEXITCODE -ne 0) { throw "curl download failed with exit code $LASTEXITCODE" }
   - ps: start -Wait -FilePath C:\Miniconda.exe -ArgumentList "/S /D=C:\Py"
   - SET PATH=C:\Py;C:\Py\Scripts;C:\Py\Library\bin;%PATH%

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -149,6 +149,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Gaetan Lehman <gaetan.lehmann at domain jouy.inra.fr>
 - Gavin E Crooks <https://github.com/gecrooks>
 - Gert Hulselmans <https://github.com/ghuls>
+- Gian Carlo D Dumpit <https://github.com/GeneratedScript-RL>
 - Gleb Kuznetsov <https://github.com/glebkuznetsov>
 - Gokcen Eraslan <https://github.com/gokceneraslan>
 - Harry Jubb <https://github.com/harryjubb>


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Increases reliability of the AppVeyor CI by adding a try catch loop to attempt the download multiple times before giving up. Currently, if left unchecked, any network issues/failures in the miniconda download will result in the .appveyor.yml attempting to run conda commands even though it does not have miniconda installed (since it failed)

Example: https://github.com/biopython/biopython/pull/5220 - https://ci.appveyor.com/project/biopython/biopython/builds/54118337

Closes #5222 
