### PR TITLE
Type-annotate Bio.PDB.PDBMLParser and fix header resolution parsing

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -34,9 +34,6 @@ ignore_errors = True
 [mypy-Bio.PDB.kdtrees]
 ignore_missing_imports = True
 
-[mypy-Bio.PDB.PDBMLParser]
-ignore_errors = True
-
 [mypy-Bio.PDB.PICIO]
 ignore_errors = True
 

--- a/Bio/PDB/PDBMLParser.py
+++ b/Bio/PDB/PDBMLParser.py
@@ -10,6 +10,7 @@ See https://pdbml.wwpdb.org/.
 """
 
 from os import PathLike
+from typing import cast
 from typing import TextIO
 from typing import Union
 from xml.etree import ElementTree
@@ -17,12 +18,34 @@ from xml.etree.ElementTree import Element
 
 import numpy as np
 
+from Bio.PDB.PDBExceptions import PDBConstructionException
 from Bio.PDB.Structure import Structure
 from Bio.PDB.StructureBuilder import StructureBuilder
 
 
+def _find(
+    parent: "ElementTree.ElementTree[Element] | Element",
+    path: str,
+    namespaces: dict[str, str],
+) -> Element:
+    """Return the first matching sub-element, raising if it is absent."""
+    element = parent.find(path, namespaces)
+    if element is None:
+        raise PDBConstructionException(f"Required PDBML element not found: {path!r}")
+    return element
+
+
+def _text(element: Element) -> str:
+    """Return an element's text content, raising if it is empty."""
+    if element.text is None:
+        raise PDBConstructionException(
+            f"PDBML element {element.tag!r} has no text content"
+        )
+    return element.text
+
+
 def _parse_resolution_from(
-    tree: ElementTree, namespaces: dict[str, str]
+    tree: "ElementTree.ElementTree[Element]", namespaces: dict[str, str]
 ) -> float | None:
     for candidate in [
         "PDBx:refineCategory/PDBx:refine/PDBx:ls_d_res_high",
@@ -30,7 +53,7 @@ def _parse_resolution_from(
         "PDBx:em_3d_reconstructionCategory/PDBx:em_3d_reconstruction/PDBx:resolution",
     ]:
         element = tree.find(candidate, namespaces)
-        if element:
+        if element is not None:
             text = element.text
             if text:
                 return float(text)
@@ -38,45 +61,48 @@ def _parse_resolution_from(
 
 
 def _parse_header_from(
-    tree: ElementTree, namespaces: dict[str, str]
-) -> dict[str, str | float]:
+    tree: "ElementTree.ElementTree[Element]", namespaces: dict[str, str]
+) -> dict[str, str | float | None]:
+    # The element must be present, but its text may be absent (an xsi:nil
+    # element parses to text=None); mirror the original None-tolerant behaviour
+    # for these optional header fields rather than raising via _text.
     return {
-        "name": tree.find(
-            "PDBx:structCategory/PDBx:struct/PDBx:title", namespaces
+        "name": _find(
+            tree, "PDBx:structCategory/PDBx:struct/PDBx:title", namespaces
         ).text,
-        "head": tree.find(
-            "PDBx:struct_keywordsCategory/PDBx:struct_keywords/PDBx:text", namespaces
-        ).text,
-        "idcode": tree.find(
-            "PDBx:entryCategory/PDBx:entry",
+        "head": _find(
+            tree,
+            "PDBx:struct_keywordsCategory/PDBx:struct_keywords/PDBx:text",
             namespaces,
-        ).attrib["id"],
-        "deposition_date": tree.find(
+        ).text,
+        "idcode": _find(tree, "PDBx:entryCategory/PDBx:entry", namespaces).attrib["id"],
+        "deposition_date": _find(
+            tree,
             "PDBx:pdbx_database_statusCategory/PDBx:pdbx_database_status/PDBx:recvd_initial_deposition_date",
             namespaces,
         ).text,
-        "structure_method": tree.find(
-            "PDBx:exptlCategory/PDBx:exptl", namespaces
+        "structure_method": _find(
+            tree, "PDBx:exptlCategory/PDBx:exptl", namespaces
         ).attrib["method"],
         "resolution": _parse_resolution_from(tree, namespaces),
     }
 
 
 def _parse_atom_from(element: Element, namespaces: dict[str, str]):
-    name = element.find("PDBx:label_atom_id", namespaces).text
-    x = float(element.find("PDBx:Cartn_x", namespaces).text)
-    y = float(element.find("PDBx:Cartn_y", namespaces).text)
-    z = float(element.find("PDBx:Cartn_z", namespaces).text)
+    name = _text(_find(element, "PDBx:label_atom_id", namespaces))
+    x = float(_text(_find(element, "PDBx:Cartn_x", namespaces)))
+    y = float(_text(_find(element, "PDBx:Cartn_y", namespaces)))
+    z = float(_text(_find(element, "PDBx:Cartn_z", namespaces)))
 
     return {
         "name": name,
         "coord": np.array((x, y, z), float),
-        "b_factor": float(element.find("PDBx:B_iso_or_equiv", namespaces).text),
-        "occupancy": float(element.find("PDBx:occupancy", namespaces).text),
-        "altloc": element.find("PDBx:label_alt_id", namespaces).text or " ",
+        "b_factor": float(_text(_find(element, "PDBx:B_iso_or_equiv", namespaces))),
+        "occupancy": float(_text(_find(element, "PDBx:occupancy", namespaces))),
+        "altloc": _find(element, "PDBx:label_alt_id", namespaces).text or " ",
         "fullname": name,
         "serial_number": int(element.attrib["id"]),
-        "element": element.find("PDBx:type_symbol", namespaces).text,
+        "element": _text(_find(element, "PDBx:type_symbol", namespaces)),
     }
 
 
@@ -84,8 +110,8 @@ def _parse_residue_id_from(
     element: Element, namespaces: dict[str, str]
 ) -> tuple[str, int, str]:
     assert element.tag == f"{{{namespaces['PDBx']}}}atom_site"
-    atom_group = element.find("PDBx:group_PDB", namespaces).text
-    component_id = element.find("PDBx:label_comp_id", namespaces).text
+    atom_group = _text(_find(element, "PDBx:group_PDB", namespaces))
+    component_id = _text(_find(element, "PDBx:label_comp_id", namespaces))
     ins_code_element = element.find("PDBx:pdbx_PDB_ins_code", namespaces)
 
     if atom_group == "HETATM":
@@ -96,8 +122,12 @@ def _parse_residue_id_from(
     else:
         hetero_field = " "
 
-    sequence_id = int(element.find("PDBx:auth_seq_id", namespaces).text)
-    insertion_code = ins_code_element.text if ins_code_element is not None else " "
+    sequence_id = int(_text(_find(element, "PDBx:auth_seq_id", namespaces)))
+    insertion_code = (
+        ins_code_element.text
+        if ins_code_element is not None and ins_code_element.text is not None
+        else " "
+    )
     return hetero_field, sequence_id, insertion_code
 
 
@@ -119,8 +149,9 @@ class PDBMLParser:
         :return: the PDB structure
         :rtype: Bio.PDB.Structure.Structure
         """
-        namespaces = dict(
-            [node for _, node in ElementTree.iterparse(source, ["start-ns"])]
+        namespaces: dict[str, str] = dict(
+            cast(tuple[str, str], node)
+            for _, node in ElementTree.iterparse(source, ["start-ns"])
         )
 
         if hasattr(source, "seek"):
@@ -129,9 +160,9 @@ class PDBMLParser:
 
         tree = ElementTree.parse(source)
         header = _parse_header_from(tree, namespaces)
-        self.structure_builder.init_structure(structure_id=header["idcode"])
+        self.structure_builder.init_structure(structure_id=cast(str, header["idcode"]))
         self.structure_builder.set_header(header)
-        atom_elements = tree.find("PDBx:atom_siteCategory", namespaces)
+        atom_elements = _find(tree, "PDBx:atom_siteCategory", namespaces)
 
         builder_model_count = 0
         builder_model_number = None
@@ -141,9 +172,11 @@ class PDBMLParser:
         for element in atom_elements:
             # See https://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v50.dic/Categories/atom_site.html
             # for definitions of the different elements.
-            model_number = int(element.find("PDBx:pdbx_PDB_model_num", namespaces).text)
-            chain_id = element.find("PDBx:auth_asym_id", namespaces).text
-            component_id = element.find("PDBx:label_comp_id", namespaces).text
+            model_number = int(
+                _text(_find(element, "PDBx:pdbx_PDB_model_num", namespaces))
+            )
+            chain_id = _text(_find(element, "PDBx:auth_asym_id", namespaces))
+            component_id = _text(_find(element, "PDBx:label_comp_id", namespaces))
             residue_id = _parse_residue_id_from(element, namespaces)
 
             if not builder_model_number or model_number != builder_model_number:

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -28,6 +28,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Alexander Decurnou <https://github.com/adcrn>
 - Allis Tauri <https://github.com/allista>
 - Alona Levy-Jurgenson <https://github.com/alonalj>
+- AlsoTheZv3n <https://github.com/AlsoTheZv3n>
 - Anders Pitman <https://github.com/anderspitman>
 - Andrea Pierleoni <andrea at the Italian domain biocomp dot unibo>
 - Andrea Rizzi <https://github.com/andrrizzi>

--- a/Tests/test_PDB_PDBMLParser.py
+++ b/Tests/test_PDB_PDBMLParser.py
@@ -5,11 +5,13 @@ These tests rely on the principle that the structure returned by the PDBML parse
 returned by the mmCIF parser for any PDB structure.
 """
 
+import io
 import unittest
 import warnings
 
 from Bio.PDB import MMCIFParser
 from Bio.PDB import PDBMLParser
+from Bio.PDB.PDBExceptions import PDBConstructionException
 from Bio.PDB.PDBExceptions import PDBConstructionWarning
 
 
@@ -23,7 +25,15 @@ class TestPDBMLParser(unittest.TestCase):
             for entry in ["1GBT", "6WG6", "3JQH"]:
                 mmcif_structure = mmcif_parser.get_structure(entry, f"PDB/{entry}.cif")
                 pdbml_structure = pdbml_parser.get_structure(f"PDB/{entry}.xml")
-            self.assertEqual(mmcif_structure, pdbml_structure)
+                self.assertEqual(mmcif_structure, pdbml_structure)
+                # `resolution` was previously always None because of the
+                # childless-leaf `if element:` truthiness bug; it must now match
+                # the mmCIF parser, i.e. _refine.ls_d_res_high
+                # (1GBT: 2.0, 6WG6: 3.54, 3JQH: 2.201 A).
+                self.assertAlmostEqual(
+                    pdbml_structure.header["resolution"],
+                    mmcif_structure.header["resolution"],
+                )
 
     def test_get_structure_filehandle(self):
         mmcif_parser = MMCIFParser()
@@ -39,6 +49,51 @@ class TestPDBMLParser(unittest.TestCase):
                     mmcif_structure = mmcif_parser.get_structure(entry, mmcif_file)
                     pdbml_structure = pdbml_parser.get_structure(pdbml_file)
                 self.assertEqual(mmcif_structure, pdbml_structure)
+
+    def test_missing_required_element_raises(self):
+        """A missing required element raises a clear PDBConstructionException."""
+        pdbml_parser = PDBMLParser()
+        # Well-formed PDBML that declares the PDBx namespace but omits the
+        # required structCategory/struct/title header element.
+        incomplete_pdbml = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<PDBx:datablock xmlns:PDBx="http://pdbml.pdb.org/schema/pdbx-v50.xsd">\n'
+            "</PDBx:datablock>\n"
+        )
+        with self.assertRaisesRegex(
+            PDBConstructionException, "Required PDBML element not found"
+        ):
+            pdbml_parser.get_structure(io.StringIO(incomplete_pdbml))
+
+    def test_optional_header_text_may_be_absent(self):
+        """A present-but-nil header text element yields None, not an error."""
+        pdbml_parser = PDBMLParser()
+        # struct_keywords/text is present but xsi:nil, as the wwPDB PDBML
+        # generator emits missing scalar values. It should parse to None rather
+        # than raising, matching the original parser and the mmCIF parser.
+        pdbml = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<PDBx:datablock xmlns:PDBx="http://pdbml.pdb.org/schema/pdbx-v50.xsd"'
+            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n'
+            "<PDBx:structCategory><PDBx:struct>"
+            "<PDBx:title>Test structure</PDBx:title>"
+            "</PDBx:struct></PDBx:structCategory>\n"
+            "<PDBx:struct_keywordsCategory><PDBx:struct_keywords>"
+            '<PDBx:text xsi:nil="true"/>'
+            "</PDBx:struct_keywords></PDBx:struct_keywordsCategory>\n"
+            '<PDBx:entryCategory><PDBx:entry id="TEST"/></PDBx:entryCategory>\n'
+            "<PDBx:pdbx_database_statusCategory><PDBx:pdbx_database_status>"
+            "<PDBx:recvd_initial_deposition_date>2020-01-01"
+            "</PDBx:recvd_initial_deposition_date>"
+            "</PDBx:pdbx_database_status></PDBx:pdbx_database_statusCategory>\n"
+            '<PDBx:exptlCategory><PDBx:exptl method="X-RAY DIFFRACTION"/>'
+            "</PDBx:exptlCategory>\n"
+            "<PDBx:atom_siteCategory/>\n"
+            "</PDBx:datablock>\n"
+        )
+        structure = pdbml_parser.get_structure(io.StringIO(pdbml))
+        self.assertEqual(structure.header["name"], "Test structure")
+        self.assertIsNone(structure.header["head"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds type annotations to `Bio.PDB.PDBMLParser` and removes its `ignore_errors`
entry from `.mypy.ini`, so the module is now type-checked like the rest of the
package. Along the way this fixes a latent bug in the header parsing.

Main changes:
- Annotate the parsed-tree parameters as `ElementTree.ElementTree` (they were
  annotated as the `ElementTree` *module*, which is not a type).
- Make XML element access explicit about `None`: `Element.find(...)` returns
  `Element | None` and `.text` is `str | None`. Two small helpers (`_find`,
  `_text`) raise `PDBConstructionException` when a required element/text is
  missing (matching the sibling `MMCIFParser`), instead of an opaque
  `AttributeError`. Optional header text fields stay `None`-tolerant, as before.
- Fix an ElementTree truthiness bug (`if element:` → `if element is not None:`).

## Behaviour
For valid PDBML, atom/coordinate data is unchanged (the existing test still
passes). Two intentional differences:
- `resolution` was previously always `None`, because `if element:` is falsy for
  a childless leaf element. It is now read correctly and matches the mmCIF
  parser (1GBT/6WG6/3JQH: 2.0 / 3.54 / 2.201 Å).
- A missing *required* element now raises a descriptive `PDBConstructionException`
  instead of an opaque `AttributeError`.

## Tests
- `test_get_structure` previously compared only the last of its three structures
  (the `assertEqual` sat outside the loop); it is moved inside and now also
  asserts the parsed `resolution` matches the mmCIF parser for each entry.
- Added `test_missing_required_element_raises` and
  `test_optional_header_text_may_be_absent`.

## Verification
`mypy` (v1.16.1) is green on `Bio`/`BioSQL` with the exclusion removed
("no issues found in 298 source files"), `pre-commit run --all-files` is clean,
and the `test_PDB_PDBMLParser` suite passes.