### PR TITLE
Set expectations on the issue tags

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -16,6 +16,33 @@ and the more widely used "3-Clause BSD License" (see our LICENSE file for more
 details).
 
 
+Tagged issues
+-------------
+
+Is general, unless there is an open pull request associated with an issue,
+or the issue discussion makes it clear that someone is working on it, any
+issue can be worked on.
+
+We have been using the `good first issue
+<https://github.com/biopython/biopython/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22>`_
+label specifically for beginners. These are minor issues where the team know
+what is needed, and could easily do it themselves (albeit some are tedious),
+but we have chosen instead to use these as teachable moments to help potential
+new contributors get involved with a little mentoring as needed. This is with
+the hope they become long term open source contributors (ideally to Biopython).
+Tackling these with AI tools defeats that purpose, and such PRs will be rejected,
+and we will likely block repeat offenders.
+
+The `help wanted
+<https://github.com/biopython/biopython/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22help%20wanted%22)>`_
+label is typically used for issues where none of the regular contributors have the
+expertise or setup to work on an issue (eg specific platforms, or restricted datasets).
+The `needs info
+<https://github.com/biopython/biopython/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Needs%20info%22>`_
+label is for unresloved issues where we lack actionable information. In some cases
+these may be best closed, but perhaps another person will run into the same problem
+and can help solve it.
+
 Git Usage
 ---------
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,7 +19,7 @@ details).
 Tagged issues
 -------------
 
-Is general, unless there is an open pull request associated with an issue,
+In general, unless there is an open pull request associated with an issue,
 or the issue discussion makes it clear that someone is working on it, any
 issue can be worked on.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,7 +25,7 @@ issue can be worked on.
 
 We have been using the `good first issue
 <https://github.com/biopython/biopython/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22>`_
-label specifically for beginners. These are minor issues where the team know
+label specifically for beginners. These are minor issues where the team knows
 what is needed, and could easily do it themselves (albeit some are tedious),
 but we have chosen instead to use these as teachable moments to help potential
 new contributors get involved with a little mentoring as needed. This is with


### PR DESCRIPTION
We are starting to have a problem with unwanted AI based PRs targeting the 'good first issue' label. See mailing list:

https://mailman.open-bio.org/pipermail/biopython/2026-June/017135.html

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
