### PR TITLE
Add PDB and PAE downloads to Bio.PDB.alphafold_db

### DIFF
--- a/Bio/PDB/alphafold_db.py
+++ b/Bio/PDB/alphafold_db.py
@@ -9,6 +9,7 @@ from os import PathLike
 from collections.abc import Iterator
 from typing import Optional
 from typing import Union
+from urllib.error import HTTPError
 from urllib.request import urlopen
 
 from Bio.PDB.MMCIFParser import MMCIFParser
@@ -22,11 +23,40 @@ def get_predictions(qualifier: str) -> Iterator[dict]:
     :type qualifier: str
     :return: The AlphaFold predictions
     :rtype: Iterator[dict]
+    :raises ValueError: If no predictions are available for the accession
     """
     url = f"https://alphafold.com/api/prediction/{qualifier}"
-    # Retrieve the AlphaFold predictions with urllib
-    with urlopen(url) as response:
-        yield from json.loads(response.read().decode())
+    try:
+        with urlopen(url) as response:
+            predictions = json.loads(response.read().decode())
+    except HTTPError as error:
+        raise ValueError(
+            f"No AlphaFold predictions found for accession {qualifier!r}"
+        ) from error
+    yield from predictions
+
+
+def _get_file_path_for(
+    prediction: dict,
+    url_key: str,
+    directory: str | bytes | PathLike | None = None,
+) -> str:
+    """Get the local path for one of an AlphaFold prediction's files.
+
+    :param prediction: An AlphaFold prediction
+    :type prediction: dict
+    :param url_key: The prediction key holding the file URL, e.g. ``"cifUrl"``
+    :type url_key: str
+    :param directory: The directory that stores the file, defaults to the current working directory
+    :type directory: Union[str, bytes, PathLike], optional
+    :return: The path to the file
+    :rtype: str
+    """
+    if directory is None:
+        directory = os.getcwd()
+
+    file_name = prediction[url_key].split("/")[-1]
+    return str(os.path.join(directory, file_name))
 
 
 def _get_mmcif_file_path_for(
@@ -37,17 +67,47 @@ def _get_mmcif_file_path_for(
     :param prediction: An AlphaFold prediction
     :type prediction: dict
     :param directory: The directory that stores the mmCIF file, defaults to the current working directory
-    :type directory: Union[int, str, bytes, PathLike], optional
+    :type directory: Union[str, bytes, PathLike], optional
     :return: The path to the mmCIF file
+    :rtype: str
+    """
+    return _get_file_path_for(prediction, "cifUrl", directory)
+
+
+def _download_url_for(
+    prediction: dict,
+    url_key: str,
+    directory: str | bytes | PathLike | None = None,
+) -> str:
+    """Download one of an AlphaFold prediction's files.
+
+    Downloads the file to the current working directory if no destination is specified.
+
+    :param prediction: An AlphaFold prediction
+    :type prediction: dict
+    :param url_key: The prediction key holding the file URL, e.g. ``"cifUrl"``
+    :type url_key: str
+    :param directory: The directory to write the file to, defaults to the current working directory
+    :type directory: Union[str, bytes, PathLike], optional
+    :return: The path to the downloaded file
     :rtype: str
     """
     if directory is None:
         directory = os.getcwd()
 
