### PR TITLE
Fix comparison of atom's element/pqr_charge/radius etc

### DIFF
--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -293,9 +293,9 @@ class Atom:
             and self.altloc == other.altloc
             and self.fullname == other.fullname
             and (np.allclose(self.coord, other.coord) if compare_coordinates else True)
-            and getattr(self, "element", None) == getattr(self, "element", None)
-            and getattr(self, "pqr_charge", None) == getattr(self, "pqr_charge", None)
-            and getattr(self, "radius", None) == getattr(self, "radius", None)
+            and getattr(self, "element", None) == getattr(other, "element", None)
+            and getattr(self, "pqr_charge", None) == getattr(other, "pqr_charge", None)
+            and getattr(self, "radius", None) == getattr(other, "radius", None)
         )
 
     # set methods

--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -288,8 +288,8 @@ class Atom:
 
         return (
             self.name == other.name
-            and np.isclose(self.bfactor, other.bfactor)
-            and np.isclose(self.occupancy, other.occupancy)
+            and np.allclose(self.bfactor, other.bfactor)
+            and np.allclose(self.occupancy, other.occupancy)
             and self.altloc == other.altloc
             and self.fullname == other.fullname
             and (np.allclose(self.coord, other.coord) if compare_coordinates else True)

--- a/Bio/PDB/Atom.py
+++ b/Bio/PDB/Atom.py
@@ -283,14 +283,25 @@ class Atom:
         :return: Whether the atoms are strictly equal
         :rtype: bool
         """
-        if not isinstance(other, type(self)):
+        if not isinstance(other, type(self)) or self.name != other.name:
+            return False
+
+        if self.bfactor is None:
+            if other.bfactor is not None:
+                return False
+        elif other.bfactor is None or not np.allclose(self.bfactor, other.bfactor):
+            return False
+
+        if self.occupancy is None:
+            if other.occupancy is not None:
+                return False
+        elif other.occupancy is None or not np.allclose(
+            self.occupancy, other.occupancy
+        ):
             return False
 
         return (
-            self.name == other.name
-            and np.allclose(self.bfactor, other.bfactor)
-            and np.allclose(self.occupancy, other.occupancy)
-            and self.altloc == other.altloc
+            self.altloc == other.altloc
             and self.fullname == other.fullname
             and (np.allclose(self.coord, other.coord) if compare_coordinates else True)
             and getattr(self, "element", None) == getattr(other, "element", None)

--- a/Tests/test_PDB_SMCRA.py
+++ b/Tests/test_PDB_SMCRA.py
@@ -13,6 +13,8 @@
 
 """Generic unit tests for the SMCRA classes of the Bio.PDB module."""
 
+from Bio.Entrez.Parser import NoneElement
+
 import unittest
 import warnings
 from copy import deepcopy
@@ -194,17 +196,54 @@ class SortingTests(unittest.TestCase):
         # Change the coordinates of an atom in structure2
         structure2[0]["A"][(" ", 180, " ")]["C"].set_coord((0, 0, 0))
 
+        # Strict equality should be symmetric
         self.assertTrue(structure.strictly_equals(structure2))
-        self.assertTrue(
-            structure2.strictly_equals(structure)
-        )  # Strict equality should be symmetric
-
+        self.assertTrue(structure2.strictly_equals(structure))
         self.assertFalse(
             structure.strictly_equals(structure2, compare_coordinates=True)
         )
         self.assertFalse(
             structure2.strictly_equals(structure, compare_coordinates=True)
-        )  # Strict equality should be symmetric
+        )
+
+        # Also change the occupancy of that atom in structure2
+        structure[0]["A"][(" ", 180, " ")]["C"].occupancy = 0.75
+        structure2[0]["A"][(" ", 180, " ")]["C"].occupancy = 0.5
+
+        self.assertFalse(structure.strictly_equals(structure2))
+        self.assertFalse(structure2.strictly_equals(structure))
+
+        # Check when one occupancy is None:
+        structure[0]["A"][(" ", 180, " ")]["C"].occupancy = None
+        structure2[0]["A"][(" ", 180, " ")]["C"].occupancy = 0.5
+
+        self.assertFalse(structure.strictly_equals(structure2))
+        self.assertFalse(structure2.strictly_equals(structure))
+
+        # Also change the b-factor of that atom in structure2
+        structure[0]["A"][(" ", 180, " ")]["C"].occupancy = 1.0
+        structure2[0]["A"][(" ", 180, " ")]["C"].occupancy = 1.0
+        structure[0]["A"][(" ", 180, " ")]["C"].bfactor = 0.4
+        structure2[0]["A"][(" ", 180, " ")]["C"].bfactor = 0.6
+
+        self.assertFalse(structure.strictly_equals(structure2))
+        self.assertFalse(structure2.strictly_equals(structure))
+
+        # And when one b-factor is None
+        structure[0]["A"][(" ", 180, " ")]["C"].bfactor = None
+        structure2[0]["A"][(" ", 180, " ")]["C"].bfactor = 0.6
+
+        self.assertFalse(structure.strictly_equals(structure2))
+        self.assertFalse(structure2.strictly_equals(structure))
+
+        # And when radius different
+        structure[0]["A"][(" ", 180, " ")]["C"].bfactor = None
+        structure2[0]["A"][(" ", 180, " ")]["C"].bfactor = None
+        structure[0]["A"][(" ", 180, " ")]["C"].radius = 1.1
+        structure2[0]["A"][(" ", 180, " ")]["C"].radius = 1.2
+
+        self.assertFalse(structure.strictly_equals(structure2))
+        self.assertFalse(structure2.strictly_equals(structure))
 
     def test_residue_sort(self):
         """Test atoms are sorted correctly in residues."""


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->


Fixes comparison of atom's element/pqr_charge/radius, an oversight (bug) in the original strictly_equals implementation. Also ensures this can cope when only one atom's occupancy or bfactor is None.

This addresses some typing issues flagged with mypy.