### PR TITLE
Fix GenBank Record serialization of WGS ranges

### DIFF
--- a/Bio/GenBank/Record.py
+++ b/Bio/GenBank/Record.py
@@ -474,14 +474,14 @@ class Record:
         output = ""
         if self.wgs:
             output += Record.BASE_FORMAT % "WGS"
-            output += self.wgs
+            output += "-".join(self.wgs) + "\n"
         return output
 
     def _wgs_scafld_line(self):
         output = ""
-        if self.wgs_scafld:
+        for scaffold in self.wgs_scafld:
             output += Record.BASE_FORMAT % "WGS_SCAFLD"
-            output += self.wgs_scafld
+            output += "-".join(scaffold) + "\n"
         return output
 
     def _contig_line(self):

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -242,6 +242,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Marc Colosimo <mcolosimo at domain mitre.org>
 - Marcin Magnus <https://github.com/mmagnus>
 - Marco Galardini <https://github.com/mgalardini>
+- Marcus Campbell <https://github.com/marcus-campbell>
 - Marie Crane <https://github.com/mariecrane>
 - Mark Amery <https://github.com/ExplodingCabbage>
 - Markus Piotrowski <https://github.com/MarkusPiotrowski>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -22,6 +22,7 @@ possible, especially the following contributors:
 - Peter Cock
 - Al Fattah Suyadi (first contribution)
 - Laura Piñero Roig (first contribution)
+- Marcus Campbell (first contribution)
 
 30 March 2026: Biopython 1.87
 =============================

--- a/Tests/test_GenBank.py
+++ b/Tests/test_GenBank.py
@@ -230,6 +230,34 @@ class TestRecordParser(unittest.TestCase):
             record, length, locus, definition, accession, titles, features
         )
 
+    def test_wgs_record_serialization(self):
+        """Test serializing WGS and WGS_SCAFLD ranges."""
+        path = "GenBank/noref.gb"
+        with open(path) as handle:
+            source = handle.read()
+        source = source.replace(
+            "ORIGIN      \n",
+            "WGS         ABCD01000001-ABCD01000002\n"
+            "WGS_SCAFLD  ABCD01000003-ABCD01000004\n"
+            "WGS_SCAFLD  ABCD01000005-ABCD01000006\n"
+            "ORIGIN      \n",
+        )
+
+        record = next(GenBank.Iterator(StringIO(source), self.rec_parser))
+
+        self.assertEqual(record.wgs, ["ABCD01000001", "ABCD01000002"])
+        self.assertEqual(
+            record.wgs_scafld,
+            [
+                ["ABCD01000003", "ABCD01000004"],
+                ["ABCD01000005", "ABCD01000006"],
+            ],
+        )
+        output = str(record)
+        self.assertIn("WGS         ABCD01000001-ABCD01000002\n", output)
+        self.assertIn("WGS_SCAFLD  ABCD01000003-ABCD01000004\n", output)
+        self.assertIn("WGS_SCAFLD  ABCD01000005-ABCD01000006\n", output)
+
     def test_record_parser_02(self):
         path = "GenBank/cor6_6.gb"
         with open(path) as handle:


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #5274 

`RecordParser` stores parsed `WGS` ranges as lists of endpoints and `WGS_SCAFLD` ranges as lists of endpoint lists. `Record.__str__` currently attempts to concatenate those lists directly with strings, causing a `TypeError`.

This change:

- joins each WGS range's endpoints with a hyphen;
- emits each `WGS_SCAFLD` range on its own line; and
- adds regression coverage for one WGS range and multiple scaffold ranges.

Tests:

- `python Tests/run_tests.py --offline`: 514 tests passed
- `pre-commit run --all-files`: all hooks passed