### PR TITLE
Calculate TLEN when writing SAM alignments

### DIFF
--- a/Bio/Align/sam.py
+++ b/Bio/Align/sam.py
@@ -114,7 +114,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
                 line = "\t".join(fields) + "\n"
                 stream.write(line)
 
-    def format_alignment(self, alignment, md=None):
+    def format_alignment(self, alignment, md=None, tlen=None):
         """Return a string with a single alignment formatted as one SAM line."""
         if not isinstance(alignment, Alignment):
             raise TypeError("Expected an Alignment object")
@@ -242,7 +242,11 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             pnext = 0
         else:
             pnext += 1  # 1-based coordinates
-        tLen = 0
+        if tlen is None:
+            try:
+                tlen = alignment.tlen
+            except AttributeError:
+                tlen = 0
         fields = [
             qName,
             str(flag),
@@ -252,7 +256,7 @@ class AlignmentWriter(interfaces.AlignmentWriter):
             cigar,
             rnext,
             str(pnext),
-            str(tLen),
+            str(tlen),
             query,
             qual,
         ]
@@ -367,6 +371,83 @@ class AlignmentWriter(interfaces.AlignmentWriter):
                 fields.append(field)
         line = "\t".join(fields) + "\n"
         return line
+
+    def write_alignments(self, stream, alignments):
+        """Write alignments to the output file, and return the number of alignments."""
+        if not isinstance(alignments, (list, tuple)):
+            return super().write_alignments(stream, alignments)
+        tlens = self._calculate_tlens(alignments)
+        for index, alignment in enumerate(alignments):
+            line = self.format_alignment(alignment, tlen=tlens.get(index))
+            stream.write(line)
+        return len(alignments)
+
+    def _calculate_tlens(self, alignments):
+        """Calculate TLEN values for paired alignments."""
+        records = {}
+        tlens = {}
+        for index, alignment in enumerate(alignments):
+            if hasattr(alignment, "tlen"):
+                continue
+            record = self._get_tlen_record(alignment)
+            if record is None:
+                continue
+            qname, rname, pnext, t_start, t_end = record
+            records.setdefault(qname, []).append((index, rname, pnext, t_start, t_end))
+        for records_by_qname in records.values():
+            if len(records_by_qname) != 2:
+                continue
+            record1, record2 = records_by_qname
+            index1, rname1, pnext1, start1, end1 = record1
+            index2, rname2, pnext2, start2, end2 = record2
+            if rname1 != rname2 or pnext1 != start2 or pnext2 != start1:
+                continue
+            tlen = max(end1, end2) - min(start1, start2)
+            if tlen == 0:
+                continue
+            if start1 < start2 or (start1 == start2 and end1 <= end2):
+                tlens[index1] = tlen
+                tlens[index2] = -tlen
+            else:
+                tlens[index1] = -tlen
+                tlens[index2] = tlen
+        return tlens
+
+    def _get_tlen_record(self, alignment):
+        """Return the information needed to calculate TLEN for an alignment."""
+        try:
+            flag = alignment.flag
+        except AttributeError:
+            return None
+        if not flag & 0x1 or flag & (0x4 | 0x8 | 0x100 | 0x800):
+            return None
+        try:
+            pnext = alignment.pnext
+        except AttributeError:
+            return None
+        if pnext < 0:
+            return None
+        try:
+            target, query = alignment.sequences
+            qname = query.id
+            rname = target.id
+        except AttributeError:
+            return None
+        try:
+            rnext = alignment.rnext
+        except AttributeError:
+            return None
+        if rnext not in ("=", rname):
+            return None
+        coordinates = alignment.coordinates
+        if coordinates is None:
+            return None
+        t_coordinates = coordinates[0, :]
+        t_start = min(t_coordinates)
+        t_end = max(t_coordinates)
+        if t_start == t_end:
+            return None
+        return qname, rname, pnext, t_start, t_end
 
 
 class AlignmentIterator(interfaces.AlignmentIterator):

--- a/Tests/test_Align_sam.py
+++ b/Tests/test_Align_sam.py
@@ -8534,6 +8534,53 @@ class TestAlign_sambam(unittest.TestCase):
         self.assertEqual(n, 200)
 
 
+class TestAlign_tlen(unittest.TestCase):
+    def test_preserve_tlen(self):
+        """Test writing an explicit TLEN value."""
+        target = SeqRecord(Seq("N" * 100), id="target")
+        query = SeqRecord(Seq("ATGCATGCAT"), id="read")
+        coordinates = np.array([[10, 20], [0, 10]])
+        alignment = Alignment([target, query], coordinates)
+        alignment.flag = 99
+        alignment.rnext = "target"
+        alignment.pnext = 30
+        alignment.tlen = 30
+        self.assertEqual(
+            alignment.format("sam"),
+            "read\t99\ttarget\t11\t255\t10M\t=\t31\t30\tATGCATGCAT\t*\n",
+        )
+
+    def test_calculate_tlen(self):
+        """Test calculating TLEN for paired alignments."""
+        target = SeqRecord(Seq("N" * 100), id="target")
+        query1 = SeqRecord(Seq("ATGCATGCAT"), id="read")
+        query2 = SeqRecord(Seq("ATGCATGCAT"), id="read")
+        coordinates1 = np.array([[10, 20], [0, 10]])
+        coordinates2 = np.array([[30, 40], [10, 0]])
+        alignment1 = Alignment([target, query1], coordinates1)
+        alignment1.flag = 99
+        alignment1.rnext = "target"
+        alignment1.pnext = 30
+        alignment2 = Alignment([target, query2], coordinates2)
+        alignment2.flag = 147
+        alignment2.rnext = "target"
+        alignment2.pnext = 10
+        stream = StringIO()
+        n = Align.write([alignment1, alignment2], stream, "sam")
+        self.assertEqual(n, 2)
+        self.assertEqual(
+            stream.getvalue(),
+            "read\t99\ttarget\t11\t255\t10M\t=\t31\t30\tATGCATGCAT\t*\n"
+            "read\t147\ttarget\t31\t255\t10M\t=\t11\t-30\tATGCATGCAT\t*\n",
+        )
+        stream.seek(0)
+        alignments = Align.parse(stream, "sam")
+        alignment1 = next(alignments)
+        alignment2 = next(alignments)
+        self.assertEqual(alignment1.tlen, 30)
+        self.assertEqual(alignment2.tlen, -30)
+
+
 class TestAlign_clipping(unittest.TestCase):
     def test_6M(self):
         """Test alignment starting at non-zero position."""


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Resolves the incorrect Template Length (TLEN) calculation when writing SAM files.

Closes #5232 
