### PR TITLE
Fix Nexus TRANSLATE block rejecting unquoted taxon names with hyphens (#1022)

### DIFF
--- a/Bio/Nexus/Nexus.py
+++ b/Bio/Nexus/Nexus.py
@@ -130,10 +130,16 @@ class CharBuffer:
         """Return a word stored in the buffer."""
         return "".join(self.buffer[: len(word)]) == word
 
-    def next_word(self):
+    def next_word(self, extra_chars=""):
         """Return the next NEXUS word from a string.
 
         This deals with single and double quotes, whitespace and punctuation.
+
+        ``extra_chars`` is an optional string of punctuation characters that
+        should be treated as ordinary word constituents instead of terminating
+        the word.  This is used to read unquoted taxon labels that legitimately
+        contain a hyphen (see issue #1022), without changing the meaning of the
+        hyphen elsewhere (e.g. ranges such as ``4-8`` parsed by ``_parse_list``).
         """
         word = []
         quoted = False
@@ -147,7 +153,7 @@ class CharBuffer:
             quoted = "'"
         elif first == '"':
             quoted = '"'
-        elif first in PUNCTUATION:
+        elif first in PUNCTUATION and first not in extra_chars:
             # if it's non-quote punctuation, return immediately
             return first
         while True:
@@ -161,7 +167,7 @@ class CharBuffer:
             elif quoted:
                 # if quoted, then add anything
                 word.append(next(self))
-            elif not c or c in PUNCTUATION or c in WHITESPACE:
+            elif not c or (c in PUNCTUATION and c not in extra_chars) or c in WHITESPACE:
                 # if not quoted and special character, stop
                 break
             else:
@@ -1111,7 +1117,7 @@ class Nexus:
             try:
                 # get id and state
                 identifier = int(opts.next_word())
-                label = quotestrip(opts.next_word())
+                label = quotestrip(opts.next_word("-"))  # hyphen allowed in unquoted labels (#1022)
                 self.translate[identifier] = label
                 # check for comma or end of command
                 c = opts.next_nonwhitespace()

--- a/Tests/test_Nexus.py
+++ b/Tests/test_Nexus.py
@@ -1601,6 +1601,26 @@ end;
         with self.assertRaises(ValueError):
             NexusWriter(handle).write_file([a, a])
 
+    def test_translate_dashed_taxon_names(self):
+        # Unquoted taxon labels containing a hyphen must be preserved in the
+        # TRANSLATE block instead of raising "Missing ','" (issue #1022).
+        handle = StringIO(
+            """#NEXUS
+        begin trees;
+        translate
+        1 dog-cat,
+        2 mouse-rat,
+        3 foo-bar
+        ;
+        tree t1 = [&U] (1,(2,3));
+        end;
+        """
+        )
+        nexus = Nexus.Nexus(handle)
+        self.assertEqual(
+            nexus.translate, {1: "dog-cat", 2: "mouse-rat", 3: "foo-bar"}
+        )
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.
- [X] I have read the ``CONTRIBUTING.rst`` file and run the style checks locally (``black``, ``ruff``, ``flake8`` all clean); I understand CI will confirm the unit tests and style checks pass.
- [ ] I have added my name to ``NEWS.rst`` / ``CONTRIB.rst`` (optional, not wished).

Fixes #1022

`Phylo.parse(..., "nexus")` (and `Bio.Nexus.Nexus`) raised `NexusError: Missing ',' in line ...` whenever a taxon label in the TRANSLATE block contained an unquoted hyphen (e.g. `1 dog-cat,`). Many tree tools (SeaView, BEAST, MrBayes, FigTree, TreeAnnotator) emit such names, and the NEXUS spec does not forbid the hyphen in identifiers.

**Root cause:** `CharBuffer.next_word()` treats `-` as punctuation, so `dog-cat` tokenized as `dog`, `-`, `cat`; `_translate` then saw `-` where it expected a comma.

**Fix:** add an optional `extra_chars` parameter to `next_word()` (default empty, so all existing call sites and the hyphen's range semantics in `_parse_list` are unchanged) and pass `"-"` when reading the label in `_translate`.

Adds regression test `test_translate_dashed_taxon_names`; `test_Nexus.py` (26) and `test_Phylo.py` (40) pass; black/ruff/flake8 clean.