### PR TITLE
Fix PDBList URL construction for non-RCSB mirrors

### DIFF
--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -86,9 +86,12 @@ class PDBList:
     http://www.pdb.org/.
     """
 
+    # Default wwPDB mirror; EBI uses https://ftp.ebi.ac.uk/pub/databases/pdb instead.
+    DEFAULT_SERVER = "https://files.wwpdb.org/pub/pdb"
+
     def __init__(
         self,
-        server="https://files.wwpdb.org",
+        server=None,
         pdb=None,
         obsolete_pdb=None,
         verbose=True,
@@ -97,9 +100,15 @@ class PDBList:
 
         Argument pdb is the local path to use, defaulting to the current
         directory at the moment of initialisation.
+
+        The server argument should be the PDB data root URL, including any
+        mirror-specific path prefix (for example the wwPDB default ends in
+        ``/pub/pdb``, while the EBI mirror ends in ``/pub/databases/pdb``).
         """
         self.assemblies = None
-        self.pdb_server = server  # remote pdb server
+        if server is None:
+            server = self.DEFAULT_SERVER
+        self.pdb_server = server.rstrip("/")  # remote pdb server
         if pdb:
             self.local_pdb = pdb  # local pdb file tree
         else:
@@ -161,7 +170,7 @@ class PDBList:
             drwxrwxr-x   2 1002     sysadmin     512 Oct 14 02:14 20031013
             -rw-r--r--   1 1002     sysadmin    1327 Mar 12  2001 README
         """
-        path = self.pdb_server + "/pub/pdb/data/status/latest/"
+        path = self.pdb_server + "/data/status/latest/"
 
         # Retrieve the lists
         added = self.get_status_list(path + "added.pdb")
@@ -174,7 +183,7 @@ class PDBList:
 
         Returns a list of PDB codes in the index file.
         """
-        url = self.pdb_server + "/pub/pdb/derived_data/index/entries.idx"
+        url = self.pdb_server + "/derived_data/index/entries.idx"
         if self._verbose:
             print("Retrieving index file. Takes about 27 MB.")
         with contextlib.closing(urlopen(url)) as handle:
