### PR TITLE
Add docstrings to SequenceDataAbstractBaseClass magic methods

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -102,34 +102,42 @@ class SequenceDataAbstractBaseClass(ABC):
 
     @abstractmethod
     def __len__(self):
-        pass
+        """Return the length of the sequence data."""
 
     @abstractmethod
     def __getitem__(self, key):
-        pass
+        """Return the sequence data item or slice at the requested index."""
 
     def __bytes__(self):
+        """Return the sequence data as a bytes object."""
         return self[:]
 
     def __hash__(self):
+        """Return a hash of the sequence data."""
         return hash(bytes(self))
 
     def __eq__(self, other):
+        """Return True if the sequence data equals other, False otherwise."""
         return bytes(self) == other
 
     def __lt__(self, other):
+        """Return True if the sequence data is less than other, False otherwise."""
         return bytes(self) < other
 
     def __le__(self, other):
+        """Return True if the sequence data is less than or equal to other."""
         return bytes(self) <= other
 
     def __gt__(self, other):
+        """Return True if the sequence data is greater than other, False otherwise."""
         return bytes(self) > other
 
     def __ge__(self, other):
+        """Return True if the sequence data is greater than or equal to other."""
         return bytes(self) >= other
 
     def __add__(self, other):
+        """Return the concatenation of the sequence data and other as bytes."""
         try:
             return bytes(self) + bytes(other)
         except UndefinedSequenceError:
@@ -138,12 +146,15 @@ class SequenceDataAbstractBaseClass(ABC):
             # by _PartiallyDefinedSequenceData.__radd__
 
     def __radd__(self, other):
+        """Return the concatenation of other and the sequence data as bytes."""
         return other + bytes(self)
 
     def __mul__(self, other):
+        """Return the sequence data repeated other times as bytes."""
         return other * bytes(self)
 
     def __contains__(self, item):
+        """Return True if item is contained in the sequence data, False otherwise."""
         return bytes(self).__contains__(item)
 
     def decode(self, encoding="utf-8"):

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -273,6 +273,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Nader Morshed <https://github.com/naderm>
 - Nate Sutton <https://github.com/nmsutton>
 - Nathan J. Edwards <nje5 at edu domain georgetown>
+- Neal Conway <https://github.com/LuciPengu>
 - Neil P. <https://github.com/npars>
 - Nick Negretti <https://github.com/nimne>
 - Nicolas Fontrodona <https://github.com/NFontrodona>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -22,6 +22,7 @@ possible, especially the following contributors:
 - Peter Cock
 - Al Fattah Suyadi (first contribution)
 - Laura Piñero Roig (first contribution)
+- Neal Conway (first contribution)
 
 30 March 2026: Biopython 1.87
 =============================


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run the style checks
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

This is a first batch towards #2116 (ruff `D105`, "Missing docstring in magic method").

It adds one-line docstrings to the 13 magic methods of
`SequenceDataAbstractBaseClass` in `Bio/Seq.py`, following the existing
imperative docstring style used elsewhere in that file. Running
`ruff check Bio/Seq.py --select=D105` now reports no violations.

No behaviour is changed. The `D105` entry is intentionally left in the ruff
ignore list in `.pre-commit-config.yaml`, since other modules still contain
undocumented magic methods; that ignore can be removed in a later PR once
they are all documented.

Towards #2116