### PR TITLE
Misc mypy fixes/clean-up

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -22,6 +22,9 @@ disallow_incomplete_defs = False
 [mypy-Bio.PDB.ccealign]
 ignore_missing_imports = True
 
+[mypy-Bio.PDB._bcif_helper]
+ignore_missing_imports = True
+
 [mypy-Bio.PDB.ic_rebuild]
 ignore_errors = True
 
@@ -38,6 +41,9 @@ ignore_errors = True
 ignore_errors = True
 
 [mypy-igraph.*]
+ignore_missing_imports = True
+
+[mypy-msgpack.*]
 ignore_missing_imports = True
 
 [mypy-mmtf.*]

--- a/Bio/Align/__init__.py
+++ b/Bio/Align/__init__.py
@@ -1250,8 +1250,7 @@ class Alignment:
             # Append the current positions to msa_coordinates
             msa_coordinates.append([reference_position] + list(positions[:, 1]))
 
-        msa_coordinates = np.array(msa_coordinates).transpose()
-        return cls(sequences, msa_coordinates)
+        return cls(sequences, np.array(msa_coordinates).transpose())
 
     def __init__(self, sequences, coordinates=None):
         """Initialize a new Alignment object.

--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -92,9 +92,9 @@ class Atom:
         self.full_id = None  # (structure id, model id, chain id, residue id, atom id)
         self.id = name  # id of atom is the atom name (e.g. "CA")
         self.disordered_flag = 0
-        self.anisou_array = None
-        self.siguij_array = None
-        self.sigatm_array = None
+        self.anisou_array: np.ndarray | None = None
+        self.siguij_array: np.ndarray | None = None
+        self.sigatm_array: np.ndarray | None = None
         self.serial_number = serial_number
         # Dictionary that keeps additional properties
         self.xtra: dict = {}


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

This addresses most of the issues flagged by running mypy 1.16.1 which is in the pre-commit configuration but not run on the pre-commit CI due to time concerns. It seems some recent work had _not_ been validated with the mypy setup.

There is still one issue in `Bio/PDB/Atom.py` with some mixing of single-element-arrays vs booleans I think:

```
$ mypy --version
mypy 1.16.1 (compiled: yes)
$ mypy Bio/ BioSQL/
Bio/PDB/Atom.py: note: In member "strictly_equals" of class "Atom":
Bio/PDB/Atom.py:290:13: error: Incompatible return value type (got
"numpy.bool[builtins.bool] | Any | builtins.bool", expected "builtins.bool")  [return-value]
                self.name == other.name
                ^
Bio/PDB/Atom.py:291:28: error: Argument 1 to "isclose" has incompatible type "float | None";
expected "complex | number[Any, int | float | complex] | numpy.bool[builtins.bool]"  [arg-type]
                and np.isclose(self.bfactor, other.bfactor)
                               ^~~~~~~~~~~~
Bio/PDB/Atom.py:291:42: error: Argument 2 to "isclose" has incompatible type "float | None";
expected "complex | number[Any, int | float | complex] | numpy.bool[builtins.bool]"  [arg-type]
                and np.isclose(self.bfactor, other.bfactor)
                                             ^~~~~~~~~~~~~
Bio/PDB/Atom.py:292:28: error: Argument 1 to "isclose" has incompatible type "float | None";
expected "complex | number[Any, int | float | complex] | numpy.bool[builtins.bool]"  [arg-type]
                and np.isclose(self.occupancy, other.occupancy)
                               ^~~~~~~~~~~~~~
Bio/PDB/Atom.py:292:44: error: Argument 2 to "isclose" has incompatible type "float | None";
expected "complex | number[Any, int | float | complex] | numpy.bool[builtins.bool]"  [arg-type]
                and np.isclose(self.occupancy, other.occupancy)
                                               ^~~~~~~~~~~~~~~
Found 5 errors in 1 file (checked 298 source files)
```

Found while testing with zuban as a possible faster alternative to mypy: https://github.com/zubanls/zuban/