@@ -206,7 +215,7 @@ class PDBList:
             ...
 
         """
-        url = self.pdb_server + "/pub/pdb/data/status/obsolete.dat"
+        url = self.pdb_server + "/data/status/obsolete.dat"
         with contextlib.closing(urlopen(url)) as handle:
             # Extract pdb codes. Could use a list comprehension, but I want
             # to include an assert to check for mis-reading the data.
@@ -294,12 +303,12 @@ class PDBList:
             )
             url = (
                 self.pdb_server
-                + f"/pub/pdb/data/structures/{pdb_dir}/{file_type}/{pdb_code[1:3]}/{archive}"
+                + f"/data/structures/{pdb_dir}/{file_type}/{pdb_code[1:3]}/{archive}"
             )
         elif file_format == "bundle":
             url = (
                 self.pdb_server
-                + f"/pub/pdb/compatible/pdb_bundle/{pdb_code[1:3]}/{pdb_code}/{archive}"
+                + f"/compatible/pdb_bundle/{pdb_code[1:3]}/{pdb_code}/{archive}"
             )
         else:
             url = f"http://mmtf.rcsb.org/v1.0/full/{pdb_code}"
@@ -534,9 +543,9 @@ class PDBList:
         archive_fn = archive[file_format]
 
         if file_format == "mmcif":
-            url = self.pdb_server + f"/pub/pdb/data/assemblies/mmCIF/all/{archive_fn}"
+            url = self.pdb_server + f"/data/assemblies/mmCIF/all/{archive_fn}"
         elif file_format == "pdb":
-            url = self.pdb_server + f"/pub/pdb/data/biounit/PDB/all/{archive_fn}"
+            url = self.pdb_server + f"/data/biounit/PDB/all/{archive_fn}"
         else:  # better safe than sorry
             raise ValueError(f"file_format '{file_format}' not supported")
 
@@ -683,7 +692,7 @@ class PDBList:
         """Retrieve and save a (big) file containing all the sequences of PDB entries."""
         if self._verbose:
             print("Retrieving sequence file (takes over 110 MB).")
-        url = self.pdb_server + "/pub/pdb/derived_data/pdb_seqres.txt"
+        url = self.pdb_server + "/derived_data/pdb_seqres.txt"
         urlretrieve(url, savefile)
 
 

--- a/Tests/test_PDB_PDBList.py
+++ b/Tests/test_PDB_PDBList.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 import requires_internet
 
@@ -46,6 +47,12 @@ class TestPBDListGetList(unittest.TestCase):
             "https://ftp.pdbj.org/pub/pdb/data/structures/divided/pdb/27/pdb127d.ent.gz",
         )
 
+    def test_server_trailing_slash_is_stripped(self):
+        pdblist = PDBList(
+            server="https://ftp.ebi.ac.uk/pub/databases/pdb/", obsolete_pdb="unimportant"
+        )
+        self.assertEqual(pdblist.pdb_server, "https://ftp.ebi.ac.uk/pub/databases/pdb")
+
     def test_get_recent_changes(self):
         """Tests the Bio.PDB.PDBList.get_recent_changes method."""
         # obsolete_pdb declared to prevent from creating the "obsolete" directory
@@ -80,6 +87,91 @@ class TestPBDListGetList(unittest.TestCase):
         # As number of obsolete entries constantly grow, test checks if a certain number
         # was exceeded
         self.assertGreater(len(entries), 100000)
+
+
+class TestPDBListURLConstruction(unittest.TestCase):
+    """Check download URLs without hitting the network."""
+
+    @staticmethod
+    def _fake_urlretrieve(_url, filename):
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        with open(filename, "wb") as handle:
+            handle.write(b"")
+        return filename, {}
+
+    def test_retrieve_pdb_file_builds_rcsb_structure_url(self):
+        pdblist = PDBList(pdb=".", obsolete_pdb="unimportant", verbose=False)
+        with tempfile.TemporaryDirectory() as tmp:
+            pdblist.local_pdb = tmp
+            with mock.patch(
+                "Bio.PDB.PDBList.urlretrieve", side_effect=self._fake_urlretrieve
+            ) as urlretrieve:
+                with mock.patch("Bio.PDB.PDBList.gzip.open") as gzip_open:
+                    gzip_open.return_value.__enter__.return_value = iter([b""])
+                    pdblist.retrieve_pdb_file("127d", file_format="pdb")
+            url = urlretrieve.call_args[0][0]
+        self.assertEqual(
+            url,
+            "https://files.wwpdb.org/pub/pdb/data/structures/divided/pdb/27/pdb127d.ent.gz",
+        )
+
+    def test_retrieve_pdb_file_builds_ebi_structure_url(self):
+        pdblist = PDBList(
+            server="https://ftp.ebi.ac.uk/pub/databases/pdb",
+            pdb=".",
+            obsolete_pdb="unimportant",
+            verbose=False,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            pdblist.local_pdb = tmp
+            with mock.patch(
+                "Bio.PDB.PDBList.urlretrieve", side_effect=self._fake_urlretrieve
+            ) as urlretrieve:
+                with mock.patch("Bio.PDB.PDBList.gzip.open") as gzip_open:
+                    gzip_open.return_value.__enter__.return_value = iter([b""])
+                    pdblist.retrieve_pdb_file("127d", file_format="mmCif")
+            url = urlretrieve.call_args[0][0]
+        self.assertEqual(
+            url,
+            "https://ftp.ebi.ac.uk/pub/databases/pdb/data/structures/divided/mmCIF/27/127d.cif.gz",
+        )
+
+    def test_get_all_entries_uses_data_root(self):
+        pdblist = PDBList(
+            server="https://ftp.pdbj.org/pub/pdb", obsolete_pdb="unimportant", verbose=False
+        )
+        with mock.patch("Bio.PDB.PDBList.urlopen") as urlopen:
+            urlopen.return_value.__enter__.return_value.readlines.return_value = [
+                b"HEADER\n",
+                b"----\n",
+            ]
+            pdblist.get_all_entries()
+        url = urlopen.call_args[0][0]
+        self.assertEqual(
+            url, "https://ftp.pdbj.org/pub/pdb/derived_data/index/entries.idx"
+        )
+
+    def test_get_recent_changes_uses_data_root(self):
+        pdblist = PDBList(
+            server="https://ftp.ebi.ac.uk/pub/databases/pdb",
+            obsolete_pdb="unimportant",
+            verbose=False,
+        )
+        with mock.patch.object(PDBList, "get_status_list", return_value=["1abc"]) as get_list:
+            pdblist.get_recent_changes()
+        urls = [call.args[0] for call in get_list.call_args_list]
+        self.assertEqual(
+            urls[0],
+            "https://ftp.ebi.ac.uk/pub/databases/pdb/data/status/latest/added.pdb",
+        )
+        self.assertEqual(
+            urls[1],
+            "https://ftp.ebi.ac.uk/pub/databases/pdb/data/status/latest/modified.pdb",
+        )
+        self.assertEqual(
+            urls[2],
+            "https://ftp.ebi.ac.uk/pub/databases/pdb/data/status/latest/obsolete.pdb",
+        )
 
 
 class TestPDBListGetStructure(unittest.TestCase):

--- a/Tests/test_PDB_PDBList.py
+++ b/Tests/test_PDB_PDBList.py
@@ -23,11 +23,34 @@ requires_internet.check()
 class TestPBDListGetList(unittest.TestCase):
     """Test methods responsible for getting lists of entries."""
 
+    def test_default_server_includes_pdb_path_prefix(self):
+        """The default server should point at the wwPDB data root."""
+        pdblist = PDBList(obsolete_pdb="unimportant")
+        self.assertEqual(pdblist.pdb_server, PDBList.DEFAULT_SERVER)
+
+    def test_mirror_server_urls(self):
+        """Custom servers should only need the mirror-specific data root."""
+        ebi = PDBList(server="https://ftp.ebi.ac.uk/pub/databases/pdb")
+        status_url = ebi.pdb_server + "/data/status/latest/added.pdb"
+        self.assertEqual(
+            status_url,
+            "https://ftp.ebi.ac.uk/pub/databases/pdb/data/status/latest/added.pdb",
+        )
+
+        pdbj = PDBList(server="https://ftp.pdbj.org/pub/pdb")
+        structure_url = (
+            pdbj.pdb_server + "/data/structures/divided/pdb/27/pdb127d.ent.gz"
+        )
+        self.assertEqual(
+            structure_url,
+            "https://ftp.pdbj.org/pub/pdb/data/structures/divided/pdb/27/pdb127d.ent.gz",
+        )
+
     def test_get_recent_changes(self):
         """Tests the Bio.PDB.PDBList.get_recent_changes method."""
         # obsolete_pdb declared to prevent from creating the "obsolete" directory
         pdblist = PDBList(obsolete_pdb="unimportant")
-        url = pdblist.pdb_server + "/pub/pdb/data/status/latest/added.pdb"
+        url = pdblist.pdb_server + "/data/status/latest/added.pdb"
         entries = pdblist.get_status_list(url)
         self.assertIsNotNone(entries)
 


### PR DESCRIPTION
## Summary

- Move the `/pub/pdb` path prefix into the configurable `server` root so mirror-specific paths work without duplicating `/pub/pdb` in every URL builder.
- Default server is now `https://files.wwpdb.org/pub/pdb`; EBI users can pass `https://ftp.ebi.ac.uk/pub/databases/pdb`.
- Add offline tests that mock downloads and verify RCSB, EBI, and PDBj URLs.

Fixes #3987

## Test plan

- [x] `python -m unittest test_PDB_PDBList.TestPDBListURLConstruction`
- [x] `python -m unittest test_PDB_PDBList.TestPBDListGetList.test_default_server_includes_pdb_path_prefix`
- [x] `python -m unittest test_PDB_PDBList.TestPBDListGetList.test_mirror_server_urls`


Made with [Cursor](https://cursor.com)