### PR TITLE
Raise ValueError for empty sequence in molecular_weight()

### DIFF
--- a/Bio/SeqUtils/__init__.py
+++ b/Bio/SeqUtils/__init__.py
@@ -447,6 +447,16 @@ def molecular_weight(
     >>> print("%0.2f" % molecular_weight("AGC", "protein"))
     249.29
 
+    The molecular weight of an empty sequence is not physically defined.
+    An empty sequence returns the mass of a single water molecule rather than zero or an error:
+
+    >>> print("%0.4f" % molecular_weight("", "DNA"))
+    18.0153
+    >>> print("%0.4f" % molecular_weight("", "RNA"))
+    18.0153
+    >>> print("%0.4f" % molecular_weight("", "protein"))
+    18.0153
+
     """
     try:
         seq = seq.seq


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [x] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [x] I have read the ``CONTRIBUTING.rst`` file, have run ``pre-commit``
locally, and understand that continuous integration checks will be used to
confirm the Biopython unit tests and style checks pass with these changes.

- [x] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

<!--- Briefly describe the changes included in this pull request below
 !--- starting with 'Closes #...' if appropriate --->

Closes #5305

Following the discussion in #5305, leave the behaviour unchanged but add the examples to the docstring.

This PR is documentation-only: it adds a note plus doctests to `molecular_weight()`.
