### PR TITLE
Fix ArrayCore initialization reference handling

### DIFF
--- a/Bio/Align/substitution_matrices/_arraycore.c
+++ b/Bio/Align/substitution_matrices/_arraycore.c
@@ -179,13 +179,10 @@ static struct PyModuleDef module = {
 PyMODINIT_FUNC
 PyInit__arraycore(void)
 {
-    int result;
     PyObject *basemodule;
     PyObject *baseclass;
-    PyTypeObject* basetype;
-
-    PyObject *mod = PyModule_Create(&module);
-    if (!mod) return NULL;
+    PyObject *mod;
+    PyTypeObject *basetype;
 
     // Import the module containing the base class
     basemodule = PyImport_ImportModule("numpy");
@@ -195,39 +192,65 @@ PyInit__arraycore(void)
     // Get the base class
     baseclass = PyObject_GetAttrString(basemodule, "ndarray");
     Py_DECREF(basemodule);
-    if (!baseclass || !PyType_Check(baseclass)) {
-        Py_XDECREF(basemodule);
+    if (!baseclass) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to get numpy.ndarray");
+        return NULL;
+    }
+    if (!PyType_Check(baseclass)) {
+        Py_DECREF(baseclass);
         PyErr_SetString(PyExc_RuntimeError, "Failed to get numpy.ndarray");
         return NULL;
     }
 
     basetype = (PyTypeObject *)baseclass;
     if (!(basetype->tp_flags & Py_TPFLAGS_BASETYPE)) {
+        Py_DECREF(baseclass);
         PyErr_SetString(PyExc_RuntimeError,
                         "numpy ndarray class is not subclassable");
         return NULL;
     }
     if (basetype->tp_itemsize != 0) {
+        Py_DECREF(baseclass);
         PyErr_Format(PyExc_RuntimeError,
                      "expected numpy arrays to have tp_itemsize 0 (found %zd)",
                      basetype->tp_itemsize);
         return NULL;
     }
     if (!basetype->tp_new) {
+        Py_DECREF(baseclass);
         PyErr_SetString(PyExc_RuntimeError,
                         "numpy ndarray class does not have tp_new");
+        return NULL;
+    }
+    if (Array_Type.tp_dict != NULL &&
+        !(Array_Type.tp_flags & Py_TPFLAGS_READY)) {
+        Py_DECREF(baseclass);
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Array type initialization previously failed");
         return NULL;
     }
 
     Array_Type.tp_basicsize = basetype->tp_basicsize + sizeof(Fields);
     Array_Type.tp_base = (PyTypeObject *)baseclass;
 
-    if (PyType_Ready(&Array_Type) < 0)
+    mod = PyModule_Create(&module);
+    if (!mod) {
+        Array_Type.tp_base = NULL;
+        Py_DECREF(baseclass);
         return NULL;
+    }
 
-    result = PyModule_AddObjectRef(mod, "Array", (PyObject*)&Array_Type);
-    Py_DECREF(&Array_Type);
-    if (result == -1) {
+    if (PyType_Ready(&Array_Type) < 0) {
+        if (Array_Type.tp_bases == NULL) {
+            Array_Type.tp_base = NULL;
+        }
+        Py_DECREF(baseclass);
+        Py_DECREF(mod);
+        return NULL;
+    }
+    Py_DECREF(baseclass);
+
+    if (PyModule_AddObjectRef(mod, "Array", (PyObject *)&Array_Type) < 0) {
         Py_DECREF(mod);
         return NULL;
     }

--- a/CONTRIB.rst
+++ b/CONTRIB.rst
@@ -332,6 +332,7 @@ please open an issue on GitHub or mention it on the mailing list.
 - Soroush Saffari <https://github.com/sorsaffari>
 - Sourav Singh <https://github.com/souravsingh>
 - Spencer Bliven <https://github.com/sbliven>
+- Stanley C. <https://github.com/stanbot8>
 - Stefans Mezulis <https://github.com/StefansM>
 - Steve Bond <https://github.com/biologyguy>
 - Steve Marshall <https://github.com/hungryhoser>

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -28,6 +28,7 @@ possible, especially the following contributors:
 - Marcus Campbell (first contribution)
 - Michiel de Hoon
 - Peter Cock
+- Stanley C. (first contribution)
 
 30 March 2026: Biopython 1.87
 =============================

--- a/Tests/arraycore_import_tests.py
+++ b/Tests/arraycore_import_tests.py
@@ -1,0 +1,123 @@
+# This code is part of the Biopython distribution and governed by its
+# license.  Please see the LICENSE file that should have been included
+# as part of this package.
+
+"""Isolated tests for ArrayCore extension initialization."""
+
+import gc
+import importlib.machinery
+import importlib.util
+import sys
+import types
+import unittest
+import weakref
+
+
+class _InvalidArray:
+    pass
+
+
+def _load_arraycore(extension):
+    module_name = "Bio.Align.substitution_matrices._arraycore"
+    loader = importlib.machinery.ExtensionFileLoader(module_name, extension)
+    spec = importlib.util.spec_from_file_location(module_name, extension, loader=loader)
+    if spec is None:
+        raise AssertionError("could not create an arraycore import specification")
+    return importlib.util.module_from_spec(spec)
+
+
+def _check_successful_arraycore_import(extension):
+    import numpy
+
+    base_references = sys.getrefcount(numpy.ndarray)
+    module = _load_arraycore(extension)
+    reference_delta = sys.getrefcount(numpy.ndarray) - base_references
+    if reference_delta not in (0, 2):
+        raise AssertionError(
+            "successful import retained an unexpected number of "
+            f"numpy.ndarray references: {reference_delta}"
+        )
+    if module.Array.__base__ is not numpy.ndarray:
+        raise AssertionError("Array does not retain numpy.ndarray as its base")
+    del module
+    gc.collect()
+
+
+def _check_retried_arraycore_import(extension):
+    fake_numpy = types.ModuleType("numpy")
+    fake_numpy.ndarray = _InvalidArray
+    previous_numpy = sys.modules.get("numpy")
+    sys.modules["numpy"] = fake_numpy
+    try:
+        try:
+            _load_arraycore(extension)
+        except Exception:
+            pass
+        else:
+            raise AssertionError("arraycore accepted a dynamically allocated base type")
+
+        fake_numpy.ndarray = object
+        try:
+            _load_arraycore(extension)
+        except RuntimeError as exception:
+            if str(exception) != "Array type initialization previously failed":
+                raise
+        else:
+            raise AssertionError("arraycore retried a poisoned static type")
+    finally:
+        if previous_numpy is None:
+            del sys.modules["numpy"]
+        else:
+            sys.modules["numpy"] = previous_numpy
+
+
+def _check_failed_arraycore_import(mode, extension):
+    fake_numpy = types.ModuleType("numpy")
+    invalid_array = _InvalidArray() if mode == "invalid" else None
+    if invalid_array is not None:
+        fake_numpy.ndarray = invalid_array
+
+    numpy_reference = weakref.ref(fake_numpy)
+    invalid_reference = (
+        weakref.ref(invalid_array) if invalid_array is not None else None
+    )
+    previous_numpy = sys.modules.get("numpy")
+    sys.modules["numpy"] = fake_numpy
+    try:
+        try:
+            _load_arraycore(extension)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("arraycore accepted an invalid numpy.ndarray")
+    finally:
+        if previous_numpy is None:
+            del sys.modules["numpy"]
+        else:
+            sys.modules["numpy"] = previous_numpy
+
+    del fake_numpy
+    del invalid_array
+    gc.collect()
+    if numpy_reference() is not None:
+        raise AssertionError("failed import retained the NumPy module")
+    if invalid_reference is not None and invalid_reference() is not None:
+        raise AssertionError("failed import retained the invalid base object")
+
+
+class ArrayCoreImportTests(unittest.TestCase):
+    def test_successful_import(self):
+        _check_successful_arraycore_import(sys.argv[2])
+
+    def test_missing_ndarray(self):
+        _check_failed_arraycore_import("missing", sys.argv[2])
+
+    def test_invalid_ndarray(self):
+        _check_failed_arraycore_import("invalid", sys.argv[2])
+
+    def test_poisoned_retry(self):
+        _check_retried_arraycore_import(sys.argv[2])
+
+
+if __name__ == "__main__":
+    unittest.main(argv=[sys.argv[0], sys.argv[1]])

--- a/Tests/test_align_substitution_matrices.py
+++ b/Tests/test_align_substitution_matrices.py
@@ -4,6 +4,13 @@
 
 """Tests for Array in the Bio.Align.substitution_matrices module."""
 
+import os
+import pickle
+import subprocess
+import sys
+import unittest
+from collections import Counter
+
 try:
     import numpy as np
 except ImportError:
@@ -13,21 +20,39 @@ except ImportError:
         "Install NumPy if you want to use Bio.Align.substitution_matrices."
     ) from None
 
-
-import os
-import pickle
-import unittest
-from collections import Counter
-
 from Bio import SeqIO
 from Bio.Align import substitution_matrices
 from Bio.Data import IUPACData
+
 
 nucleotide_alphabet = IUPACData.unambiguous_dna_letters
 protein_alphabet = IUPACData.protein_letters
 
 
 class TestBasics(unittest.TestCase):
+    @unittest.skipUnless(sys.implementation.name == "cpython", "requires CPython")
+    def test_arraycore_import_preserves_references(self):
+        extension = sys.modules["Bio.Align.substitution_matrices._arraycore"].__file__
+        tests = (
+            "ArrayCoreImportTests.test_successful_import",
+            "ArrayCoreImportTests.test_missing_ndarray",
+            "ArrayCoreImportTests.test_invalid_ndarray",
+            "ArrayCoreImportTests.test_poisoned_retry",
+        )
+        for test in tests:
+            with self.subTest(test=test):
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "Tests.arraycore_import_tests",
+                        test,
+                        extension,
+                    ],
+                    check=True,
+                    cwd=os.path.dirname(os.path.dirname(__file__)),
+                )
+
     def test_basics_vector(self):
         """Test basic vector operations."""
         counts = substitution_matrices.Array("XYZ")


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

## Summary of Changes

Fixed a few memory issues in `PyInit_arraycore`:
- `basemodule` was decremented twice while `baseclass` leaked. Both references are now released once, and `basetype` remains a non-owning alias. `Bio/Align/substitution_matrices/_arraycore.c`: `185-220, 227, 239, 247, 251`
- `mod` leaked after later initialization failures. Moved module creation after base validation. Failure paths release it. `Bio/Align/substitution_matrices/_arraycore.c`: `184, 236-241, 248`
- A failed `PyType_Ready()` could poison retries. Retries now fail with the exact initialization error. `Bio/Align/substitution_matrices/_arraycore.c`: `225-231, 243-250`
- `Array_Type`'s permanent static reference was incorrectly decremented. Registration now leaves it untouched. `Bio/Align/substitution_matrices/_arraycore.c`: `253`
- Test `test_arraycore_import_preserves_references` covers the success, invalid/missing, and retry cases. `Tests/test_align_substitution_matrices.py`

Closes #5271
