### PR TITLE
Add pymysql driver support to BioSQL

### DIFF
--- a/BioSQL/BioSeqDatabase.py
+++ b/BioSQL/BioSeqDatabase.py
@@ -52,7 +52,7 @@ def open_database(driver="MySQLdb", **kwargs):
 
     # Different drivers use different keywords...
     kw = kwargs.copy()
-    if driver in ["MySQLdb", "mysql.connector"]:
+    if driver in ["MySQLdb", "mysql.connector", "pymysql"]:
         if "database" in kw:
             kw["db"] = kw["database"]
             del kw["database"]
@@ -80,7 +80,7 @@ def open_database(driver="MySQLdb", **kwargs):
     server = DBServer(conn, module)
 
     # Sets MySQL to allow double quotes, rather than only backticks
-    if driver in ["MySQLdb", "mysql.connector"]:
+    if driver in ["MySQLdb", "mysql.connector", "pymysql"]:
         server.adaptor.execute("SET sql_mode='ANSI_QUOTES';")
 
     # TODO - Remove the following once BioSQL Bug 2839 is fixed.
@@ -240,7 +240,7 @@ class DBServer:
             self.adaptor.cursor.execute(sql)
         # 2. MySQL needs the database loading split up into single lines of
         # SQL executed one at a time
-        elif self.module_name in ["mysql.connector", "MySQLdb", "sqlite3"]:
+        elif self.module_name in ["mysql.connector", "MySQLdb", "pymysql", "sqlite3"]:
             sql_parts = sql.split(";")  # one line per sql command
             # don't use the last item, it's blank
             for sql_line in sql_parts[:-1]:
@@ -585,6 +585,7 @@ _interface_specific_adaptors = {
     # If SQL interfaces require a specific adaptor, use this to map the adaptor
     "mysql.connector": MysqlConnectorAdaptor,
     "MySQLdb": MysqlConnectorAdaptor,
+    "pymysql": MysqlConnectorAdaptor,
 }
 
 _allowed_lookups = {

--- a/BioSQL/DBUtils.py
+++ b/BioSQL/DBUtils.py
@@ -94,6 +94,7 @@ class Mysql_dbutils(Generic_dbutils):
 
 
 _dbutils["MySQLdb"] = Mysql_dbutils
+_dbutils["pymysql"] = Mysql_dbutils
 
 
 class _PostgreSQL_dbutils(Generic_dbutils):

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -370,6 +370,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Will Tyler <https://github.com/Will-Tyler>
 - Wolfgang Schueler <wolfgang at domain proceryon.at>
 - Xiaoyu Zhuo <https://github.com/xzhuo>
+- Xinxiang Wang <https://github.com/yiyabo>
 - Yair Benita <Y.Benita at domain pharm.uu.nl>
 - Yanbo Ye <https://github.com/lijax>
 - Yasar L. Ahmed <https://github.com/pyahmed>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -22,6 +22,7 @@ possible, especially the following contributors:
 - Peter Cock
 - Al Fattah Suyadi (first contribution)
 - Laura Piñero Roig (first contribution)
+- Xinxiang Wang (first contribution)
 
 30 March 2026: Biopython 1.87
 =============================


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally, and understand that continuous integration checks will be used to confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files ``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request. (*This acknowledgement is optional.*)

Closes #4291

## Problem

`BioSQL.BioSeqDatabase.open_database(driver="pymysql", ...)` fails with:

```
pymysql.err.ProgrammingError: (1064, 'You have an error in your SQL syntax;
... near '"rank") VALUES (1, 1, ...' at line 1')
```

`rank` is a reserved keyword in MySQL 8.0+ (window function). BioSQL uses double quotes `"rank"` to quote this column name, which only works when `ANSI_QUOTES` SQL mode is enabled. The code sets this mode for `MySQLdb` and `mysql.connector`, but `pymysql` was missing from all the MySQL driver whitelists.

## Changes

**`BioSQL/BioSeqDatabase.py`** — 4 additions of `"pymysql"`:
- Connection parameter name mapping (`database`->`db`, `password`->`passwd`)
- `SET sql_mode='ANSI_QUOTES'` execution
- SQL schema loader module whitelist (`load_database_sql`)
- `MysqlConnectorAdaptor` registration for bytearray-to-string conversion

**`BioSQL/DBUtils.py`** — 1 addition:
- `Mysql_dbutils` mapping for proper `last_insert_id` handling

## Testing

- Verified bug reproduction with pymysql 1.2.0 + MySQL 8.0 before fix
- Verified fix: `db.load(SeqIO.parse("cor6_6.gb", "gb"))` succeeds (6 records loaded)
- Ran 25 core BioSQL tests with pymysql driver: **all passed**
- Ran 73 SQLite BioSQL tests: **all passed** (no regression)
