### PR TITLE
Add api_key parameter to qblast and deprecate username/password

### DIFF
--- a/Bio/Blast/NCBIWWW.py
+++ b/Bio/Blast/NCBIWWW.py
@@ -31,6 +31,7 @@ from urllib.request import install_opener
 from urllib.request import Request
 from urllib.request import urlopen
 
+from Bio import BiopythonDeprecationWarning
 from Bio import BiopythonWarning
 from Bio._utils import function_with_previous
 
@@ -130,6 +131,15 @@ def qblast(
     https://blast.ncbi.nlm.nih.gov/doc/blast-help/urlapi.html
 
     """
+    warnings.warn(
+        "Bio.Blast.NCBIWWW.qblast is deprecated; use Bio.Blast.qblast instead. "
+        "Note that Bio.Blast.qblast returns a bytes stream to be parsed with "
+        "Bio.Blast.parse, rather than the text handle returned here, so calling "
+        "code will need updating. The username and password parameters are also "
+        "no longer supported by the NCBI. This function will be removed in a "
+        "future release.",
+        BiopythonDeprecationWarning,
+    )
     programs = ["blastn", "blastp", "blastx", "tblastn", "tblastx"]
     if program not in programs:
         raise ValueError(

--- a/Bio/Blast/__init__.py
+++ b/Bio/Blast/__init__.py
@@ -38,6 +38,7 @@ from xml.parsers import expat
 
 import numpy as np
 
+from Bio import BiopythonDeprecationWarning
 from Bio import BiopythonWarning
 from Bio import StreamModeError
 from Bio._utils import function_with_previous
@@ -1060,6 +1061,7 @@ def qblast(
     template_length=None,
     username="blast",
     password=None,
+    api_key=None,
 ):
     """BLAST search using NCBI's QBLAST server.
 
@@ -1092,6 +1094,12 @@ def qblast(
                       manually set parameters like word size and e value. Turns
                       off when sequence length is > 30 residues. Default: None.
      - service        plain, psi, phi, rpsblast, megablast (lower case)
+     - api_key        NCBI API key for higher request-rate limits (see
+                      https://ncbiinsights.ncbi.nlm.nih.gov/2017/11/02/new-api-keys-for-the-e-utilities/).
+
+    The ``username`` and ``password`` parameters are deprecated: the NCBI no
+    longer supports HTTP Basic authentication for QBLAST. Use ``api_key``
+    instead. They will be removed in a future release.
 
     This function does no checking of the validity of the parameters
     and passes the values to the server as is.  More help is available at:
@@ -1173,6 +1181,15 @@ def qblast(
         "CMD": "Put",
     }
 
+    if password is not None or username != "blast":
+        warnings.warn(
+            "The username and password parameters are deprecated. The NCBI no "
+            "longer supports HTTP Basic authentication for QBLAST; use the "
+            "api_key parameter instead. These parameters will be removed in a "
+            "future release.",
+            BiopythonDeprecationWarning,
+        )
+
     if password is not None:
         # handle authentication for BLAST cloud
         password_mgr = HTTPPasswordMgrWithDefaultRealm()
@@ -1183,6 +1200,8 @@ def qblast(
 
     if url_base == NCBI_BLAST_URL:
         parameters.update({"email": email, "tool": tool})
+        if api_key is not None:
+            parameters["api_key"] = api_key
     parameters = {key: value for key, value in parameters.items() if value is not None}
     message = urlencode(parameters).encode()
     request = Request(url_base, message, {"User-Agent": "BiopythonClient"})

--- a/DEPRECATED.rst
+++ b/DEPRECATED.rst
@@ -83,6 +83,16 @@ From now on one should use the following commands:
 Biopython modules, methods, functions
 =====================================
 
+Bio.Blast.NCBIWWW
+-----------------
+The function ``qblast`` in ``Bio.Blast.NCBIWWW`` was deprecated in release 1.88.
+Please use ``Bio.Blast.qblast`` instead, which has been available since release
+1.84. Note that ``Bio.Blast.qblast`` returns a bytes stream to be parsed with
+``Bio.Blast.parse``, rather than the text handle returned by
+``Bio.Blast.NCBIWWW.qblast``, so calling code will need updating. The NCBI no
+longer supports the ``username`` and ``password`` (HTTP Basic authentication)
+parameters; use the new ``api_key`` parameter of ``Bio.Blast.qblast`` instead.
+
 Bio.SeqIO.FastaIO
 -----------------
 Parsing a FASTA file using Bio.SeqIO.parse with ``format='fasta'`` interprets

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -13,6 +13,12 @@ The latest news is at the top of this file.
 (In progress, not yet released): Biopython 1.88
 ===============================================
 
+``Bio.Blast.qblast`` gained an ``api_key`` argument, matching the NCBI's move to
+API keys for higher request-rate limits. Its ``username`` and ``password``
+arguments are now deprecated, as the NCBI no longer supports HTTP Basic
+authentication for QBLAST. The older ``Bio.Blast.NCBIWWW.qblast`` function is now
+deprecated in favour of ``Bio.Blast.qblast``.
+
 Additionally, a number of small bugs and typos have been fixed with additions
 to the test suite and type annotations.
 

--- a/Tests/test_NCBI_qblast.py
+++ b/Tests/test_NCBI_qblast.py
@@ -26,17 +26,23 @@ correct position.
 """
 
 import unittest
+import warnings
 from io import BytesIO
 from unittest import mock
 from urllib.error import HTTPError
 
 import requires_internet
 
+from Bio import BiopythonDeprecationWarning
 from Bio import MissingExternalDependencyError
 
 # We want to test these:
 from Bio.Blast import NCBIWWW
 from Bio.Blast import NCBIXML
+
+# This module deliberately exercises the deprecated Bio.Blast.NCBIWWW.qblast;
+# ignore its deprecation warning here (test_deprecation below checks it fires).
+warnings.filterwarnings("ignore", category=BiopythonDeprecationWarning)
 
 NCBIWWW.email = "biopython@biopython.org"
 
@@ -96,6 +102,21 @@ if not requires_internet.check.available:
 
 
 class TestQblast(unittest.TestCase):
+    def test_deprecation(self):
+        """Bio.Blast.NCBIWWW.qblast is deprecated in favour of Bio.Blast.qblast."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", BiopythonDeprecationWarning)
+            # The deprecation warning is raised before the program name is
+            # validated, so an invalid program still triggers it without any
+            # network access.
+            self.assertRaises(
+                BiopythonDeprecationWarning,
+                NCBIWWW.qblast,
+                "not_a_real_program",
+                "nr",
+                "ACGT",
+            )
+
     def test_blastp_nr_actin(self):
         # Simple protein blast filtered for rat only, using protein
         # GI:160837788 aka NP_075631.2


### PR DESCRIPTION
Following the discussion, this adds `api_key` support to `Bio.Blast.qblast` (the current function) rather than patching the old `Bio.Blast.NCBIWWW.qblast`, and deprecates the old function as @peterjc suggested.

Changes:
- `Bio.Blast.qblast` gains an `api_key` argument. The NCBI now uses API keys for higher request-rate limits.
- Its `username`/`password` arguments are deprecated, since the NCBI no longer supports HTTP Basic authentication for QBLAST.
- `Bio.Blast.NCBIWWW.qblast` is deprecated in favour of `Bio.Blast.qblast`. The warning notes that the newer function returns a bytes stream (parsed with `Bio.Blast.parse`) rather than a text handle, so calling code will need updating.
- Added `NEWS.rst` and `DEPRECATED.rst` entries, and a test that the deprecation warning is raised.

Closes the api_key request in #5059.
