### PR TITLE
Add title parameter to Phylo.draw

### DIFF
--- a/Bio/Phylo/_utils.py
+++ b/Bio/Phylo/_utils.py
@@ -284,6 +284,7 @@ def draw(
     label_func=str,
     do_show=True,
     show_confidence=True,
+    title=None,
     # For power users
     axes=None,
     branch_labels=None,
@@ -343,6 +344,9 @@ def draw(
             A function or a dictionary specifying the color of the tip label.
             If the tip label can't be found in the dict or label_colors is
             None, the label will be shown in black.
+        title : str or None
+            An optional title for the plot. If not provided, the tree name
+            attribute is used as the title (if available).
 
     """
     try:
@@ -582,14 +586,16 @@ def draw(
         axes.add_collection(i)
 
     # Aesthetics
-
-    try:
-        name = tree.name
-    except AttributeError:
-        pass
+    if title is not None:
+        axes.set_title(title)
     else:
-        if name:
-            axes.set_title(name)
+        try:
+            name = tree.name
+        except AttributeError:
+            pass
+        else:
+            if name:
+                axes.set_title(name)
     axes.set_xlabel("branch length")
     axes.set_ylabel("taxa")
     # Add margins around the tree to prevent overlapping the axes


### PR DESCRIPTION
This PR adds an optional  parameter to the  function.

## Changes

- Added  parameter to the  function signature
- Added documentation for the new parameter in the docstring
- Updated the title logic to use the provided title, falling back to  if not provided

## Motivation

Currently,  uses  as the plot title if available. This change allows users to explicitly set a custom title, which is useful when:

- Plotting multiple trees with different titles
- Providing a more descriptive title than the tree name
- Suppressing the title by passing an empty string

## Example usage

```python
from Bio import Phylo

tree = Phylo.read('tree.nwk', 'newick')

# Custom title
Phylo.draw(tree, title='My Phylogenetic Tree')

# No title (suppress tree.name)
Phylo.draw(tree, title='')
```

## Testing

The existing tests continue to pass. The new parameter is optional and defaults to , maintaining full backward compatibility.

Closes #5250