### PR TITLE
Fix d105 docstrings asghar

### DIFF
--- a/Bio/Align/bigbed.py
+++ b/Bio/Align/bigbed.py
@@ -131,6 +131,7 @@ class AutoSQLTable(list):
         return cls.from_bytes(data.encode() + b"\0")
 
     def __str__(self):
+        """Return a formatted AutoSQL representation of the table."""        
         type_width = max(len(str(field.as_type)) for field in self)
         name_width = max(len(field.name) for field in self) + 1
         lines = []
@@ -151,9 +152,11 @@ class AutoSQLTable(list):
         return "".join(lines)
 
     def __bytes__(self):
+        """Return the AutoSQL table encoded as a NULL-terminated bytes object."""
         return str(self).encode() + b"\0"
 
     def __getitem__(self, i):
+        """Return a field or a sliced AutoSQLTable."""
         if isinstance(i, slice):
             fields = super().__getitem__(i)
             return AutoSQLTable(self.name, self.comment, fields)
@@ -1037,6 +1040,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         return alignment
 
     def __len__(self):
+        """Returns Count of items"""
         return self._length
 
     def search(self, chromosome=None, start=None, end=None):

--- a/Bio/Align/hhr.py
+++ b/Bio/Align/hhr.py
@@ -233,4 +233,5 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         return alignment
 
     def __len__(self):
+        """Returns the count of items"""
         return self._length

--- a/Bio/Align/interfaces.py
+++ b/Bio/Align/interfaces.py
@@ -103,9 +103,11 @@ class AlignmentIterator(AlignmentsAbstractBaseClass):
         return length
 
     def __enter__(self):
+        """Enter runtime context and return the iterator."""
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
+        """Exit runtime context and close the underlying stream if needed."""   
         try:
             stream = self._stream
         except AttributeError:

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -252,6 +252,7 @@ class TreeElement:
         )
 
     def __str__(self) -> str:
+        """Returns a definition of The Tree Element"""
         return self.__repr__()
 
 

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -122,9 +122,11 @@ class SequenceIterator(ABC, Generic[AnyStr]):
         return self
 
     def __enter__(self):
+        """Enter runtime context and return self."""
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
+        """Exit runtime context and clean up the underlying stream."""
         try:
             stream = self.stream
         except AttributeError:

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -2499,6 +2499,7 @@ class InvalidCharError(ValueError):
     r: int = 3
 
     def __str__(self) -> str:
+        """Return a detailed error message describing the invalid quality string character."""
         char = self.full_string[self.index]
 
         surrounding_characters = self.full_string[

--- a/Bio/phenotype/phen_micro.py
+++ b/Bio/phenotype/phen_micro.py
@@ -396,6 +396,7 @@ class PlateRecord:
             yield self._wells[well]
 
     def __contains__(self, wellid):
+        """Return whether item is in container"""
         if wellid in self._wells:
             return True
         return False
@@ -405,6 +406,7 @@ class PlateRecord:
         return len(self._wells)
 
     def __eq__(self, other):
+        """Return whether objects are equal"""
         if isinstance(other, self.__class__):
             return self._wells == other._wells
         else:

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -383,3 +383,4 @@ please open an issue on GitHub or mention it on the mailing list.
 - Zaid Ur-Rehman <https://github.com/zaidurrehman>
 - Zheng Ruan <https://github.com/zruan>
 - Ziyan Rao <https://github.com/starrzy>
+- Asghar Ale <https://github.com/asgharale>


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #2116 
Improve docstrings for selected magic methods in Biopython modules.

This change adds or improves documentation for a small subset of
magic methods where behavior is non-trivial or used in public APIs,
such as context managers and string representations.
