### PR TITLE
Return NotImplemented for unsupported Seq comparison types

### DIFF
--- a/Bio/Seq.py
+++ b/Bio/Seq.py
@@ -454,8 +454,9 @@ class _SeqAbstractBaseClass(ABC):
             return self._data < other._data
         elif isinstance(other, str):
             return self._data < other.encode("ASCII")
-        else:
+        elif isinstance(other, (bytes, bytearray)):
             return self._data < other
+        return NotImplemented
 
     def __le__(self, other):
         """Implement the less-than or equal operand."""
@@ -463,8 +464,9 @@ class _SeqAbstractBaseClass(ABC):
             return self._data <= other._data
         elif isinstance(other, str):
             return self._data <= other.encode("ASCII")
-        else:
+        elif isinstance(other, (bytes, bytearray)):
             return self._data <= other
+        return NotImplemented
 
     def __gt__(self, other):
         """Implement the greater-than operand."""
@@ -472,8 +474,9 @@ class _SeqAbstractBaseClass(ABC):
             return self._data > other._data
         elif isinstance(other, str):
             return self._data > other.encode("ASCII")
-        else:
+        elif isinstance(other, (bytes, bytearray)):
             return self._data > other
+        return NotImplemented
 
     def __ge__(self, other):
         """Implement the greater-than or equal operand."""
@@ -481,8 +484,9 @@ class _SeqAbstractBaseClass(ABC):
             return self._data >= other._data
         elif isinstance(other, str):
             return self._data >= other.encode("ASCII")
-        else:
+        elif isinstance(other, (bytes, bytearray)):
             return self._data >= other
+        return NotImplemented
 
     def __len__(self):
         """Return the length of the sequence."""

--- a/Tests/test_seq.py
+++ b/Tests/test_seq.py
@@ -257,6 +257,16 @@ class TestSeqStringMethods(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.s >= 1
 
+    def test_less_than_comparison_with_bytes(self):
+        """Test __lt__ comparison with bytes."""
+        self.assertLess(self.s, b"\xff" * len(self.s))
+
+    def test_incompatible_comparison_error_mentions_seq(self):
+        """Test incompatible-type comparison raises a TypeError naming Seq."""
+        with self.assertRaises(TypeError) as context:
+            self.s < 1
+        self.assertIn("Seq", str(context.exception))
+
     def test_add_method_using_wrong_object(self):
         with self.assertRaises(TypeError):
             self.s + {}


### PR DESCRIPTION
Fixes #5292

`Seq`'s rich-comparison operators (`__lt__`, `__le__`, `__gt__`, `__ge__`) fell back to `self._data < other` for unsupported operand types, which raised an opaque `TypeError` exposing the internal `bytes` representation. This changes them to return `NotImplemented` for unsupported types (so Python raises a standard `Seq`-level error), while preserving `str`/`bytes`/`bytearray` comparison.

Before: `Seq('ACG') < 5` → `TypeError: '<' not supported between instances of 'bytes' and 'int'`
After:  `Seq('ACG') < 5` → `TypeError: '<' not supported between instances of 'Seq' and 'int'`

## Test log

```
$ python -m unittest test_seq.TestSeqStringMethods.<comparison tests>
Ran 8 tests ... OK
```
