### PR TITLE
DOCS: fix stale param name in Bio.Entrez._open docstring

### DIFF
--- a/Bio/Entrez/__init__.py
+++ b/Bio/Entrez/__init__.py
@@ -568,8 +568,8 @@ def _open(request):
     ``max_retries`` times. This function also enforces the "up to three queries per second
     rule" to avoid abusing the NCBI servers (this limit is increased to 10 if using an API key).
 
-    :param req_or_cgi: A Request object returned by ``_build_request``.
-    :type req_or_cgi: urllib.request.Request
+    :param request: A Request object returned by ``_build_request``.
+    :type request: urllib.request.Request
     :returns: Handle to HTTP response as returned by ``urllib.request.urlopen``. Will be wrapped in
         an ``io.TextIOWrapper`` if its content type is plain text.
     :rtype: http.client.HTTPResponse or io.TextIOWrapper


### PR DESCRIPTION
The `_open()` function takes request, but its docstring still refers to the parameter as `req_or_cgi`. This updates the parameter name in the docstring to match the function signature.

_Git history shows this docstring was rewritten when `_open` was refactored from `_open(cgi, params=None, post=None, ecitmatch=False)` down to `_open(request)`; the doc field was never updated to match the new parameter name and has said `req_or_cgi` ever since._

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #NA