-    cif_url = prediction["cifUrl"]
-    # Get the file name from the URL
-    file_name = cif_url.split("/")[-1]
-    return str(os.path.join(directory, file_name))
+    os.makedirs(directory, exist_ok=True)
+    file_path = _get_file_path_for(prediction, url_key, directory)
+
+    if os.path.exists(file_path):
+        print(f"File {file_path} already exists, skipping download.")
+        return file_path
+
+    with urlopen(prediction[url_key]) as response:
+        data = response.read()
+    with open(file_path, "wb") as file:
+        file.write(data)
+
+    return file_path
 
 
 def download_cif_for(
@@ -60,28 +120,45 @@ def download_cif_for(
     :param prediction: An AlphaFold prediction
     :type prediction: dict
     :param directory: The directory to write the mmCIF data to, defaults to the current working directory
-    :type directory: Union[int, str, bytes, PathLike], optional
+    :type directory: Union[str, bytes, PathLike], optional
     :return: The path to the mmCIF file
     :rtype: str
     """
-    if directory is None:
-        directory = os.getcwd()
+    return _download_url_for(prediction, "cifUrl", directory)
 
-    cif_url = prediction["cifUrl"]
-    # Create the directory in case it does not exist
-    os.makedirs(directory, exist_ok=True)
-    file_path = _get_mmcif_file_path_for(prediction, directory)
 
-    if os.path.exists(file_path):
-        print(f"File {file_path} already exists, skipping download.")
-    else:
-        with urlopen(cif_url) as response:
-            data = response.read()
-        # Write the data to destination
-        with open(file_path, "wb") as file:
-            file.write(data)
+def download_pdb_for(
+    prediction: dict, directory: str | bytes | PathLike | None = None
+) -> str:
+    """Download the PDB file for an AlphaFold prediction.
 
-    return file_path
+    Downloads the file to the current working directory if no destination is specified.
+
+    :param prediction: An AlphaFold prediction
+    :type prediction: dict
+    :param directory: The directory to write the PDB data to, defaults to the current working directory
+    :type directory: Union[str, bytes, PathLike], optional
+    :return: The path to the PDB file
+    :rtype: str
+    """
+    return _download_url_for(prediction, "pdbUrl", directory)
+
+
+def download_pae_for(
+    prediction: dict, directory: str | bytes | PathLike | None = None
+) -> str:
+    """Download the predicted aligned error (PAE) file for an AlphaFold prediction.
+
+    Downloads the file to the current working directory if no destination is specified.
+
+    :param prediction: An AlphaFold prediction
+    :type prediction: dict
+    :param directory: The directory to write the PAE data to, defaults to the current working directory
+    :type directory: Union[str, bytes, PathLike], optional
+    :return: The path to the PAE file
+    :rtype: str
+    """
+    return _download_url_for(prediction, "paeDocUrl", directory)
 
 
 def get_structural_models_for(
@@ -98,7 +175,7 @@ def get_structural_models_for(
     :param mmcif_parser: The mmCIF parser to use, defaults to ``MMCIFParser()``
     :type mmcif_parser: MMCIFParser, optional
     :param directory: The directory to store the mmCIF data, defaults to the current working directory
-    :type directory: Union[int, str, bytes, PathLike], optional
+    :type directory: Union[str, bytes, PathLike], optional
     :return: An iterator over the PDB structures
     :rtype: Iterator[PDBStructure]
     """

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -169,6 +169,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Jack Twilley <https://github.com/mathuin>
 - Jacob Beal <https://github.com/jakebeal>
 - Jacob Byerly <https://github.com/byerlyj>
+- Jae Min Yoon <https://github.com/jam-sudo>
 - Jakub Lipinski <https://github.com/jakublipinski>
 - James Baker <https://github.com/JamesABaker>
 - James Casbon <https://github.com/jamescasbon>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -13,6 +13,11 @@ The latest news is at the top of this file.
 (In progress, not yet released): Biopython 1.88
 ===============================================
 
+The ``Bio.PDB.alphafold_db`` module can now download PDB format and predicted
+aligned error (PAE) files via the new ``download_pdb_for`` and
+``download_pae_for`` functions, and ``get_predictions`` raises a clearer
+``ValueError`` when no prediction is available for an accession.
+
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite and type annotations.
 
@@ -21,6 +26,7 @@ possible, especially the following contributors:
 
 - Peter Cock
 - Al Fattah Suyadi (first contribution)
+- Jae Min Yoon (first contribution)
 - Laura Piñero Roig (first contribution)
 
 30 March 2026: Biopython 1.87

--- a/Tests/test_PDB_alphafold_db.py
+++ b/Tests/test_PDB_alphafold_db.py
@@ -1,6 +1,7 @@
 """Tests for the alphafold_db module."""
 
 import os
+import tempfile
 import unittest
 
 import requires_internet
@@ -18,9 +19,33 @@ class AlphafoldDBTests(unittest.TestCase):
             self.assertIsInstance(prediction, dict)
             self.assertGreater(len(prediction), 0)
 
+    def test_get_predictions_invalid_accession(self):
+        with self.assertRaises(ValueError):
+            next(alphafold_db.get_predictions("ZZZZZZ"))
+
     def test_get_mmcif_file_path_for(self):
         prediction = {
             "cifUrl": "https://alphafold.ebi.ac.uk/files/AF-P00520-F1-model_v4.cif",
         }
         file_path = alphafold_db._get_mmcif_file_path_for(prediction, "test")
         self.assertEqual(file_path, os.path.join("test", "AF-P00520-F1-model_v4.cif"))
+
+    def test_get_file_path_for(self):
+        prediction = {
+            "pdbUrl": "https://alphafold.ebi.ac.uk/files/AF-P00520-F1-model_v4.pdb",
+        }
+        file_path = alphafold_db._get_file_path_for(prediction, "pdbUrl", "test")
+        self.assertEqual(file_path, os.path.join("test", "AF-P00520-F1-model_v4.pdb"))
+
+    def test_download_pdb_for(self):
+        prediction = next(alphafold_db.get_predictions("P00520"))
+        with tempfile.TemporaryDirectory() as directory:
+            file_path = alphafold_db.download_pdb_for(prediction, directory)
+            self.assertTrue(file_path.endswith(".pdb"))
+            self.assertTrue(os.path.isfile(file_path))
+
+    def test_download_pae_for(self):
+        prediction = next(alphafold_db.get_predictions("P00520"))
+        with tempfile.TemporaryDirectory() as directory:
+            file_path = alphafold_db.download_pae_for(prediction, directory)
+            self.assertTrue(os.path.isfile(file_path))


### PR DESCRIPTION
- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request.

Relates to #3990

This extends `Bio.PDB.alphafold_db` so AlphaFold predictions can be fetched in PDB format and with their predicted aligned error (PAE) data, not just mmCIF.

Changes:

- `download_pdb_for(prediction, directory=None)` downloads the prediction's `pdbUrl` file.
- `download_pae_for(prediction, directory=None)` downloads the prediction's `paeDocUrl` file.
- The shared download and path-building logic now lives in `_download_url_for` and `_get_file_path_for`; `download_cif_for` and `_get_mmcif_file_path_for` delegate to them, so existing behaviour is unchanged.
- `get_predictions` now raises `ValueError` for an accession with no prediction instead of letting a raw `HTTPError` propagate.

Tests for the new download functions, the path helper, and the error path are added to `Tests/test_PDB_alphafold_db.py`.