### PR TITLE
BigBed writer: Don't check the written data; only check if it reads in correctly

### DIFF
--- a/Tests/test_Align_bigbed.py
+++ b/Tests/test_Align_bigbed.py
@@ -6916,8 +6916,8 @@ AlignmentCounts object with
             )
             output.flush()
             output.seek(0)
-            data = output.read()
-        self.assertEqual(correct, data)
+            alignments = Align.parse(output, "bigbed")
+            self.check_alignments(alignments)
         alignments = Align.parse(path, "bigbed")
         targets = alignments.targets
         with tempfile.TemporaryFile() as output:
@@ -6932,8 +6932,8 @@ AlignmentCounts object with
             )
             output.flush()
             output.seek(0)
-            data = output.read()
-        self.assertEqual(correct, data)
+            alignments = Align.parse(output, "bigbed")
+            self.check_alignments(alignments)
 
 
 class TestAlign_searching(unittest.TestCase):


### PR DESCRIPTION
Don't check the written data byte-by-byte, as the written data may differ between different implementations of zlib

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

Closes #5239
