### PR TITLE
Preserve small Newick branch lengths

### DIFF
--- a/Bio/Phylo/NewickIO.py
+++ b/Bio/Phylo/NewickIO.py
@@ -278,7 +278,7 @@ class Writer:
         ladderize=None,
         max_confidence=1.0,
         format_confidence="%1.2f",
-        format_branch_length="%1.5f",
+        format_branch_length="%1.8g",
     ):
         """Return an iterable of PAUP-compatible tree lines."""
         # If there's a conflict in the arguments, we override plain=True

--- a/Tests/test_Phylo.py
+++ b/Tests/test_Phylo.py
@@ -125,6 +125,18 @@ class IOTests(unittest.TestCase):
         self.assertTrue(value.endswith(";"))
         self.assertEqual(value[2:-1], "%.0e" % 0.1)
 
+    def test_newick_writer_preserves_small_branch_lengths(self):
+        """Small nonzero branch lengths should not be rounded to zero."""
+        tree = Phylo.read(StringIO("(A:0.000001,B:0.000002);"), "newick")
+
+        mem_file = StringIO()
+        Phylo.write(tree, mem_file, "newick")
+
+        newick = mem_file.getvalue()
+        self.assertNotIn(":0.00000", newick)
+        self.assertIn(":1e-06", newick)
+        self.assertIn(":2e-06", newick)
+
     def test_convert(self):
         """Convert a tree between all supported formats."""
         mem_file_1 = StringIO()
@@ -197,7 +209,7 @@ class IOTests(unittest.TestCase):
         mem_file = StringIO()
         Phylo.write(tree, mem_file, "newick")
         mem_file.seek(0)
-        self.assertEqual(mem_file.read(), "('Node''Name':0.00000)Root:0.00000;\n")
+        self.assertEqual(mem_file.read(), "('Node''Name':0)Root:0;\n")
 
 
 class TreeTests(unittest.TestCase):


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #5184

This PR updates the default Newick branch length format from `%1.5f` to `%1.8g`.

The previous default could silently round small nonzero branch lengths to `0.00000` when writing Newick trees, which can lose biologically meaningful distance information. Using significant digits preserves small values such as `0.000001` while avoiding unnecessarily long fixed-width decimal output for all branch lengths.

Changes included:

- Update the default `format_branch_length` used by the Newick writer.
- Add regression coverage for small nonzero branch lengths.
- Update the expected Newick output for zero-length branches under the new default format.

Testing:

```bash
cd Tests
python -m pytest test_Phylo.py
python -m pre_commit run --files Bio/Phylo/NewickIO.py Tests/test_Phylo.py

Result:

39 passed, 1 warning
pre-commit passed