### PR TITLE
Add radius of gyration to Bio.PDB Entity (#5257)

### DIFF
--- a/Bio/PDB/Entity.py
+++ b/Bio/PDB/Entity.py
@@ -349,16 +349,14 @@ class Entity(Generic[_Parent, _Child]):
         for o in self.get_list():
             o.transform(rot, tran)
 
-    def center_of_mass(self, geometric=False):
-        """Return the center of mass of the Entity as a numpy array.
+    def _get_atoms(self):
+        """Return all Atom children, unpacking disordered residues (PRIVATE).
 
-        If geometric is True, returns the center of geometry instead.
+        Recursively walks the entity hierarchy until only atom-level children
+        remain, unpacking disordered residues/atoms so every alternative is
+        represented.  Shared by :meth:`center_of_mass` and
+        :meth:`radius_of_gyration`.
         """
-        # Recursively iterate through children until we get all atom coordinates
-
-        if not len(self):
-            raise ValueError(f"{self} does not have children")
-
         maybe_disordered = {"R", "C"}  # to know when to use get_unpacked_list
         only_atom_level = {"A"}
 
@@ -370,10 +368,19 @@ class Entity(Generic[_Parent, _Child]):
             else:
                 entities += e.child_list
 
-            elevels = {e.level for e in entities}
-            if elevels == only_atom_level:
+            if {e.level for e in entities} == only_atom_level:
                 break  # nothing else to unpack
+        return entities
 
+    def center_of_mass(self, geometric=False):
+        """Return the center of mass of the Entity as a numpy array.
+
+        If geometric is True, returns the center of geometry instead.
+        """
+        if not len(self):
+            raise ValueError(f"{self} does not have children")
+
+        entities = self._get_atoms()
         coords = np.asarray([a.coord for a in entities], dtype=np.float32)
         if geometric:
             masses = None
@@ -381,6 +388,36 @@ class Entity(Generic[_Parent, _Child]):
             masses = np.asarray([a.mass for a in entities], dtype=np.float32)
 
         return np.average(coords, axis=0, weights=masses)
+
+    def radius_of_gyration(self, geometric=False):
+        """Return the radius of gyration of the Entity as a float (Angstrom).
+
+        The radius of gyration (Rg) is the root-mean-square distance of the
+        atoms from their center of mass, weighted by atomic mass.  If
+        geometric is True, all atoms are weighted equally instead.
+
+        Examples
+        --------
+        >>> from Bio.PDB import PDBParser
+        >>> parser = PDBParser(QUIET=True)
+        >>> structure = parser.get_structure("1gbt", "PDB/1GBT.cif")  # doctest: +SKIP
+        >>> round(structure.radius_of_gyration(), 2)  # doctest: +SKIP
+        10.34
+
+        """
+        if not len(self):
+            raise ValueError(f"{self} does not have children")
+
+        entities = self._get_atoms()
+        coords = np.asarray([a.coord for a in entities], dtype=np.float32)
+        if geometric:
+            masses = np.ones(len(coords), dtype=np.float32)
+        else:
+            masses = np.asarray([a.mass for a in entities], dtype=np.float32)
+
+        center = np.average(coords, axis=0, weights=masses)
+        sq_dist = ((coords - center) ** 2).sum(axis=1)
+        return float(np.sqrt(np.average(sq_dist, weights=masses)))
 
     def copy(self):
         """Copy entity recursively."""

--- a/Tests/test_PDB_SMCRA.py
+++ b/Tests/test_PDB_SMCRA.py
@@ -598,6 +598,38 @@ class CenterOfMassTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             s.center_of_mass()
 
+    def test_structure_rog(self):
+        """Calculate Structure mass-weighted radius of gyration."""
+        rog = self.structure.radius_of_gyration()
+
+        self.assertAlmostEqual(rog, 13.944, places=3)
+
+    def test_structure_rog_geometric(self):
+        """Calculate Structure geometric radius of gyration."""
+        rog = self.structure.radius_of_gyration(geometric=True)
+
+        self.assertAlmostEqual(rog, 13.729, places=3)
+
+    def test_chain_rog_geometric(self):
+        """Calculate geometric radius of gyration of individual chains."""
+        expected = {"A": 11.279, "B": 12.338, "C": 12.508}
+
+        for chain in self.structure[0].get_chains():  # one model only
+            rog = chain.radius_of_gyration(geometric=True)
+            self.assertAlmostEqual(rog, expected[chain.id], places=3)
+
+    def test_rog_empty_structure(self):
+        """Radius of gyration of empty structure raises ValueError."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", PDBConstructionWarning)
+            s = self.parser.get_structure("c", "PDB/disordered.pdb")  # smaller
+
+        for child in list(s):
+            s.detach_child(child.id)
+
+        with self.assertRaises(ValueError):
+            s.radius_of_gyration()
+
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
- [X] I hereby agree to dual licence this and any previous contributions under both the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.
- [X] I have read the ``CONTRIBUTING.rst`` file and run the style checks locally (``black``, ``ruff``, ``flake8`` all clean); I understand CI will confirm the unit tests and style checks pass.
- [ ] I have added my name to ``NEWS.rst`` / ``CONTRIB.rst`` (optional, not wished).

Closes #5257

Adds `Entity.radius_of_gyration(geometric=False)` (proposed by @Grumb0t): the mass-weighted root-mean-square distance of the atoms from their center of mass, available on Structure/Model/Chain/Residue like `center_of_mass()`.

Uses each `Atom.mass` (IUPAC weights); the atom-collection walk is factored into a shared `_get_atoms()` helper also used by `center_of_mass()` (behaviour unchanged); raises `ValueError` on empty entity.

Adds tests (structure mass/geometric, per-chain, empty-structure) cross-checked against an independent NumPy computation; `test_PDB_SMCRA.py` (29) + related PDB tests pass; black/ruff/flake8 clean.