### PR TITLE
Add missing docstring to TreeElement.__str__ (fixes D105)

### DIFF
--- a/Bio/Phylo/BaseTree.py
+++ b/Bio/Phylo/BaseTree.py
@@ -252,6 +252,7 @@ class TreeElement:
         )
 
     def __str__(self) -> str:
+        """Return the object's constructor representation, as given by __repr__."""
         return self.__repr__()
 
 


### PR DESCRIPTION
## Description
This fixes one instance of D105 (missing docstring in magic method) as mentioned in #2116.
Added a docstring to `TreeElement.__str__` in `Bio/Phylo/BaseTree.py`, describing that it returns the same representation as `__repr__`.

## Testing
Verified with:
- `python -m pydocstyle --select D105 Bio/Phylo/BaseTree.py` (no longer flags this line)
- `pre-commit run --files Bio/Phylo/BaseTree.py` (all checks passed)

## Checklist
- [x] I have read the contributing guidelines.
- [x] I have checked that this change follows the project's style guidelines.
- [x] I have tested my changes locally.
- [x] I have included any relevant documentation changes.

## AI Usage
I used AI assistance (Claude) to help me understand the existing code pattern and guide me through writing and formatting the docstring. I reviewed the suggestion, applied the change myself, and verified it locally before submitting.

## Licensing
I agree to my contribution being dual licensed under the Biopython License Agreement and the 3-Clause BSD License.

## Related Issues
Related to #2116