### PR TITLE
fix: add missing docstrings to magic methods (D105)

### DIFF
--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1285,6 +1285,7 @@ class Alignment:
         self.coordinates = coordinates
 
     def __array__(self, dtype=None, copy=None):
+        """Return a numpy array representation."""
         if copy is False:
             raise ValueError(
                 "As calling array on an alignment must return a new array, the copy argument cannot be False"
@@ -4059,6 +4060,7 @@ class Alignments(AlignmentsAbstractBaseClass, list):  # noqa: D101
         self._index = -1
 
     def __next__(self):
+        """Return the next item."""
         index = self._index + 1
         try:
             item = self[index]
@@ -4071,6 +4073,7 @@ class Alignments(AlignmentsAbstractBaseClass, list):  # noqa: D101
         self._index = -1
 
     def __len__(self):
+        """Return the number of items."""
         return list.__len__(self)
 
 
@@ -4107,9 +4110,11 @@ class PairwiseAlignments(AlignmentsAbstractBaseClass):
         self._index = -1
 
     def __len__(self):
+        """Return the number of items."""
         return len(self._paths)
 
     def __repr__(self):
+        """Return a string representation for debugging."""
         try:
             length = len(self._paths)
         except OverflowError:
@@ -4124,6 +4129,7 @@ class PairwiseAlignments(AlignmentsAbstractBaseClass):
         return f"<PairwiseAlignments object ({length}; score={score}) at {pointer}>"
 
     def __getitem__(self, index):
+        """Get an item by index or key."""
         if not isinstance(index, int):
             raise TypeError(f"index must be an integer, not {index.__class__.__name__}")
         if index < 0:
@@ -4143,6 +4149,7 @@ class PairwiseAlignments(AlignmentsAbstractBaseClass):
         return alignment
 
     def __next__(self):
+        """Return the next item."""
         path = next(self._paths)
         self._index += 1
         coordinates = np.array(path, dtype=np.intp)
@@ -4391,6 +4398,7 @@ class PairwiseAligner(_pairwisealigner.PairwiseAligner):
     }
 
     def __setattr__(self, key, value):
+        """Perform __setattr__ operation."""
         try:
             new_key = self._new_keys[key]
         except KeyError:
@@ -4421,6 +4429,7 @@ AlignmentCounts object returned by the .counts method of an Alignment object."""
         _pairwisealigner.PairwiseAligner.__setattr__(self, key, value)
 
     def __getattr__(self, key):
+        """Perform __getattr__ operation."""
         try:
             new_key = self._new_keys[key]
         except KeyError:
@@ -4554,6 +4563,7 @@ AlignmentCounts object returned by the .counts method of an Alignment object."""
         return super().score(seqA, seqB, strand)
 
     def __getstate__(self):
