### PR TITLE
fix: create CEL and vector views with reshape

### DIFF
--- a/Bio/Affy/CelFile.py
+++ b/Bio/Affy/CelFile.py
@@ -263,14 +263,9 @@ def _read_v4(f):
         record.npix[i] = npix
 
     # reshape without copying.
-    def reshape(array):
-        view = array.view()
-        view.shape = (record.nrows, record.ncols)
-        return view
-
-    record.intensities = reshape(record.intensities)
-    record.stdevs = reshape(record.stdevs)
-    record.npix = reshape(record.npix)
+    record.intensities = record.intensities.reshape((record.nrows, record.ncols))
+    record.stdevs = record.stdevs.reshape((record.nrows, record.ncols))
+    record.npix = record.npix.reshape((record.nrows, record.ncols))
 
     return record
 

--- a/Bio/PDB/vectors.py
+++ b/Bio/PDB/vectors.py
@@ -171,8 +171,7 @@ def refmat(p, q):
         return np.identity(3)
     pq = p - q
     pq.normalize()
-    b = pq.get_array()
-    b.shape = (3, 1)
+    b = pq.get_array().reshape((3, 1))
     i = np.identity(3)
     ref = i - 2 * np.dot(b, np.transpose(b))
     return ref


### PR DESCRIPTION
CEL parsing and reflection matrix creation assign to `ndarray.shape`. NumPy 2.5.1 emits a `DeprecationWarning` for these assignments.

Create CEL matrices directly with `array.reshape`. Create the reflection matrix column with reshape.

- [x] I hereby agree to dual licence this and any previous contributions under both the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit`` locally, and understand that continuous integration checks will be used to confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files ``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed already, or do not wish to be listed. (*This acknowledgement is optional.*)
