### PR TITLE
Add missing magic method docstrings in SeqIO interfaces lines 124 & 127

### DIFF
--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -122,9 +122,11 @@ class SequenceIterator(ABC, Generic[AnyStr]):
         return self
 
     def __enter__(self):
+        """ Return the context manager object """
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
+        """ Close the stream when exiting context manager """ 
         try:
             stream = self.stream
         except AttributeError:

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -122,11 +122,11 @@ class SequenceIterator(ABC, Generic[AnyStr]):
         return self
 
     def __enter__(self):
-        """Return the context manager object"""
+        """Return the context manager object."""
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        """Close the stream when exiting context manager"""
+        """Close the stream when exiting context manager."""
         try:
             stream = self.stream
         except AttributeError:

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -122,11 +122,11 @@ class SequenceIterator(ABC, Generic[AnyStr]):
         return self
 
     def __enter__(self):
-        """ Return the context manager object """
+        """Return the context manager object"""
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        """ Close the stream when exiting context manager """ 
+        """Close the stream when exiting context manager""" 
         try:
             stream = self.stream
         except AttributeError:

--- a/Bio/SeqIO/Interfaces.py
+++ b/Bio/SeqIO/Interfaces.py
@@ -126,7 +126,7 @@ class SequenceIterator(ABC, Generic[AnyStr]):
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        """Close the stream when exiting context manager""" 
+        """Close the stream when exiting context manager"""
         try:
             stream = self.stream
         except AttributeError:


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #...

## Summary

Adds missing docstrings for the `__enter__` and `__exit__` magic methods in `Bio/SeqIO/Interfaces.py` on line 124 and 127

Part of #2116.

## Testing

Ran:

```bash
flake8 --isolated --select D105 Bio/SeqIO/Interfaces.py