### PR TITLE
Upgrade pip before setuptools and wheel.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,7 +374,8 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools wheel
 
     - name: Install dependencies
       if: steps.cache-pip.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip setuptools wheel build
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools wheel build
 
     - name: Install Python dependencies
       if: steps.cache-pip.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,8 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip setuptools wheel build
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools wheel build
 
     - name: Package tarball
       run: |
@@ -130,7 +131,8 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip setuptools wheel build
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools wheel build
 
     - name: Build wheel
       run: |
@@ -235,7 +237,8 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip setuptools wheel coverage
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools wheel coverage
 
     - name: Install minimal Python dependencies
       run: |
@@ -281,7 +284,8 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip setuptools wheel coverage
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools wheel coverage
 
     - name: Install minimal Python dependencies
       run: |
@@ -327,7 +331,8 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools wheel
 
     - name: Install minimal Python dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install pip==26.2.0
         python -m pip install --upgrade setuptools wheel build
 
     - name: Install Python dependencies
@@ -106,7 +106,7 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install pip==26.2.0
         python -m pip install --upgrade setuptools wheel build
 
     - name: Package tarball
@@ -131,7 +131,7 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install pip==26.2.0
         python -m pip install --upgrade setuptools wheel build
 
     - name: Build wheel
@@ -237,7 +237,7 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install pip==26.2.0
         python -m pip install --upgrade setuptools wheel coverage
 
     - name: Install minimal Python dependencies
@@ -284,7 +284,7 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install pip==26.2.0
         python -m pip install --upgrade setuptools wheel coverage
 
     - name: Install minimal Python dependencies
@@ -331,7 +331,7 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install pip==26.2.0
         python -m pip install --upgrade setuptools wheel
 
     - name: Install minimal Python dependencies
@@ -379,7 +379,7 @@ jobs:
 
     - name: Install Python packaging tools
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install pip==26.2.0
         python -m pip install --upgrade setuptools wheel
 
     - name: Install dependencies


### PR DESCRIPTION
Hopefully fixes this failure trying to use `get_runnable_pip` which is only a very recent addition to pip:

`ImportError: cannot import name 'get_runnable_pip' from 'pip._internal.utils.misc' (/opt/hostedtoolcache/Python/3.14.6/x64/lib/python3.14/site-packages/pip/_internal/utils/misc.py)`

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Seems to be a very recent glitch, perhaps with pip 26.2.1 released 4 August?