### PR TITLE
Deprecate NCBIXML letter attributes

### DIFF
--- a/Bio/Blast/NCBIXML.py
+++ b/Bio/Blast/NCBIXML.py
@@ -34,6 +34,7 @@ import warnings
 import xml.sax
 from xml.sax.handler import ContentHandler
 
+from Bio import BiopythonDeprecationWarning
 from Bio import BiopythonParserWarning
 
 from Bio.Align import MultipleSeqAlignment
@@ -74,11 +75,35 @@ class Header:
         self.reference = ""
 
         self.query = ""
-        self.query_letters = None
+        self._query_letters = None
 
         self.database = ""
         self.database_sequences = None
-        self.database_letters = None
+        self._database_letters = None
+
+    @property
+    def query_letters(self):
+        """Number of letters in the query sequence. DEPRECATED."""
+        import warnings
+
+        warnings.warn(
+            "The query_letters attribute is deprecated; please use query_length instead.",
+            BiopythonDeprecationWarning,
+            stacklevel=2,
+        )
+        return self._query_letters
+
+    @property
+    def database_letters(self):
+        """Number of letters in the database. DEPRECATED."""
+        import warnings
+
+        warnings.warn(
+            "The database_letters attribute is deprecated; please use database_length instead.",
+            BiopythonDeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(self, "database_length", self._database_letters)
 
 
 class Description:
@@ -774,13 +799,13 @@ class BlastParser(_XMLparser):
             self._blast.query = self._header.query
         if not hasattr(self._blast, "query_id") or not self._blast.query_id:
             self._blast.query_id = self._header.query_id
-        if not hasattr(self._blast, "query_letters") or not self._blast.query_letters:
-            self._blast.query_letters = self._header.query_letters
+        if not self._blast._query_letters:
+            self._blast._query_letters = self._header._query_letters
 
         # Hack to record the query length as both the query_letters and
         # query_length properties (as in the plain text parser, see
         # Bug 2176 comment 12):
-        self._blast.query_length = self._blast.query_letters
+        self._blast.query_length = self._blast._query_letters
         # Perhaps in the long term we should deprecate one, but I would
         # prefer to drop query_letters - so we need a transition period
         # with both.
@@ -877,7 +902,7 @@ class BlastParser(_XMLparser):
         Important in old pre 2.2.14 BLAST, for recent versions
         <Iteration_query-len> is enough
         """
-        self._header.query_letters = int(self._value)
+        self._header._query_letters = int(self._value)
 
     def _set_record_query_id(self):
         """Record the identifier of the query (PRIVATE)."""
@@ -889,7 +914,7 @@ class BlastParser(_XMLparser):
 
     def _set_record_query_letters(self):
         """Record the length of the query (PRIVATE)."""
-        self._blast.query_letters = int(self._value)
+        self._blast._query_letters = int(self._value)
 
     # def _end_BlastOutput_query_seq(self):
     #     """The query sequence (PRIVATE)."""

--- a/Tests/test_NCBIXML.py
+++ b/Tests/test_NCBIXML.py
@@ -9,12 +9,27 @@ import os
 import unittest
 import warnings
 
+from Bio import BiopythonDeprecationWarning
 from Bio import BiopythonParserWarning
 from Bio.Blast import NCBIXML
 
 
 class TestNCBIXML(unittest.TestCase):
     """Tests for the NCBI XML parser."""
+
+    def test_deprecated_letter_attributes(self):
+        """Accessing legacy BLAST record letter counts emits deprecation warnings."""
+        filename = "xml_2212L_blastp_001.xml"
+        datafile = os.path.join("Blast", filename)
+        with open(datafile, "rb") as handle:
+            record = NCBIXML.read(handle)
+
+        self.assertEqual(record.query_length, 103)
+        self.assertEqual(record.database_length, 1011751523)
+        with self.assertWarns(BiopythonDeprecationWarning):
+            self.assertEqual(record.query_letters, 103)
+        with self.assertWarns(BiopythonDeprecationWarning):
+            self.assertEqual(record.database_letters, 1011751523)
 
     def test_xml_2212L_blastp_001(self):
         """Parsing BLASTP 2.2.12, gi|49176427|ref|NP_418280.3| (xml_2212L_blastp_001)."""


### PR DESCRIPTION
## Summary
- Deprecate legacy `record.query_letters` and `record.database_letters` attributes with `BiopythonDeprecationWarning`
- Keep the existing `record.query_length` and `record.database_length` access paths working without warning
- Add regression coverage for the deprecated legacy attributes

Fixes #1000

## Validation
- `python -m compileall -q Bio/Blast/NCBIXML.py Tests/test_NCBIXML.py`
- `python -m unittest test_NCBIXML` from the `Tests` directory

Note: Local Windows validation used an isolated venv with NumPy and prebuilt Biopython wheel extension modules copied into the source tree for import compatibility.