### PR TITLE
Fix obsolete move logic in PDBList.update_pdb for mmCIF/mmtf and assemblies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
             coverage run --source Bio,BioSQL --source Bio,BioSQL run_tests.py --offline
             echo "Tests run"
             coverage xml
-      - run:
-          name: Upload to Codecov
-          command: |
-            codecov upload-process -n CircleCI -f biopython-*/Tests/coverage.xml || echo "Codecov upload failed; continuing."
+      - codecov/upload:
+          upload_name: CircleCI
+          disable_search: true
+          files: biopython-*/Tests/coverage.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,3 +54,4 @@ jobs:
           upload_name: CircleCI
           disable_search: true
           files: biopython-*/Tests/coverage.xml
+          fail_ci_if_error: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,7 @@ jobs:
             coverage run --source Bio,BioSQL --source Bio,BioSQL run_tests.py --offline
             echo "Tests run"
             coverage xml
-      - codecov/upload:
-          upload_name: CircleCI
-          disable_search: true
-          files: biopython-*/Tests/coverage.xml
-          fail_ci_if_error: false
+      - run:
+          name: Upload to Codecov
+          command: |
+            codecov upload-process -n CircleCI -f biopython-*/Tests/coverage.xml || echo "Codecov upload failed; continuing."

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -445,9 +445,7 @@ class PDBList:
                     try:
                         shutil.move(old_assembly_file, new_assembly_file)
                     except Exception:
-                        print(
-                            f"Could not move {old_assembly_file} to obsolete folder"
-                        )
+                        print(f"Could not move {old_assembly_file} to obsolete folder")
 
     def download_pdb_files(
         self,

--- a/Bio/PDB/PDBList.py
+++ b/Bio/PDB/PDBList.py
@@ -37,6 +37,7 @@
 
 import contextlib
 import functools
+import glob
 import gzip
 import json
 import os
@@ -384,21 +385,38 @@ class PDBList:
                 # you can insert here some more log notes that
                 # something has gone wrong.
 
-        # Move the obsolete files to a special folder
-        # NOTE: This should be updated to handle multiple file types and
-        # assemblies. As of now, it only looks for PDB-formatted files.
-        # Using pathlib will be probably the best approach here, to build
-        # and index of which files we have efficiently (or glob them).
+        final_name = {
+            "pdb": "pdb{pdb_code}.ent",
+            "mmCif": "{pdb_code}.cif",
+            "xml": "{pdb_code}.xml",
+            "mmtf": "{pdb_code}.mmtf",
+            "bundle": "{pdb_code}-pdb-bundle.tar",
+        }
+        assembly_glob = {
+            "pdb": "{pdb_code}.pdb*",
+            "mmCif": "{pdb_code}-assembly*.cif",
+        }
+
+        # Move obsolete files to the obsolete folder for the selected format,
+        # and include assembly files when available for that format.
         for pdb_code in obsolete:
             if self.flat_tree:
-                old_file = os.path.join(self.local_pdb, f"pdb{pdb_code}.{file_format}")
+                old_file = os.path.join(
+                    self.local_pdb,
+                    final_name[file_format].format(pdb_code=pdb_code),
+                )
                 new_dir = self.obsolete_pdb
             else:
                 old_file = os.path.join(
-                    self.local_pdb, pdb_code[1:3], f"pdb{pdb_code}.{file_format}"
+                    self.local_pdb,
+                    pdb_code[1:3],
+                    final_name[file_format].format(pdb_code=pdb_code),
                 )
                 new_dir = os.path.join(self.obsolete_pdb, pdb_code[1:3])
-            new_file = os.path.join(new_dir, f"pdb{pdb_code}.{file_format}")
+            new_file = os.path.join(
+                new_dir,
+                final_name[file_format].format(pdb_code=pdb_code),
+            )
             if os.path.isfile(old_file):
                 os.makedirs(new_dir, exist_ok=True)
                 try:
@@ -411,6 +429,25 @@ class PDBList:
             else:
                 if self._verbose:
                     print(f"Obsolete file {old_file} is missing")
+
+            pattern = assembly_glob.get(file_format)
+            if pattern is not None:
+                source_pattern = os.path.join(
+                    os.path.dirname(old_file),
+                    pattern.format(pdb_code=pdb_code),
+                )
+                for old_assembly_file in glob.glob(source_pattern):
+                    new_assembly_file = os.path.join(
+                        new_dir,
+                        os.path.basename(old_assembly_file),
+                    )
+                    os.makedirs(new_dir, exist_ok=True)
+                    try:
+                        shutil.move(old_assembly_file, new_assembly_file)
+                    except Exception:
+                        print(
+                            f"Could not move {old_assembly_file} to obsolete folder"
+                        )
 
     def download_pdb_files(
         self,

--- a/Tests/test_PDB_PDBList.py
+++ b/Tests/test_PDB_PDBList.py
@@ -282,7 +282,9 @@ class TestPDBListUpdateObsoleteHandling(unittest.TestCase):
                 pdblist.update_pdb(file_format="mmCif")
 
             self.assertFalse(os.path.exists(source_file))
-            self.assertTrue(os.path.exists(os.path.join(obsolete_dir, f"{pdb_code}.cif")))
+            self.assertTrue(
+                os.path.exists(os.path.join(obsolete_dir, f"{pdb_code}.cif"))
+            )
 
     def test_update_pdb_moves_obsolete_mmcif_assemblies(self):
         pdb_code = "127d"
@@ -305,7 +307,9 @@ class TestPDBListUpdateObsoleteHandling(unittest.TestCase):
 
             self.assertFalse(os.path.exists(source_file))
             self.assertFalse(os.path.exists(source_assembly))
-            self.assertTrue(os.path.exists(os.path.join(obsolete_dir, f"{pdb_code}.cif")))
+            self.assertTrue(
+                os.path.exists(os.path.join(obsolete_dir, f"{pdb_code}.cif"))
+            )
             self.assertTrue(
                 os.path.exists(os.path.join(obsolete_dir, f"{pdb_code}-assembly1.cif"))
             )

--- a/Tests/test_PDB_PDBList.py
+++ b/Tests/test_PDB_PDBList.py
@@ -254,6 +254,63 @@ class TestPDBListGetAssembly(unittest.TestCase):
         )
 
 
+class TestPDBListUpdateObsoleteHandling(unittest.TestCase):
+    """Regression tests for moving obsolete files in update_pdb."""
+
+    @contextlib.contextmanager
+    def make_temp_directory(self, directory):
+        temp_dir = tempfile.mkdtemp(dir=directory)
+        try:
+            yield temp_dir
+        finally:
+            shutil.rmtree(temp_dir)
+
+    def test_update_pdb_moves_obsolete_mmcif(self):
+        pdb_code = "127d"
+        with self.make_temp_directory(os.getcwd()) as tmp:
+            pdblist = PDBList(pdb=tmp)
+            current_dir = os.path.join(tmp, pdb_code[1:3])
+            obsolete_dir = os.path.join(tmp, "obsolete", pdb_code[1:3])
+            os.makedirs(current_dir, exist_ok=True)
+            source_file = os.path.join(current_dir, f"{pdb_code}.cif")
+            with open(source_file, "w", encoding="utf-8") as handle:
+                handle.write("stub")
+
+            with unittest.mock.patch.object(
+                pdblist, "get_recent_changes", return_value=([], [], [pdb_code])
+            ):
+                pdblist.update_pdb(file_format="mmCif")
+
+            self.assertFalse(os.path.exists(source_file))
+            self.assertTrue(os.path.exists(os.path.join(obsolete_dir, f"{pdb_code}.cif")))
+
+    def test_update_pdb_moves_obsolete_mmcif_assemblies(self):
+        pdb_code = "127d"
+        with self.make_temp_directory(os.getcwd()) as tmp:
+            pdblist = PDBList(pdb=tmp)
+            current_dir = os.path.join(tmp, pdb_code[1:3])
+            obsolete_dir = os.path.join(tmp, "obsolete", pdb_code[1:3])
+            os.makedirs(current_dir, exist_ok=True)
+            source_file = os.path.join(current_dir, f"{pdb_code}.cif")
+            source_assembly = os.path.join(current_dir, f"{pdb_code}-assembly1.cif")
+            with open(source_file, "w", encoding="utf-8") as handle:
+                handle.write("stub")
+            with open(source_assembly, "w", encoding="utf-8") as handle:
+                handle.write("stub")
+
+            with unittest.mock.patch.object(
+                pdblist, "get_recent_changes", return_value=([], [], [pdb_code])
+            ):
+                pdblist.update_pdb(file_format="mmCif", with_assemblies=True)
+
+            self.assertFalse(os.path.exists(source_file))
+            self.assertFalse(os.path.exists(source_assembly))
+            self.assertTrue(os.path.exists(os.path.join(obsolete_dir, f"{pdb_code}.cif")))
+            self.assertTrue(
+                os.path.exists(os.path.join(obsolete_dir, f"{pdb_code}-assembly1.cif"))
+            )
+
+
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)
     unittest.main(testRunner=runner)


### PR DESCRIPTION
## Summary
- fix PDBList.update_pdb obsolete-file move logic to use format-specific final filenames instead of hardcoded pdb*.{file_format} patterns
- move obsolete assembly files for formats that support assemblies (pdb, mmCif) during weekly updates
- add regression tests for mmCIF obsolete move and mmCIF assembly obsolete move

## Why this matters
Issue #3988 reports that obsolete handling was tied to PDB naming assumptions and did not account for other formats/assemblies. This change makes weekly update behavior consistent with retrieval naming conventions.

## Testing
- Added offline regression tests:
  - TestPDBListUpdateObsoleteHandling.test_update_pdb_moves_obsolete_mmcif
  - TestPDBListUpdateObsoleteHandling.test_update_pdb_moves_obsolete_mmcif_assemblies
- Local full test execution was blocked by missing MSVC build tools for Biopython C extensions in this environment.