### PR TITLE
Fix HSP coordinate properties crashing when some fragments have None coords

### DIFF
--- a/Bio/SearchIO/_model/hsp.py
+++ b/Bio/SearchIO/_model/hsp.py
@@ -438,6 +438,7 @@ class HSP(_BaseHSP):
                 "'None' exist in %s coordinates; ignored" % (coord_name),
                 BiopythonWarning,
             )
+            coords = [x for x in coords if x is not None]
         return coords
 
     def _hit_start_get(self):

--- a/Tests/test_SearchIO_model.py
+++ b/Tests/test_SearchIO_model.py
@@ -18,6 +18,7 @@ from io import BytesIO
 
 from search_tests_common import SearchTestBaseClass
 
+from Bio import BiopythonWarning
 from Bio.Align import MultipleSeqAlignment
 from Bio.SearchIO._model import Hit
 from Bio.SearchIO._model import HSP
@@ -1276,6 +1277,28 @@ class HSPMultipleFragmentCases(SearchTestBaseClass):
         self.assertRaises(AttributeError, setattr, self.hsp, "aln_all", None)
         self.assertRaises(AttributeError, setattr, self.hsp, "hit_all", None)
         self.assertRaises(AttributeError, setattr, self.hsp, "query_all", None)
+
+    def test_range_with_none_coordinate(self):
+        """Test HSP range properties when one fragment has None coordinates."""
+        self.frag2.query_start = None
+        self.frag2.query_end = None
+        with self.assertWarns(BiopythonWarning):
+            query_start = self.hsp.query_start
+        with self.assertWarns(BiopythonWarning):
+            query_end = self.hsp.query_end
+        # the None coordinates from frag2 should be ignored, as advertised
+        # by the warning, not propagated into the min()/max() call
+        self.assertEqual(0, query_start)
+        self.assertEqual(6, query_end)
+
+    def test_range_with_all_none_coordinates(self):
+        """Test HSP range properties when all fragments have None coordinates."""
+        self.frag1.query_start = None
+        self.frag1.query_end = None
+        self.frag2.query_start = None
+        self.frag2.query_end = None
+        with self.assertWarns(BiopythonWarning):
+            self.assertRaises(ValueError, lambda: self.hsp.query_start)
 
 
 class HSPFragmentWithoutSeqCases(unittest.TestCase):


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

`HSP._get_coords()` warns that `None` coordinates are "ignored" when a fragment is missing a start or end, but it returns them in the list unchanged. `hit_start`/`query_start` call `min()` on that list and `hit_end`/`query_end` call `max()`, so any HSP with a mix of `None` and real coordinates across its fragments raises `TypeError: '<' not supported between instances of 'NoneType' and 'int'` instead of just warning.

This fixes `_get_coords` to actually drop the `None` values after warning, so the coordinate is ignored as the message says. If every fragment has `None` for that coordinate, `min()`/`max()` now raise a plain `ValueError` on an empty sequence instead of a confusing type-comparison error.

Repro before the fix:

```python
from Bio.SearchIO._model.hsp import HSP, HSPFragment

f1 = HSPFragment("hit1", "query1")
f1.query_start = None
f1.query_end = None

f2 = HSPFragment("hit1", "query1")
f2.query_start = 0
f2.query_end = 10

hsp = HSP([f1, f2])
hsp.query_start
# BiopythonWarning: 'None' exist in query_start coordinates; ignored
# TypeError: '<' not supported between instances of 'NoneType' and 'int'
```

After the fix, `hsp.query_start` returns `0` (the real minimum) with just the warning, as intended.

Added two regression tests to `HSPMultipleFragmentCases` in `Tests/test_SearchIO_model.py` covering the mixed `None`/int case and the all-`None` case.

I also checked the `hit_span`/`query_span` properties (`end - start`) in this file for a possible off-by-one on inclusive coordinates, since Biopython's `SearchIO` coordinates are 0-based half-open (see the module docstring example: `Query range: [1:61]` for a 60-residue match, and the existing test comment `# span is always end - start`). That's correct as written, so I left it alone.

Ran `python -m pytest Tests/test_SearchIO_model.py Tests/test_SearchIO*.py -q`: 464 passed, no regressions. `pre-commit run --files Bio/SearchIO/_model/hsp.py Tests/test_SearchIO_model.py` passes (ruff, black, flake8, mypy, blacken-docs).
