### PR TITLE
Guard Tree.collapse() against children without branch lengths

### DIFF
--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -593,7 +593,8 @@ class TreeMixin:
         popped = parent.clades.pop(parent.clades.index(path[-1]))
         extra_length = popped.branch_length or 0
         for child in popped:
-            child.branch_length += extra_length
+            if child.branch_length is not None:
+                child.branch_length += extra_length
         parent.clades.extend(popped.clades)
         return parent
 

--- a/Tests/test_Phylo.py
+++ b/Tests/test_Phylo.py
@@ -481,6 +481,12 @@ class MixinTests(unittest.TestCase):
         for clade in d2:
             self.assertAlmostEqual(d1[clade], d2[clade])
 
+    def test_collapse_without_branch_lengths(self):
+        tree = Phylo.read(StringIO("(((A,B),C),D);"), "newick")
+        tree.collapse_all()
+        self.assertEqual(len(tree.get_terminals()), 4)
+        self.assertEqual(len(tree.get_nonterminals()), 1)
+
     def test_ladderize(self):
         """TreeMixin: ladderize() method."""
 


### PR DESCRIPTION
- [ x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #5245

Tree.collapse() added the removed node's branch length to each child with child.branch_length += extra_length, which raised TypeError when a child had branch_length None (cladograms / trees parsed without branch lengths). Mirror the guard already used in the sibling prune() method.