### PR TITLE
Handle empty QUAL title line without raising IndexError

### DIFF
--- a/Bio/SeqIO/QualityIO.py
+++ b/Bio/SeqIO/QualityIO.py
@@ -1086,7 +1086,11 @@ class FastqIteratorAbstractBaseClass(SequenceIterator[str]):
             self.line = None
 
         descr = title_line
-        id = descr.split()[0]
+        try:
+            id = descr.split(None, 1)[0]
+        except IndexError:
+            # Empty title line (a bare ">"), matching FastaIO behaviour.
+            id = ""
         name = id
 
         if not quality_string.isascii():
@@ -1538,7 +1542,11 @@ class QualPhredIterator(SequenceIterator):
             raise StopIteration
         while True:
             descr = line[1:].rstrip()
-            id = descr.split()[0]
+            try:
+                id = descr.split(None, 1)[0]
+            except IndexError:
+                # Empty title line (a bare ">"), matching FastaIO behaviour.
+                id = ""
             name = id
 
             qualities: list[int] = []

--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -277,9 +277,9 @@ class TestQual(QualityIOTestBaseClass):
     def test_qual_empty_title(self):
         """Check QUAL record with empty title."""
         record = SeqIO.read(StringIO(">\n1 2 3"), "qual")
-        self.assertEqual(records.id, "")
-        self.assertEqual(records.description, "")
-        self.assertEqual(records.letter_annotations["phred_quality"], [1, 2, 3])
+        self.assertEqual(record.id, "")
+        self.assertEqual(record.description, "")
+        self.assertEqual(record.letter_annotations["phred_quality"], [1, 2, 3])
 
     def test_qual(self):
         """Check FASTQ parsing matches QUAL parsing."""

--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -274,6 +274,14 @@ class TestQual(QualityIOTestBaseClass):
         records2 = list(SeqIO.parse("Quality/example.fastq", "fastq"))
         self.compare_records(records1, records2)
 
+    def test_qual_empty_title(self):
+        """A QUAL record with an empty title (bare '>') parses with id=''."""
+        records = list(SeqIO.parse(StringIO(">\n10 20 30\n"), "qual"))
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].id, "")
+        self.assertEqual(records[0].description, "")
+        self.assertEqual(records[0].letter_annotations["phred_quality"], [10, 20, 30])
+
     def test_qual(self):
         """Check FASTQ parsing matches QUAL parsing."""
         records1 = list(SeqIO.parse("Quality/example.qual", "qual"))

--- a/Tests/test_SeqIO_QualityIO.py
+++ b/Tests/test_SeqIO_QualityIO.py
@@ -275,12 +275,11 @@ class TestQual(QualityIOTestBaseClass):
         self.compare_records(records1, records2)
 
     def test_qual_empty_title(self):
-        """A QUAL record with an empty title (bare '>') parses with id=''."""
-        records = list(SeqIO.parse(StringIO(">\n10 20 30\n"), "qual"))
-        self.assertEqual(len(records), 1)
-        self.assertEqual(records[0].id, "")
-        self.assertEqual(records[0].description, "")
-        self.assertEqual(records[0].letter_annotations["phred_quality"], [10, 20, 30])
+        """Check QUAL record with empty title."""
+        record = SeqIO.read(StringIO(">\n1 2 3"), "qual")
+        self.assertEqual(records.id, "")
+        self.assertEqual(records.description, "")
+        self.assertEqual(records.letter_annotations["phred_quality"], [1, 2, 3])
 
     def test_qual(self):
         """Check FASTQ parsing matches QUAL parsing."""


### PR DESCRIPTION
- [ ] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ ] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

---

### Problem

The QUAL parsers in `Bio/SeqIO/QualityIO.py` extract the record id with `descr.split()[0]`. A record whose title line is empty (a bare `>`) makes `descr.split()` return an empty list, so parsing raises `IndexError` instead of reading the record:

```python
import io
from Bio import SeqIO
list(SeqIO.parse(io.StringIO('>\n10 20 30\n'), 'qual'))
# IndexError: list index out of range
```

`FastaIO` already handles this case (it falls back to an empty id via `try: title.split(None, 1)[0] except IndexError: ''`), so FASTA parses a bare `>` fine while QUAL crashes.

### Fix

Fall back to an empty id when the title line is empty, in both QUAL iterator paths, matching `FastaIO`'s behaviour.

### Test

Added `test_qual_empty_title`: a bare `>` record parses with `id == ''` and its qualities intact. It raises `IndexError` before this change and passes after. The full `test_SeqIO_QualityIO.py` suite passes (53 tests).