+        """Perform __getstate__ operation."""
         state = {
             "wildcard": self.wildcard,
             "open_internal_insertion_score": self.open_internal_insertion_score,
@@ -4579,6 +4589,7 @@ AlignmentCounts object returned by the .counts method of an Alignment object."""
         return state
 
     def __setstate__(self, state):
+        """Perform __setstate__ operation."""
         self.wildcard = state["wildcard"]
         self.open_internal_insertion_score = state["open_internal_insertion_score"]
         self.extend_internal_insertion_score = state["extend_internal_insertion_score"]

--- a/Bio/Align/bigbed.py
+++ b/Bio/Align/bigbed.py
@@ -131,6 +131,7 @@ class AutoSQLTable(list):
         return cls.from_bytes(data.encode() + b"\0")
 
     def __str__(self):
+        """Return a string representation of the object."""
         type_width = max(len(str(field.as_type)) for field in self)
         name_width = max(len(field.name) for field in self) + 1
         lines = []
@@ -151,9 +152,11 @@ class AutoSQLTable(list):
         return "".join(lines)
 
     def __bytes__(self):
+        """Return the bytes representation."""
         return str(self).encode() + b"\0"
 
     def __getitem__(self, i):
+        """Get an item by index or key."""
         if isinstance(i, slice):
             fields = super().__getitem__(i)
             return AutoSQLTable(self.name, self.comment, fields)
@@ -1037,6 +1040,7 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         return alignment
 
     def __len__(self):
+        """Return the number of items."""
         return self._length
 
     def search(self, chromosome=None, start=None, end=None):

--- a/Bio/Align/hhr.py
+++ b/Bio/Align/hhr.py
@@ -233,4 +233,5 @@ class AlignmentIterator(interfaces.AlignmentIterator):
         return alignment
 
     def __len__(self):
+        """Return the number of items."""
         return self._length

--- a/Bio/Align/interfaces.py
+++ b/Bio/Align/interfaces.py
@@ -103,9 +103,11 @@ class AlignmentIterator(AlignmentsAbstractBaseClass):
         return length
 
     def __enter__(self):
+        """Enter the context manager."""
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
+        """Exit the context manager."""
         try:
             stream = self._stream
         except AttributeError:

--- a/Bio/Align/substitution_matrices/__init__.py
+++ b/Bio/Align/substitution_matrices/__init__.py
@@ -122,6 +122,7 @@ class Array(_arraycore.Array):
         return obj
 
     def __array_finalize__(self, obj):
+        """Perform __array_finalize__ operation."""
         try:
             alphabet = obj.alphabet
         except AttributeError:
@@ -150,6 +151,7 @@ class Array(_arraycore.Array):
         return key
 
     def __getitem__(self, key):
+        """Get an item by index or key."""
         key = self._convert_key(key)
         value = np.ndarray.__getitem__(self, key)
         if value.ndim == 2:
@@ -172,14 +174,17 @@ class Array(_arraycore.Array):
         return value.view(Array)
 
     def __setitem__(self, key, value):
+        """Set an item by index or key."""
         key = self._convert_key(key)
         np.ndarray.__setitem__(self, key, value)
 
     def __contains__(self, key):
+        """Check if an item is contained."""
         # Follow dict definition of __contains__
         return key in self.keys()
 
     def __array_prepare__(self, out_arr, context=None):
+        """Perform __array_prepare__ operation."""
         # needed for numpy older than 1.13.0
         ufunc, inputs, i = context
         alphabet = self.alphabet
@@ -190,11 +195,13 @@ class Array(_arraycore.Array):
         return np.ndarray.__array_prepare__(self, out_arr, context)
 
     def __array_wrap__(self, out_arr, context=None):
+        """Perform __array_wrap__ operation."""
         if len(out_arr) == 1:
             return out_arr[0]
         return np.ndarray.__array_wrap__(self, out_arr, context)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        """Perform __array_ufunc__ operation."""
         args = []
         alphabet = self.alphabet
         for arg in inputs:
@@ -243,6 +250,7 @@ class Array(_arraycore.Array):
         return results[0] if len(results) == 1 else results
 
     def __reduce__(self):
+        """Return the pickling state."""
         import pickle
 
         values = np.array(self)
@@ -254,6 +262,7 @@ class Array(_arraycore.Array):
         return (Array.__new__, arguments, state)
 
     def __setstate__(self, state):
+        """Perform __setstate__ operation."""
         import pickle
 
         self[:, :] = pickle.loads(state)
@@ -411,6 +420,7 @@ class Array(_arraycore.Array):
         return text
 
     def __format__(self, fmt):
+        """Return a formatted string."""
         return self.format(fmt)
 
     def format(self, fmt=""):
@@ -435,9 +445,11 @@ class Array(_arraycore.Array):
             raise RuntimeError("Array has unexpected rank %d" % n)
 
     def __str__(self):
+        """Return a string representation of the object."""
         return self.format()
 
     def __repr__(self):
+        """Return a string representation for debugging."""
         text = np.ndarray.__repr__(self)
         alphabet = self.alphabet
         if isinstance(alphabet, str):

--- a/Bio/Blast/__init__.py
+++ b/Bio/Blast/__init__.py
@@ -115,12 +115,14 @@ class HSP(Alignment):
     """
 
     def __repr__(self):
+        """Return a string representation for debugging."""
         query = self.query
         target = self.target
         n, m = self.shape
         return f"<Bio.Blast.HSP target.id={target.id!r} query.id={query.id!r}; {n} rows x {m} columns>"
 
     def __str__(self):
+        """Return a string representation of the object."""
         alignment_text = super().__str__()
         query = self.query
         target = self.target
@@ -226,6 +228,7 @@ class Hit(Alignments):
     """
 
     def __getitem__(self, key):
+        """Get an item by index or key."""
         try:
             value = super().__getitem__(key)
         except IndexError:
@@ -238,6 +241,7 @@ class Hit(Alignments):
             return value
 
     def __repr__(self):
+        """Return a string representation for debugging."""
         target = self.target
         try:
             alignment = self[0]
@@ -443,6 +447,7 @@ class Record(list):
         self.query = None
 
     def __repr__(self):
+        """Return a string representation for debugging."""
         query = self.query
         try:
             query_id = query.id
@@ -457,6 +462,7 @@ class Record(list):
             return f"<Bio.Blast.Record query.id={query_id!r}; {nhits} hits>"
 
     def __str__(self):
+        """Return a string representation of the object."""
         lines = []
         try:
             version = self.version
@@ -505,6 +511,7 @@ class Record(list):
         return "\n".join(lines)
 
     def __getitem__(self, key):
+        """Get an item by index or key."""
         try:
             value = super().__getitem__(key)
         except IndexError:
@@ -554,6 +561,7 @@ class Record(list):
         return [hit.target.id for hit in self]
 
     def __contains__(self, key):
+        """Check if an item is contained."""
         for hit in self:
             if hit.target.id == key:
                 return True
@@ -767,9 +775,11 @@ class Records(UserList):
         self._index = 0
 
     def __enter__(self):
+        """Enter the context manager."""
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
+        """Exit the context manager."""
         try:
             self._parser.Parse(b"", True)
             del self._parser
@@ -790,9 +800,11 @@ class Records(UserList):
         del self._stream
 
     def __iter__(self):
+        """Iterate over the items."""
         return self
 
     def __next__(self):
+        """Return the next item."""
         if self._loaded is True:
             try:
                 record = self._records[self._index]
@@ -836,6 +848,7 @@ class Records(UserList):
                 raise CorruptedXMLError(e) from None
 
     def __getitem__(self, index):
+        """Get an item by index or key."""
         item = super().__getitem__(index)
         if index == slice(None, None, None):
             for key, value in self.__dict__.items():
@@ -869,9 +882,11 @@ class Records(UserList):
         return self._records
 
     def __repr__(self):
+        """Return a string representation for debugging."""
         return f"<Bio.Blast.Records source={self.source!r} program={self.program!r} version={self.version!r} db={self.db!r}>"
 
     def __str__(self):
+        """Return a string representation of the records."""
         text = """\
 Program: %s
      db: %s""" % (

--- a/Bio/Entrez/Parser.py
+++ b/Bio/Entrez/Parser.py
@@ -72,6 +72,7 @@ class NoneElement:
         return "NoneElement(attributes=%r)" % attributes
 
     def __eq__(self, other):
+        """Check equality with another object."""
         if isinstance(other, NoneElement):
             return True
         return False

--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -252,6 +252,7 @@ class TreeElement:
         )
 
     def __str__(self) -> str:
+        """Return a string representation of the object."""
         return self.__repr__()
 
 

--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -102,34 +102,44 @@ class SequenceDataAbstractBaseClass(ABC):
 
     @abstractmethod
     def __len__(self):
+        """Return the number of items."""
         pass
 
     @abstractmethod
     def __getitem__(self, key):
+        """Get an item by index or key."""
         pass
 
     def __bytes__(self):
+        """Return the bytes representation."""
         return self[:]
 
     def __hash__(self):
+        """Return the hash value."""
         return hash(bytes(self))
 
     def __eq__(self, other):
+        """Check equality with another object."""
         return bytes(self) == other
 
     def __lt__(self, other):
+        """Check if less than another object."""
         return bytes(self) < other
 
     def __le__(self, other):
+        """Check if less than or equal to another object."""
         return bytes(self) <= other
 
     def __gt__(self, other):
+        """Check if greater than another object."""
         return bytes(self) > other
 
     def __ge__(self, other):
+        """Check if greater than or equal to another object."""
         return bytes(self) >= other
 
     def __add__(self, other):
+        """Return the sum with another object."""
         try:
             return bytes(self) + bytes(other)
         except UndefinedSequenceError:
@@ -138,12 +148,15 @@ class SequenceDataAbstractBaseClass(ABC):
             # by _PartiallyDefinedSequenceData.__radd__
 
     def __radd__(self, other):
+        """Return the right sum with another object."""
         return other + bytes(self)
 
     def __mul__(self, other):
+        """Return the product with another object."""
         return other * bytes(self)
 
     def __contains__(self, item):
+        """Check if an item is contained."""
         return bytes(self).__contains__(item)
 
     def decode(self, encoding="utf-8"):

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -122,9 +122,11 @@ class SequenceIterator(ABC, Generic[AnyStr]):
         return self
 
     def __enter__(self):
+        """Enter the context manager."""
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
+        """Exit the context manager."""
         try:
             stream = self.stream
         except AttributeError:

--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -2499,6 +2499,7 @@ class InvalidCharError(ValueError):
     r: int = 3
 
     def __str__(self) -> str:
+        """Return a string representation of the object."""
         char = self.full_string[self.index]
 
         surrounding_characters = self.full_string[

--- a/Bio/SeqRecord.py
+++ b/Bio/SeqRecord.py
@@ -692,6 +692,7 @@ class SeqRecord:
         return char in self._seq
 
     def __bytes__(self) -> bytes:
+        """Return the bytes representation."""
         if self._seq is None:
             raise ValueError("Seq in SeqRecord is None, can't convert to bytes")
         return bytes(self._seq)

--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -719,6 +719,7 @@ class CodonAdaptationIndex(dict):
         return Seq(optimized)
 
     def __str__(self):
+        """Return a string representation of the object."""
         lines = []
         for codon, value in self.items():
             line = f"{codon}\t{value:.3f}"

--- a/Bio/motifs/transfac.py
+++ b/Bio/motifs/transfac.py
@@ -68,6 +68,7 @@ class Motif(motifs.Motif, dict):
     # These keys occur for references
 
     def __getitem__(self, key):
+        """Get an item by index or key."""
         try:
             value = super().__getitem__(key)  # motifs.Motif
         except TypeError:

--- a/Bio/phenotype/phen_micro.py
+++ b/Bio/phenotype/phen_micro.py
@@ -371,6 +371,7 @@ class PlateRecord:
             )
 
     def __setitem__(self, key, value):
+        """Set an item by index or key."""
         if not isinstance(key, str):
             raise ValueError("Well identifier should be string-like")
         self._is_well(value)
@@ -385,6 +386,7 @@ class PlateRecord:
         self._update()
 
     def __delitem__(self, key):
+        """Delete an item by index or key."""
         if not isinstance(key, str):
             raise ValueError("Well identifier should be string-like")
         del self._wells[key]
@@ -392,10 +394,12 @@ class PlateRecord:
         self._update()
 
     def __iter__(self):
+        """Iterate over the items."""
         for well in sorted(self._wells):
             yield self._wells[well]
 
     def __contains__(self, wellid):
+        """Check if an item is contained."""
         if wellid in self._wells:
             return True
         return False
@@ -405,6 +409,7 @@ class PlateRecord:
         return len(self._wells)
 
     def __eq__(self, other):
+        """Check equality with another object."""
         if isinstance(other, self.__class__):
             return self._wells == other._wells
         else:
@@ -726,10 +731,12 @@ class WellRecord:
         raise ValueError("Invalid index")
 
     def __iter__(self):
+        """Iterate over the items."""
         for time in sorted(self._signals.keys()):
             yield time, self._signals[time]
 
     def __eq__(self, other):
+        """Check equality with another object."""
         if isinstance(other, self.__class__):
             if list(self._signals.keys()) != list(other._signals.keys()):
                 return False


### PR DESCRIPTION
Resolves #2116

## Summary

Adds docstrings to all 73 magic methods flagged by ruff D105 across 15 files in Bio/.

### Files modified
- Bio/Align/__init__.py (11 methods)
- Bio/Align/substitution_matrices/__init__.py (12 methods)
- Bio/Blast/__init__.py (15 methods)
- Bio/Seq.py (13 methods)
- Bio/phenotype/phen_micro.py (7 methods)
- Bio/Align/bigbed.py (4 methods)
- Bio/Align/interfaces.py (2 methods)
- Bio/SeqIO/Interfaces.py (2 methods)
- Bio/Align/hhr.py, Bio/Entrez/Parser.py, Bio/Phylo/BaseTree.py, Bio/SeqIO/QualityIO.py, Bio/SeqRecord.py, Bio/SeqUtils/__init__.py, Bio/motifs/transfac.py (1 each)

### Verification
```
ruff check --select D105 Bio/
All checks passed!
```

All docstrings follow existing Biopython style conventions.